### PR TITLE
Add the ability to map PT blocks to LLVM IR blocks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "ykllvmwrap",
     "ykrt",
     "yktrace",
+    "ykutil",
 ]

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 # The service providing the commit statuses to GitHub.
-status = ["buildbot/yorick-buildbot-build-script-hw"]
+status = ["buildbot/yk-buildbot-build-script-hw"]
 
 # Allow eight hours for builds + tests.
 timeout_sec = 28800

--- a/c_tests/tests/mapper_funcs_branches.c
+++ b/c_tests/tests/mapper_funcs_branches.c
@@ -1,0 +1,51 @@
+// Compiler:
+// Run-time:
+
+// Check that inter-procedural tracing works.
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+__attribute__((noinline))
+int
+add_one_or_two(int arg)
+{
+    if (arg % 2 == 0) {
+        arg++;
+    } else {
+        arg += 2;
+    }
+    return arg;
+}
+
+int
+main(int argc, char **argv)
+{
+    void *tt = __yktrace_start_tracing(HW_TRACING);
+    argc = add_one_or_two(argc);
+    void *tr = __yktrace_stop_tracing(tt);
+
+    size_t len = __yktrace_irtrace_len(tr);
+    assert(len >= 4); // At least one block for `main`, at least 3 blocks for `add_one_or_two`.
+    for (int i = 0; i < len; i++) {
+        char *func_name = NULL;
+        size_t bb = 0;
+        __yktrace_irtrace_get(tr, i, &func_name, &bb);
+
+        // We expect blocks from `add_one_or_two` to be book-ended by `main` bb0.
+        // Note that in LLVM, a call does not terminate a block.
+        if ((i == 0) || (i == len - 1)) {
+            assert((strcmp(func_name, "main") == 0) && (bb == 0));
+        } else {
+            assert(strcmp(func_name, "add_one_or_two") == 0);
+        }
+        free(func_name);
+    }
+
+    __yktrace_drop_irtrace(tr);
+    return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/mapper_simple.c
+++ b/c_tests/tests/mapper_simple.c
@@ -1,0 +1,29 @@
+// Compiler:
+// Run-time:
+
+// Check that basic tracing works.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+int
+main(int argc, char **argv)
+{
+    void *tt = __yktrace_start_tracing(HW_TRACING);
+    void *tr = __yktrace_stop_tracing(tt);
+    assert(__yktrace_irtrace_len(tr) == 1);
+
+    char *func_name = NULL;
+    size_t bb = 0;
+    __yktrace_irtrace_get(tr, 0, &func_name, &bb);
+    assert(strcmp(func_name, "main") == 0);
+    assert(bb == 0);
+
+    free(func_name);
+    __yktrace_drop_irtrace(tr);
+
+    return (EXIT_SUCCESS);
+}

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -42,7 +42,11 @@ pub extern "C" fn yk_drop_location(loc: *mut Location) {
 /// These symbols are not shipped as part of the main API.
 #[cfg(feature = "c_testing")]
 mod c_testing {
-    use yktrace::BlockMap;
+    use std::{ffi::CString, mem, os::raw::c_char};
+    use yktrace::{start_tracing, BlockMap, IRTrace, ThreadTracer, TracingKind};
+
+    const SW_TRACING: usize = 0;
+    const HW_TRACING: usize = 1;
 
     #[no_mangle]
     pub extern "C" fn __yktrace_hwt_mapper_blockmap_new() -> *mut BlockMap {
@@ -58,7 +62,55 @@ mod c_testing {
     pub extern "C" fn __yktrace_hwt_mapper_blockmap_len(bm: *mut BlockMap) -> usize {
         let bm = unsafe { Box::from_raw(bm) };
         let ret = bm.len();
-        Box::leak(bm);
+        mem::forget(bm);
         ret
+    }
+
+    #[no_mangle]
+    pub extern "C" fn __yktrace_start_tracing(kind: usize) -> *mut ThreadTracer {
+        let kind: TracingKind = match kind {
+            SW_TRACING => TracingKind::SoftwareTracing,
+            HW_TRACING => TracingKind::HardwareTracing,
+            _ => panic!(),
+        };
+        Box::into_raw(Box::new(start_tracing(kind)))
+    }
+
+    #[no_mangle]
+    pub extern "C" fn __yktrace_stop_tracing(tt: *mut ThreadTracer) -> *mut IRTrace {
+        let tt = unsafe { Box::from_raw(tt) };
+        Box::into_raw(Box::new(tt.stop_tracing().unwrap())) as *mut _
+    }
+
+    #[no_mangle]
+    pub extern "C" fn __yktrace_irtrace_len(trace: *mut IRTrace) -> usize {
+        let trace = unsafe { Box::from_raw(trace) };
+        let ret = trace.len();
+        mem::forget(trace);
+        ret
+    }
+
+    /// Fetches the function name (`res_func`) and the block index (`res_bb`) at position `idx` in
+    /// `trace`. The caller must free() the function name.
+    #[no_mangle]
+    pub extern "C" fn __yktrace_irtrace_get(
+        trace: *mut IRTrace,
+        idx: usize,
+        res_func: *mut *mut c_char,
+        res_bb: *mut usize,
+    ) {
+        let trace = unsafe { Box::from_raw(trace) };
+        let blk = trace.get(idx).unwrap();
+        let c_func = CString::new(blk.func_name()).unwrap();
+        unsafe {
+            *res_func = c_func.into_raw();
+            *res_bb = blk.bb();
+        }
+        mem::forget(trace);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn __yktrace_drop_irtrace(trace: *mut IRTrace) {
+        unsafe { Box::from_raw(trace) };
     }
 }

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -1,5 +1,17 @@
 // Functions exported only for testing.
 
+#include <stdint.h>
+
+#define SW_TRACING 0
+#define HW_TRACING 1
+
 void *__yktrace_hwt_mapper_blockmap_new(void);
 size_t __yktrace_hwt_mapper_blockmap_len(void *mapper);
 void __yktrace_hwt_mapper_blockmap_free(void *mapper);
+
+void *__yktrace_start_tracing(uintptr_t kind);
+void *__yktrace_stop_tracing(void *tt);
+
+size_t __yktrace_irtrace_len(void *trace);
+void __yktrace_irtrace_get(void *trace, size_t idx, char **res_func, size_t *res_bb);
+void __yktrace_drop_irtrace(void *trace);

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -7,13 +7,18 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 byteorder = "1.4.3"
+elf = "0.0.10"
 fxhash = "0.2.1"
 gimli = "0.23.0"
 hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
+intervaltree = "0.2.6"
 leb128 = "0.2.4"
 libc = "0.2.82"
 memmap2 = "0.2.2"
+once_cell = "1.7.2"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
+ykllvmwrap = { path = "../ykllvmwrap" }
+ykutil = { path = "../ykutil" }
 
 [dependencies.object]
 version = "0.23.0"

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -25,11 +25,22 @@ impl Default for TracingKind {
 }
 
 /// A globally unique block ID for an LLVM IR block.
+#[derive(Debug)]
 pub struct IRBlock {
     /// The name of the function containing the block.
-    _func_name: String,
+    func_name: String,
     /// The index of the block within the function.
-    _bb: usize,
+    bb: usize,
+}
+
+impl IRBlock {
+    pub fn func_name(&self) -> &str {
+        &self.func_name
+    }
+
+    pub fn bb(&self) -> usize {
+        self.bb
+    }
 }
 
 /// An LLVM IR trace.
@@ -45,8 +56,12 @@ impl IRTrace {
         Self { blocks }
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.blocks.len()
+    }
+
+    pub fn get(&self, idx: usize) -> Option<&IRBlock> {
+        self.blocks.get(idx)
     }
 }
 

--- a/ykutil/Cargo.toml
+++ b/ykutil/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
-name = "ykllvmwrap"
+name = "ykutil"
 version = "0.1.0"
 authors = ["The Yorick Developers"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-cc = "1.0.67"
-libc = "0.2.94"
-ykutil = { path = "../ykutil" }
-
-[build-dependencies]
-cc = "1.0.67"
+libc = "0.2.82"
+once_cell = "1.7.2"
+phdrs = { git = "https://github.com/softdevteam/phdrs" }

--- a/ykutil/src/addr.rs
+++ b/ykutil/src/addr.rs
@@ -1,0 +1,45 @@
+//! Address utilities.
+
+use libc::{c_void, dladdr, Dl_info};
+use once_cell::sync::Lazy;
+use phdrs::objects;
+use std::{
+    convert::TryFrom,
+    env,
+    ffi::{CStr, CString},
+    ptr::{null, null_mut},
+};
+
+static CUR_EXE_C: Lazy<CString> =
+    Lazy::new(|| CString::new(env::current_exe().unwrap().to_str().unwrap()).unwrap());
+
+/// Given a virtual address, returns a pair indicating the object in which the address originated
+/// and the byte offset.
+pub fn code_vaddr_to_off(vaddr: usize) -> Option<(&'static CStr, u64)> {
+    // Find the object file from which the virtual address was loaded.
+    let mut info: Dl_info = Dl_info {
+        dli_fname: null(),
+        dli_fbase: null_mut(),
+        dli_sname: null(),
+        dli_saddr: null_mut(),
+    };
+    if unsafe { dladdr(vaddr as *const c_void, &mut info as *mut Dl_info) } == 0 {
+        return None;
+    }
+    let containing_obj = unsafe { CStr::from_ptr(info.dli_fname) };
+
+    // Find the corresponding byte offset of the virtual address in the object.
+    for obj in &objects() {
+        let mut obj_name = obj.name();
+        let obj_name_p = obj_name.as_ptr();
+        if unsafe { *obj_name_p } == 0 {
+            // On some systems, the empty string indicates the main binary.
+            obj_name = CUR_EXE_C.as_c_str();
+        }
+        if obj_name != containing_obj {
+            continue;
+        }
+        return Some((containing_obj, u64::try_from(vaddr).unwrap() - obj.addr()));
+    }
+    None
+}

--- a/ykutil/src/lib.rs
+++ b/ykutil/src/lib.rs
@@ -1,0 +1,3 @@
+//! Miscellaneous utilities.
+
+pub mod addr;


### PR DESCRIPTION
This change allows us to translate the block addresses found in a PT
trace into block identifiers in LLVM IR.

We don't yet look up the IR block in the LLVM bitcode, only collect the
information necessary to do so.

In doing so I've also created a little crate called `ykutil` which
currently only shares a routine between both `ykllvmwrap` and `yktrace`
in a sensible and dependency-cycle-free manner.

Observations:
 - LLVM blocks are not terminated by calls.
 - One PT block may map to many LLVM blocks (see doc string on
   HWTMapper::map_block() for more info).