### PR TITLE
Switch to using ykllvm.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -25,16 +25,9 @@ rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo fmt --all -- --check
 
 # Build LLVM for the C tests.
-#
-# This is required because we have an un-upstreamed patch to get the post-LTO
-# blockmap section into the end binaries.
-#
-# Also note that this is a fork of Rust's fork, as we hope to get all of this
-# working for Rust binaries one day. Blocker:
-# https://github.com/rust-lang/rust/issues/84395
 mkdir -p target && cd target
-git clone -b yk/12.0-2021-04-15 https://github.com/vext01/llvm-project
-cd llvm-project
+git clone https://github.com/ykjit/ykllvm
+cd ykllvm
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \

--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -30,6 +30,7 @@ fn mk_compiler(exe: &Path, src: &Path) -> Command {
         "-fuse-ld=lld",
         "-flto",
         "-Wl,--plugin-opt=-lto-embed-bitcode=optimized",
+        "-Wl,--lto-basic-block-sections=labels",
         "-I",
         ykcapi_dir.to_str().unwrap(),
         "-L",


### PR DESCRIPTION
Note also that we currently don't need any local LLVM patches, as I've
recently found the (undocumented) -Wl,--lto-basic-block-sections=labels
option, which does exactly what we need: puts the post-lto blockmap into
the binary.