### PR TITLE
Add a yk_stopgap_safe marker.

### DIFF
--- a/c_tests/tests/basic_mt.c
+++ b/c_tests/tests/basic_mt.c
@@ -10,6 +10,7 @@ main(int argc, char **argv)
     YkLocation loc = yk_location_new();
     for (int i = 0; i < yk_mt_hot_threshold(mt); i++) {
         yk_control_point(mt, &loc);
+        yk_stopgap_safe();
     }
     yk_location_drop(loc);
     return 0;

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -29,6 +29,12 @@ pub extern "C" fn yk_control_point(mt: *mut MT, loc: *mut Location) {
 }
 
 #[no_mangle]
+pub extern "C" fn yk_stopgap_safe() {
+    // This function is a marker for the trace compiler. It might need to become an LLVM builtin,
+    // or we may need to add an LLVM annotation or ...
+}
+
+#[no_mangle]
 pub extern "C" fn yk_location_new() -> Location {
     Location::new()
 }

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -45,6 +45,13 @@ YkHotThreshold yk_mt_hot_threshold(MT *);
 // ever be the beginning of a trace.
 void yk_control_point(MT *, YkLocation *);
 
+// Mark this point in the program as being a safe point for the stopgap
+// interpreter to transition back to normal program execution. Typical stopgap
+// safe points are at the backwards jump(s) of an interpreter's main for/while
+// loop. If, for example, your interpreter uses interpreted gotos, you may want
+// to mark multiple locations as stopgap safe.
+void yk_stopgap_safe();
+
 // Create a new `Location`.
 //
 // Note that a `Location` created by this call must not simply be discarded: if


### PR DESCRIPTION
When adjusting an existing C interpreter, we often want to mark multiple points in the interpreter as being safe for the stopgap interpreter to transition back to normal "C" interpretation. This commit adds a function that we can use as such as a marker in the future (at the moment it's a no-op). Exactly how we teach clang/rustc/LLVM about what's special about this function is something we can worry about in the future. Similarly, the precise name for the function is something we can tweak in the future.

Why do we need this marker at all? Well, previously we assumed this was synonymous with control points, but in the presence of computed gotos this isn't really enough: interpreters rarely go through control points. So while it should always be safe for the stopgap interpreter to transition back to normal execution at a control point, that potentially means we execute *lots* of code in the stopgap interpreter unnecessarily. "yk_stopgap_safe" allows an interpreter author to add extra places in their interpreter where it's safe to transition back to normal execution. The precise rules of "safe" are deeply unclear, but I believe a safe, conservative approximation is "add it either
directly before a `goto` (if you're using computed gotos for your main interpreter loop) or at the very end or beginning of your interpreter's main loop". We might be able to relax these requirements later, but I don't think it's something we should worry about for now.