### PR TITLE
Make IRBlock store a CString, not a String.

### DIFF
--- a/c_tests/tests/mapper_funcs_branches.c
+++ b/c_tests/tests/mapper_funcs_branches.c
@@ -43,7 +43,6 @@ main(int argc, char **argv)
         } else {
             assert(strcmp(func_name, "add_one_or_two") == 0);
         }
-        free(func_name);
     }
 
     __yktrace_drop_irtrace(tr);

--- a/c_tests/tests/mapper_simple.c
+++ b/c_tests/tests/mapper_simple.c
@@ -22,7 +22,6 @@ main(int argc, char **argv)
     assert(strcmp(func_name, "main") == 0);
     assert(bb == 0);
 
-    free(func_name);
     __yktrace_drop_irtrace(tr);
 
     return (EXIT_SUCCESS);

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -1,6 +1,7 @@
 //! Utilities for collecting and decoding traces.
 
 mod errors;
+use std::ffi::{CStr, CString};
 mod hwt;
 
 pub use errors::InvalidTraceError;
@@ -28,14 +29,14 @@ impl Default for TracingKind {
 #[derive(Debug)]
 pub struct IRBlock {
     /// The name of the function containing the block.
-    func_name: String,
+    func_name: CString,
     /// The index of the block within the function.
     bb: usize,
 }
 
 impl IRBlock {
-    pub fn func_name(&self) -> &str {
-        &self.func_name
+    pub fn func_name(&self) -> &CStr {
+        &self.func_name.as_c_str()
     }
 
     pub fn bb(&self) -> usize {


### PR DESCRIPTION
Currently when we hand out an IRBlock's function name to C/C++ we have
to convert the internal Rust string into a CString, before passing it to
the caller. The caller is then responsible for freeing the string. This is
unergonomic and slower than it could be.

We didn't care before as we only do this in testing, but soon we will
have some C++ code on the critical path which will need to walk an
IRTrace querying IRBlocks. Therefore we should fix this now.

Storing a CString instead of a String means that we can hand out
borrowed `char *` pointers (via CStr) without having to allocate each
time and without the caller having to free the result.