### PR TITLE
Stub out the C++ trace compilation routine.

### DIFF
--- a/c_tests/tests/compile_simple.c
+++ b/c_tests/tests/compile_simple.c
@@ -1,0 +1,25 @@
+// Compiler:
+// Run-time:
+
+// Check that basic trace compilation works.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+int
+main(int argc, char **argv)
+{
+    void *tt = __yktrace_start_tracing(HW_TRACING);
+    int res = argc + 1;
+    void *tr = __yktrace_stop_tracing(tt);
+
+    assert(res == 2);
+    __yktrace_irtrace_compile(tr); // FIXME test something.
+
+    __yktrace_drop_irtrace(tr);
+
+    return (EXIT_SUCCESS);
+}

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -112,4 +112,9 @@ mod c_testing {
     pub extern "C" fn __yktrace_drop_irtrace(trace: *mut IRTrace) {
         unsafe { Box::from_raw(trace) };
     }
+
+    #[no_mangle]
+    pub extern "C" fn __yktrace_irtrace_compile(trace: *mut IRTrace) {
+        unsafe { &*trace }.compile();
+    }
 }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -60,10 +60,7 @@ mod c_testing {
 
     #[no_mangle]
     pub extern "C" fn __yktrace_hwt_mapper_blockmap_len(bm: *mut BlockMap) -> usize {
-        let bm = unsafe { Box::from_raw(bm) };
-        let ret = bm.len();
-        mem::forget(bm);
-        ret
+        unsafe { &*bm }.len()
     }
 
     #[no_mangle]
@@ -84,10 +81,7 @@ mod c_testing {
 
     #[no_mangle]
     pub extern "C" fn __yktrace_irtrace_len(trace: *mut IRTrace) -> usize {
-        let trace = unsafe { Box::from_raw(trace) };
-        let ret = trace.len();
-        mem::forget(trace);
-        ret
+        unsafe { &*trace }.len()
     }
 
     /// Fetches the function name (`res_func`) and the block index (`res_bb`) at position `idx` in
@@ -99,13 +93,12 @@ mod c_testing {
         res_func: *mut *const c_char,
         res_bb: *mut usize,
     ) {
-        let trace = unsafe { Box::from_raw(trace) };
+        let trace = unsafe { &*trace };
         let blk = trace.get(idx).unwrap();
         unsafe {
             *res_func = blk.func_name().as_ptr();
             *res_bb = blk.bb();
         }
-        mem::forget(trace);
     }
 
     #[no_mangle]

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -11,7 +11,7 @@ void __yktrace_hwt_mapper_blockmap_free(void *mapper);
 
 void *__yktrace_start_tracing(uintptr_t kind);
 void *__yktrace_stop_tracing(void *tt);
-
 size_t __yktrace_irtrace_len(void *trace);
 void __yktrace_irtrace_get(void *trace, size_t idx, char **res_func, size_t *res_bb);
+void __yktrace_irtrace_compile(void *trace);
 void __yktrace_drop_irtrace(void *trace);

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -1,3 +1,14 @@
 // Exporting parts of the LLVM C++ API not present in the LLVM C API.
 
+use libc::size_t;
+use std::os::raw::c_char;
+
 pub mod symbolizer;
+
+extern "C" {
+    pub fn __ykllvmwrap_irtrace_compile(
+        func_names: *const *const c_char,
+        bbs: *const size_t,
+        len: size_t,
+    );
+}

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -32,3 +32,16 @@ extern "C" char *__yk_symbolizer_find_code_sym(LLVMSymbolizer *Symbolizer, const
     // OPTIMISE_ME: get rid of heap allocation.
     return strdup(LineInfo->FunctionName.c_str());
 }
+
+/// Compiles an IRTrace to executable code in memory.
+//
+// The trace to compile is passed in as two arrays of length Len. Then each
+// (FuncName[I], BBs[I]) pair identifies the LLVM block at position `I` in the
+// trace.
+extern "C" void __ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[], size_t Len) {
+    for (size_t Idx = 0; Idx < Len; Idx++) {
+        // FIXME populate.
+        //auto FuncName = FuncNames[Idx];
+        //auto BB = BBs[Idx];
+    }
+}

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -64,6 +64,17 @@ impl IRTrace {
     pub fn get(&self, idx: usize) -> Option<&IRBlock> {
         self.blocks.get(idx)
     }
+
+    pub fn compile(&self) {
+        let len = self.len();
+        let mut func_names = Vec::with_capacity(len);
+        let mut bbs = Vec::with_capacity(len);
+        for blk in &self.blocks {
+            func_names.push(blk.func_name().as_ptr());
+            bbs.push(blk.bb());
+        }
+        unsafe { ykllvmwrap::__ykllvmwrap_irtrace_compile(func_names.as_ptr(), bbs.as_ptr(), len) }
+    }
 }
 
 /// Binary executable trace code.


### PR DESCRIPTION
**Do not merge, this isn't finished**

This is an attempt to:
 * Make accessors for getting a trace's length and its blocks available to C++.
 * Stubbing out a C++ function that Lukas can drop his LLVM code into to compile a trace.

I'm getting this error when a C test is compiled:
```
/tmp/.tmpDLh635/blockmap: symbol lookup error: /home/vext01/research/yorick/yk/target/debug/deps/libykcapi.so: undefined symbol: _Z21__yktrace_irtrace_lenPv
```

I've never seen this kind of error before.

And I've narrowed it down to this (seemingly unrelated) function:
```
#[no_mangle]                                                                                                                                                                                              
pub extern "C" fn __yktrace_irtrace_compile(trace: *mut IRTrace) {                                                                                                                                        
    unsafe {&*trace}.compile(); // XXX                                                                                                                                                           
}
```

Comment out the line marked `XXX` and the error goes away.

I'm baffled. Does anyone see anything wrong?