### PR TITLE
Implement compilation of simple traces.

### DIFF
--- a/c_tests/tests/compile_simple.c
+++ b/c_tests/tests/compile_simple.c
@@ -2,6 +2,8 @@
 // Run-time:
 
 // Check that basic trace compilation works.
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
 
 #include <assert.h>
 #include <stdio.h>
@@ -13,13 +15,15 @@ int
 main(int argc, char **argv)
 {
     void *tt = __yktrace_start_tracing(HW_TRACING);
-    int res = argc + 1;
+    int res = 1 + 1;
     void *tr = __yktrace_stop_tracing(tt);
 
     assert(res == 2);
-    __yktrace_irtrace_compile(tr); // FIXME test something.
 
+    void *ptr = __yktrace_irtrace_compile(tr);
     __yktrace_drop_irtrace(tr);
+    void(*func)() = (void(*)())ptr;
+    func();
 
     return (EXIT_SUCCESS);
 }

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0 OR MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
+libc = "0.2.94"
 ykllvmwrap = { path = "../ykllvmwrap" }
 ykrt = { path = "../ykrt" }
 yktrace = { path = "../yktrace" }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -42,7 +42,8 @@ pub extern "C" fn yk_location_drop(loc: Location) {
 /// These symbols are not shipped as part of the main API.
 #[cfg(feature = "c_testing")]
 mod c_testing {
-    use std::{mem, os::raw::c_char};
+    use libc::c_void;
+    use std::os::raw::c_char;
     use yktrace::{start_tracing, BlockMap, IRTrace, ThreadTracer, TracingKind};
 
     const SW_TRACING: usize = 0;
@@ -107,7 +108,7 @@ mod c_testing {
     }
 
     #[no_mangle]
-    pub extern "C" fn __yktrace_irtrace_compile(trace: *mut IRTrace) {
-        unsafe { &*trace }.compile();
+    pub extern "C" fn __yktrace_irtrace_compile(trace: *mut IRTrace) -> *const c_void {
+        unsafe { &*trace }.compile()
     }
 }

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -13,5 +13,5 @@ void *__yktrace_start_tracing(uintptr_t kind);
 void *__yktrace_stop_tracing(void *tt);
 size_t __yktrace_irtrace_len(void *trace);
 void __yktrace_irtrace_get(void *trace, size_t idx, char **res_func, size_t *res_bb);
-void __yktrace_irtrace_compile(void *trace);
+void *__yktrace_irtrace_compile(void *trace);
 void __yktrace_drop_irtrace(void *trace);

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -1,6 +1,6 @@
 // Exporting parts of the LLVM C++ API not present in the LLVM C API.
 
-use libc::size_t;
+use libc::{c_void, size_t};
 use std::os::raw::c_char;
 
 pub mod symbolizer;
@@ -10,5 +10,7 @@ extern "C" {
         func_names: *const *const c_char,
         bbs: *const size_t,
         len: size_t,
-    );
+        sec_ptr: *const c_char,
+        sec_size: size_t,
+    ) -> *const c_void;
 }

--- a/ykllvmwrap/src/memman.cc
+++ b/ykllvmwrap/src/memman.cc
@@ -1,0 +1,77 @@
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+#include <sys/mman.h>
+
+using namespace llvm;
+
+struct AllocMem {
+  uint8_t *Ptr;
+  uintptr_t Size;
+};
+
+class MemMan : public RTDyldMemoryManager {
+public:
+  MemMan();
+  ~MemMan() override;
+
+  uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
+                               unsigned SectionID,
+                               StringRef SectionName) override;
+
+  uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
+                               unsigned SectionID, StringRef SectionName,
+                               bool isReadOnly) override;
+
+  bool finalizeMemory(std::string *ErrMsg) override;
+  void freeMemory();
+
+private:
+  std::vector<AllocMem> code;
+  std::vector<AllocMem> data;
+};
+
+MemMan::MemMan() {}
+MemMan::~MemMan() {}
+
+uint8_t *alloc_mem(uintptr_t Size, unsigned Alignment,
+                   std::vector<AllocMem> *Vec) {
+  uintptr_t RequiredSize = Alignment * ((Size + Alignment - 1) / Alignment + 1);
+  auto Ptr = (unsigned char *)mmap(0, RequiredSize, PROT_WRITE,
+                                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(Ptr != MAP_FAILED);
+  Vec->push_back({Ptr, RequiredSize});
+  return Ptr;
+}
+
+uint8_t *MemMan::allocateCodeSection(uintptr_t Size, unsigned Alignment,
+                                     unsigned SectionID,
+                                     StringRef SectionName) {
+  return alloc_mem(Size, Alignment, &code);
+}
+
+uint8_t *MemMan::allocateDataSection(uintptr_t Size, unsigned Alignment,
+                                     unsigned SectionID, StringRef SectionName,
+                                     bool isReadOnly) {
+  return alloc_mem(Size, Alignment, &data);
+}
+
+bool MemMan::finalizeMemory(std::string *ErrMsg) {
+  for (const AllocMem &Value : code) {
+    if (mprotect(Value.Ptr, Value.Size, PROT_READ | PROT_EXEC) == -1) {
+      errx(EXIT_FAILURE, "Can't make allocated memory executable.");
+    }
+  }
+  return true;
+}
+
+void MemMan::freeMemory() {
+  for (const AllocMem &Value : code) {
+    if (munmap(Value.Ptr, Value.Size) == -1) {
+      errx(EXIT_FAILURE, "Failed to unmap memory.");
+    }
+  }
+  for (const AllocMem &Value : data) {
+    if (munmap(Value.Ptr, Value.Size) == -1) {
+      errx(EXIT_FAILURE, "Failed to unmap memory.");
+    }
+  }
+}

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -4,48 +4,162 @@
 #define _GNU_SOURCE
 #endif
 
-#include <dlfcn.h>
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>
-#include <string.h>
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/MCJIT.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Transforms/Utils/ValueMapper.h>
+
+#include <dlfcn.h>
+#include <err.h>
 #include <link.h>
+#include <stdlib.h>
+#include <string.h>
 
 using namespace llvm;
 using namespace llvm::symbolize;
 
+#define TRACE_FUNC_NAME "__yk_compiled_trace"
+#define YKTRACE_START "__yktrace_start_tracing"
+#define YKTRACE_STOP "__yktrace_stop_tracing"
+
 extern "C" LLVMSymbolizer *__yk_llvmwrap_symbolizer_new() {
-    return new LLVMSymbolizer;
+  return new LLVMSymbolizer;
 }
 
 extern "C" void __yk_llvmwrap_symbolizer_free(LLVMSymbolizer *Symbolizer) {
-    delete Symbolizer;
+  delete Symbolizer;
 }
 
 // Finds the name of a code symbol from a virtual address.
 // The caller is responsible for freeing the returned (heap-allocated) C string.
-extern "C" char *__yk_llvmwrap_symbolizer_find_code_sym(
-    LLVMSymbolizer *Symbolizer,
-    const char *Obj,
-    uint64_t Off)
-{
-    object::SectionedAddress Mod{Off, object::SectionedAddress::UndefSection};
-    auto LineInfo = Symbolizer->symbolizeCode(Obj, Mod);
-    if (auto Err = LineInfo.takeError()) {
-        return NULL;
-    }
+extern "C" char *
+__yk_llvmwrap_symbolizer_find_code_sym(LLVMSymbolizer *Symbolizer,
+                                       const char *Obj, uint64_t Off) {
+  object::SectionedAddress Mod{Off, object::SectionedAddress::UndefSection};
+  auto LineInfo = Symbolizer->symbolizeCode(Obj, Mod);
+  if (auto Err = LineInfo.takeError()) {
+    return NULL;
+  }
 
-    // OPTIMISE_ME: get rid of heap allocation.
-    return strdup(LineInfo->FunctionName.c_str());
+  // OPTIMISE_ME: get rid of heap allocation.
+  return strdup(LineInfo->FunctionName.c_str());
 }
 
-/// Compiles an IRTrace to executable code in memory.
+// Load an LLVM module from an address.
+std::unique_ptr<Module> load_module(LLVMContext &Context, char *Ptr,
+                                    size_t Len) {
+  auto Sf = StringRef(Ptr, Len);
+  auto Mb = MemoryBufferRef(Sf, "");
+  SMDiagnostic Error;
+  auto M = parseIR(Mb, Error, Context);
+  if (!M)
+    errx(EXIT_FAILURE, "Can't load module.");
+  return M;
+}
+
+// Compile a module in-memory and return a pointer to its function.
+extern "C" void *compile_module(Module *M) {
+  InitializeNativeTarget();
+  InitializeNativeTargetAsmPrinter();
+  InitializeNativeTargetAsmParser();
+
+  auto MPtr = std::unique_ptr<Module>(M);
+  ExecutionEngine *EE = EngineBuilder(std::move(MPtr)).create();
+  EE->finalizeObject();
+
+  if (EE->hasError())
+    errx(EXIT_FAILURE, "Couldn't compile trace: %s",
+         EE->getErrorMessage().c_str());
+
+    return (void *) EE->getFunctionAddress(TRACE_FUNC_NAME);
+}
+
+// Compile an IRTrace to executable code in memory.
 //
 // The trace to compile is passed in as two arrays of length Len. Then each
 // (FuncName[I], BBs[I]) pair identifies the LLVM block at position `I` in the
 // trace.
-extern "C" void __ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[], size_t Len) {
-    for (size_t Idx = 0; Idx < Len; Idx++) {
-        // FIXME populate.
-        //auto FuncName = FuncNames[Idx];
-        //auto BB = BBs[Idx];
+//
+// Returns a pointer to the compiled function.
+extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
+                                              size_t Len, char *SecPtr,
+                                              size_t SecSize) {
+  LLVMContext Context;
+  auto DstMod = new Module("", Context);
+
+  // Set up new module for the trace.
+  llvm::FunctionType *FType =
+      llvm::FunctionType::get(Type::getVoidTy(Context), false);
+  llvm::Function *DstFunc = llvm::Function::Create(
+      FType, Function::InternalLinkage, TRACE_FUNC_NAME, DstMod);
+  DstFunc->setCallingConv(CallingConv::C);
+  auto DstBB = BasicBlock::Create(Context, "bb0", DstFunc);
+  llvm::IRBuilder<> Builder(Context);
+  Builder.SetInsertPoint(DstBB);
+
+  auto SrcMod = load_module(Context, SecPtr, SecSize);
+
+  llvm::ValueToValueMapTy VMap;
+  bool Tracing = false;
+
+  // Iterate over the PT trace and stitch together all traced blocks.
+  for (size_t Idx = 0; Idx < Len; Idx++) {
+    auto FuncName = FuncNames[Idx];
+
+    // Get a traced function so we can extract blocks from it.
+    Function *F = SrcMod->getFunction(FuncName);
+    if (!F)
+      errx(EXIT_FAILURE, "can't find function %s", FuncName);
+
+    // Skip to the correct block.
+    auto It = F->begin();
+    std::advance(It, BBs[Idx]);
+    BasicBlock *BB = &*It;
+    // Iterate over all instructions within this block and copy them over
+    // to our new module.
+    for (auto I = BB->begin(); I != BB->end(); I++) {
+      if (isa<CallInst>(I)) {
+        Function *CF = cast<CallInst>(&*I)->getCalledFunction();
+        if (CF->getName() == YKTRACE_START) {
+          Tracing = true;
+          I++; // FIXME Better way of removing result of
+               // __yktrace_start_tracing.
+          continue;
+        } else if (CF->getName() == YKTRACE_STOP) {
+          // FIXME Remove argument setup before __yktrace_stop_tracing call.
+          Tracing = false;
+        }
+      }
+      if (!Tracing && !llvm::isa<AllocaInst>(I)) {
+        // FIXME Remove allocas not needed in traced code.
+        continue;
+      }
+      if (llvm::isa<llvm::BranchInst>(I)) {
+        // FIXME Replace all branch instruction with guards.
+        continue;
+      }
+
+      // Copy instruction over into the IR trace. Since the instruction
+      // operands still reference values in the original bitcode, remap
+      // the operands to point to new values within the IR trace.
+      auto NewInst = &*I->clone();
+      llvm::RemapInstruction(NewInst, VMap, RF_NoModuleLevelChanges);
+      VMap[&*I] = NewInst;
+      Builder.Insert(NewInst);
     }
+  }
+  Builder.CreateRetVoid();
+#ifdef DEBUG
+  llvm::verifyModule(*DstMod, &llvm::errs());
+#endif
+
+  // Compile IR trace and return a pointer to its function.
+  return compile_module(DstMod);
 }


### PR DESCRIPTION
This is the first stab at our API which takes a PT trace and compiles it
using LLVM. There's still a lot missing here, so the traces we can
successfully compile are very simple.  For example, we can't yet compile
function calls like `printf` or pass values into or out of a trace.

As this may suggest, this limits us in our ability to test that the
compiled function does the right thing, so for now we only test that an
executed trace doesn't segfault.