### PR TITLE
Run the C tests with different optimisation levels.

### DIFF
--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -9,8 +9,8 @@ use tempfile::TempDir;
 
 const COMMENT: &str = "//";
 
-/// Make a compiler command that compiles `src` to `exe`.
-fn mk_compiler(exe: &Path, src: &Path) -> Command {
+/// Make a compiler command that compiles `src` to `exe` using the optimisation flag `opt`.
+fn mk_compiler(exe: &Path, src: &Path, opt: &str) -> Command {
     let mut compiler = Command::new("clang");
 
     let mut lib_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -27,6 +27,7 @@ fn mk_compiler(exe: &Path, src: &Path) -> Command {
     ykcapi_dir.push("ykcapi");
 
     compiler.args(&[
+        opt,
         "-fuse-ld=lld",
         "-flto",
         "-Wl,--plugin-opt=-lto-embed-bitcode=optimized",
@@ -43,7 +44,9 @@ fn mk_compiler(exe: &Path, src: &Path) -> Command {
     compiler
 }
 
-fn main() {
+fn run_suite(opt: &'static str) {
+    println!("Running C tests with {}...", opt);
+
     let tempdir = TempDir::new().unwrap();
     LangTester::new()
         .test_dir("tests")
@@ -62,9 +65,21 @@ fn main() {
             let mut exe = PathBuf::new();
             exe.push(&tempdir);
             exe.push(p.file_stem().unwrap());
-            let compiler = mk_compiler(&exe, p);
+            let compiler = mk_compiler(&exe, p, opt);
             let runtime = Command::new(exe.clone());
             vec![("Compiler", compiler), ("Run-time", runtime)]
         })
         .run();
+}
+
+fn main() {
+    // Run the suite with the various different clang optimisation levels. We do this to maximise
+    // the possibility of shaking out bugs (in both the JIT and the tests themselves).
+    run_suite("-O0");
+    run_suite("-O1");
+    run_suite("-O2");
+    run_suite("-O3");
+    run_suite("-Ofast");
+    run_suite("-Os");
+    run_suite("-Oz");
 }

--- a/c_tests/tests/mapper_funcs_branches.c
+++ b/c_tests/tests/mapper_funcs_branches.c
@@ -25,20 +25,12 @@ int main(int argc, char **argv) {
   void *tr = __yktrace_stop_tracing(tt);
 
   size_t len = __yktrace_irtrace_len(tr);
-  assert(len >= 4); // At least one block for `main`, at least 3 blocks for
-                    // `add_one_or_two`.
   for (int i = 0; i < len; i++) {
     char *func_name = NULL;
     size_t bb = 0;
     __yktrace_irtrace_get(tr, i, &func_name, &bb);
-
-    // We expect blocks from `add_one_or_two` to be book-ended by `main` bb0.
-    // Note that in LLVM, a call does not terminate a block.
-    if ((i == 0) || (i == len - 1)) {
-      assert((strcmp(func_name, "main") == 0) && (bb == 0));
-    } else {
-      assert(strcmp(func_name, "add_one_or_two") == 0);
-    }
+    assert((strcmp(func_name, "main") == 0 ||
+            strcmp(func_name, "add_one_or_two") == 0));
   }
 
   __yktrace_drop_irtrace(tr);


### PR DESCRIPTION
We test all of clang's different optimization levels to try and shake
out bugs, which it already has!

Namely:

 * One of our tests was checking an outcome specific to -O0 IR and had
   to have its assertions weakened.

 * Higher optimisation levels exposed bugs in the code that allocates dummy
   storage space for initialisations prior to starting tracing. It assumed
   that: a) we only need to do this for stores and loads (not true); and
   b) that all values are stack allocated (not true). I've fixed this
   and revised the comment to be more descriptive too.

All tests now passing for all optimisation levels.