### PR TITLE
Integrate C++ debugging with Cargo.

### DIFF
--- a/ykllvmwrap/build.rs
+++ b/ykllvmwrap/build.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{env, process::Command};
 
 fn main() {
     // Compile our wrappers with the right LLVM C++ flags.
@@ -19,6 +19,12 @@ fn main() {
         // Lots of unused parameters in the LLVM headers.
         .flag("-Wno-unused-parameter")
         .cpp(true);
+
+    // Set the C NDEBUG macro if Cargo is building in release mode. This ensures that assertions
+    // (and other things we guard with NDEBUG) only happen in debug builds.
+    if env::var("PROFILE").unwrap() == "release" {
+        comp.flag("-DNDEBUG");
+    }
     comp.compile("ykllvmwrap");
 
     // Ensure that downstream crates performing linkage use the right -L and -l flags.

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -195,7 +195,7 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
     }
   }
   Builder.CreateRetVoid();
-#ifdef DEBUG
+#ifndef NDEBUG
   llvm::verifyModule(*DstMod, &llvm::errs());
 #endif
 


### PR DESCRIPTION
We set NDEBUG for release builds, thus only running assertions and LLVM
module verification in cargo debug builds.