### PR TITLE
Add clang-format as an xtask.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "ykrt",
     "yktrace",
     "ykutil",
+    "xtask",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+walkdir = "2.3.2"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::process::Command;
+use walkdir::{DirEntry, WalkDir};
+
+fn ignore_dir(entry: &DirEntry) -> bool {
+    if entry.path().starts_with("./target")
+        || entry.path().starts_with("./.cargo")
+        || entry.path().starts_with("./.git")
+    {
+        return false;
+    }
+    true
+}
+
+fn clang_format() {
+    for entry in WalkDir::new(".")
+        .into_iter()
+        .filter_entry(|e| ignore_dir(e))
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if let Some(ext) = entry.path().extension() {
+            match ext.to_str().unwrap() {
+                "h" | "c" | "cpp" | "cc" => {
+                    Command::new("clang-format")
+                        .arg("-i")
+                        .arg(entry.path())
+                        .output()
+                        .expect("Failed to execute xtask: cfmt");
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn main() {
+    let task = env::args().nth(1);
+    match task.as_deref() {
+        Some("cfmt") => clang_format(),
+        _ => println!(
+            "Please specify task to run:
+cfmt       Formats C/C++ files with clang-format."
+        ),
+    }
+}


### PR DESCRIPTION
Use `cargo xtask cfmt" to format all header, C, and C++ files with clang-format.

Personally I think this is a bit overkill for something that could have been a single line in bash. But apparently this is more "rusty" and I guess would also work in Windows if `clang-format` is installed.