### PR TITLE
Make the trace compilation routine thread safe.

### DIFF
--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -37,6 +37,7 @@ fn mk_compiler(exe: &Path, src: &Path, opt: &str) -> Command {
         "-L",
         lib_dir.to_str().unwrap(),
         "-lykcapi",
+        "-pthread",
         "-o",
         exe.to_str().unwrap(),
         src.to_str().unwrap(),

--- a/c_tests/tests/compile_many.c
+++ b/c_tests/tests/compile_many.c
@@ -1,0 +1,32 @@
+// Compiler:
+// Run-time:
+
+// Check that compiling and running multiple traces in sequence works.
+//
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+void trace(void) {
+  void *tt = __yktrace_start_tracing(HW_TRACING);
+  int res = 1 + 1;
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 2);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)() = (void (*)())ptr;
+  func();
+}
+
+int main(int argc, char **argv) {
+  for (int i = 0; i < 3; i++)
+    trace();
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/compile_many_threads.c
+++ b/c_tests/tests/compile_many_threads.c
@@ -1,0 +1,53 @@
+// Compiler:
+// Run-time:
+
+// Check that compiling and running traces in parallel works.
+//
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <err.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+#ifdef linux
+#include <sys/sysinfo.h>
+#endif
+
+static void *trace(void *unused) {
+  for (int i = 0; i < 3; i++) {
+    void *tt = __yktrace_start_tracing(HW_TRACING);
+    int res = 1 + 1;
+    void *tr = __yktrace_stop_tracing(tt);
+    assert(res == 2);
+
+    void *ptr = __yktrace_irtrace_compile(tr);
+    __yktrace_drop_irtrace(tr);
+    void (*func)() = (void (*)())ptr;
+    func();
+  }
+  return NULL;
+}
+
+int main() {
+#ifdef linux
+  int n_thr = get_nprocs();
+#else
+#error unimplemented
+#endif
+
+  pthread_t tids[n_thr];
+  for (int i = 0; i < n_thr; i++)
+    if (pthread_create(&tids[i], NULL, trace, NULL) != 0)
+      err(EXIT_FAILURE, "pthread_create");
+
+  for (int i = 0; i < n_thr; i++)
+    if (pthread_join(tids[i], NULL) != 0)
+      err(EXIT_FAILURE, "pthread_join");
+
+  return (EXIT_SUCCESS);
+}

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -47,7 +47,7 @@ once_flag GlobalAOTModLoaded;
 // A thread should never access this directly, but should instead go via
 // getThreadAOTMod() which deals with the necessary lazy initialisation.
 //
-// OPTIMISE_ME Copying GlobalAOTMod is quite expensive (cloneToNewContext()
+// PERF: Copying GlobalAOTMod is quite expensive (cloneToNewContext()
 // serialises and deserializes). When a compilation thread dies, we should
 // return its ThreadAOTMod to a pool and transfer ownership to the next thread
 // that needs its own copy of GlobalAOTMod.
@@ -82,7 +82,7 @@ __yk_llvmwrap_symbolizer_find_code_sym(LLVMSymbolizer *Symbolizer,
     return NULL;
   }
 
-  // OPTIMISE_ME: get rid of heap allocation.
+  // PERF: get rid of heap allocation.
   return strdup(LineInfo->FunctionName.c_str());
 }
 


### PR DESCRIPTION
`LLVMContext` isn't thread safe and since `Module` holds a reference to a
context, neither is `Module`.

This change uses `ThreadSafeContext`, `ThreadSafeModule` and `std::call_once`
to: a) ensure that the in-binary bitcode is loaded exactly once; b)
share the resulting IR between threads safely, thus allowing parallel
trace compilation.

Added a test to check it works, and that commenting out locking of the
`ThreadSafeContext` causes tests to fail as expected.

Relevant docs:
 - https://llvm.org/docs/ORCv2.html#how-to-use-threadsafemodule-and-threadsafecontext
 - https://en.cppreference.com/w/cpp/thread/call_once