### PR TITLE
Test compiled traces

### DIFF
--- a/c_tests/tests/compile_multiblocks.c
+++ b/c_tests/tests/compile_multiblocks.c
@@ -12,18 +12,26 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
+  int cond = argc;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &cond);
   int res = 0;
-  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
-  res = 2;
+  if (cond) {
+    res = 2;
+    cond = 3;
+  } else {
+    res = 4;
+  }
   void *tr = __yktrace_stop_tracing(tt);
+
+  assert(cond == 3);
   assert(res == 2);
 
   void *ptr = __yktrace_irtrace_compile(tr);
   __yktrace_drop_irtrace(tr);
-  void (*func)(int *) = (void (*)(int *))ptr;
-  int res2 = 0;
-  func(&res2);
-  assert(res2 == 2);
+  void (*func)(void *) = (void (*)(void *))ptr;
+  int output = 0;
+  func(&output);
+  assert(output == 3);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/compile_trace_not_entry_bb.c
+++ b/c_tests/tests/compile_trace_not_entry_bb.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     abort();
 
   int res;
-  void *tt = __yktrace_start_tracing(HW_TRACING);
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res, &argc);
   // Causes both a load and a store to things defined outside the trace.
   res = 1 + argc;
   void *tr = __yktrace_stop_tracing(tt);
@@ -30,8 +30,10 @@ int main(int argc, char **argv) {
 
   void *ptr = __yktrace_irtrace_compile(tr);
   __yktrace_drop_irtrace(tr);
-  void (*func)() = (void (*)())ptr;
-  func();
+  void (*func)(int *, int *) = (void (*)(int *, int *))ptr;
+  int res2;
+  func(&res2, &argc);
+  assert(res2 == 2);
 
   return (EXIT_SUCCESS);
 }

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -9,7 +9,7 @@ void *__yktrace_hwt_mapper_blockmap_new(void);
 size_t __yktrace_hwt_mapper_blockmap_len(void *mapper);
 void __yktrace_hwt_mapper_blockmap_free(void *mapper);
 
-void *__yktrace_start_tracing(uintptr_t kind);
+void *__yktrace_start_tracing(uintptr_t kind, ...);
 void *__yktrace_stop_tracing(void *tt);
 size_t __yktrace_irtrace_len(void *trace);
 void __yktrace_irtrace_get(void *trace, size_t idx, char **res_func,

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -51,12 +51,13 @@ impl BlockMap {
         while crsr.position() < sec_size {
             let f_off = crsr.read_u64::<NativeEndian>().unwrap();
             let n_blks = leb128::read::unsigned(&mut crsr).unwrap();
-            for bb in 0..n_blks {
+            for _ in 0..n_blks {
                 let b_off = leb128::read::unsigned(&mut crsr).unwrap();
                 // Skip the block size. We still have to parse the field, as it's variable-size.
                 let b_sz = leb128::read::unsigned(&mut crsr).unwrap();
                 // Skip over block meta-data.
                 crsr.seek(SeekFrom::Current(1)).unwrap();
+                let b_idx = leb128::read::unsigned(&mut crsr).unwrap();
 
                 let lo = f_off + b_off;
                 let hi = lo + b_sz;
@@ -64,7 +65,7 @@ impl BlockMap {
                     (lo..hi),
                     BlockMapEntry {
                         f_off,
-                        bb: usize::try_from(bb).unwrap(),
+                        bb: usize::try_from(b_idx).unwrap(),
                     },
                 ));
             }


### PR DESCRIPTION
Depends on: https://github.com/ykjit/ykllvm/pull/2

Until now a compiled trace was a bit of a black box as we had no means
to observe what it was doing when run. This change allows us to pass
pointers into a compiled trace which we can then write to, in order to
test that the trace is executing correctly.