### PR TITLE
Correctly stitch together PT traces containing function calls.

### DIFF
--- a/c_tests/tests/compile_call_args.c
+++ b/c_tests/tests/compile_call_args.c
@@ -1,5 +1,11 @@
 // Compiler:
 // Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       store i32 5, i32* %0, align 4, !tbaa !0
+//       ret void
+//     }
+//     ...
 
 // Check that basic trace compilation works.
 // FIXME An optimising compiler can remove all of the code between start/stop

--- a/c_tests/tests/compile_call_args.c
+++ b/c_tests/tests/compile_call_args.c
@@ -1,0 +1,34 @@
+// Compiler:
+// Run-time:
+
+// Check that basic trace compilation works.
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+__attribute__((noinline)) int f(int a, int b) {
+  int c = a + b;
+  return c;
+}
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  res = f(2, 3);
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 5);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(void *) = (void (*)(void *))ptr;
+  int output = 0;
+  func(&output);
+  assert(output == 5);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/compile_call_args.c.O0
+++ b/c_tests/tests/compile_call_args.c.O0
@@ -1,0 +1,20 @@
+// Compiler:
+// Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       %2 = alloca i8*, align 8
+//       store i8* null, i8** %2, align 8
+//       %3 = alloca i32, align 4
+//       %4 = alloca i32, align 4
+//       %5 = alloca i32, align 4
+//       store i32 2, i32* %3, align 4
+//       store i32 3, i32* %4, align 4
+//       %6 = load i32, i32* %3, align 4
+//       %7 = load i32, i32* %4, align 4
+//       %8 = add nsw i32 %6, %7
+//       store i32 %8, i32* %5, align 4
+//       %9 = load i32, i32* %5, align 4
+//       store i32 %9, i32* %0, align 4
+//       %10 = load i8*, i8** %2, align 8
+//       ret void
+//     }

--- a/c_tests/tests/compile_call_args.c.O1
+++ b/c_tests/tests/compile_call_args.c.O1
@@ -1,0 +1,9 @@
+// Compiler:
+// Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       %2 = add nsw i32 3, 2
+//       store i32 %2, i32* %0, align 4, !tbaa !0
+//       ret void
+//     }
+//     ...

--- a/c_tests/tests/compile_calls.c
+++ b/c_tests/tests/compile_calls.c
@@ -1,0 +1,31 @@
+// Compiler:
+// Run-time:
+
+// Check that basic trace compilation works.
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+void f() { int b = 1; }
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  f();
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 0);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(void *) = (void (*)(void *))ptr;
+  int output = 0;
+  func(&output);
+  assert(output == 0);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/compile_calls.c
+++ b/c_tests/tests/compile_calls.c
@@ -11,21 +11,24 @@
 #include <string.h>
 #include <yk_testing.h>
 
-void f() { int b = 1; }
+__attribute__((noinline)) int f() {
+  int b = 2;
+  return b;
+}
 
 int main(int argc, char **argv) {
   int res = 0;
   void *tt = __yktrace_start_tracing(HW_TRACING, &res);
-  f();
+  res = f();
   void *tr = __yktrace_stop_tracing(tt);
-  assert(res == 0);
+  assert(res == 2);
 
   void *ptr = __yktrace_irtrace_compile(tr);
   __yktrace_drop_irtrace(tr);
   void (*func)(void *) = (void (*)(void *))ptr;
   int output = 0;
   func(&output);
-  assert(output == 0);
+  assert(output == 2);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/compile_calls_double.c
+++ b/c_tests/tests/compile_calls_double.c
@@ -1,5 +1,11 @@
 // Compiler:
 // Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       store i32 3, i32* %0, align 4, !tbaa !0
+//       ret void
+//     }
+//     ...
 
 // Check that basic trace compilation works.
 // FIXME An optimising compiler can remove all of the code between start/stop

--- a/c_tests/tests/compile_calls_double.c
+++ b/c_tests/tests/compile_calls_double.c
@@ -1,0 +1,33 @@
+// Compiler:
+// Run-time:
+
+// Check that basic trace compilation works.
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+__attribute__((noinline)) int f(a) { return a; }
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  int a = f(1);
+  int b = f(2);
+  res = a + b;
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 3);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(void *) = (void (*)(void *))ptr;
+  int output = 0;
+  func(&output);
+  assert(output == 3);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/compile_calls_double.c.O0
+++ b/c_tests/tests/compile_calls_double.c.O0
@@ -1,0 +1,23 @@
+// Compiler:
+// Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       %2 = alloca i8*, align 8
+//       store i8* null, i8** %2, align 8
+//       %3 = alloca i32, align 4
+//       store i32 1, i32* %3, align 4
+//       %4 = load i32, i32* %3, align 4
+//       %5 = alloca i32, align 4
+//       store i32 %4, i32* %5, align 4
+//       %6 = alloca i32, align 4
+//       store i32 2, i32* %6, align 4
+//       %7 = load i32, i32* %6, align 4
+//       %8 = alloca i32, align 4
+//       store i32 %7, i32* %8, align 4
+//       %9 = load i32, i32* %5, align 4
+//       %10 = load i32, i32* %8, align 4
+//       %11 = add nsw i32 %9, %10
+//       store i32 %11, i32* %0, align 4
+//       %12 = load i8*, i8** %2, align 8
+//       ret void
+//     }

--- a/c_tests/tests/compile_multiblocks.c
+++ b/c_tests/tests/compile_multiblocks.c
@@ -1,5 +1,13 @@
 // Compiler:
 // Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       %2 = load i32, i32* %0, align 4, !tbaa !0
+//       %3 = icmp eq i32 %2, 0
+//       store i32 3, i32* %0, align 4, !tbaa !0
+//       ret void
+//     }
+//     ...
 
 // Check that basic trace compilation works.
 // FIXME An optimising compiler can remove all of the code between start/stop

--- a/c_tests/tests/compile_multiblocks.c.O0
+++ b/c_tests/tests/compile_multiblocks.c.O0
@@ -1,0 +1,15 @@
+// Compiler:
+// Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       %2 = alloca i8*, align 8
+//       store i8* null, i8** %2, align 8
+//       %3 = alloca i32, align 4
+//       store i32 0, i32* %3, align 4
+//       %4 = load i32, i32* %0, align 4
+//       %5 = icmp ne i32 %4, 0
+//       store i32 2, i32* %3, align 4
+//       store i32 3, i32* %0, align 4
+//       %6 = load i8*, i8** %2, align 8
+//       ret void
+//     }

--- a/c_tests/tests/compile_simple.c
+++ b/c_tests/tests/compile_simple.c
@@ -1,5 +1,11 @@
 // Compiler:
 // Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//        store i32 2, i32* %0, align 4, !tbaa !0
+//        ret void
+//     }
+//     ...
 
 // Check that basic trace compilation works.
 // FIXME An optimising compiler can remove all of the code between start/stop

--- a/c_tests/tests/compile_simple.c.O0
+++ b/c_tests/tests/compile_simple.c.O0
@@ -1,0 +1,10 @@
+// Compiler:
+// Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       %2 = alloca i8*, align 8
+//       store i8* null, i8** %2, align 8
+//       store i32 2, i32* %0, align 4
+//       %3 = load i8*, i8** %2, align 8
+//       ret void
+//     }

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -9,6 +9,10 @@ void *__yktrace_hwt_mapper_blockmap_new(void);
 size_t __yktrace_hwt_mapper_blockmap_len(void *mapper);
 void __yktrace_hwt_mapper_blockmap_free(void *mapper);
 
+// Until we have a proper API for tracing, variables that we want to pass into
+// a compiled trace need to be "registered" by passing them into
+// __yktrace_start_tracing. While the start tracing call ignores them, it
+// allows us identify them when preparing the inlined trace code.
 void *__yktrace_start_tracing(uintptr_t kind, ...);
 void *__yktrace_stop_tracing(void *tt);
 size_t __yktrace_irtrace_len(void *trace);

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -353,6 +353,13 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
 #ifndef NDEBUG
   llvm::verifyModule(*JITMod, &llvm::errs());
 #endif
+  auto PrintIR = std::getenv("YKDEBUG_PRINT_IR");
+  if (PrintIR != nullptr) {
+    if (strcmp(PrintIR, "1") == 0) {
+      // Print out the compiled trace's IR to stderr.
+      JITMod->dump();
+    }
+  }
 
   // Compile IR trace and return a pointer to its function.
   return compile_module(TraceName, JITMod);

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -286,7 +286,12 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
       if (isa<ReturnInst>(I)) {
         last_call = inlined_calls.back();
         inlined_calls.pop_back();
-        // FIXME write return value to LHS of the call.
+        // Replace the return variable of the call with its return value.
+        // Since the return value will have already been copied over to the
+        // JITModule, make sure we look up the copy.
+        auto OldRetVal = ((ReturnInst *)&*I)->getReturnValue();
+        auto NewRetVal = VMap[OldRetVal];
+        VMap[last_call] = NewRetVal;
         continue;
       }
 


### PR DESCRIPTION
This PR ensures that blocks in PT traces are stitched together correctly. This is necessary because calls in LLVM IR are not terminators and thus PT traces an extra block that isn't needed. For example if we have two functions A and B, where A calls B, a PT trace would be A B A.

Luckily, using LLVM has made implementing this a lot easier than in our old system. The "hardest" of these commits is 2e47b79 which implements the stitching together of functions inlined by the trace. We have to be careful here since calls are no longer terminators in LLVM bitcode, which means we see the same block twice after a call. See the commit message for more information. The remaining commits implement inlining of function returns (25ff397) and arguments (1828eef).