### PR TITLE
Fix returning a constant from a traced function.

### DIFF
--- a/c_tests/tests/compile_constant_ret.c
+++ b/c_tests/tests/compile_constant_ret.c
@@ -1,0 +1,37 @@
+// Compiler:
+// Run-time:
+//   stderr:
+//     define internal void @__yk_compiled_trace_0(i32* %0) {
+//       ...
+//       store i32 30, i32* %0, align 4...
+//       ...
+
+// Check that returning a constant value from a traced function works.
+//
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+__attribute__((noinline)) int f() { return 30; }
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  res = f();
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 30);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(int *) = (void (*)(int *))ptr;
+  int res2 = 0;
+  func(&res2);
+  assert(res2 == 30);
+
+  return (EXIT_SUCCESS);
+}

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -303,8 +303,12 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
         // Since the return value will have already been copied over to the
         // JITModule, make sure we look up the copy.
         auto OldRetVal = ((ReturnInst *)&*I)->getReturnValue();
-        auto NewRetVal = VMap[OldRetVal];
-        VMap[last_call] = NewRetVal;
+        if (isa<Constant>(OldRetVal)) {
+          VMap[last_call] = OldRetVal;
+        } else {
+          auto NewRetVal = VMap[OldRetVal];
+          VMap[last_call] = NewRetVal;
+        }
         continue;
       }
 


### PR DESCRIPTION
Prior to this change, we would miscompile the JIT module and the verifier would crash.

We were looking to the variable map for a mapped variable, which doesn't make sense for a constant.

[@ptersilie helped me understand what was going on here]