### PR TITLE
Add the ability to dump an annotated trace to stderr.

### DIFF
--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -12,7 +12,7 @@ const COMMENT: &str = "//";
 /// Make a compiler command that compiles `src` to `exe` using the optimisation flag `opt`.
 fn mk_compiler(exe: &Path, src: &Path, opt: &str) -> Command {
     let mut compiler = Command::new("clang");
-    compiler.env("YKDEBUG_PRINT_IR", "1");
+    compiler.env("YK_PRINT_IR", "1");
 
     let mut lib_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     lib_dir.push("..");
@@ -80,7 +80,7 @@ fn run_suite(opt: &'static str) {
 
 fn main() {
     // Causes the trace compiler to print out the IR of the compiled trace to stderr.
-    env::set_var("YKDEBUG_PRINT_IR", "1");
+    env::set_var("YK_PRINT_IR", "1");
     // Run the suite with the various different clang optimisation levels. We do this to maximise
     // the possibility of shaking out bugs (in both the JIT and the tests themselves).
     run_suite("-O0");


### PR DESCRIPTION
This is a debugging aid which makes it easier to:
 - see the inlining thresholds in our JIT module.
 - see the variable mapping between the JIT and AOT module.

This feature is available only in debug builds and the dump is enabled by
setting `YKDEBUG_PRINT_IR_ANNOTATED=1` in the environment.

Here's a sample dump:

```
 -- Begin annotated trace dump for __yk_compiled_trace_0 ---
 JIT Module                                 | AOT Module
 # main()
 %3 = load i32, i32* %1, align 4, !tbaa !0  |  %8 = load i32, i32* %3, align 4, !tbaa !5
 # f()
 %4 = icmp eq i32 %3, 1                     |  %2 = icmp eq i32 %0, 1
 %5 = select i1 %4, i32 47, i32 52          |  %3 = select i1 %2, i32 47, i32 52
 %6 = icmp eq i32 %3, 0                     |  %4 = icmp eq i32 %0, 0
 %7 = select i1 %6, i32 30, i32 %5          |  %5 = select i1 %4, i32 30, i32 %3
 # main()
 store i32 %7, i32* %0, align 4, !tbaa !0   |  store i32 %9, i32* %4, align 4, !tbaa !5
 ret void
 --- End annotated trace dump for __yk_compiled_trace_0 ---
```

This could be improved by showing the inlined call sites (and their arguments)
in the AOT column, but one step at a time.

Co-authored-by: Lukas Diekmann <lukas.diekmann@gmail.com>