### PR TITLE
Use the new version of lang_tester to set env vars on a per-test basis.

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -11,6 +11,6 @@ path = "run.rs"
 harness = false
 
 [dev-dependencies]
-lang_tester = "0.5.0"
+lang_tester = "0.7.0"
 tempfile = "3.2.0"
 ykcapi = { path = "../ykcapi", features = ["c_testing"] }

--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -79,8 +79,6 @@ fn run_suite(opt: &'static str) {
 }
 
 fn main() {
-    // Causes the trace compiler to print out the IR of the compiled trace to stderr.
-    env::set_var("YK_PRINT_IR", "1");
     // Run the suite with the various different clang optimisation levels. We do this to maximise
     // the possibility of shaking out bugs (in both the JIT and the tests themselves).
     run_suite("-O0");

--- a/c_tests/tests/compile_call_args.c
+++ b/c_tests/tests/compile_call_args.c
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       store i32 5, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_call_args.c.O0
+++ b/c_tests/tests/compile_call_args.c.O0
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/compile_call_args.c.O1
+++ b/c_tests/tests/compile_call_args.c.O1
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = add nsw i32 3, 2

--- a/c_tests/tests/compile_calls_double.c
+++ b/c_tests/tests/compile_calls_double.c
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       store i32 3, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_calls_double.c.O0
+++ b/c_tests/tests/compile_calls_double.c.O0
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/compile_constant_ret.c
+++ b/c_tests/tests/compile_constant_ret.c
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       ...

--- a/c_tests/tests/compile_multiblocks.c
+++ b/c_tests/tests/compile_multiblocks.c
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = load i32, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_multiblocks.c.O0
+++ b/c_tests/tests/compile_multiblocks.c.O0
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/compile_simple.c
+++ b/c_tests/tests/compile_simple.c
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //        store i32 2, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_simple.c.O0
+++ b/c_tests/tests/compile_simple.c.O0
@@ -1,5 +1,6 @@
 // Compiler:
 // Run-time:
+//   env-var: YK_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8


### PR DESCRIPTION
This means we no longer have to set environment variables for *every* test, as before.