### PR TITLE
Dealing with recursive traces.

### DIFF
--- a/c_tests/tests/compile_recursion.c
+++ b/c_tests/tests/compile_recursion.c
@@ -1,0 +1,44 @@
+// Compiler:
+// Run-time:
+
+// Check that basic trace compilation works.
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+__attribute__((noinline)) int fib(int num) {
+  if (num == 0)
+    return 0;
+  if (num == 1)
+    return 1;
+  if (num == 2)
+    return 1;
+  int a = fib(num - 2);
+  int b = fib(num - 2);
+  int c = a + b;
+  return c;
+}
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  res = fib(3);
+  void *tr = __yktrace_stop_tracing(tt);
+  printf("Result: %i\n", res);
+  assert(res == 2);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(void *) = (void (*)(void *))ptr;
+  int output = 0;
+  func(&output);
+  fprintf(stderr, "Result: %i\n", output);
+  assert(output == 2);
+
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
This is a work-in-progress PR attempting to deal with traces of recursive functions. The problem with recursion in traces lies in the way we copy over instructions from the AOT module to the JIT module. In short: Inlining the same function twice overwrites the mapping in the ValueToValueMap, which is used to update references in cloned instructions with their cloned counterparts. Here's an example:

```
f() AOTMod                    JITMod                VMAP
  %1 = i32 1                  %1 = i32 1            %1 => %1
  %2 = add 1, %1              %2 = add 1, %1        %2 => %2
  # call f()                      
      %1 = i32 1              %3 = i32, 1           %1 => %3
      %2 = add 1, %1          %4 = add 1, %3        %2 => %4
      # call f() skipped        
      %3 = add %2, %2         %5 = add %4, %4       %3 => %5
  %3 = add %2, %2             %6 = add %4, %4       %3 => %6
```

On the LHS are the traced instructions from the AOT module (minus calls/returns). In the middle is the JIT module after we've cloned over each traced instruction into the JIT module. On the RHS is shown how we update the VMap after each instruction. Note, how when we clone the same instruction a second time (e.g. %2 = add 1, %1), we overwrite its VMap entry, which previously mapped `%2` to `%2`, but now maps to `%4`. This means, that when update the references in instruction `%6`, we map to the wrong values, i.e. instead of `%6 = add %4, %4`, it should read `%6 = add %2, %2`.

This PR solves this by having a separate VMap for each function boundary that we traced, i.e. each inlined function gets its own VMap during construction of the JIT module. This way instructions can't clash and won't be overwritten. However, there's a few things I dislike about this approach:
1) Due to VMaps being non-movable we need to jump through some hoops, to switch out the active VMap when reaching a new function boundary or returning from it, see the `(*VMap)[V] = V` stuff. This might just be my lacking knowledge of C++ though.
2) We need to copy over all globals, each time we create a new VMap for another function.

I had an idea for another approach, which involves only using one VMap, but remembering each time another function overwrites an entry, and then after returning from that function, restores those overwritten values back to their previous version. But this solution isn't much better, since we'd need to keep a stack of hashmaps around (one per nested function).

I'd be grateful for any ideas/comments.