### PR TITLE
Make the trace compiler slightly more robust.

### DIFF
--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -352,7 +352,7 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
           StartTracingInstr = &*I;
           continue;
         } else if (CF->getName() == YKTRACE_STOP) {
-          break;
+          goto done;
         } else {
           // Skip remainder of this block and remember where we stopped so we
           // can continue tracing from this position after returning frome the
@@ -493,6 +493,11 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
       Builder.Insert(NewInst);
     }
   }
+
+  // If we fell out of the loop, then we never saw YKTRACE_STOP.
+  return NULL;
+
+done:
   Builder.CreateRetVoid();
 
   // Fix initialisers/referrers for copied global variables.

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -2,7 +2,10 @@
 
 mod errors;
 use libc::c_void;
-use std::ffi::{CStr, CString};
+use std::{
+    ffi::{CStr, CString},
+    ptr,
+};
 mod hwt;
 
 pub use errors::InvalidTraceError;
@@ -75,7 +78,11 @@ impl IRTrace {
             bbs.push(blk.bb());
         }
 
-        unsafe { ykllvmwrap::__ykllvmwrap_irtrace_compile(func_names.as_ptr(), bbs.as_ptr(), len) }
+        let ret = unsafe {
+            ykllvmwrap::__ykllvmwrap_irtrace_compile(func_names.as_ptr(), bbs.as_ptr(), len)
+        };
+        assert_ne!(ret, ptr::null());
+        ret
     }
 }
 


### PR DESCRIPTION
This change ensures that we observe yk_stop_tracing() when preparing a
trace. Before, in theory we could compile a truncated trace and not know
about it (until perhaps later, when trace doesn't do what it is supposed
to).