### PR TITLE
Add the ability to express holes in a trace.

### DIFF
--- a/c_tests/tests/mapper_funcs_branches.c
+++ b/c_tests/tests/mapper_funcs_branches.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
   void *tr = __yktrace_stop_tracing(tt);
 
   size_t len = __yktrace_irtrace_len(tr);
-  for (int i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     char *func_name = NULL;
     size_t bb = 0;
     __yktrace_irtrace_get(tr, i, &func_name, &bb);

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -54,7 +54,7 @@ pub extern "C" fn __ykutil_get_llvmbc_section(res_addr: *mut *const c_void, res_
 #[cfg(feature = "c_testing")]
 mod c_testing {
     use libc::c_void;
-    use std::os::raw::c_char;
+    use std::{os::raw::c_char, ptr};
     use yktrace::{start_tracing, BlockMap, IRTrace, ThreadTracer, TracingKind};
 
     const SW_TRACING: usize = 0;
@@ -107,9 +107,17 @@ mod c_testing {
     ) {
         let trace = unsafe { &*trace };
         let blk = trace.get(idx).unwrap();
-        unsafe {
-            *res_func = blk.func_name().as_ptr();
-            *res_bb = blk.bb();
+        if let Some(blk) = blk {
+            unsafe {
+                *res_func = blk.func_name().as_ptr();
+                *res_bb = blk.bb();
+            }
+        } else {
+            // The block was unmappable.
+            unsafe {
+                *res_func = ptr::null();
+                *res_bb = 0;
+            }
         }
     }
 

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -315,6 +315,9 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
   for (size_t Idx = 0; Idx < Len; Idx++) {
     auto FuncName = FuncNames[Idx];
 
+    // FIXME: Deal with holes in the trace, e.g. calls to libc.
+    assert(FuncName != nullptr);
+
     // Get a traced function so we can extract blocks from it.
     Function *F = AOTMod->getFunction(FuncName);
     if (!F)


### PR DESCRIPTION
Currently we stop mapping a trace at the first (non-prefix) unmappable
block. This is incorrect in the long run, as the trace may not be
complete. For example, it could be that there's a call to external code
for which we have no IR.

This change allows us to express holes in a trace, which we then leave
up to the trace compiler to interpret as it sees fit.

This will be refined with follow-up PRs. Namely:
 - Use a more compact representation for holes in traces.
 - Strip "holes" from the beginning and end of the trace, as they are
   never helpful.