### PR TITLE
Use `YKD` as the prefix for internal yk debugging environment variables.

### DIFF
--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -12,7 +12,7 @@ const COMMENT: &str = "//";
 /// Make a compiler command that compiles `src` to `exe` using the optimisation flag `opt`.
 fn mk_compiler(exe: &Path, src: &Path, opt: &str) -> Command {
     let mut compiler = Command::new("clang");
-    compiler.env("YK_PRINT_IR", "1");
+    compiler.env("YKD_PRINT_IR", "1");
 
     let mut lib_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     lib_dir.push("..");

--- a/c_tests/tests/compile_call_args.c
+++ b/c_tests/tests/compile_call_args.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       store i32 5, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_call_args.c.O0
+++ b/c_tests/tests/compile_call_args.c.O0
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/compile_call_args.c.O1
+++ b/c_tests/tests/compile_call_args.c.O1
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = add nsw i32 3, 2

--- a/c_tests/tests/compile_calls_double.c
+++ b/c_tests/tests/compile_calls_double.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       store i32 3, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_calls_double.c.O0
+++ b/c_tests/tests/compile_calls_double.c.O0
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/compile_constant_ret.c
+++ b/c_tests/tests/compile_constant_ret.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       ...

--- a/c_tests/tests/compile_fib.c
+++ b/c_tests/tests/compile_fib.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0, i32* %1) {

--- a/c_tests/tests/compile_fib.c.O0
+++ b/c_tests/tests/compile_fib.c.O0
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0, i32* %1) {
 //       ...

--- a/c_tests/tests/compile_fib.c.O1
+++ b/c_tests/tests/compile_fib.c.O1
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0, i32* %1) {
 //       ...

--- a/c_tests/tests/compile_multiblocks.c
+++ b/c_tests/tests/compile_multiblocks.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = load i32, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_multiblocks.c.O0
+++ b/c_tests/tests/compile_multiblocks.c.O0
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/compile_simple.c
+++ b/c_tests/tests/compile_simple.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //        store i32 2, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_simple.c.O0
+++ b/c_tests/tests/compile_simple.c.O0
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/c_tests/tests/rel_path.c
+++ b/c_tests/tests/rel_path.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {

--- a/c_tests/tests/rel_path.c.O0
+++ b/c_tests/tests/rel_path.c.O0
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=1
 //   stderr:
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -247,13 +247,13 @@ extern "C" void *__ykllvmwrap_irtrace_compile(char *FuncNames[], size_t BBs[],
                                 FAddrVals, FAddrLen);
 
 #ifndef NDEBUG
-  char *SBS = getenv("YK_PRINT_IR_SBS");
+  char *SBS = getenv("YKD_PRINT_IR_SBS");
   if ((SBS != nullptr) && (strcmp(SBS, "1") == 0)) {
     printSBS(AOTMod, JITMod, JB.RevVMap);
   }
   llvm::verifyModule(*JITMod, &llvm::errs());
 #endif
-  auto PrintIR = std::getenv("YK_PRINT_IR");
+  auto PrintIR = std::getenv("YKD_PRINT_IR");
   if (PrintIR != nullptr) {
     if (strcmp(PrintIR, "1") == 0) {
       // Print out the compiled trace's IR to stderr.


### PR DESCRIPTION
At some point we're almost certainly going to expose environment variables for "normal" users to play with: making clear which are internal debugging variables now will probably save us some confusion in the future.