### PR TITLE
Add a NOOPT macro to try and block optimisations in tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.gdb_history

--- a/c_tests/tests/compile_call_args.c
+++ b/c_tests/tests/compile_call_args.c
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       store i32 5, i32* %0, align 4, !tbaa !0
 //       ret void
@@ -9,8 +10,6 @@
 //     ...
 
 // Check that basic trace compilation works.
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_call_args.c.O0
+++ b/c_tests/tests/compile_call_args.c.O0
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8
 //       store i8* null, i8** %2, align 8
@@ -19,3 +20,4 @@
 //       %10 = load i8*, i8** %2, align 8
 //       ret void
 //     }
+//     ...

--- a/c_tests/tests/compile_call_args.c.O1
+++ b/c_tests/tests/compile_call_args.c.O1
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = add nsw i32 3, 2
 //       store i32 %2, i32* %0, align 4, !tbaa !0

--- a/c_tests/tests/compile_calls.c
+++ b/c_tests/tests/compile_calls.c
@@ -2,8 +2,6 @@
 // Run-time:
 
 // Check that basic trace compilation works.
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_calls_double.c
+++ b/c_tests/tests/compile_calls_double.c
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       store i32 3, i32* %0, align 4, !tbaa !0
 //       ret void
@@ -9,8 +10,6 @@
 //     ...
 
 // Check that basic trace compilation works.
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_calls_double.c.O0
+++ b/c_tests/tests/compile_calls_double.c.O0
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8
 //       store i8* null, i8** %2, align 8
@@ -22,3 +23,4 @@
 //       %12 = load i8*, i8** %2, align 8
 //       ret void
 //     }
+//     ...

--- a/c_tests/tests/compile_choice.c
+++ b/c_tests/tests/compile_choice.c
@@ -2,9 +2,6 @@
 // Run-time:
 
 // Check that tracing a cascading "if...else if...else" works.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_const_global.c
+++ b/c_tests/tests/compile_const_global.c
@@ -1,9 +1,6 @@
 // Compiler:
 // Run-time:
 
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/c_tests/tests/compile_constant_ret.c
+++ b/c_tests/tests/compile_constant_ret.c
@@ -1,16 +1,14 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       ...
 //       store i32 30, i32* %0, align 4...
 //       ...
 
 // Check that returning a constant value from a traced function works.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_fib.c
+++ b/c_tests/tests/compile_fib.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0, i32* %1) {
@@ -19,9 +19,6 @@
 //     ...
 
 // Check that recursive function calls are not unrolled.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_fib.c.O0
+++ b/c_tests/tests/compile_fib.c.O0
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0, i32* %1) {
 //       ...
 //       %21 = call i32 @fib(i32 %19, i32* %20)

--- a/c_tests/tests/compile_fib.c.O1
+++ b/c_tests/tests/compile_fib.c.O1
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0, i32* %1) {
 //       ...
 //       %7 = call i32 @fib(i32 %6, i32* %1)

--- a/c_tests/tests/compile_many_threads.c
+++ b/c_tests/tests/compile_many_threads.c
@@ -2,9 +2,6 @@
 // Run-time:
 
 // Check that compiling and running traces in parallel works.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <err.h>

--- a/c_tests/tests/compile_multiblocks.c
+++ b/c_tests/tests/compile_multiblocks.c
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = load i32, i32* %0, align 4, !tbaa !0
 //       %3 = icmp eq i32 %2, 0
@@ -11,8 +12,6 @@
 //     ...
 
 // Check that basic trace compilation works.
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_multiblocks.c.O0
+++ b/c_tests/tests/compile_multiblocks.c.O0
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8
 //       store i8* null, i8** %2, align 8
@@ -14,3 +15,4 @@
 //       %6 = load i8*, i8** %2, align 8
 //       ret void
 //     }
+//     ...

--- a/c_tests/tests/compile_mutable_global.c
+++ b/c_tests/tests/compile_mutable_global.c
@@ -2,9 +2,6 @@
 // Compiler:
 // Run-time:
 
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/c_tests/tests/compile_simple.c
+++ b/c_tests/tests/compile_simple.c
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //        store i32 2, i32* %0, align 4, !tbaa !0
 //        ret void
@@ -9,8 +10,6 @@
 //     ...
 
 // Check that basic trace compilation works.
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/compile_simple.c.O0
+++ b/c_tests/tests/compile_simple.c.O0
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8
 //       store i8* null, i8** %2, align 8
@@ -9,3 +10,4 @@
 //       %3 = load i8*, i8** %2, align 8
 //       ret void
 //     }
+//     ...

--- a/c_tests/tests/compile_switchtable.c
+++ b/c_tests/tests/compile_switchtable.c
@@ -1,9 +1,6 @@
 // Compiler:
 // Run-time:
 
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/c_tests/tests/compile_trace_not_entry_bb.c
+++ b/c_tests/tests/compile_trace_not_entry_bb.c
@@ -5,9 +5,6 @@
 //
 // Since LLVM allocas typically appear in the entry block of a function, we
 // will miss the allocas if tracing starts in a later block.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdio.h>

--- a/c_tests/tests/inline_asm.c
+++ b/c_tests/tests/inline_asm.c
@@ -1,15 +1,12 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     ...
 //     ...call i32 asm "mov $$5, $0"...
 //     ...
 
 // Check that we can handle inline asm properly.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <stdlib.h>

--- a/c_tests/tests/noopts.c
+++ b/c_tests/tests/noopts.c
@@ -1,0 +1,58 @@
+// Compiler:
+// Run-time:
+//   env-var: YKD_PRINT_IR=aot,jit-pre-opt,jit-post-opt
+//   stderr:
+//     ...
+//     --- Begin aot ---
+//     ...
+//     store i32 2...
+//     ...
+//     ...add...
+//     ...
+//     --- End aot ---
+//     --- Begin jit-pre-opt ---
+//     ...
+//     store i32 2...
+//     ...
+//     ...add...
+//     ...
+//     --- End jit-pre-opt ---
+//     --- Begin jit-post-opt ---
+//     ...
+//     store i32 2...
+//     ...
+//     ...add...
+//     ...
+//     --- End jit-post-opt ---
+//     ...
+
+// Check that our NOOPT_VAL macro blocks optimisations.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  int x, res;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res, &x);
+  // __yktrace_start_tracing() will already inhibit optimisations on `x` since
+  // its address is passed as an argument and the compiler must assume that it
+  // may be mutated. Therefore to properly test NOOPT_VAL we need to initialise
+  // `x` after the call to __yktrace_start_tracing..
+  x = 2;
+  NOOPT_VAL(x);
+  res = x + 3; // We don't want this operation to be optimised away.
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 5);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(int *, int *) = (void (*)(int *, int *))ptr;
+  int res2 = 0;
+  func(&res2, &x);
+  assert(res2 == 5);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/rel_path.c
+++ b/c_tests/tests/rel_path.c
@@ -1,8 +1,9 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //        store i32 2, i32* %0, align 4, !tbaa !0
 //        ret void
@@ -10,9 +11,6 @@
 //     ...
 
 // Check that running a traced binary via a relative path works.
-//
-// FIXME An optimising compiler can remove all of the code between start/stop
-// tracing.
 
 #include <assert.h>
 #include <err.h>

--- a/c_tests/tests/rel_path.c.O0
+++ b/c_tests/tests/rel_path.c.O0
@@ -1,7 +1,8 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_PRINT_IR=1
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
+//     ...
 //     define internal void @__yk_compiled_trace_0(i32* %0) {
 //       %2 = alloca i8*, align 8
 //       store i8* null, i8** %2, align 8
@@ -9,3 +10,4 @@
 //       %3 = load i8*, i8** %2, align 8
 //       ret void
 //     }
+//     ...

--- a/c_tests/tests/void_ret.c
+++ b/c_tests/tests/void_ret.c
@@ -1,29 +1,26 @@
 // Compiler:
 // Run-time:
 
-// Check that compiling and running multiple traces in sequence works.
+// Check that inlining a function with a void return type works.
+//
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
 
 #include <assert.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <yk_testing.h>
 
-void trace(void) {
+void __attribute__((noinline)) f() { return; }
+
+int main(int argc, char **argv) {
   void *tt = __yktrace_start_tracing(HW_TRACING);
-  int res = 1 + 1;
+  f();
   void *tr = __yktrace_stop_tracing(tt);
-  assert(res == 2);
 
   void *ptr = __yktrace_irtrace_compile(tr);
   __yktrace_drop_irtrace(tr);
   void (*func)() = (void (*)())ptr;
   func();
-}
-
-int main(int argc, char **argv) {
-  for (int i = 0; i < 3; i++)
-    trace();
 
   return (EXIT_SUCCESS);
 }

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -20,3 +20,19 @@ void __yktrace_irtrace_get(void *trace, size_t idx, char **res_func,
                            size_t *res_bb);
 void *__yktrace_irtrace_compile(void *trace);
 void __yktrace_drop_irtrace(void *trace);
+
+// Blocks the compiler from optimising the specified value or expression.
+//
+// This is similar to the non-const variant borrowed from Google benchmark:
+// https://github.com/google/benchmark/blob/e451e50e9b8af453f076dec10bd6890847f1624e/include/benchmark/benchmark.h#L350
+//
+// Our version works on a value, rather than a pointer.
+//
+// Note that Google Benchmark also defines a variant for constant data. At the
+// time of writing, NOOPT_VAL seems to suffice (even for constants), but we may
+// need to consider using the const version later.
+#ifdef __clang__
+#define NOOPT_VAL(X) asm volatile("" : "+r,m"(X) : : "memory");
+#else
+#error non-clang compilers are not supported.
+#endif

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -21,7 +21,8 @@ std::vector<Value *> getTraceInputs(Function *F, uintptr_t BBIdx) {
   for (auto I = BB->begin(); I != BB->end(); I++) {
     if (isa<CallInst>(I)) {
       CallInst *CI = cast<CallInst>(&*I);
-      if (CI->getCalledFunction()->getName() == YKTRACE_START) {
+      Function *CF = CI->getCalledFunction();
+      if ((CF != nullptr) && (CF->getName() == YKTRACE_START)) {
         // Skip first argument to start_tracing.
         for (auto Arg = CI->arg_begin() + 1; Arg != CI->arg_end(); Arg++) {
           Vec.push_back(Arg->get());
@@ -246,7 +247,8 @@ public:
           // Since the return value will have already been copied over to the
           // JITModule, make sure we look up the copy.
           auto OldRetVal = ((ReturnInst *)&*I)->getReturnValue();
-          VMap[last_call] = getMappedValue(OldRetVal);
+          if (OldRetVal != nullptr)
+            VMap[last_call] = getMappedValue(OldRetVal);
           break;
         }
 


### PR DESCRIPTION
**This is a draft PR for discussion for now. I'll adapt the existing tests if this is the right approach.**

For context, see:
https://stackoverflow.com/questions/37786547/enforcing-statement-order-in-c/38025837#38025837

We use (the latest version of) the method proposed there.

In the new test, I checked that without using NOOPT, the compiler was
able to optimise `x = 2; y = 3; res = x + y` to `res = 5`. And that with
NOOPT, the addition remains intact.