### PR TITLE
Handle inlining functions which return void.

### DIFF
--- a/c_tests/tests/void_ret.c
+++ b/c_tests/tests/void_ret.c
@@ -1,0 +1,26 @@
+// Compiler:
+// Run-time:
+
+// Check that inlining a function with a void return type works.
+//
+// FIXME An optimising compiler can remove all of the code between start/stop
+// tracing.
+
+#include <assert.h>
+#include <stdlib.h>
+#include <yk_testing.h>
+
+void __attribute__((noinline)) f() { return; }
+
+int main(int argc, char **argv) {
+  void *tt = __yktrace_start_tracing(HW_TRACING);
+  f();
+  void *tr = __yktrace_stop_tracing(tt);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)() = (void (*)())ptr;
+  func();
+
+  return (EXIT_SUCCESS);
+}

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -246,7 +246,8 @@ public:
           // Since the return value will have already been copied over to the
           // JITModule, make sure we look up the copy.
           auto OldRetVal = ((ReturnInst *)&*I)->getReturnValue();
-          VMap[last_call] = getMappedValue(OldRetVal);
+          if (OldRetVal != nullptr)
+            VMap[last_call] = getMappedValue(OldRetVal);
           break;
         }
 


### PR DESCRIPTION
In these cases we simply do not update the VMap.

Co-authored-by: Lukas Diekmann <lukas.diekmann@gmail.com>