### PR TITLE
Mapper fixes

### DIFF
--- a/c_tests/tests/bf.c
+++ b/c_tests/tests/bf.c
@@ -1,0 +1,128 @@
+// Compiler:
+// Run-time:
+//   stdout:
+//     Hello World!
+//     Hello World!
+
+// This is bf_base.c from https://github.com/ykjit/ykcbf modified to:
+//  - hard-code the input to the interpreter (hello.bf from the same repo).
+//  - replay the entire program execution via the JIT.
+
+#include <err.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define CELLS_LEN 30000
+#define INPUT_PROG                                                             \
+  "++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<++++++" \
+  "+++++++++.>.+++.------.--------.>+.>."
+
+void interp(char *prog, char *prog_end, char *cells, char *cells_end) {
+  char *instr = prog;
+  char *cell = cells;
+  while (instr < prog_end) {
+    switch (*instr) {
+    case '>': {
+      if (cell++ == cells_end)
+        errx(1, "out of memory");
+      break;
+    }
+    case '<': {
+      if (cell > cells)
+        cell--;
+      break;
+    }
+    case '+': {
+      (*cell)++;
+      break;
+    }
+    case '-': {
+      (*cell)--;
+      break;
+    }
+    case '.': {
+      if (putchar(*cell) == EOF)
+        err(1, "(stdout)");
+      break;
+    }
+    case ',': {
+      if (read(STDIN_FILENO, cell, 1) == -1)
+        err(1, "(stdin)");
+      break;
+    }
+    case '[': {
+      if (*cell == 0) {
+        int count = 0;
+        while (true) {
+          instr++;
+          if (*instr == ']') {
+            if (count == 0)
+              break;
+            count--;
+          } else if (*instr == '[')
+            count++;
+        }
+      }
+      break;
+    }
+    case ']': {
+      if (*cell != 0) {
+        int count = 0;
+        while (true) {
+          instr--;
+          if (*instr == '[') {
+            if (count == 0)
+              break;
+            count--;
+          } else if (*instr == ']')
+            count++;
+        }
+      }
+      break;
+    }
+    default:
+      break;
+    }
+    instr++;
+  }
+}
+
+// Traces an entire execution of the program and then runs is a second time
+// using JITted code. Expect all output twice in sequence.
+void jit(char *prog, char *prog_end) {
+  // First run collects a trace.
+  char *cells = calloc(1, CELLS_LEN);
+  if (cells == NULL)
+    err(1, "out of memory");
+  char *cells_end = cells + CELLS_LEN;
+
+  void *tt =
+      __yktrace_start_tracing(HW_TRACING, &prog, &prog_end, &cells, &cells_end);
+  NOOPT_VAL(prog);
+  NOOPT_VAL(prog_end);
+  NOOPT_VAL(cells);
+  NOOPT_VAL(cells_end);
+  interp(prog, prog_end, cells, cells_end);
+  CLOBBER_MEM();
+  void *tr = __yktrace_stop_tracing(tt);
+
+  // Compile and run trace.
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+
+  memset(cells, '\0', CELLS_LEN);
+  void (*func)(void *, void *, void *, void *) =
+      (void (*)(void *, void *, void *, void *))ptr;
+  func(&prog, &prog_end, &cells, &cells_end);
+}
+
+int main(int argc, char *argv[]) {
+  jit(INPUT_PROG, &INPUT_PROG[strlen(INPUT_PROG)]);
+}

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -36,3 +36,12 @@ void __yktrace_drop_irtrace(void *trace);
 #else
 #error non-clang compilers are not supported.
 #endif
+
+// Tries to block optimisations by telling the compiler that all memory
+// locations are touched. `NOOPT_VAL` is preferred, but you may not always have
+// direct access to the value(s) or expression(s) that you wish to block
+// optimisations to.
+//
+// Borrowed from:
+// https://github.com/google/benchmark/blob/ab74ae5e104f72fa957c1712707a06a781a974a6/include/benchmark/benchmark.h#L359
+#define CLOBBER_MEM() asm volatile("" : : : "memory");

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -129,15 +129,27 @@ impl HWTMapper {
                 }
             } else {
                 for irblock in irblocks.into_iter() {
-                    // A basic block may map to >1 *machine* basic block. If we see the same block
-                    // repeated, then we need to check if we re-executing the same basic block or
-                    // if we are executing next machine basic block for that same block. In the
-                    // latter case, we mustn't record the block in the trace again.
-                    if !(ret_irblocks.last() == Some(&irblock)
-                        && prev_block.as_ref().map(|x| x.first_instr())
-                            != Some(block.first_instr()))
-                    {
-                        ret_irblocks.push(irblock);
+                    if let Some(irblock) = irblock {
+                        // An IR basic block may map to >1 *machine* basic block. If we see the
+                        // same IR block repeated, then we need to check if we re-executing the
+                        // same basic block or if we are executing the next machine basic block for
+                        // that same block. In the latter case, we mustn't record the block in the
+                        // trace again.
+                        if !(ret_irblocks.last() == Some(&irblock)
+                            && prev_block.as_ref().map(|x| x.first_instr())
+                                != Some(block.first_instr()))
+                        {
+                            ret_irblocks.push(irblock);
+                        }
+                    } else {
+                        // Part of a PT block mapped to a machine block in the LLVM block address
+                        // map, but the machine block has no corresponding IR blocks.
+                        //
+                        // FIXME: https://github.com/ykjit/yk/issues/388
+                        // We *think* this happens because LLVM can introduce extra
+                        // `MachineBasicBlock`s to help with laying out machine code. If that's the
+                        // case, then for our purposes these extra blocks can be ignored. However,
+                        // we should really investigate to be sure.
                     }
                 }
             }
@@ -162,6 +174,27 @@ impl HWTMapper {
 
     /// Maps one PT block to one or many LLVM IR blocks.
     ///
+    /// Mapping a PT block to IRBlocks occurs in two phases. First the mapper tries to find machine
+    /// blocks whose address ranges overlap with the address range of the PT block (by using the
+    /// LLVM block address map section). Once machine blocks have been found, the mapper then tries
+    /// to find which LLVM IR blocks the machine blocks are part of.
+    ///
+    /// A `Some` element in the returned vector means that the mapper found a machine block that
+    /// maps to part of the PT block and that the machine block could be directly mapped
+    /// to an IR block.
+    ///
+    /// A `None` element in the returned vector means that the mapper found a machine block that
+    /// corresponds with part of the PT block but that the machine block could *not* be directly
+    /// mapped to an IR block. This happens when `MachineBasicBlock::getBasicBlock()` returns
+    /// `nullptr`.
+    ///
+    /// This function returns an empty vector if the PT block was unmappable (no matching machine
+    /// blocks could be found).
+    ///
+    /// The reason we cannot simply ignore the `None` case is that it is important to differentiate
+    /// "there were no matching machine blocks" from "there were matching machine blocks, but we
+    /// were unable to find IR blocks for them".
+    ///
     /// The reason that there may be many corresponding blocks is due to the following scenario.
     ///
     /// Suppose that the LLVM IR looked like this:
@@ -175,7 +208,7 @@ impl HWTMapper {
     /// During codegen LLVM may remove the unconditional jump and simply place bb1 and bb2
     /// consecutively, allowing bb1 to fall-thru to bb2. In the eyes of the PT block decoder, a
     /// fall-thru does not terminate a block, so whereas LLVM sees two blocks, PT sees only one.
-    fn map_block(&mut self, block: &hwtracer::Block) -> Vec<IRBlock> {
+    fn map_block(&mut self, block: &hwtracer::Block) -> Vec<Option<IRBlock>> {
         let block_vaddr = block.first_instr();
         let (obj_name, block_off) = code_vaddr_to_off(block_vaddr as usize).unwrap();
 
@@ -202,17 +235,17 @@ impl HWTMapper {
         // blocks may not appear consecutive.
         ents.sort_by(|x, y| x.range.start.partial_cmp(&y.range.start).unwrap());
         for ent in ents {
-            // Check that the MachineBasicBlock observed in the trace has a corresponding BasicBlock.
-            // PERF: can we guarantee this won't happen and downgrade to a debug assertion?
-            assert!(!ent.value.corr_bbs.is_empty());
-
-            let func_name = self.symb.find_code_sym(&obj_name, ent.value.f_off).unwrap();
-            self.faddrs.insert(func_name.clone(), ent.value.f_off);
-            for bb in &ent.value.corr_bbs {
-                ret.push(IRBlock {
-                    func_name: func_name.clone(),
-                    bb: usize::try_from(*bb).unwrap(),
-                });
+            if !ent.value.corr_bbs.is_empty() {
+                let func_name = self.symb.find_code_sym(&obj_name, ent.value.f_off).unwrap();
+                self.faddrs.insert(func_name.clone(), ent.value.f_off);
+                for bb in &ent.value.corr_bbs {
+                    ret.push(Some(IRBlock {
+                        func_name: func_name.clone(),
+                        bb: usize::try_from(*bb).unwrap(),
+                    }));
+                }
+            } else {
+                ret.push(None);
             }
         }
         ret


### PR DESCRIPTION
This makes Hello World in BF JIT!

I need to come clean about one aspect of this PR:
> // Part of a PT block mapped to a machine block in the LLVM block address
map, but the machine block has no corresponding IR blocks. This happens because LLVM can introduce extra `MachineBasicBlock`s to help with laying out machine code. For our purposes these extra blocks can be ignored.

The sentence starting "this happens because" is pure speculation. Despite some grepping, asking in discord, and asking a [stackoverflow question](https://stackoverflow.com/questions/68532562/llvm-when-does-machinebasicblockgetbasicblock-return-nullptr), I'm still not 100% sure why `MachineBasicBlock::getParent()` may return `nullptr`. The [LLVM docs](https://llvm.org/doxygen/classllvm_1_1MachineBasicBlock.html#a856266240556bbae90bc5ba75c156eef) are vague...

If we want a conclusive answer, I'll need to spend more time on this. What do you think?