### PR TITLE
Add some struct tests.

### DIFF
--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -88,11 +88,15 @@ fn run_suite(opt: &'static str) {
 fn main() {
     // Run the suite with the various different clang optimisation levels. We do this to maximise
     // the possibility of shaking out bugs (in both the JIT and the tests themselves).
+    //
+    // FIXME: https://github.com/ykjit/yk/issues/389
+    // For now we are working without static AOT optimisations (i.e. -O0 only) in an attempt to
+    // minimise the chance of temporary trace inputs, which we cannot yet handle.
     run_suite("-O0");
-    run_suite("-O1");
-    run_suite("-O2");
-    run_suite("-O3");
-    run_suite("-Ofast");
-    run_suite("-Os");
-    run_suite("-Oz");
+    //run_suite("-O1");
+    //run_suite("-O2");
+    //run_suite("-O3");
+    //run_suite("-Ofast");
+    //run_suite("-Os");
+    //run_suite("-Oz");
 }

--- a/c_tests/tests/struct_phi.c
+++ b/c_tests/tests/struct_phi.c
@@ -1,0 +1,53 @@
+// Compiler:
+// Run-time:
+//   env-var: YKD_PRINT_IR=aot
+//   stderr:
+//     ...
+//     define dso_local i32 @main...
+//       ...
+//       ...phi...
+//       ...
+//       ... = call i8* (i64, ...) @__yktrace_start_tracing(...
+//       ...
+//       }
+//       ...
+
+// Check that we can handle struct field accesses where the field is
+// initialised via a phi node.
+//
+// FIXME: https://github.com/ykjit/yk/issues/389
+// At some optimisation levels we get a temproary trace input, which we can't
+// handle.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+struct s {
+  int x;
+};
+
+int main(int argc, char **argv) {
+  int z = 5;
+  struct s s1;
+  s1.x = argc || z; // Creates a phi node.
+  int y1 = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &y1, &s1);
+  NOOPT_VAL(s1);
+  y1 = s1.x;
+  NOOPT_VAL(y1);
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(y1 == 1);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(int *, struct s *) = (void (*)(int *, struct s *))ptr;
+  int y2 = 0;
+  func(&y2, &s1);
+  printf("%d\n", y2);
+  assert(y2 == 1);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/struct_simple.c
+++ b/c_tests/tests/struct_simple.c
@@ -1,0 +1,35 @@
+// Compiler:
+// Run-time:
+
+// Check that we can handle struct field accesses.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+struct s {
+  int x;
+};
+
+int main(int argc, char **argv) {
+  struct s s1 = {argc};
+  int y1 = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &y1, &s1);
+  NOOPT_VAL(s1);
+  y1 = s1.x;
+  NOOPT_VAL(y1);
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(y1 == 1);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(int *, struct s *) = (void (*)(int *, struct s *))ptr;
+  int y2 = 0;
+  func(&y2, &s1);
+  printf("%d\n", y2);
+  assert(y2 == 1);
+
+  return (EXIT_SUCCESS);
+}

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -10,6 +10,13 @@ atomic<uint64_t> NextTraceIdx(0);
 #define YKTRACE_START "__yktrace_start_tracing"
 #define YKTRACE_STOP "__yktrace_stop_tracing"
 
+// Dump an error message and an LLVM value to stderr and exit with failure.
+void dumpValueAndExit(const char *Msg, Value *V) {
+  errs() << Msg << ": ";
+  V->dump();
+  exit(EXIT_FAILURE);
+}
+
 std::vector<Value *> getTraceInputs(Function *F, uintptr_t BBIdx) {
   std::vector<Value *> Vec;
   auto It = F->begin();
@@ -367,7 +374,7 @@ public:
           Value *NullVal = Constant::getNullValue(OpTy);
           VMap[Op] = NullVal;
         } else {
-          errx(EXIT_FAILURE, "don't know how to handle operand");
+          dumpValueAndExit("don't know how to handle operand", Op);
         }
       }
     }


### PR DESCRIPTION
These new tests work fine at AOT `-O0` but bork at higher opt levels due to temporary trace inputs.

As discussed offline, we will focus only on `-O0` for now.