### PR TITLE
Make traces more debuggable.

### DIFF
--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -1,5 +1,7 @@
 // Classes and functions for constructing a new LLVM module from a trace.
 
+#include "llvm/IR/DebugInfo.h"
+
 using namespace llvm;
 using namespace std;
 
@@ -187,7 +189,7 @@ public:
             StartTracingInstr = &*I;
             continue;
           } else if (CF->getName() == YKTRACE_STOP) {
-            finalise(&Builder);
+            finalise(AOTMod, &Builder);
             return JITMod;
           } else if ((StartTracingInstr != nullptr) && (CF->isDeclaration())) {
             // The definition of the callee is external to AOTMod. We still
@@ -383,29 +385,21 @@ public:
     // cloning the instruction.
     auto NewInst = &*I->clone();
 
-    // FIXME: For now we strip debugging meta-data from the JIT module just
-    // so that the module will verify and compile. In the long run we should
-    // include the debug info for the trace code. This would entail copying
-    // over the various module-level debugging declarations that are
-    // dependencies of instructions with !dbg meta-data attached.
-    if (NewInst->hasMetadata()) {
-      SmallVector<std::pair<unsigned, MDNode *>> InstrMD;
-      NewInst->getAllMetadata(InstrMD);
-      for (auto &MD : InstrMD) {
-        if (MD.first != LLVMContext::MD_dbg)
-          continue;
-        NewInst->setMetadata(MD.first, NULL);
-      }
-    }
-
     // Since the instruction operands still reference values from the AOT
     // module, we must remap them to point to new values in the JIT module.
     llvm::RemapInstruction(NewInst, VMap, RF_NoModuleLevelChanges);
     VMap[&*I] = NewInst;
-
 #ifndef NDEBUG
     RevVMap[NewInst] = &*I;
 #endif
+
+    // Copy over any debugging metadata required by the instruction.
+    llvm::SmallVector<std::pair<unsigned, llvm::MDNode *>, 1> metadataList;
+    I->getAllMetadata(metadataList);
+    for (auto MD : metadataList) {
+      NewInst->setMetadata(
+          MD.first, MapMetadata(MD.second, VMap, llvm::RF_MoveDistinctMDs));
+    }
 
     // And finally insert the new instruction into the JIT module.
     Builder->Insert(NewInst);
@@ -413,7 +407,7 @@ public:
 
   // Finalise the JITModule by adding a return instruction and initialising
   // global variables.
-  void finalise(IRBuilder<> *Builder) {
+  void finalise(Module *AOTMod, IRBuilder<> *Builder) {
     Builder->CreateRetVoid();
 
     // Fix initialisers/referrers for copied global variables.
@@ -425,6 +419,21 @@ public:
 
       if (G->hasInitializer())
         NewGV->setInitializer(MapValue(G->getInitializer(), VMap));
+    }
+
+    // Ensure that the JITModule has a `!llvm.dbg.cu`.
+    // This code is borrowed from LLVM's `cloneFunction()` implementation.
+    // OPT: Is there a faster way than scanning the whole module?
+    DebugInfoFinder DIFinder;
+    DIFinder.processModule(*AOTMod);
+    if (DIFinder.compile_unit_count()) {
+      auto *NMD = JITMod->getOrInsertNamedMetadata("llvm.dbg.cu");
+      SmallPtrSet<const void *, 8> Visited;
+      for (auto *Operand : NMD->operands())
+        Visited.insert(Operand);
+      for (auto *Unit : DIFinder.compile_units())
+        if (Visited.insert(Unit).second)
+          NMD->addOperand(Unit);
     }
   }
 };

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -152,6 +152,7 @@ public:
     // Keep track of the AOT function we are currently in so that we can print
     // inlined function thresholds in the dumped trace.
     StringRef LastAOTFunc;
+    const DebugLoc *LastDebugLoc = nullptr;
     for (auto &JITBlock : *JITFunc) {
       for (auto &JITInst : JITBlock) {
         auto V = RevVMap[&JITInst];
@@ -171,6 +172,14 @@ public:
         if (AOTFuncName != LastAOTFunc) {
           // Print an inlining threshold.
           errs() << "# " << AOTFuncName << "()\n";
+          LastAOTFunc = AOTFuncName;
+        }
+        const DebugLoc &ThisDebugLoc = JITInst.getDebugLoc();
+        if (LastDebugLoc != &ThisDebugLoc) {
+          string LocStr;
+          raw_string_ostream RSO(LocStr);
+          ThisDebugLoc.print(RSO);
+          errs() << "# " << LocStr << "\n";
           LastAOTFunc = AOTFuncName;
         }
         string JITStr;


### PR DESCRIPTION
We do this by:
 - Copying dbg! metadata over into the JIT module.
 - Displaying file and line info in the SBS trace print.

E.g.:

```
--- Begin trace dump for __yk_compiled_trace_0 ---
Trace                                      | AOT
%2 = alloca i8*, align 8
# main()
# tests/xxx.c:22:9
store i8* null, i8** %2, align 8, !dbg !9  |  store i8* %12, i8** %7,
align 8, !dbg !31
# tests/xxx.c:23:7
store i32 2, i32* %0, align 4, !dbg !17    |  store i32 2, i32* %6,
align 4, !dbg !33
# tests/xxx.c:24:37
%3 = load i8*, i8** %2, align 8, !dbg !18  |  %13 = load i8*, i8** %7,
align 8, !dbg !36
ret void
--- End trace dump for __yk_compiled_trace_0 ---
```

**This is a draft, as the tests have not yet been updated**