### PR TITLE
More linkage tests

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -12,5 +12,6 @@ harness = false
 
 [dev-dependencies]
 lang_tester = "0.7.0"
+once_cell = "1.8.0"
 tempfile = "3.2.0"
 ykcapi = { path = "../ykcapi", features = ["c_testing"] }

--- a/c_tests/extra_linkage/call_me.c
+++ b/c_tests/extra_linkage/call_me.c
@@ -1,0 +1,1 @@
+int call_me(int x) { return 5; }

--- a/c_tests/tests/call_ext_in_obj.c
+++ b/c_tests/tests/call_ext_in_obj.c
@@ -1,0 +1,38 @@
+// Compiler:
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   stderr:
+//     ...
+//     ...call i32 @call_me(...
+//     ...
+//     declare i32 @call_me(i32)
+//     ...
+
+// Check that we can call a function without IR from another object (.o) file.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+extern int call_me(int);
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  NOOPT_VAL(argc);
+  res = call_me(argc);
+  NOOPT_VAL(res);
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 5);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(int *) = (void (*)(int *))ptr;
+  int res2 = 0;
+  func(&res2);
+  assert(res2 == 5);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/internal_linkage_same_obj.c
+++ b/c_tests/tests/internal_linkage_same_obj.c
@@ -1,0 +1,46 @@
+// Compiler:
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   stderr:
+//     ...
+//     ...call i32 @call_me(...
+//     ...
+//     declare i32 @call_me(i32)
+//     ...
+
+// Check that we can call a static function with internal linkage from the same
+// compilation unit.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk_testing.h>
+
+static int call_me(int x) {
+  if (x == 5)
+    return x;
+  else {
+    // The recursion will cause a call to be emitted in the trace.
+    return call_me(x + 1);
+  }
+}
+
+int main(int argc, char **argv) {
+  int res = 0;
+  void *tt = __yktrace_start_tracing(HW_TRACING, &res);
+  NOOPT_VAL(argc);
+  res = call_me(argc);
+  NOOPT_VAL(res);
+  void *tr = __yktrace_stop_tracing(tt);
+  assert(res == 5);
+
+  void *ptr = __yktrace_irtrace_compile(tr);
+  __yktrace_drop_irtrace(tr);
+  void (*func)(int *) = (void (*)(int *))ptr;
+  int res2 = 0;
+  func(&res2);
+  assert(res2 == 5);
+
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
I had intended to write a failing test to form the basis of a fix for #407, however, I was unable to make a test where a trace called a static function from another object and the function has no IR. It doesn't look like this situation can happen...

Nonetheless I think it would still be good to add these two tests, as they check scenarios that were not previously tested.

Note that I had to extend the test runner. See individual commits.