### PR TITLE
Mapper: Ensure we are looking up an offset from the right object.

### DIFF
--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -212,6 +212,17 @@ impl HWTMapper {
         let block_vaddr = block.first_instr();
         let (obj_name, block_off) = code_vaddr_to_off(block_vaddr as usize).unwrap();
 
+        // Currently we only read in a block map and IR for the currently running binary (and not
+        // for dynamically linked shared objects). Thus, if we see code from another object, we
+        // can't map it.
+        //
+        // FIXME: https://github.com/ykjit/yk/issues/413
+        // In the future we could inline code from shared objects if they were built for use with
+        // yk (i.e. they have a blockmap and IR embedded).
+        if obj_name != env::current_exe().unwrap() {
+            return Vec::new();
+        }
+
         // The HW mapper gives us the start address of the last instruction in a block, which gives
         // us an exclusive upper bound when the interval tree expects an inclusive upper bound.
         // This is a problem when the last block in our sequence has a single 1 byte instruction:


### PR DESCRIPTION
The mapper uses `code_vaddr_to_offset()` to find the file offset of a
block. The resulting offset is then used to query the block map.

The code is incorrect because `code_vaddr_to_offset()` also succeeds on
externally linked code such as shared objects, yet the blockmap only
describes blocks in the main binary, thus sometimes we look up an offset
for the wrong file.

Most of the time this is harmless, as block offsets in different objects
rarely collide, and thus looking up a foreign offset in the blockmap
gives no result anyway. However, when experimenting with tracing the
Ruby interpreter, we did observe a collision, leading to
`find_code_sym()` to fail and in turn the JIT to crash.

The correct thing to do is to check that the offset in question comes
from the main binary and failing that report that there's external code
in the trace (return an empty vector).

Unfortunately this is very hard to devise a test for (we'd need objects
with colliding block addresses).