### PR TITLE
Add the '%%' prefix for matching non-literal LLVM variables in lang tests.

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -10,6 +10,9 @@ name = "c_tests"
 path = "run.rs"
 harness = false
 
+[dependencies]
+regex = "1.5.4"
+
 [dev-dependencies]
 lang_tester = "0.7.0"
 once_cell = "1.8.0"

--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -1,5 +1,6 @@
 use lang_tester::LangTester;
 use once_cell::sync::Lazy;
+use regex::Regex;
 use std::{
     collections::HashMap,
     env,
@@ -167,6 +168,12 @@ fn run_suite(opt: &'static str) {
             let compiler = mk_compiler(&exe, p, opt, &extra_objs);
             let runtime = Command::new(exe.clone());
             vec![("Compiler", compiler), ("Run-time", runtime)]
+        })
+        .fm_options(|_, _, fmb| {
+            // Use `%%` to match non-literal LLVM variables in tests.
+            let ptn_re = Regex::new(r"%%.+?\b").unwrap();
+            let text_re = Regex::new(r"%.+?\b").unwrap();
+            fmb.name_matcher(ptn_re, text_re)
         })
         .run();
 }


### PR DESCRIPTION
Tested on our sprint branch, but makes sense to include now.