### PR TITLE
Rough fix for #424

### DIFF
--- a/ykllvmwrap/build.rs
+++ b/ykllvmwrap/build.rs
@@ -17,6 +17,8 @@ fn main() {
     comp.flag("-Wall");
     comp.flag("-Werror");
     comp.file("src/ykllvmwrap.cc")
+        .file("src/jitmodbuilder.cc")
+        .file("src/memman.cc")
         .compiler("clang++")
         // Lots of unused parameters in the LLVM headers.
         .flag("-Wno-unused-parameter")

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -1,6 +1,8 @@
 // Classes and functions for constructing a new LLVM module from a trace.
 
-#include "llvm/IR/DebugInfo.h"
+#include "ykllvmwrap.h"
+#include <err.h>
+#include <llvm/IR/DebugInfo.h>
 
 using namespace llvm;
 using namespace std;
@@ -25,78 +27,46 @@ void dumpValueAndExit(const char *Msg, Value *V) {
   exit(EXIT_FAILURE);
 }
 
-// A function name and basic block index pair that identifies a block in the
-// AOT LLVM IR.
-struct IRBlock {
-  // A non-null pointer to the function name.
-  char *FuncName;
-  // The index of the block in the parent LLVM function.
-  size_t BBIdx;
-};
+InputTrace::InputTrace(char **FuncNames, size_t *BBs, size_t Len)
+    : FuncNames(FuncNames), BBs(BBs), Len(Len) {}
+size_t InputTrace::Length() { return Len; }
 
-// Describes the software or hardware trace to be compiled using LLVM.
-class InputTrace {
-private:
-  // An ordered array of function names. Each non-null element describes the
-  // function part of a (function, block) pair that identifies an LLVM
-  // BasicBlock. A null element represents unmappable code in the trace.
-  char **FuncNames;
-  // An ordered array of basic block indices. Each element corresponds with
-  // an element (at the same index) in the above `FuncNames` array to make a
-  // (function, block) pair that identifies an LLVM BasicBlock.
-  size_t *BBs;
-  // The length of the `FuncNames` and `BBs` arrays.
-  size_t Len;
-
-public:
-  InputTrace(char **FuncNames, size_t *BBs, size_t Len)
-      : FuncNames(FuncNames), BBs(BBs), Len(Len) {}
-  size_t Length() { return Len; }
-
-  // Returns the optional IRBlock at index `Idx` in the trace. No value is
-  // returned if element at `Idx` was unmappable. It is undefined behaviour to
-  // invoke this method with an out-of-bounds `Idx`.
-  const Optional<IRBlock> operator[](size_t Idx) {
-    assert(Idx < Len);
-    char *FuncName = FuncNames[Idx];
-    if (FuncName == nullptr) {
-      return Optional<IRBlock>();
-    } else {
-      return Optional<IRBlock>(IRBlock{FuncName, BBs[Idx]});
-    }
+// Returns the optional IRBlock at index `Idx` in the trace. No value is
+// returned if element at `Idx` was unmappable. It is undefined behaviour to
+// invoke this method with an out-of-bounds `Idx`.
+const Optional<IRBlock> InputTrace::operator[](size_t Idx) {
+  assert(Idx < Len);
+  char *FuncName = FuncNames[Idx];
+  if (FuncName == nullptr) {
+    return Optional<IRBlock>();
+  } else {
+    return Optional<IRBlock>(IRBlock{FuncName, BBs[Idx]});
   }
+}
 
-  // The same as `operator[]`, but for scenarios where you are certain that the
-  // element at position `Idx` cannot be unmappable.
-  const IRBlock getUnchecked(size_t Idx) {
-    assert(Idx < Len);
-    char *FuncName = FuncNames[Idx];
-    assert(FuncName != nullptr);
-    return IRBlock{FuncName, BBs[Idx]};
+// The same as `operator[]`, but for scenarios where you are certain that the
+// element at position `Idx` cannot be unmappable.
+const IRBlock InputTrace::getUnchecked(size_t Idx) {
+  assert(Idx < Len);
+  char *FuncName = FuncNames[Idx];
+  assert(FuncName != nullptr);
+  return IRBlock{FuncName, BBs[Idx]};
+}
+
+FuncAddrs::FuncAddrs(char **FuncNames, void **VAddrs, size_t Len) {
+  for (size_t I = 0; I < Len; I++) {
+    Map.insert({FuncNames[I], VAddrs[I]});
   }
-};
+}
 
-// Function virtual addresses observed in the input trace.
-// Maps a function symbol name to a virtual address.
-class FuncAddrs {
-  map<string, void *> Map;
-
-public:
-  FuncAddrs(char **FuncNames, void **VAddrs, size_t Len) {
-    for (size_t I = 0; I < Len; I++) {
-      Map.insert({FuncNames[I], VAddrs[I]});
-    }
-  }
-
-  // Lookup the address of the specified function name or return nullptr on
-  // failure.
-  void *operator[](const char *FuncName) {
-    auto It = Map.find(FuncName);
-    if (It == Map.end())
-      return nullptr; // Not found.
-    return It->second;
-  }
-};
+// Lookup the address of the specified function name or return nullptr on
+// failure.
+void *FuncAddrs::operator[](const char *FuncName) {
+  auto It = Map.find(FuncName);
+  if (It == Map.end())
+    return nullptr; // Not found.
+  return It->second;
+}
 
 /// Get the `Value` of the `YkCtrlPointVars` struct by looking it up inside the
 /// arguments of the new control point.
@@ -108,616 +78,550 @@ Value *getYkCtrlPointVarsStruct(Module *AOTMod, InputTrace &InpTrace) {
   return CI->getArgOperand(YK_CONTROL_POINT_ARG_IDX);
 }
 
-class JITModBuilder {
-  // Global variables/functions that were copied over and need to be
-  // initialised.
-  vector<GlobalVariable *> cloned_globals;
-  // The module being traced.
-  Module *AOTMod;
-  // The new module that is being build.
-  Module *JITMod;
-  // A pointer to the call to YK_NEW_CONTROL_POINT in the AOT module (once
-  // encountered). When this changes from NULL to non-NULL, then we start
-  // copying instructions from the AOT module into the JIT module.
-  Instruction *NewControlPointCall = nullptr;
-  // Stack of inlined calls, required to resume at the correct place in the
-  // caller.
-  std::vector<tuple<size_t, CallInst *>> InlinedCalls;
-  // Instruction at which to continue after an a call.
-  Optional<tuple<size_t, CallInst *>> ResumeAfter;
-  // Depth of nested calls when outlining a recursive function.
-  size_t RecCallDepth = 0;
-  // Signifies a hole (for which we have no IR) in the trace.
-  bool ExpectUnmappable = false;
-  // The JITMod's builder.
-  llvm::IRBuilder<> Builder;
-  // Dead values to recursively delete upon finalisation of the JITMod. This is
-  // required because it's not safe to recursively delete values in the middle
-  // of creating the JIT module. We don't know if any of those values might be
-  // required later in the trace.
-  vector<Value *> DeleteDeadOnFinalise;
-
-  // Information about the trace we are compiling.
-  InputTrace InpTrace;
-  // Function virtual addresses discovered from the input trace.
-  FuncAddrs FAddrs;
-
-  // A stack of BasicBlocks. Each time we enter a new call frame, we push the
-  // first basic block to the stack. Following a branch to another basic block
-  // updates the most recently pushed block. This is required for selecting the
-  // correct incoming value when tracing a PHI node.
-  vector<BasicBlock *> LastCompletedBlocks;
-
-  // Since a trace starts tracing after the control point but ends before it,
-  // we need to map the values inserted into the `YkCtrlPointVars` (appearing
-  // before the control point) to the extracted values (appearing after the
-  // control point). This map helps to match inserted values to their
-  // corresponding extracted values using their index in the struct.
-  std::map<uint64_t, Value *> InsertValueMap;
-
-  Value *getMappedValue(Value *V) {
-    if (VMap.find(V) != VMap.end()) {
-      return VMap[V];
-    }
-    assert(isa<Constant>(V));
-    return V;
+Value *JITModBuilder::getMappedValue(Value *V) {
+  if (VMap.find(V) != VMap.end()) {
+    return VMap[V];
   }
+  assert(isa<Constant>(V));
+  return V;
+}
 
-  // Returns true if the given function exists on the call stack, which means
-  // this is a recursive call.
-  bool isRecursiveCall(Function *F) {
-    for (auto Tup : InlinedCalls) {
-      CallInst *CInst = get<1>(Tup);
-      if (CInst->getCalledFunction() == F) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // Add an external declaration for the given function to JITMod.
-  void declareFunction(Function *F) {
-    assert(JITMod->getFunction(F->getName()) == nullptr);
-    auto DeclFunc = llvm::Function::Create(F->getFunctionType(),
-                                           GlobalValue::ExternalLinkage,
-                                           F->getName(), JITMod);
-    VMap[F] = DeclFunc;
-  }
-
-  // Find the machine code corresponding to the given AOT IR function and
-  // ensure there's a mapping from its name to that machine code.
-  void addGlobalMappingForFunction(Function *CF) {
-    StringRef CFName = CF->getName();
-    void *FAddr = FAddrs[CFName.data()];
-    assert(FAddr != nullptr);
-    globalMappings.insert({CF, FAddr});
-  }
-
-  void handleCallInst(CallInst *CI, Function *CF, size_t &CurInstrIdx) {
-    if (CF == nullptr || CF->isDeclaration()) {
-      // The definition of the callee is external to AOTMod. We still
-      // need to declare it locally if we have not done so yet.
-      if (CF != nullptr && VMap.find(CF) == VMap.end()) {
-        declareFunction(CF);
-      }
-      if (RecCallDepth == 0) {
-        copyInstruction(&Builder, (Instruction *)&*CI);
-      }
-      // We should expect an "unmappable hole" in the trace. This is
-      // where the trace followed a call into external code for which we
-      // have no IR, and thus we cannot map blocks for.
-      ExpectUnmappable = true;
-      ResumeAfter = make_tuple(CurInstrIdx, CI);
-    } else {
-      LastCompletedBlocks.push_back(nullptr);
-      if (RecCallDepth > 0) {
-        // When outlining a recursive function, we need to count all other
-        // function calls so we know when we left the recusion.
-        RecCallDepth += 1;
-        InlinedCalls.push_back(make_tuple(CurInstrIdx, CI));
-        return;
-      }
-      // If this is a recursive call that has been inlined, remove the
-      // inlined code and turn it into a normal call.
-      if (isRecursiveCall(CF)) {
-        if (VMap.find(CF) == VMap.end()) {
-          declareFunction(CF);
-          addGlobalMappingForFunction(CF);
-        }
-        copyInstruction(&Builder, CI);
-        InlinedCalls.push_back(make_tuple(CurInstrIdx, CI));
-        RecCallDepth = 1;
-        return;
-      }
-      // This is neither recursion nor an external call, so keep it inlined.
-      InlinedCalls.push_back(make_tuple(CurInstrIdx, CI));
-      // Remap function arguments to the variables passed in by the caller.
-      for (unsigned int i = 0; i < CI->arg_size(); i++) {
-        Value *Var = CI->getArgOperand(i);
-        Value *Arg = CF->getArg(i);
-        // Check the operand for things we need to remap, e.g. globals.
-        handleOperand(Var);
-        // If the operand has already been cloned into JITMod then we
-        // need to use the cloned value in the VMap.
-        VMap[Arg] = getMappedValue(Var);
-      }
+bool JITModBuilder::isRecursiveCall(Function *F) {
+  for (auto Tup : InlinedCalls) {
+    CallInst *CInst = get<1>(Tup);
+    if (CInst->getCalledFunction() == F) {
+      return true;
     }
   }
+  return false;
+}
 
-  void handleReturnInst(Instruction *I) {
-    ResumeAfter = InlinedCalls.back();
-    InlinedCalls.pop_back();
-    LastCompletedBlocks.pop_back();
+void JITModBuilder::declareFunction(Function *F) {
+  assert(JITMod->getFunction(F->getName()) == nullptr);
+  auto DeclFunc = llvm::Function::Create(
+      F->getFunctionType(), GlobalValue::ExternalLinkage, F->getName(), JITMod);
+  VMap[F] = DeclFunc;
+}
+
+// Find the machine code corresponding to the given AOT IR function and
+// ensure there's a mapping from its name to that machine code.
+void JITModBuilder::addGlobalMappingForFunction(Function *CF) {
+  StringRef CFName = CF->getName();
+  void *FAddr = FAddrs[CFName.data()];
+  assert(FAddr != nullptr);
+  globalMappings.insert({CF, FAddr});
+}
+
+void JITModBuilder::handleCallInst(CallInst *CI, Function *CF,
+                                   size_t &CurInstrIdx) {
+  if (CF == nullptr || CF->isDeclaration()) {
+    // The definition of the callee is external to AOTMod. We still
+    // need to declare it locally if we have not done so yet.
+    if (CF != nullptr && VMap.find(CF) == VMap.end()) {
+      declareFunction(CF);
+    }
+    if (RecCallDepth == 0) {
+      copyInstruction(&Builder, (Instruction *)&*CI);
+    }
+    // We should expect an "unmappable hole" in the trace. This is
+    // where the trace followed a call into external code for which we
+    // have no IR, and thus we cannot map blocks for.
+    ExpectUnmappable = true;
+    ResumeAfter = make_tuple(CurInstrIdx, CI);
+  } else {
+    LastCompletedBlocks.push_back(nullptr);
     if (RecCallDepth > 0) {
-      RecCallDepth -= 1;
+      // When outlining a recursive function, we need to count all other
+      // function calls so we know when we left the recusion.
+      RecCallDepth += 1;
+      InlinedCalls.push_back(make_tuple(CurInstrIdx, CI));
       return;
     }
-    // Replace the return variable of the call with its return value.
-    // Since the return value will have already been copied over to the
-    // JITModule, make sure we look up the copy.
-    auto OldRetVal = ((ReturnInst *)&*I)->getReturnValue();
-    if (OldRetVal != nullptr) {
-      assert(ResumeAfter.hasValue());
-      VMap[get<1>(ResumeAfter.getValue())] = getMappedValue(OldRetVal);
-    }
-  }
-
-  void handlePHINode(Instruction *I, BasicBlock *BB) {
-    Value *V = ((PHINode *)&*I)->getIncomingValueForBlock(BB);
-    VMap[&*I] = getMappedValue(V);
-  }
-
-  Function *createJITFunc(Value *TraceInputs, Type *RetTy) {
-    // Compute a name for the trace.
-    uint64_t TraceIdx = getNewTraceIdx();
-    TraceName = string(TRACE_FUNC_PREFIX) + to_string(TraceIdx);
-
-    // Create the function.
-    std::vector<Type *> InputTypes;
-    InputTypes.push_back(TraceInputs->getType());
-    llvm::FunctionType *FType =
-        llvm::FunctionType::get(RetTy, InputTypes, false);
-    llvm::Function *JITFunc = llvm::Function::Create(
-        FType, Function::InternalLinkage, TraceName, JITMod);
-    JITFunc->setCallingConv(CallingConv::C);
-
-    return JITFunc;
-  }
-
-  // Delete the dead value `V` from its parent, also deleting any dependencies
-  // of `V` (i.e. operands) which then become dead.
-  void deleteDeadTransitive(Value *V) {
-    assert(V->user_empty()); // The value should be dead.
-    vector<Value *> Work;
-    Work.push_back(V);
-    while (!Work.empty()) {
-      Value *V = Work.back();
-      Work.pop_back();
-      // Remove `V` (an instruction or a global variable) from its parent
-      // container. If any of the operands of `V` have a sole use, then they
-      // will become dead and can also be deleted too.
-      if (isa<Instruction>(V)) {
-        Instruction *I = cast<Instruction>(V);
-        for (auto &Op : I->operands()) {
-          if (Op->hasOneUser()) {
-            Work.push_back(&*Op);
-          }
-        }
-        I->eraseFromParent();
-      } else if (isa<GlobalVariable>(V)) {
-        GlobalVariable *G = cast<GlobalVariable>(V);
-        for (auto &Op : G->operands()) {
-          if (Op->hasOneUser()) {
-            Work.push_back(&*Op);
-          }
-        }
-        // Be sure to remove this global variable from `cloned_globals` too, so
-        // that we don't try to add an initialiser later in `finalise()`.
-        erase_if(cloned_globals, [G, this](GlobalVariable *CG) {
-          assert(VMap.find(CG) != VMap.end());
-          return G == VMap[CG];
-        });
-        G->eraseFromParent();
-      } else {
-        dumpValueAndExit("Unexpected Value", V);
+    // If this is a recursive call that has been inlined, remove the
+    // inlined code and turn it into a normal call.
+    if (isRecursiveCall(CF)) {
+      if (VMap.find(CF) == VMap.end()) {
+        declareFunction(CF);
+        addGlobalMappingForFunction(CF);
       }
+      copyInstruction(&Builder, CI);
+      InlinedCalls.push_back(make_tuple(CurInstrIdx, CI));
+      RecCallDepth = 1;
+      return;
+    }
+    // This is neither recursion nor an external call, so keep it inlined.
+    InlinedCalls.push_back(make_tuple(CurInstrIdx, CI));
+    // Remap function arguments to the variables passed in by the caller.
+    for (unsigned int i = 0; i < CI->arg_size(); i++) {
+      Value *Var = CI->getArgOperand(i);
+      Value *Arg = CF->getArg(i);
+      // Check the operand for things we need to remap, e.g. globals.
+      handleOperand(Var);
+      // If the operand has already been cloned into JITMod then we
+      // need to use the cloned value in the VMap.
+      VMap[Arg] = getMappedValue(Var);
     }
   }
+}
 
-public:
-  // Store virtual addresses for called functions.
-  std::map<GlobalValue *, void *> globalMappings;
-  // The function name of this trace.
-  string TraceName;
-  // Mapping from AOT instructions to JIT instructions.
-  ValueToValueMapTy VMap;
-
-  // OPT: https://github.com/ykjit/yk/issues/419
-  JITModBuilder(Module *AOTMod, char *FuncNames[], size_t BBs[],
-                size_t TraceLen, char *FAddrKeys[], void *FAddrVals[],
-                size_t FAddrLen)
-      : Builder(AOTMod->getContext()), InpTrace(FuncNames, BBs, TraceLen),
-        FAddrs(FAddrKeys, FAddrVals, FAddrLen) {
-    this->AOTMod = AOTMod;
-
-    JITMod = new Module("", AOTMod->getContext());
+void JITModBuilder::handleReturnInst(Instruction *I) {
+  ResumeAfter = InlinedCalls.back();
+  InlinedCalls.pop_back();
+  LastCompletedBlocks.pop_back();
+  if (RecCallDepth > 0) {
+    RecCallDepth -= 1;
+    return;
   }
+  // Replace the return variable of the call with its return value.
+  // Since the return value will have already been copied over to the
+  // JITModule, make sure we look up the copy.
+  auto OldRetVal = ((ReturnInst *)&*I)->getReturnValue();
+  if (OldRetVal != nullptr) {
+    assert(ResumeAfter.hasValue());
+    VMap[get<1>(ResumeAfter.getValue())] = getMappedValue(OldRetVal);
+  }
+}
 
-  // Generate the JIT module.
-  Module *createModule() {
-    LLVMContext &JITContext = JITMod->getContext();
-    // Find the trace inputs.
-    Value *TraceInputs = getYkCtrlPointVarsStruct(AOTMod, InpTrace);
+void JITModBuilder::handlePHINode(Instruction *I, BasicBlock *BB) {
+  Value *V = ((PHINode *)&*I)->getIncomingValueForBlock(BB);
+  VMap[&*I] = getMappedValue(V);
+}
 
-    // Get new control point call.
-    Function *F = AOTMod->getFunction(YK_NEW_CONTROL_POINT);
-    User *CallSite = F->user_back();
-    CallInst *CPCI = cast<CallInst>(CallSite);
-    Type *OutputStructTy = CPCI->getType();
+Function *JITModBuilder::createJITFunc(Value *TraceInputs, Type *RetTy) {
+  // Compute a name for the trace.
+  uint64_t TraceIdx = getNewTraceIdx();
+  TraceName = string(TRACE_FUNC_PREFIX) + to_string(TraceIdx);
 
-    // When assembling a trace, we start collecting instructions below the
-    // control point and finish above it. This means that alloca'd variables
-    // become undefined (as they are defined outside of the trace) and thus
-    // need to be remapped to the input of the compiled trace. SSA values
-    // remain correct as phi nodes at the beginning of the trace automatically
-    // select the appropriate input value.
-    //
-    // For example, once patched, a typical interpreter loop will look like
-    // this:
-    //
-    // ```
-    // bb0:
-    //   %a = alloca  // Stack variable
-    //   store 0, %a
-    //   %b = 1       // Register variable
-    //   br %bb1
-    //
-    // bb1:
-    //   %b1 = phi [%b, %bb0], [%binc, %bb1]
-    //   %s = new YkCtrlPointVars
-    //
-    //   insertvalue %s, %a, 0
-    //   insertvalue %s, %b1, 1           // traces end here
-    //   %s2 = call yk_new_control_point(%s)
-    //   %anew = extractvalue %s, 0       // traces start here
-    //   %bnew = extractvalue %s, 1
-    //
-    //   %aload = load %anew
-    //   %ainc = add 1, %aload
-    //   store %ainc, %a
-    //   %binc = add 1, %bnew
-    //   br %bb1
-    // ```
-    //
-    // There are two trace inputs (`%a` and `%b1`) and two trace outputs
-    // (`%anew` and `%bnew`). `%a` and `%anew` correspond to the same
-    // high-level variable, and so do `%b1` and `%bnew`. When assembling a
-    // trace from the above IR, it would look like this:
-    //
-    // ```
-    // void compiled_trace(%YkCtrlPointVars %s) {
-    //   %anew = extractvalue %s, 0     // traces start here
-    //   %bnew = extractvalue %s, 1
-    //
-    //   %aload = load %anew
-    //   %ainc = add 1, %aload
-    //   store %ainc, %a                // %a is undefined
-    //   %binc = add 1, %bnew
-    //   %b1 = phi(bb0: %b, bb1: %binc)
-    //   %s = new struct
-    //
-    //   insertvalue %s, %a, 0
-    //   insertvalue %s, %b1, 1         // traces end here
-    //   br %bb0
-    // }
-    // ```
-    //
-    // Here `%a` is undefined because we didn't trace its allocation. Instead
-    // it needs to be extracted from the `YkCtrlPointVars`, which means we need
-    // to replace `%a` with `%anew` in the store instruction. The other value
-    // `%b` doesn't have this problem, since the PHI node already makes sure it
-    // selects the correct SSA value `%binc`.
-    Value *OutS = CPCI->getArgOperand(1);
-    while (isa<InsertValueInst>(OutS)) {
-      InsertValueInst *IVI = cast<InsertValueInst>(OutS);
-      if (!isa<PHINode>(IVI->getInsertedValueOperand())) {
-        InsertValueMap[*IVI->idx_begin()] = IVI->getInsertedValueOperand();
+  // Create the function.
+  std::vector<Type *> InputTypes;
+  InputTypes.push_back(TraceInputs->getType());
+  llvm::FunctionType *FType = llvm::FunctionType::get(RetTy, InputTypes, false);
+  llvm::Function *JITFunc = llvm::Function::Create(
+      FType, Function::InternalLinkage, TraceName, JITMod);
+  JITFunc->setCallingConv(CallingConv::C);
+
+  return JITFunc;
+}
+
+void JITModBuilder::deleteDeadTransitive(Value *V) {
+  assert(V->user_empty()); // The value should be dead.
+  vector<Value *> Work;
+  Work.push_back(V);
+  while (!Work.empty()) {
+    Value *V = Work.back();
+    Work.pop_back();
+    // Remove `V` (an instruction or a global variable) from its parent
+    // container. If any of the operands of `V` have a sole use, then they
+    // will become dead and can also be deleted too.
+    if (isa<Instruction>(V)) {
+      Instruction *I = cast<Instruction>(V);
+      for (auto &Op : I->operands()) {
+        if (Op->hasOneUser()) {
+          Work.push_back(&*Op);
+        }
       }
-      OutS = IVI->getAggregateOperand();
+      I->eraseFromParent();
+    } else if (isa<GlobalVariable>(V)) {
+      GlobalVariable *G = cast<GlobalVariable>(V);
+      for (auto &Op : G->operands()) {
+        if (Op->hasOneUser()) {
+          Work.push_back(&*Op);
+        }
+      }
+      // Be sure to remove this global variable from `cloned_globals` too, so
+      // that we don't try to add an initialiser later in `finalise()`.
+      erase_if(cloned_globals, [G, this](GlobalVariable *CG) {
+        assert(VMap.find(CG) != VMap.end());
+        return G == VMap[CG];
+      });
+      G->eraseFromParent();
+    } else {
+      dumpValueAndExit("Unexpected Value", V);
+    }
+  }
+}
+
+// OPT: https://github.com/ykjit/yk/issues/419
+JITModBuilder::JITModBuilder(Module *AOTMod, char *FuncNames[], size_t BBs[],
+                             size_t TraceLen, char *FAddrKeys[],
+                             void *FAddrVals[], size_t FAddrLen)
+    : Builder(AOTMod->getContext()), InpTrace(FuncNames, BBs, TraceLen),
+      FAddrs(FAddrKeys, FAddrVals, FAddrLen) {
+  this->AOTMod = AOTMod;
+
+  JITMod = new Module("", AOTMod->getContext());
+}
+
+Module *JITModBuilder::createModule() {
+  LLVMContext &JITContext = JITMod->getContext();
+  // Find the trace inputs.
+  Value *TraceInputs = getYkCtrlPointVarsStruct(AOTMod, InpTrace);
+
+  // Get new control point call.
+  Function *F = AOTMod->getFunction(YK_NEW_CONTROL_POINT);
+  User *CallSite = F->user_back();
+  CallInst *CPCI = cast<CallInst>(CallSite);
+  Type *OutputStructTy = CPCI->getType();
+
+  // When assembling a trace, we start collecting instructions below the
+  // control point and finish above it. This means that alloca'd variables
+  // become undefined (as they are defined outside of the trace) and thus
+  // need to be remapped to the input of the compiled trace. SSA values
+  // remain correct as phi nodes at the beginning of the trace automatically
+  // select the appropriate input value.
+  //
+  // For example, once patched, a typical interpreter loop will look like
+  // this:
+  //
+  // ```
+  // bb0:
+  //   %a = alloca  // Stack variable
+  //   store 0, %a
+  //   %b = 1       // Register variable
+  //   br %bb1
+  //
+  // bb1:
+  //   %b1 = phi [%b, %bb0], [%binc, %bb1]
+  //   %s = new YkCtrlPointVars
+  //
+  //   insertvalue %s, %a, 0
+  //   insertvalue %s, %b1, 1           // traces end here
+  //   %s2 = call yk_new_control_point(%s)
+  //   %anew = extractvalue %s, 0       // traces start here
+  //   %bnew = extractvalue %s, 1
+  //
+  //   %aload = load %anew
+  //   %ainc = add 1, %aload
+  //   store %ainc, %a
+  //   %binc = add 1, %bnew
+  //   br %bb1
+  // ```
+  //
+  // There are two trace inputs (`%a` and `%b1`) and two trace outputs
+  // (`%anew` and `%bnew`). `%a` and `%anew` correspond to the same
+  // high-level variable, and so do `%b1` and `%bnew`. When assembling a
+  // trace from the above IR, it would look like this:
+  //
+  // ```
+  // void compiled_trace(%YkCtrlPointVars %s) {
+  //   %anew = extractvalue %s, 0     // traces start here
+  //   %bnew = extractvalue %s, 1
+  //
+  //   %aload = load %anew
+  //   %ainc = add 1, %aload
+  //   store %ainc, %a                // %a is undefined
+  //   %binc = add 1, %bnew
+  //   %b1 = phi(bb0: %b, bb1: %binc)
+  //   %s = new struct
+  //
+  //   insertvalue %s, %a, 0
+  //   insertvalue %s, %b1, 1         // traces end here
+  //   br %bb0
+  // }
+  // ```
+  //
+  // Here `%a` is undefined because we didn't trace its allocation. Instead
+  // it needs to be extracted from the `YkCtrlPointVars`, which means we need
+  // to replace `%a` with `%anew` in the store instruction. The other value
+  // `%b` doesn't have this problem, since the PHI node already makes sure it
+  // selects the correct SSA value `%binc`.
+  Value *OutS = CPCI->getArgOperand(1);
+  while (isa<InsertValueInst>(OutS)) {
+    InsertValueInst *IVI = cast<InsertValueInst>(OutS);
+    if (!isa<PHINode>(IVI->getInsertedValueOperand())) {
+      InsertValueMap[*IVI->idx_begin()] = IVI->getInsertedValueOperand();
+    }
+    OutS = IVI->getAggregateOperand();
+  }
+
+  // Create function to store compiled trace.
+  Function *JITFunc = createJITFunc(TraceInputs, CPCI->getType());
+
+  // Remap control point return value.
+  VMap[CPCI] = JITFunc->getArg(0);
+
+  // Map the YkCtrlPointVars struct used inside the trace to the argument of
+  // the compiled trace function.
+  VMap[TraceInputs] = JITFunc->getArg(0);
+
+  // Create entry block and setup builder.
+  auto DstBB = BasicBlock::Create(JITContext, "", JITFunc);
+  Builder.SetInsertPoint(DstBB);
+
+  LastCompletedBlocks.push_back(nullptr);
+  BasicBlock *NextCompletedBlock = nullptr;
+
+  // Iterate over the trace and stitch together all traced blocks.
+  for (size_t Idx = 0; Idx < InpTrace.Length(); Idx++) {
+    Optional<IRBlock> MaybeIB = InpTrace[Idx];
+    if (ExpectUnmappable && !MaybeIB.hasValue()) {
+      ExpectUnmappable = false;
+      continue;
+    }
+    assert(MaybeIB.hasValue());
+    IRBlock IB = MaybeIB.getValue();
+
+    // Get a traced function so we can extract blocks from it.
+    Function *F = AOTMod->getFunction(IB.FuncName);
+    if (!F)
+      errx(EXIT_FAILURE, "can't find function %s", IB.FuncName);
+
+    if (F->getName() == YK_NEW_CONTROL_POINT) {
+      continue;
     }
 
-    // Create function to store compiled trace.
-    Function *JITFunc = createJITFunc(TraceInputs, CPCI->getType());
+    // Skip to the correct block.
+    auto It = F->begin();
+    std::advance(It, IB.BBIdx);
+    BasicBlock *BB = &*It;
 
-    // Remap control point return value.
-    VMap[CPCI] = JITFunc->getArg(0);
+    assert(LastCompletedBlocks.size() >= 1);
+    LastCompletedBlocks.back() = NextCompletedBlock;
+    NextCompletedBlock = BB;
 
-    // Map the YkCtrlPointVars struct used inside the trace to the argument of
-    // the compiled trace function.
-    VMap[TraceInputs] = JITFunc->getArg(0);
+    // Iterate over all instructions within this block and copy them over
+    // to our new module.
+    for (size_t CurInstrIdx = 0; CurInstrIdx < BB->size(); CurInstrIdx++) {
+      // If we've returned from a call, skip ahead to the instruction where
+      // we left off.
+      if (ResumeAfter.hasValue() != 0) {
+        CurInstrIdx = std::get<0>(ResumeAfter.getValue()) + 1;
+        ResumeAfter.reset();
+      }
+      auto I = BB->begin();
+      std::advance(I, CurInstrIdx);
+      assert(I != BB->end());
 
-    // Create entry block and setup builder.
-    auto DstBB = BasicBlock::Create(JITContext, "", JITFunc);
-    Builder.SetInsertPoint(DstBB);
-
-    LastCompletedBlocks.push_back(nullptr);
-    BasicBlock *NextCompletedBlock = nullptr;
-
-    // Iterate over the trace and stitch together all traced blocks.
-    for (size_t Idx = 0; Idx < InpTrace.Length(); Idx++) {
-      Optional<IRBlock> MaybeIB = InpTrace[Idx];
-      if (ExpectUnmappable && !MaybeIB.hasValue()) {
-        ExpectUnmappable = false;
+      // Skip calls to debug intrinsics (e.g. @llvm.dbg.value). We don't
+      // currently handle debug info and these "pseudo-calls" cause our blocks
+      // to be prematurely terminated.
+      if (isa<DbgInfoIntrinsic>(I))
         continue;
-      }
-      assert(MaybeIB.hasValue());
-      IRBlock IB = MaybeIB.getValue();
 
-      // Get a traced function so we can extract blocks from it.
-      Function *F = AOTMod->getFunction(IB.FuncName);
-      if (!F)
-        errx(EXIT_FAILURE, "can't find function %s", IB.FuncName);
-
-      if (F->getName() == YK_NEW_CONTROL_POINT) {
-        continue;
-      }
-
-      // Skip to the correct block.
-      auto It = F->begin();
-      std::advance(It, IB.BBIdx);
-      BasicBlock *BB = &*It;
-
-      assert(LastCompletedBlocks.size() >= 1);
-      LastCompletedBlocks.back() = NextCompletedBlock;
-      NextCompletedBlock = BB;
-
-      // Iterate over all instructions within this block and copy them over
-      // to our new module.
-      for (size_t CurInstrIdx = 0; CurInstrIdx < BB->size(); CurInstrIdx++) {
-        // If we've returned from a call, skip ahead to the instruction where
-        // we left off.
-        if (ResumeAfter.hasValue() != 0) {
-          CurInstrIdx = std::get<0>(ResumeAfter.getValue()) + 1;
-          ResumeAfter.reset();
-        }
-        auto I = BB->begin();
-        std::advance(I, CurInstrIdx);
-        assert(I != BB->end());
-
-        // Skip calls to debug intrinsics (e.g. @llvm.dbg.value). We don't
-        // currently handle debug info and these "pseudo-calls" cause our blocks
-        // to be prematurely terminated.
-        if (isa<DbgInfoIntrinsic>(I))
-          continue;
-
-        if (isa<CallInst>(I)) {
-          CallInst *CI = cast<CallInst>(I);
-          Function *CF = CI->getCalledFunction();
-          if (CF == nullptr) {
-            if (NewControlPointCall == nullptr) {
-              continue;
-            }
-            // The target isn't statically known, so we can't inline the
-            // callee.
-            if (!isa<InlineAsm>(CI->getCalledOperand())) {
-              // Look ahead in the trace to find the callee so we can
-              // map the arguments if we are inlining the call.
-              Optional<IRBlock> MaybeNextIB = InpTrace[Idx + 1];
-              if (MaybeNextIB.hasValue()) {
-                CF = AOTMod->getFunction(MaybeNextIB.getValue().FuncName);
-              } else {
-                CF = nullptr;
-              }
-              // FIXME Don't inline indirect calls unless promoted.
-              handleCallInst(CI, CF, CurInstrIdx);
-              break;
-            }
-          } else if (CF->getName() == YK_NEW_CONTROL_POINT) {
-            if (NewControlPointCall == nullptr) {
-              NewControlPointCall = &*CI;
-            } else {
-              VMap[CI] = getMappedValue(CI->getArgOperand(1));
-              ResumeAfter = make_tuple(CurInstrIdx, CI);
-              break;
-            }
+      if (isa<CallInst>(I)) {
+        CallInst *CI = cast<CallInst>(I);
+        Function *CF = CI->getCalledFunction();
+        if (CF == nullptr) {
+          if (NewControlPointCall == nullptr) {
             continue;
-          } else if (CF->getName() == YKTRACE_STOP) {
-            finalise(AOTMod, &Builder);
-            return JITMod;
-          } else if (NewControlPointCall != nullptr) {
+          }
+          // The target isn't statically known, so we can't inline the
+          // callee.
+          if (!isa<InlineAsm>(CI->getCalledOperand())) {
+            // Look ahead in the trace to find the callee so we can
+            // map the arguments if we are inlining the call.
+            Optional<IRBlock> MaybeNextIB = InpTrace[Idx + 1];
+            if (MaybeNextIB.hasValue()) {
+              CF = AOTMod->getFunction(MaybeNextIB.getValue().FuncName);
+            } else {
+              CF = nullptr;
+            }
+            // FIXME Don't inline indirect calls unless promoted.
             handleCallInst(CI, CF, CurInstrIdx);
             break;
           }
-        }
-
-        // We don't start copying instructions into the JIT module until we've
-        // seen the call to YK_NEW_CONTROL_POINT.
-        if (NewControlPointCall == nullptr)
+        } else if (CF->getName() == YK_NEW_CONTROL_POINT) {
+          if (NewControlPointCall == nullptr) {
+            NewControlPointCall = &*CI;
+          } else {
+            VMap[CI] = getMappedValue(CI->getArgOperand(1));
+            ResumeAfter = make_tuple(CurInstrIdx, CI);
+            break;
+          }
           continue;
-
-        if (isa<IndirectBrInst>(I)) {
-          // FIXME Replace all potential CFG divergence with guards.
-          //
-          // It isn't necessary to copy the indirect branch into the `JITMod`
-          // as the successor block is known from the trace. However, naively
-          // not copying the branch would lead to dangling references in the IR
-          // because the `address` operand typically (indirectly) references
-          // AOT block addresses not present in the `JITMod`. Therefore we also
-          // remove the IR instruction which defines the `address` operand and
-          // anything which also becomes dead as a result (recursively).
-          Value *FirstOp = I->getOperand(0);
-          assert(VMap.find(FirstOp) != VMap.end());
-          DeleteDeadOnFinalise.push_back(VMap[FirstOp]);
-          continue;
-        }
-
-        if ((isa<BranchInst>(I)) || isa<SwitchInst>(I)) {
-          // FIXME Replace all potential CFG divergence with guards.
-          continue;
-        }
-
-        if (isa<ReturnInst>(I)) {
-          handleReturnInst(&*I);
+        } else if (CF->getName() == YKTRACE_STOP) {
+          finalise(AOTMod, &Builder);
+          return JITMod;
+        } else if (NewControlPointCall != nullptr) {
+          handleCallInst(CI, CF, CurInstrIdx);
           break;
         }
-
-        if (RecCallDepth > 0) {
-          // We are currently ignoring an inlined function.
-          continue;
-        }
-
-        if (isa<PHINode>(I)) {
-          assert(LastCompletedBlocks.size() >= 1);
-          handlePHINode(&*I, LastCompletedBlocks.back());
-          continue;
-        }
-
-        // If execution reaches here, then the instruction I is to be copied
-        // into JITMod.
-        copyInstruction(&Builder, (Instruction *)&*I);
-
-        // Perform the remapping described by InsertValueMap. See comments
-        // above.
-        if (isa<ExtractValueInst>(I)) {
-          ExtractValueInst *EVI = cast<ExtractValueInst>(I);
-          if (EVI->getAggregateOperand()->getType() == OutputStructTy) {
-            Value *IV = InsertValueMap[*EVI->idx_begin()];
-            VMap[IV] = getMappedValue(EVI);
-          }
-        }
       }
-    }
 
-    Builder.CreateRet(VMap[CPCI]);
-    finalise(AOTMod, &Builder);
-    return JITMod;
-  }
-
-  void handleOperand(Value *Op) {
-    if (VMap.find(Op) == VMap.end()) {
-      // The operand is undefined in JITMod.
-      Type *OpTy = Op->getType();
-
-      // Variables allocated outside of the traced section must be passed into
-      // the trace and thus must already have a mapping.
-      assert(!isa<llvm::AllocaInst>(Op));
-
-      if (isa<ConstantExpr>(Op)) {
-        // A `ConstantExpr` may contain operands that require remapping, e.g.
-        // global variables. Iterate over all operands and recursively call
-        // `handleOperand` on them, then generate a new `ConstantExpr` with
-        // the remapped operands.
-        ConstantExpr *CExpr = cast<ConstantExpr>(Op);
-        std::vector<Constant *> NewCEOps;
-        for (unsigned CEOpIdx = 0; CEOpIdx < CExpr->getNumOperands();
-             CEOpIdx++) {
-          Value *CEOp = CExpr->getOperand(CEOpIdx);
-          handleOperand(CEOp);
-          NewCEOps.push_back(cast<Constant>(getMappedValue(CEOp)));
-        }
-        Constant *NewCExpr = CExpr->getWithOperands(NewCEOps);
-        VMap[CExpr] = NewCExpr;
-      } else if (isa<GlobalVariable>(Op)) {
-        // If there's a reference to a GlobalVariable, copy it over to the
-        // new module.
-        GlobalVariable *OldGV = cast<GlobalVariable>(Op);
-        // Global variable is a constant so just copy it into the trace.
-        // We don't need to check if this global already exists, since
-        // we're skipping any operand that's already been cloned into
-        // the VMap.
-        GlobalVariable *GV = new GlobalVariable(
-            *JITMod, OldGV->getValueType(), OldGV->isConstant(),
-            OldGV->getLinkage(), (Constant *)nullptr, OldGV->getName(),
-            (GlobalVariable *)nullptr, OldGV->getThreadLocalMode(),
-            OldGV->getType()->getAddressSpace());
-        VMap[OldGV] = GV;
-        if (OldGV->isConstant()) {
-          GV->copyAttributesFrom(&*OldGV);
-          cloned_globals.push_back(OldGV);
-        }
-      } else if ((isa<Constant>(Op)) || (isa<InlineAsm>(Op))) {
-        if (isa<Function>(Op)) {
-          // We are storing a function pointer in a variable, so we need to
-          // redeclare the function in the JITModule in case it gets called.
-          declareFunction(cast<Function>(Op));
-        }
-        // Constants and inline asm don't need to be mapped.
-      } else if (Op == NewControlPointCall) {
-        // The value generated by NewControlPointCall is the thread tracer.
-        // At some optimisation levels, this gets stored in an alloca'd
-        // stack space. Since we've stripped the instruction that
-        // generates that value (from the JIT module), we have to make a
-        // dummy stack slot to keep LLVM happy.
-        Value *NullVal = Constant::getNullValue(OpTy);
-        VMap[Op] = NullVal;
-      } else {
-        dumpValueAndExit("don't know how to handle operand", Op);
-      }
-    }
-  }
-
-  void copyInstruction(IRBuilder<> *Builder, Instruction *I) {
-    // Before copying an instruction, we have to scan the instruction's
-    // operands checking that each is defined in JITMod.
-    for (unsigned OpIdx = 0; OpIdx < I->getNumOperands(); OpIdx++) {
-      Value *Op = I->getOperand(OpIdx);
-      handleOperand(Op);
-    }
-
-    // Shortly we will copy the instruction into the JIT module. We start by
-    // cloning the instruction.
-    auto NewInst = &*I->clone();
-
-    // Since the instruction operands still reference values from the AOT
-    // module, we must remap them to point to new values in the JIT module.
-    llvm::RemapInstruction(NewInst, VMap, RF_NoModuleLevelChanges);
-    VMap[&*I] = NewInst;
-
-    // Copy over any debugging metadata required by the instruction.
-    llvm::SmallVector<std::pair<unsigned, llvm::MDNode *>, 1> metadataList;
-    I->getAllMetadata(metadataList);
-    for (auto MD : metadataList) {
-      NewInst->setMetadata(
-          MD.first, MapMetadata(MD.second, VMap, llvm::RF_MoveDistinctMDs));
-    }
-
-    // And finally insert the new instruction into the JIT module.
-    Builder->Insert(NewInst);
-  }
-
-  // Finalise the JITModule by adding a return instruction and initialising
-  // global variables.
-  void finalise(Module *AOTMod, IRBuilder<> *Builder) {
-    // Now that we've seen all possible uses of values in the JITMod, we can
-    // delete the values we've marked dead (and possibly their dependencies if
-    // they too turn out to be dead).
-    for (auto &V : DeleteDeadOnFinalise)
-      deleteDeadTransitive(V);
-
-    // Fix initialisers/referrers for copied global variables.
-    // FIXME Do we also need to copy Linkage, MetaData, Comdat?
-    for (GlobalVariable *G : cloned_globals) {
-      GlobalVariable *NewGV = cast<GlobalVariable>(VMap[G]);
-      if (G->isDeclaration())
+      // We don't start copying instructions into the JIT module until we've
+      // seen the call to YK_NEW_CONTROL_POINT.
+      if (NewControlPointCall == nullptr)
         continue;
 
-      if (G->hasInitializer())
-        NewGV->setInitializer(MapValue(G->getInitializer(), VMap));
-    }
+      if (isa<IndirectBrInst>(I)) {
+        // FIXME Replace all potential CFG divergence with guards.
+        //
+        // It isn't necessary to copy the indirect branch into the `JITMod`
+        // as the successor block is known from the trace. However, naively
+        // not copying the branch would lead to dangling references in the IR
+        // because the `address` operand typically (indirectly) references
+        // AOT block addresses not present in the `JITMod`. Therefore we also
+        // remove the IR instruction which defines the `address` operand and
+        // anything which also becomes dead as a result (recursively).
+        Value *FirstOp = I->getOperand(0);
+        assert(VMap.find(FirstOp) != VMap.end());
+        DeleteDeadOnFinalise.push_back(VMap[FirstOp]);
+        continue;
+      }
 
-    // Ensure that the JITModule has a `!llvm.dbg.cu`.
-    // This code is borrowed from LLVM's `cloneFunction()` implementation.
-    // OPT: Is there a faster way than scanning the whole module?
-    DebugInfoFinder DIFinder;
-    DIFinder.processModule(*AOTMod);
-    if (DIFinder.compile_unit_count()) {
-      auto *NMD = JITMod->getOrInsertNamedMetadata("llvm.dbg.cu");
-      SmallPtrSet<const void *, 8> Visited;
-      for (auto *Operand : NMD->operands())
-        Visited.insert(Operand);
-      for (auto *Unit : DIFinder.compile_units())
-        if (Visited.insert(Unit).second)
-          NMD->addOperand(Unit);
+      if ((isa<BranchInst>(I)) || isa<SwitchInst>(I)) {
+        // FIXME Replace all potential CFG divergence with guards.
+        continue;
+      }
+
+      if (isa<ReturnInst>(I)) {
+        handleReturnInst(&*I);
+        break;
+      }
+
+      if (RecCallDepth > 0) {
+        // We are currently ignoring an inlined function.
+        continue;
+      }
+
+      if (isa<PHINode>(I)) {
+        assert(LastCompletedBlocks.size() >= 1);
+        handlePHINode(&*I, LastCompletedBlocks.back());
+        continue;
+      }
+
+      // If execution reaches here, then the instruction I is to be copied
+      // into JITMod.
+      copyInstruction(&Builder, (Instruction *)&*I);
+
+      // Perform the remapping described by InsertValueMap. See comments
+      // above.
+      if (isa<ExtractValueInst>(I)) {
+        ExtractValueInst *EVI = cast<ExtractValueInst>(I);
+        if (EVI->getAggregateOperand()->getType() == OutputStructTy) {
+          Value *IV = InsertValueMap[*EVI->idx_begin()];
+          VMap[IV] = getMappedValue(EVI);
+        }
+      }
     }
   }
-};
+
+  Builder.CreateRet(VMap[CPCI]);
+  finalise(AOTMod, &Builder);
+  return JITMod;
+}
+
+void JITModBuilder::handleOperand(Value *Op) {
+  if (VMap.find(Op) == VMap.end()) {
+    // The operand is undefined in JITMod.
+    Type *OpTy = Op->getType();
+
+    // Variables allocated outside of the traced section must be passed into
+    // the trace and thus must already have a mapping.
+    assert(!isa<llvm::AllocaInst>(Op));
+
+    if (isa<ConstantExpr>(Op)) {
+      // A `ConstantExpr` may contain operands that require remapping, e.g.
+      // global variables. Iterate over all operands and recursively call
+      // `handleOperand` on them, then generate a new `ConstantExpr` with
+      // the remapped operands.
+      ConstantExpr *CExpr = cast<ConstantExpr>(Op);
+      std::vector<Constant *> NewCEOps;
+      for (unsigned CEOpIdx = 0; CEOpIdx < CExpr->getNumOperands(); CEOpIdx++) {
+        Value *CEOp = CExpr->getOperand(CEOpIdx);
+        handleOperand(CEOp);
+        NewCEOps.push_back(cast<Constant>(getMappedValue(CEOp)));
+      }
+      Constant *NewCExpr = CExpr->getWithOperands(NewCEOps);
+      VMap[CExpr] = NewCExpr;
+    } else if (isa<GlobalVariable>(Op)) {
+      // If there's a reference to a GlobalVariable, copy it over to the
+      // new module.
+      GlobalVariable *OldGV = cast<GlobalVariable>(Op);
+      // Global variable is a constant so just copy it into the trace.
+      // We don't need to check if this global already exists, since
+      // we're skipping any operand that's already been cloned into
+      // the VMap.
+      GlobalVariable *GV = new GlobalVariable(
+          *JITMod, OldGV->getValueType(), OldGV->isConstant(),
+          OldGV->getLinkage(), (Constant *)nullptr, OldGV->getName(),
+          (GlobalVariable *)nullptr, OldGV->getThreadLocalMode(),
+          OldGV->getType()->getAddressSpace());
+      VMap[OldGV] = GV;
+      if (OldGV->isConstant()) {
+        GV->copyAttributesFrom(&*OldGV);
+        cloned_globals.push_back(OldGV);
+      }
+    } else if ((isa<Constant>(Op)) || (isa<InlineAsm>(Op))) {
+      if (isa<Function>(Op)) {
+        // We are storing a function pointer in a variable, so we need to
+        // redeclare the function in the JITModule in case it gets called.
+        declareFunction(cast<Function>(Op));
+      }
+      // Constants and inline asm don't need to be mapped.
+    } else if (Op == NewControlPointCall) {
+      // The value generated by NewControlPointCall is the thread tracer.
+      // At some optimisation levels, this gets stored in an alloca'd
+      // stack space. Since we've stripped the instruction that
+      // generates that value (from the JIT module), we have to make a
+      // dummy stack slot to keep LLVM happy.
+      Value *NullVal = Constant::getNullValue(OpTy);
+      VMap[Op] = NullVal;
+    } else {
+      dumpValueAndExit("don't know how to handle operand", Op);
+    }
+  }
+}
+
+void JITModBuilder::copyInstruction(IRBuilder<> *Builder, Instruction *I) {
+  // Before copying an instruction, we have to scan the instruction's
+  // operands checking that each is defined in JITMod.
+  for (unsigned OpIdx = 0; OpIdx < I->getNumOperands(); OpIdx++) {
+    Value *Op = I->getOperand(OpIdx);
+    handleOperand(Op);
+  }
+
+  // Shortly we will copy the instruction into the JIT module. We start by
+  // cloning the instruction.
+  auto NewInst = &*I->clone();
+
+  // Since the instruction operands still reference values from the AOT
+  // module, we must remap them to point to new values in the JIT module.
+  llvm::RemapInstruction(NewInst, VMap, RF_NoModuleLevelChanges);
+  VMap[&*I] = NewInst;
+
+  // Copy over any debugging metadata required by the instruction.
+  llvm::SmallVector<std::pair<unsigned, llvm::MDNode *>, 1> metadataList;
+  I->getAllMetadata(metadataList);
+  for (auto MD : metadataList) {
+    NewInst->setMetadata(
+        MD.first, MapMetadata(MD.second, VMap, llvm::RF_MoveDistinctMDs));
+  }
+
+  // And finally insert the new instruction into the JIT module.
+  Builder->Insert(NewInst);
+}
+
+void JITModBuilder::finalise(Module *AOTMod, IRBuilder<> *Builder) {
+  // Now that we've seen all possible uses of values in the JITMod, we can
+  // delete the values we've marked dead (and possibly their dependencies if
+  // they too turn out to be dead).
+  for (auto &V : DeleteDeadOnFinalise)
+    deleteDeadTransitive(V);
+
+  // Fix initialisers/referrers for copied global variables.
+  // FIXME Do we also need to copy Linkage, MetaData, Comdat?
+  for (GlobalVariable *G : cloned_globals) {
+    GlobalVariable *NewGV = cast<GlobalVariable>(VMap[G]);
+    if (G->isDeclaration())
+      continue;
+
+    if (G->hasInitializer())
+      NewGV->setInitializer(MapValue(G->getInitializer(), VMap));
+  }
+
+  // Ensure that the JITModule has a `!llvm.dbg.cu`.
+  // This code is borrowed from LLVM's `cloneFunction()` implementation.
+  // OPT: Is there a faster way than scanning the whole module?
+  DebugInfoFinder DIFinder;
+  DIFinder.processModule(*AOTMod);
+  if (DIFinder.compile_unit_count()) {
+    auto *NMD = JITMod->getOrInsertNamedMetadata("llvm.dbg.cu");
+    SmallPtrSet<const void *, 8> Visited;
+    for (auto *Operand : NMD->operands())
+      Visited.insert(Operand);
+    for (auto *Unit : DIFinder.compile_units())
+      if (Visited.insert(Unit).second)
+        NMD->addOperand(Unit);
+  }
+}

--- a/ykllvmwrap/src/memman.cc
+++ b/ykllvmwrap/src/memman.cc
@@ -1,33 +1,8 @@
-#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+#include "ykllvmwrap.h"
+#include <err.h>
 #include <sys/mman.h>
 
 using namespace llvm;
-
-struct AllocMem {
-  uint8_t *Ptr;
-  uintptr_t Size;
-};
-
-class MemMan : public RTDyldMemoryManager {
-public:
-  MemMan();
-  ~MemMan() override;
-
-  uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
-                               unsigned SectionID,
-                               StringRef SectionName) override;
-
-  uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
-                               unsigned SectionID, StringRef SectionName,
-                               bool isReadOnly) override;
-
-  bool finalizeMemory(std::string *ErrMsg) override;
-  void freeMemory();
-
-private:
-  std::vector<AllocMem> code;
-  std::vector<AllocMem> data;
-};
 
 MemMan::MemMan() {}
 MemMan::~MemMan() {}

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -11,7 +11,7 @@
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/MCJIT.h>
-#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
@@ -19,9 +19,7 @@
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/TargetSelect.h>
-#include <llvm/Transforms/Utils/ValueMapper.h>
 
-#include <atomic>
 #include <dlfcn.h>
 #include <err.h>
 #include <limits>
@@ -30,8 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "jitmodbuilder.cc"
-#include "memman.cc"
+#include "ykllvmwrap.h"
 
 using namespace llvm;
 using namespace llvm::orc;

--- a/ykllvmwrap/src/ykllvmwrap.h
+++ b/ykllvmwrap/src/ykllvmwrap.h
@@ -1,0 +1,173 @@
+#ifndef _YKLLVMWRAP_H
+#define _YKLLVMWRAP_H
+
+#include <atomic>
+
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/Transforms/Utils/ValueMapper.h>
+
+using namespace llvm;
+
+// A function name and basic block index pair that identifies a block in the
+// AOT LLVM IR.
+struct IRBlock {
+  // A non-null pointer to the function name.
+  char *FuncName;
+  // The index of the block in the parent LLVM function.
+  size_t BBIdx;
+};
+
+// Function virtual addresses observed in the input trace.
+// Maps a function symbol name to a virtual address.
+class FuncAddrs {
+  std::map<std::string, void *> Map;
+
+public:
+  FuncAddrs(char **FuncNames, void **VAddrs, size_t Len);
+
+  // Lookup the address of the specified function name or return nullptr on
+  // failure.
+  void *operator[](const char *FuncName);
+};
+
+// Describes the software or hardware trace to be compiled using LLVM.
+class InputTrace {
+  // An ordered array of function names. Each non-null element describes the
+  // function part of a (function, block) pair that identifies an LLVM
+  // BasicBlock. A null element represents unmappable code in the trace.
+  char **FuncNames;
+  // An ordered array of basic block indices. Each element corresponds with
+  // an element (at the same index) in the above `FuncNames` array to make a
+  // (function, block) pair that identifies an LLVM BasicBlock.
+  size_t *BBs;
+  // The length of the `FuncNames` and `BBs` arrays.
+  size_t Len;
+
+public:
+  InputTrace(char **FuncNames, size_t *BBs, size_t Len);
+  size_t Length();
+  const Optional<IRBlock> operator[](size_t Idx);
+  const IRBlock getUnchecked(size_t Idx);
+};
+
+class JITModBuilder {
+  // Global variables/functions that were copied over and need to be
+  // initialised.
+  std::vector<GlobalVariable *> cloned_globals;
+  // The module being traced.
+  Module *AOTMod;
+  // The new module that is being build.
+  Module *JITMod;
+  // A pointer to the call to YK_NEW_CONTROL_POINT in the AOT module (once
+  // encountered). When this changes from NULL to non-NULL, then we start
+  // copying instructions from the AOT module into the JIT module.
+  Instruction *NewControlPointCall = nullptr;
+  // Stack of inlined calls, required to resume at the correct place in the
+  // caller.
+  std::vector<std::tuple<size_t, CallInst *>> InlinedCalls;
+  // Instruction at which to continue after an a call.
+  Optional<std::tuple<size_t, CallInst *>> ResumeAfter;
+  // Depth of nested calls when outlining a recursive function.
+  size_t RecCallDepth = 0;
+  // Signifies a hole (for which we have no IR) in the trace.
+  bool ExpectUnmappable = false;
+  // The JITMod's builder.
+  llvm::IRBuilder<> Builder;
+  // Dead values to recursively delete upon finalisation of the JITMod. This is
+  // required because it's not safe to recursively delete values in the middle
+  // of creating the JIT module. We don't know if any of those values might be
+  // required later in the trace.
+  std::vector<Value *> DeleteDeadOnFinalise;
+
+  // Information about the trace we are compiling.
+  InputTrace InpTrace;
+  // Function virtual addresses discovered from the input trace.
+  FuncAddrs FAddrs;
+
+  // A stack of BasicBlocks. Each time we enter a new call frame, we push the
+  // first basic block to the stack. Following a branch to another basic block
+  // updates the most recently pushed block. This is required for selecting the
+  // correct incoming value when tracing a PHI node.
+  std::vector<BasicBlock *> LastCompletedBlocks;
+
+  // Since a trace starts tracing after the control point but ends before it,
+  // we need to map the values inserted into the `YkCtrlPointVars` (appearing
+  // before the control point) to the extracted values (appearing after the
+  // control point). This map helps to match inserted values to their
+  // corresponding extracted values using their index in the struct.
+  std::map<uint64_t, Value *> InsertValueMap;
+
+  Value *getMappedValue(Value *V);
+
+  // Returns true if the given function exists on the call stack, which means
+  // this is a recursive call.
+  bool isRecursiveCall(Function *F);
+
+  // Add an external declaration for the given function to JITMod.
+  void declareFunction(Function *F);
+
+  // Find the machine code corresponding to the given AOT IR function and
+  // ensure there's a mapping from its name to that machine code.
+  void addGlobalMappingForFunction(Function *CF);
+
+  void handleCallInst(CallInst *CI, Function *CF, size_t &CurInstrIdx);
+  void handleReturnInst(Instruction *I);
+  void handlePHINode(Instruction *I, BasicBlock *BB);
+  void handleOperand(Value *Op);
+
+  void copyInstruction(IRBuilder<> *Builder, Instruction *I);
+  Function *createJITFunc(Value *TraceInputs, Type *RetTy);
+
+  // Delete the dead value `V` from its parent, also deleting any dependencies
+  // of `V` (i.e. operands) which then become dead.
+  void deleteDeadTransitive(Value *V);
+
+  // Finalise the JITModule by adding a return instruction and initialising
+  // global variables.
+  void finalise(Module *AOTMod, IRBuilder<> *Builder);
+
+public:
+  // Store virtual addresses for called functions.
+  std::map<GlobalValue *, void *> globalMappings;
+  // The function name of this trace.
+  std::string TraceName;
+  // Mapping from AOT instructions to JIT instructions.
+  ValueToValueMapTy VMap;
+
+  JITModBuilder(Module *AOTMod, char *FuncNames[], size_t BBs[],
+                size_t TraceLen, char *FAddrKeys[], void *FAddrVals[],
+                size_t FAddrLen);
+
+  // Generate the JIT module.
+  Module *createModule();
+};
+
+struct AllocMem {
+  uint8_t *Ptr;
+  uintptr_t Size;
+};
+
+class MemMan : public RTDyldMemoryManager {
+public:
+  MemMan();
+  ~MemMan() override;
+
+  uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
+                               unsigned SectionID,
+                               StringRef SectionName) override;
+
+  uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
+                               unsigned SectionID, StringRef SectionName,
+                               bool isReadOnly) override;
+
+  bool finalizeMemory(std::string *ErrMsg) override;
+  void freeMemory();
+
+private:
+  std::vector<AllocMem> code;
+  std::vector<AllocMem> data;
+};
+
+#endif


### PR DESCRIPTION
This is a rough draft fix for https://github.com/ykjit/yk/issues/424.

Please don't review this yet. The change serve only to demonstrate how to use a header file for ykllvmwrap and to help with the following discussion.

The change eliminates `#include`s of C++ files, which currently make rebuilding `yk` unreliable (changing an included file doesn't trigger a rebuild).

If we want multiple C++ files in this crate, rather than including C++ files, the correct thing to do is to use a header file to stub out the classes, include the header where needed, and then build each file independently, linking them at the end (see build.rs change).

This is the "correct" way to do things in C++ land, but I've taken pause because an "easier" and "more maintainable" way of doing things would be to simply merge the three C++ files into one. The advantage would be that we don't need a header file at all, and this could be a good thing since there'd be no need to duplicate every method signature in the header. This could speed up development, where method sigs are in flux: there'd only be one place to update.

[Another thing I learned about C++ headers today: you have to stub out private methods and attributes too. So those definitions would be duplicated too. There's a way to hide this, but it would involve proxy classes]

The downside of merging the C++ files would be that we have one quite large C++ file.

Does anyone have a preference?
 