### PR TITLE
For now, crash upon encontering an `indirectbr`.

### DIFF
--- a/c_tests/tests/indirect_branch.c
+++ b/c_tests/tests/indirect_branch.c
@@ -1,52 +1,39 @@
-// ignore: broken during new control point design
+// ignore: guards for indirect branches not implemented.
 // Compiler:
+//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
-//   env-var: YKD_PRINT_IR=aot
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     ...
-//     indirectbr i8* %...
-//     ...
 
-// Check that we can handle indirect branches.
+// Check that tracing an `indirectbr` works.
 
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <yk.h>
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  // Note that LLVM knows that `l1` is dead code because `argc` is always >0.
-  void *dispatch[] = {&&l1, &&l2, &&l3};
-  int z = 0, idx = argc;
-
-  __yktrace_start_tracing(HW_TRACING, &z, &idx);
+  int loc = 0;
+  int i = 5;
+  int idx = 1;
+  void *dispatch[] = {&&label1, &&label3, &&label2};
+  NOOPT_VAL(i);
   NOOPT_VAL(idx);
-
-  // Now jump to l2 and then l3 via computed gotos.
-  goto *dispatch[idx];
-l1:
-  // unreachable.
-  exit(EXIT_FAILURE);
-l2:
-  z += 1;
-  idx += 1;
-  goto *dispatch[idx];
-l3:
-  z += 2;
-
-  NOOPT_VAL(z);
-  void *tr = __yktrace_stop_tracing();
-  printf("ZZZ %d\n", z);
-  assert(z == 3);
-
-  void *ptr = __yktrace_irtrace_compile(tr);
-  __yktrace_drop_irtrace(tr);
-  void (*func)(int *, int *) = (void (*)(int *, int *))ptr;
-  int z2 = 0;
-  int idx2 = argc;
-  func(&z2, &idx2);
-  assert(z2 == 3);
+  while (i > 0) {
+    yk_control_point(loc);
+    fprintf(stderr, "i=%d\n", i);
+    goto *dispatch[idx];
+label1:
+    abort(); // unreachable.
+label2:
+    abort(); // unreachable.
+label3:
+    i--;
+  }
+  abort(); // FIXME: unreachable due to aborting guard failure earlier.
 
   return (EXIT_SUCCESS);
 }

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -722,8 +722,6 @@ public:
       SuccBB = handleSwitchInst(JITFunc, NextBB, &*I);
     } else {
       assert(isa<IndirectBrInst>(I));
-      // FIXME: Implement guards for these.
-      //
       // It isn't necessary to copy the indirect branch into the `JITMod`
       // as the successor block is known from the trace. However, naively
       // not copying the branch would lead to dangling references in the
@@ -735,6 +733,9 @@ public:
       Value *FirstOp = I->getOperand(0);
       assert(VMap.find(FirstOp) != VMap.end());
       DeleteDeadOnFinalise.push_back(VMap[FirstOp]);
+      // FIXME: guards for indirect branches are not yet implemented.
+      // https://github.com/ykjit/yk/issues/438
+      abort();
     }
 
     // If a guard was emitted, then the block we had been building the trace


### PR DESCRIPTION
We haven't yet implemented guards for `indirectbr` and currently no test
encounters one (I've included a (skipped) test that we can use later).

See https://github.com/ykjit/yk/issues/438 for details.