### PR TITLE
Update tests so that the control point takes a `Location`.

### DIFF
--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -1,35 +1,68 @@
-// ignore: broken during new control point design
 // Compiler:
+//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt,aot
+//   stderr:
+//     jit-state: start-tracing
+//     ...
+//     define internal %YkCtrlPointVars @__yk_compiled_trace_0(%YkCtrlPointVars %0) {
+//        ...
+//        %{{x}} = extractvalue %YkCtrlPointVars %0, ...
+//        ...
+//        %{{a}} = add nsw i32 %{{b}}, 2...
+//        ...
+//        %{{cond}} = icmp sgt i32 %{{val}}, ...
+//        br i1 %{{cond}}, label %{{guard-succ-bb}}, label %{{guard-fail-bb}}
+//
+//     {{guard-fail-bb}}:...
+//       ...
+//       call void (i32, i8*, ...) @errx(i32 0,...
+//       unreachable
+//
+//     {{guard-succ-bb}}:...
+//        ...
+//        %{{z}} = insertvalue %YkCtrlPointVars %{{y}}, ...
+//        ...
+//        ret %YkCtrlPointVars %{{ret}}
+//     }
+//     ...
+//     jit-state: stop-tracing
+//     i=4
+//     jit-state: enter-jit-code
+//     i=3
+//     jit-state: exit-jit-code
+//     jit-state: enter-jit-code
+//     i=2
+//     jit-state: exit-jit-code
+//     jit-state: enter-jit-code
+//     i=1
+//     const_global: guard-failure
+
+// Check that using a global constant works.
 
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <yk.h>
 #include <yk_testing.h>
 
-const volatile int global_int = 6;
-
-__attribute__((noinline)) int foo() {
-  int x = global_int;
-  int y = global_int;
-  int z = x + y;
-  return z;
-}
+const int add = 2;
 
 int main(int argc, char **argv) {
   int res = 0;
-  __yktrace_start_tracing(HW_TRACING, &res);
-  res = foo();
-  void *tr = __yktrace_stop_tracing();
-  assert(res == 12);
-
-  void *ptr = __yktrace_irtrace_compile(tr);
-  __yktrace_drop_irtrace(tr);
-  void (*func)(void *) = (void (*)(void *))ptr;
-  int output = 0;
-  func(&output);
-  assert(output == 12);
+  YkLocation loc = yk_location_new();
+  int i = 5;
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_control_point(&loc);
+    fprintf(stderr, "i=%d\n", i);
+    res += add;
+    i--;
+  }
+  abort(); // FIXME: unreachable due to aborting guard failure earlier.
+  NOOPT_VAL(res);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -1,33 +1,69 @@
-// ignore: Mutable global variables not supported.
 // Compiler:
+//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt,aot
+//   stderr:
+//     jit-state: start-tracing
+//     ...
+//     define internal %YkCtrlPointVars @__yk_compiled_trace_0(%YkCtrlPointVars %0) {
+//        ...
+//        %{{x}} = extractvalue %YkCtrlPointVars %0, ...
+//        ...
+//        %{{a}} = add nsw i32 %{{b}}, %{{add}}...
+//        ...
+//        %{{cond}} = icmp sgt i32 %{{val}}, ...
+//        br i1 %{{cond}}, label %{{guard-succ-bb}}, label %{{guard-fail-bb}}
+//
+//     {{guard-fail-bb}}:...
+//       ...
+//       call void (i32, i8*, ...) @errx(i32 0,...
+//       unreachable
+//
+//     {{guard-succ-bb}}:...
+//        ...
+//        %{{z}} = insertvalue %YkCtrlPointVars %{{y}}, ...
+//        ...
+//        ret %YkCtrlPointVars %{{ret}}
+//     }
+//     ...
+//     jit-state: stop-tracing
+//     i=4
+//     jit-state: enter-jit-code
+//     i=3
+//     jit-state: exit-jit-code
+//     jit-state: enter-jit-code
+//     i=2
+//     jit-state: exit-jit-code
+//     jit-state: enter-jit-code
+//     i=1
+//     mutable_global: guard-failure
+
+// Check that using a global works.
 
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <yk.h>
 #include <yk_testing.h>
 
-int global_int = 12;
-
-__attribute__((noinline)) int foo(int num) {
-  global_int = num;
-  return global_int;
-}
+int add;
 
 int main(int argc, char **argv) {
   int res = 0;
-  __yktrace_start_tracing(HW_TRACING, &res);
-  res = foo(2);
-  void *tr = __yktrace_stop_tracing();
-  assert(res == 2);
-
-  void *ptr = __yktrace_irtrace_compile(tr);
-  __yktrace_drop_irtrace(tr);
-  void (*func)(void *) = (void (*)(void *))ptr;
-  int output = 0;
-  func(&output);
-  assert(output == 4);
+  YkLocation loc = yk_location_new();
+  int i = 5;
+  add = argc + 1; // 2
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_control_point(&loc);
+    fprintf(stderr, "i=%d\n", i);
+    res += add;
+    i--;
+  }
+  abort(); // FIXME: unreachable due to aborting guard failure earlier.
+  NOOPT_VAL(res);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/ptr_global.c
+++ b/c_tests/tests/ptr_global.c
@@ -1,0 +1,37 @@
+// Compiler:
+//   env-var: YKD_PRINT_JITSTATE=1
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   stderr:
+//     ...
+//     i=25
+//     ptr_global: guard-failure
+
+// Check that tracing mutation of a global pointer works.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+char *p = NULL;
+
+int main(int argc, char **argv) {
+  int i = 0;
+  YkLocation loc = yk_location_new();
+  p = argv[0];
+  NOOPT_VAL(i);
+  while (*p != '\0') {
+    yk_control_point(&loc);
+    fprintf(stderr, "i=%d\n", i);
+    i++;
+    p++;
+  }
+  abort(); // FIXME: unreachable due to aborting guard failure earlier.
+  NOOPT_VAL(i);
+  NOOPT_VAL(p);
+
+  return (EXIT_SUCCESS);
+}

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -54,12 +54,12 @@ void _yk_test(int i, int res) {
 
 int main(int argc, char **argv) {
   int res = 0;
-  int loc = 0;
+  YkLocation loc = yk_location_new();
   int i = 5;
   NOOPT_VAL(res);
   NOOPT_VAL(i);
   while (i > 0) {
-    yk_control_point(loc);
+    yk_control_point(&loc);
     fprintf(stderr, "i=%d\n", i);
     res += 2;
     i--;

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -59,17 +59,24 @@ int main(int argc, char **argv) {
   int prog[] = {1, 1, 1, 2, 1, 1};
   size_t prog_len = sizeof(prog) / sizeof(prog[0]);
 
-  // The program counter (FIXME: also serving as a location ID for now).
+  // Create one location for each potential PC value.
+  YkLocation locs[prog_len];
+  for (int i = 0; i < prog_len; i++)
+    locs[i] = yk_location_new();
+
+  // The program counter.
   int pc = 0;
 
   NOOPT_VAL(prog);
   NOOPT_VAL(prog_len);
   NOOPT_VAL(pc);
   NOOPT_VAL(mem);
+  NOOPT_VAL(locs);
 
   // interpreter loop.
   while (true) {
-    yk_control_point(pc);
+    YkLocation *loc = &locs[pc];
+    yk_control_point(loc);
     if (pc >= prog_len) {
       exit(0);
     }

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -62,17 +62,24 @@ int main(int argc, char **argv) {
   int prog[] = {0, 0, 1, 2, 0, 3};
   size_t prog_len = sizeof(prog) / sizeof(prog[0]);
 
-  // The program counter (FIXME: also serving as a location ID for now).
+  // Create one location for each potential PC value.
+  YkLocation locs[prog_len];
+  for (int i = 0; i < prog_len; i++)
+    locs[i] = yk_location_new();
+
+  // The program counter.
   int pc = 0;
 
   NOOPT_VAL(pc);
   NOOPT_VAL(prog);
   NOOPT_VAL(prog_len);
   NOOPT_VAL(mem);
+  NOOPT_VAL(locs);
 
   // interpreter loop.
   while (true) {
-    yk_control_point(pc);
+    YkLocation *loc = &locs[pc];
+    yk_control_point(loc);
     assert(pc < prog_len);
     int bc = prog[pc];
     fprintf(stderr, "pc=%d, mem=%d\n", pc, mem);

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -29,13 +29,13 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  int loc = 0;
+  YkLocation loc = yk_location_new();
   int i = 3;
   int j = 300;
   NOOPT_VAL(i);
   NOOPT_VAL(j);
   while (i > 0) {
-    yk_control_point(loc);
+    yk_control_point(&loc);
     fprintf(stderr, "i=%d\n", i);
     switch (j) {
       case 100:

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -32,11 +32,11 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  int loc = 0;
+  YkLocation loc = yk_location_new();
   int i = 3;
   NOOPT_VAL(i);
   while (i > 0) {
-    yk_control_point(loc);
+    yk_control_point(&loc);
     fprintf(stderr, "i=%d\n", i);
     switch (i) {
       case 100:

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -9,14 +9,14 @@
 #![feature(bench_black_box)]
 #![feature(c_variadic)]
 
-use std::{ffi::c_void, os::raw::c_int};
+use std::ffi::c_void;
 use ykrt::Location;
 use ykutil;
 
 // The "dummy control point" that is replaced in an LLVM pass.
 // FIXME for now the "location identifiers" are assumed to be `int`.
 #[no_mangle]
-pub extern "C" fn yk_control_point(_loc: c_int) {
+pub extern "C" fn yk_control_point(_loc: *mut Location) {
     // Intentionally empty.
 }
 

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -8,7 +8,7 @@ struct MT;
 typedef struct MT YkMT;
 
 // A `Location` stores state that the meta-tracer needs to identify hot loops
-// and run associated machine code.
+// and run associated machine code. This is a C mirror of `ykrt::Location`.
 //
 // Each position in the end user's program that may be a control point (i.e.
 // the possible start of a trace) must have an associated `Location`. The
@@ -38,7 +38,7 @@ typedef uint32_t YkHotThreshold;
 // FIXME: should accept `YkLocation`, not `int`.
 // FIXME: once the above is fixed, talk about locations for which a loop cannot
 // start.
-void yk_control_point(int);
+void yk_control_point(YkLocation *);
 
 // Create a new `Location`.
 //


### PR DESCRIPTION
This also exposed a bug where we failed to map a value if it was defined
by a Phi node from a prior block. Fixed in this change.

Companion to https://github.com/ykjit/ykllvm/pull/13 -- Companion PR merges first.