### PR TITLE
Make __yk_debug_print() opaque to C programs.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -9,7 +9,8 @@
 #![feature(bench_black_box)]
 #![feature(c_variadic)]
 
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr};
+use std::os::raw::c_char;
 use ykrt::Location;
 use ykutil;
 
@@ -38,6 +39,11 @@ pub extern "C" fn __ykutil_get_llvmbc_section(res_addr: *mut *const c_void, res_
         *res_addr = addr as *const c_void;
         *res_size = size;
     }
+}
+
+#[no_mangle]
+pub extern "C" fn __yk_debug_print(s: *const c_char) {
+    eprintln!("{}", unsafe { CStr::from_ptr(s) }.to_str().unwrap());
 }
 
 /// The following module contains exports only used for testing from external C code.

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -22,7 +22,7 @@ void __yktrace_irtrace_get(void *trace, size_t idx, char **res_func,
 void *__yktrace_irtrace_compile(void *trace);
 void __yktrace_drop_irtrace(void *trace);
 
-void __yk_debug_print(char *str) { fputs(str, stderr); }
+void __yk_debug_print(char *str);
 
 // Blocks the compiler from optimising the specified value or expression.
 //


### PR DESCRIPTION
A compiler-side companion PR is ~coming soon~ [here](https://github.com/ykjit/ykllvm/pull/14). The compiler change will be merged first.

When building ykcbf with JIT support I was getting:

```
ld.lld: error: undefined symbol: __yk_debug_print
>>> referenced by ld-temp.o
>>>               lto.tmp:(yk_new_control_point)
```

I think what has happened is that clang has considered the
yk_debug_print() dead and removed it, not knowing that there's an LLVM
pass (`YkControlPoint`) that requires the symbol to exist.

I spent some time getting the control point pass to just call fputs(2)
directly, so that we wouldn't need this wrapper function at all, but
there be dragons.

When we call fputs(2), we want to pass `stderr` as the second argument.
The C standard says that `stderr` is a macro. This means that `stderr`
may not resolve to a symbol of the same name (or any symbol at all, for
that matter).

It turns out it would work by chance on linux/amd64, as the header
reads:

```
/* Standard streams.  */
extern FILE *stdin;     /* Standard input stream.  */
extern FILE *stdout;        /* Standard output stream.  */
extern FILE *stderr;        /* Standard error output stream.  */
/* C89/C99 say they're macros.  Make them happy.  */
#define stdin stdin
#define stdout stdout
#define stderr stderr
```

But it wouldn't work on OSX, where you have:

```
#define stderr __stderrp
```

So in general, there is no "correct" way to obtain a pointer to stderr
without the use of a C pre-processor. And the way we generate the
control point function, there is no preprocessor.

For this reason, I'm leaving the `__yk_debug_print()` wrapper in, but
making it opaque to C by moving it into Rust code.

Thanks to Tim Northover for discussion on this madness.