### PR TITLE
Add parser for LLVM stackmaps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "ykrt",
     "yktrace",
     "ykutil",
+    "yksmp",
     "xtask",
 ]

--- a/yksmp/.gitignore
+++ b/yksmp/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/yksmp/Cargo.toml
+++ b/yksmp/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "yksmp"
+version = "0.1.0"
+edition = "2018"
+authors = ["The Yorick Developers"]
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+object = "0.28.1"

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -1,0 +1,342 @@
+//! Note that LLVM currently only supports stackmaps for 64 bit architectures. Once they support
+//! others we will need to either make this parser more dynamic or create a new one for each
+//! architecture.
+#[cfg(not(target_arch = "x86_64"))]
+compile_error!("The stackmap parser currently only supports x86_64.");
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::error;
+use std::ffi::c_void;
+use std::{ptr, slice};
+
+struct Function {
+    addr: u64,
+    record_count: u64,
+}
+
+struct Record {
+    offset: u32,
+    locs: Vec<Location>,
+}
+
+#[derive(Debug)]
+enum Location {
+    Register(u16),
+    Direct(u16, i32),
+    Indirect(u16, i32),
+    Constant(u32),
+    LargeConstant(u64),
+}
+
+/// Parses LLVM stackmaps version 3 from a given address. Provides a way to query relevant
+/// locations given the return address of a `__llvm_deoptimize` function.
+struct StackMapParser<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl StackMapParser<'_> {
+    pub fn parse(data: &[u8]) -> Result<HashMap<u64, Vec<Location>>, Box<dyn error::Error>> {
+        let mut smp = StackMapParser { data, offset: 0 };
+        smp.read()
+    }
+
+    fn read(&mut self) -> Result<HashMap<u64, Vec<Location>>, Box<dyn error::Error>> {
+        // Read version number.
+        if self.read_u8() != 3 {
+            return Err("Only stackmap format version 3 is supported.".into());
+        }
+
+        // Reserved
+        assert_eq!(self.read_u8(), 0);
+        assert_eq!(self.read_u16(), 0);
+
+        let num_funcs = self.read_u32();
+        let num_consts = self.read_u32();
+        let num_recs = self.read_u32();
+
+        let funcs = self.read_functions(num_funcs);
+        let consts = self.read_consts(num_consts);
+
+        let mut map = HashMap::new();
+
+        // Check that the records match the sum of the expected records per function.
+        assert_eq!(
+            funcs.iter().map(|f| f.record_count).sum::<u64>(),
+            u64::from(num_recs)
+        );
+
+        // Parse records.
+        for f in funcs {
+            let records = self.read_records(f.record_count, &consts);
+            for r in records {
+                let key = f.addr + u64::from(r.offset);
+                map.insert(key, r.locs);
+            }
+        }
+
+        Ok(map)
+    }
+
+    fn read_functions(&mut self, num: u32) -> Vec<Function> {
+        let mut v = Vec::new();
+        for _ in 0..num {
+            let addr = self.read_u64();
+            let _stack_size = self.read_u64();
+            let record_count = self.read_u64();
+            v.push(Function { addr, record_count });
+        }
+        v
+    }
+
+    fn read_consts(&mut self, num: u32) -> Vec<u64> {
+        let mut v = Vec::new();
+        for _ in 0..num {
+            v.push(self.read_u64());
+        }
+        v
+    }
+
+    fn read_records(&mut self, num: u64, consts: &Vec<u64>) -> Vec<Record> {
+        let mut v = Vec::new();
+        for _ in 0..num {
+            let _id = self.read_u64();
+            let offset = self.read_u32();
+            self.read_u16();
+            let num_locs = self.read_u16();
+            let locs = self.read_locations(num_locs, consts);
+            // Padding
+            self.align_8();
+            self.read_u16();
+            let num_liveouts = self.read_u16();
+            self.read_liveouts(num_liveouts);
+            self.align_8();
+            v.push(Record { offset, locs });
+        }
+        v
+    }
+
+    fn read_locations(&mut self, num: u16, consts: &Vec<u64>) -> Vec<Location> {
+        let mut v = Vec::new();
+        for _ in 0..num {
+            let kind = self.read_u8();
+            self.read_u8();
+            let _size = self.read_u16();
+            let dwreg = self.read_u16();
+            self.read_u16();
+
+            let location = match kind {
+                0x01 => {
+                    self.read_i32();
+                    Location::Register(dwreg)
+                }
+                0x02 => {
+                    let offset = self.read_i32();
+                    Location::Direct(dwreg, offset)
+                }
+                0x03 => {
+                    let offset = self.read_i32();
+                    Location::Indirect(dwreg, offset)
+                }
+                0x04 => {
+                    let offset = self.read_u32();
+                    Location::Constant(offset)
+                }
+                0x05 => {
+                    let offset = self.read_i32();
+                    Location::LargeConstant(consts[usize::try_from(offset).unwrap()])
+                }
+                _ => unreachable!(),
+            };
+
+            v.push(location)
+        }
+        v
+    }
+
+    fn read_liveouts(&mut self, num: u16) {
+        for _ in 0..num {
+            let _dwreg = self.read_u16();
+            let _size = self.read_u8();
+        }
+    }
+
+    fn align_8(&mut self) {
+        self.offset += (8 - (self.offset % 8)) % 8;
+    }
+
+    fn read_u8(&mut self) -> u8 {
+        let d = u8::from_ne_bytes(self.data[self.offset..self.offset + 1].try_into().unwrap());
+        self.offset += 1;
+        d
+    }
+
+    fn read_u16(&mut self) -> u16 {
+        let d = u16::from_ne_bytes(self.data[self.offset..self.offset + 2].try_into().unwrap());
+        self.offset += 2;
+        d
+    }
+
+    fn read_u32(&mut self) -> u32 {
+        let d = u32::from_ne_bytes(self.data[self.offset..self.offset + 4].try_into().unwrap());
+        self.offset += 4;
+        d
+    }
+
+    fn read_i32(&mut self) -> i32 {
+        let d = i32::from_ne_bytes(self.data[self.offset..self.offset + 4].try_into().unwrap());
+        self.offset += 4;
+        d
+    }
+
+    fn read_u64(&mut self) -> u64 {
+        let d = u64::from_ne_bytes(self.data[self.offset..self.offset + 8].try_into().unwrap());
+        self.offset += 8;
+        d
+    }
+}
+
+struct Registers {
+    rax: usize,
+    rdx: usize,
+    rcx: usize,
+    rbx: usize,
+    rsi: usize,
+    rdi: usize,
+    rsp: usize,
+}
+
+impl Registers {
+    fn from_ptr(ptr: *const c_void) -> Registers {
+        Registers {
+            rax: Registers::read_from_stack(ptr, 0),
+            rdx: Registers::read_from_stack(ptr, 1),
+            rcx: Registers::read_from_stack(ptr, 2),
+            rbx: Registers::read_from_stack(ptr, 3),
+            rsi: Registers::read_from_stack(ptr, 4),
+            rdi: Registers::read_from_stack(ptr, 5),
+            rsp: Registers::read_from_stack(ptr, 6),
+        }
+    }
+
+    fn read_from_stack(rsp: *const c_void, off: isize) -> usize {
+        unsafe {
+            let ptr = rsp as *const usize;
+            ptr::read::<usize>(ptr.offset(off))
+        }
+    }
+
+    fn get(&self, id: u16) -> usize {
+        match id {
+            0 => self.rax,
+            1 => self.rdx,
+            2 => self.rcx,
+            3 => self.rbx,
+            4 => self.rsi,
+            5 => self.rdi,
+            6 => unreachable!("We currently have no way to access RBP of the previous stackframe."),
+            7 => self.rsp,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn __yk_stopgap(
+    addr: *const c_void,
+    size: usize,
+    retaddr: usize,
+    rsp: *const c_void,
+) {
+    // Restore saved registers from the stack.
+    let registers = Registers::from_ptr(rsp);
+
+    // Parse the stackmap.
+    let slice = unsafe { slice::from_raw_parts(addr as *mut u8, size) };
+    let map = StackMapParser::parse(slice).unwrap();
+    let locs = map.get(&retaddr.try_into().unwrap()).unwrap();
+
+    // Extract live values from the stackmap.
+    // FIXME: Until we have a stopgap interpreter we simply print the values.
+    for l in locs {
+        match l {
+            Location::Direct(reg, off) => {
+                // When using `llvm.experimental.deoptimize` then direct locations should always be
+                // in relation to RSP.
+                assert_eq!(*reg, 7);
+                // We need to add 2 bytes to the value of RSP to factor in the return address and
+                // the pushed RBP value of the previous frame.
+                let addr = registers.get(*reg) + (*off as usize) + 16;
+                let _v = unsafe { ptr::read::<u8>(addr as *mut u8) };
+                todo!();
+            }
+            Location::Constant(_v) => {
+                todo!();
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::{Location, StackMapParser};
+    use object::{Object, ObjectSection};
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    fn build_test(target: &str) {
+        let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let mut src = PathBuf::from(md);
+        src.push("tests");
+        env::set_current_dir(&src).unwrap();
+
+        let res = Command::new("make").arg(target).output().unwrap();
+        if !res.status.success() {
+            eprintln!("Building test input failed: {:?}", res);
+            panic!();
+        }
+    }
+
+    fn load_bin(target: &str) -> Vec<u8> {
+        build_test(target);
+        let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let mut src = PathBuf::from(md);
+        src.push("..");
+        src.push("target");
+        src.push(target);
+        fs::read(src).unwrap()
+    }
+
+    #[test]
+    fn test_simple() {
+        let data = load_bin("simple.o");
+        let objfile = object::File::parse(&*data).unwrap();
+        let smsec = objfile.section_by_name(".llvm_stackmaps").unwrap();
+        let map = StackMapParser::parse(smsec.data().unwrap()).unwrap();
+        let locs = &map.iter().nth(0).unwrap().1;
+        assert_eq!(locs.len(), 2);
+        assert!(matches!(locs[0], Location::Direct(6, -4)));
+        assert!(matches!(locs[1], Location::Direct(6, -8)));
+    }
+
+    #[test]
+    fn test_deopt() {
+        let data = load_bin("deopt.o");
+        let objfile = object::File::parse(&*data).unwrap();
+        let smsec = objfile.section_by_name(".llvm_stackmaps").unwrap();
+        let map = StackMapParser::parse(smsec.data().unwrap()).unwrap();
+        let locs = &map.iter().nth(0).unwrap().1;
+        assert_eq!(locs.len(), 5);
+        assert!(matches!(locs[0], Location::Constant(0)));
+        assert!(matches!(locs[1], Location::Constant(0)));
+        assert!(matches!(locs[2], Location::Constant(2)));
+        assert!(matches!(locs[3], Location::Direct(7, 12)));
+        assert!(matches!(locs[4], Location::Direct(7, 8)));
+    }
+}

--- a/yksmp/tests/Makefile
+++ b/yksmp/tests/Makefile
@@ -1,0 +1,17 @@
+TARGET_DIR = $(shell readlink -f $(shell pwd)/../../target/)
+
+simple.o:
+	clang simple.ll -o ${TARGET_DIR}/simple.o
+
+deopt.o:
+	clang deopt.ll -o ${TARGET_DIR}/deopt.o
+
+simple.ll:
+	clang -emit-llvm -S -o simple.ll -c simple.c
+
+deopt.ll:
+	clang -emit-llvm -S -o deopt.ll -c deopt.c
+
+clean:
+	rm simple.o
+	rm deopt.o

--- a/yksmp/tests/deopt.c
+++ b/yksmp/tests/deopt.c
@@ -1,0 +1,16 @@
+void __llvm_deoptimize() { printf("deopt\n"); }
+
+void foo() {
+  int x = 11;
+  int y = 13;
+  int z;
+  if (x == 11) {
+    z = 3;
+  } else {
+    // Insert deopt here.
+    z = 4;
+  }
+  printf("%d %d %d", x, y, z);
+}
+
+int main() { foo(); }

--- a/yksmp/tests/deopt.ll
+++ b/yksmp/tests/deopt.ll
@@ -1,0 +1,63 @@
+; ModuleID = 'deopt.c'
+source_filename = "deopt.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@.str = private unnamed_addr constant [7 x i8] c"deopt\0A\00", align 1
+@.str.1 = private unnamed_addr constant [9 x i8] c"%d %d %d\00", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @__llvm_deoptimize() #0 {
+entry:
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @.str, i64 0, i64 0))
+  ret void
+}
+
+declare dso_local i32 @printf(i8*, ...) #1
+declare void @llvm.experimental.deoptimize.isVoid(...)
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @foo() #0 {
+entry:
+  %x = alloca i32, align 4
+  %y = alloca i32, align 4
+  %z = alloca i32, align 4
+  store i32 11, i32* %x, align 4
+  store i32 13, i32* %y, align 4
+  %0 = load i32, i32* %x, align 4
+  %cmp = icmp eq i32 %0, 11
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:                                          ; preds = %entry
+  store i32 3, i32* %z, align 4
+  br label %if.end
+
+if.else:                                          ; preds = %entry
+  call void (...) @llvm.experimental.deoptimize.isVoid() [ "deopt"(i32* %x, i32* %y) ]
+  ret void
+
+if.end:                                           ; preds = %if.then
+  %1 = load i32, i32* %x, align 4
+  %2 = load i32, i32* %y, align 4
+  %3 = load i32, i32* %z, align 4
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i64 0, i64 0), i32 %1, i32 %2, i32 %3)
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+entry:
+  call void @foo()
+  ret i32 0
+}
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 1}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{!"clang version 13.0.0 (https://github.com/ykjit/ykllvm.git b9b9cb845c7576daf0337b38902fcadd93637686)"}

--- a/yksmp/tests/simple.c
+++ b/yksmp/tests/simple.c
@@ -1,0 +1,7 @@
+int main() {
+  int x = 11;
+  int y = 13;
+  // Insert stackmap here.
+  int z = 17;
+  printf("%d %d %d", x, y, z);
+}

--- a/yksmp/tests/simple.ll
+++ b/yksmp/tests/simple.ll
@@ -1,0 +1,38 @@
+; ModuleID = 'simple.c'
+source_filename = "simple.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+@.str = private unnamed_addr constant [9 x i8] c"%d %d %d\00", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+entry:
+  %x = alloca i32, align 4
+  %y = alloca i32, align 4
+  %z = alloca i32, align 4
+  store i32 11, i32* %x, align 4
+  store i32 13, i32* %y, align 4
+  store i32 17, i32* %z, align 4
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32* %x, i32* %y)
+  %0 = load i32, i32* %x, align 4
+  %1 = load i32, i32* %y, align 4
+  %2 = load i32, i32* %z, align 4
+  %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str, i64 0, i64 0), i32 %0, i32 %1, i32 %2)
+  ret i32 0
+}
+
+declare dso_local i32 @printf(i8*, ...) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 1}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{!"clang version 13.0.0 (https://github.com/ykjit/ykllvm.git b9b9cb845c7576daf0337b38902fcadd93637686)"}


### PR DESCRIPTION
This commit implements a parser for LLVM stackmaps which we will later
use to initialise a stopgap interpreter during a guard failure. Unlike
other standard stackmap parsers, this one doesn't create a 1:1
representation of the stackmap as it contains more data than we care
about (for example things like function/const/record counts whose only
purpose is to aid parsing in the stackmap and serve no other purpose
otherwise). Instead, the chosen representation makes it easier to query
the data during a guard failure, e.g. values referred by `ConstIndex`
are folded into `Locations` and records can be retrieved via the return
address of the `__llvm_deoptimize` call, which is calculated during
parsing.

I'm cautiously marking this as a draft as I'm aware of a few things that might be contentious which I'm hoping to get some opinions on (e.g. my use of allow dead code which I only did because I wasn't sure if this data would be needed later on). But the more I think about it, there's probably no need to store `Record`s at all, and instead have `SMQuery.map` directly store a vector of `Location`s, as we don't really care about the other data. But let's see what you guys think first.

Once this PR is merged there'll be a follow up PR which hooks this stuff into our guards.