### PR TITLE
Hook in transition_location properly.

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -18,3 +18,4 @@ lang_tester = "0.7.0"
 once_cell = "1.8.0"
 tempfile = "3.2.0"
 ykcapi = { path = "../ykcapi", features = ["c_testing"] }
+ykrt = { path = "../ykrt", features = ["jit_state_debug"] }

--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -1,9 +1,12 @@
 // Compiler:
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
-//   env-var: YKD_PRINT_IR=jit-pre-opt,aot
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
+//     i=5
+//     jit-state: stop-tracing
+//     --- Begin jit-pre-opt ---
 //     ...
 //     define internal void @__yk_compiled_trace_0(%YkCtrlPointVars* %0) {
 //        ...
@@ -28,11 +31,9 @@
 //        ret void
 //     }
 //     ...
-//     jit-state: stop-tracing
+//     --- End jit-pre-opt ---
 //     i=4
-//     jit-state: enter-jit-code
 //     i=3
-//     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=2
 //     jit-state: exit-jit-code

--- a/c_tests/tests/intrinsics.c
+++ b/c_tests/tests/intrinsics.c
@@ -4,12 +4,14 @@
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
+//     jit-state: stop-tracing
+//     --- Begin jit-pre-opt ---
 //     ...
 //     define internal void @__yk_compiled_trace_0(%YkCtrlPointVars* %0) {
 //        ...
 //     }
 //     ...
-//     jit-state: stop-tracing
+//     --- End jit-pre-opt ---
 //     jit-state: enter-jit-code
 //     intrinsics: guard-failure
 
@@ -30,7 +32,7 @@ void _yk_test(int i, int res) {
 int main(int argc, char **argv) {
   int res = 0;
   YkLocation loc = yk_location_new();
-  int i = 3;
+  int i = 4;
   NOOPT_VAL(res);
   NOOPT_VAL(i);
   while (i > 0) {

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -1,9 +1,12 @@
 // Compiler:
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
-//   env-var: YKD_PRINT_IR=jit-pre-opt,aot
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
+//     i=5
+//     jit-state: stop-tracing
+//     --- Begin jit-pre-opt ---
 //     ...
 //     define internal void @__yk_compiled_trace_0(%YkCtrlPointVars* %0) {
 //        ...
@@ -28,11 +31,9 @@
 //        ret void
 //     }
 //     ...
-//     jit-state: stop-tracing
+//     --- End jit-pre-opt ---
 //     i=4
-//     jit-state: enter-jit-code
 //     i=3
-//     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=2
 //     jit-state: exit-jit-code

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -4,6 +4,9 @@
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
+//     i=5
+//     jit-state: stop-tracing
+//     --- Begin jit-pre-opt ---
 //     ...
 //     define internal void @__yk_compiled_trace_0(%YkCtrlPointVars* %0) {
 //        ...
@@ -28,11 +31,9 @@
 //        ret void
 //     }
 //     ...
-//     jit-state: stop-tracing
+//     --- End jit-pre-opt ---
 //     i=4
-//     jit-state: enter-jit-code
 //     i=3
-//     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=2
 //     jit-state: exit-jit-code

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -1,13 +1,15 @@
 // Compiler:
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
-//   env-var: YKD_PRINT_IR=aot,jit-pre-opt
+//   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
-//     pc=0, mem=9
-//     pc=1, mem=8
-//     pc=2, mem=7
-//     pc=3, mem=6
+//     pc=0, mem=12
+//     pc=1, mem=11
+//     pc=2, mem=10
+//     pc=3, mem=9
+//     jit-state: stop-tracing
+//     --- Begin jit-pre-opt ---
 //     ...
 //     define internal void @__yk_compiled_trace_0(%YkCtrlPointVars* %0) {
 //       ...
@@ -31,7 +33,11 @@
 //       ret void
 //     }
 //     ...
-//     jit-state: stop-tracing
+//     --- End jit-pre-opt ---
+//     pc=0, mem=9
+//     pc=1, mem=8
+//     pc=2, mem=7
+//     pc=3, mem=6
 //     pc=0, mem=6
 //     pc=1, mem=5
 //     pc=2, mem=4
@@ -52,7 +58,7 @@
 #include <yk_testing.h>
 
 // The sole mutable memory cell of the interpreter.
-int mem = 9;
+int mem = 12;
 
 // The bytecodes accepted by the interpreter.
 #define DEC 1
@@ -79,11 +85,11 @@ int main(int argc, char **argv) {
 
   // interpreter loop.
   while (true) {
-    YkLocation *loc = &locs[pc];
-    yk_control_point(loc);
     if (pc >= prog_len) {
       exit(0);
     }
+    YkLocation *loc = &locs[pc];
+    yk_control_point(loc);
     int bc = prog[pc];
     fprintf(stderr, "pc=%d, mem=%d\n", pc, mem);
     switch (bc) {

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -4,10 +4,12 @@
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
-//     pc=0, mem=3
-//     pc=1, mem=3
-//     pc=2, mem=3
-//     pc=3, mem=2
+//     pc=0, mem=4
+//     pc=1, mem=4
+//     pc=2, mem=4
+//     pc=3, mem=3
+//     jit-state: stop-tracing
+//     --- Begin jit-pre-opt ---
 //     ...
 //     define internal void @__yk_compiled_trace_0(%YkCtrlPointVars* %0) {
 //       ...
@@ -32,7 +34,11 @@
 //       ret void
 //     }
 //     ...
-//     jit-state: stop-tracing
+//     --- End jit-pre-opt ---
+//     pc=0, mem=3
+//     pc=1, mem=3
+//     pc=2, mem=3
+//     pc=3, mem=2
 //     pc=0, mem=2
 //     pc=1, mem=2
 //     pc=2, mem=2
@@ -53,7 +59,7 @@
 #include <yk_testing.h>
 
 // The sole mutable memory cell of the interpreter.
-int mem = 3;
+int mem = 4;
 
 // The bytecodes accepted by the interpreter.
 #define NOP 0
@@ -82,9 +88,9 @@ int main(int argc, char **argv) {
 
   // interpreter loop.
   while (true) {
+    assert(pc < prog_len);
     YkLocation *loc = &locs[pc];
     yk_control_point(loc);
-    assert(pc < prog_len);
     int bc = prog[pc];
     fprintf(stderr, "pc=%d, mem=%d\n", pc, mem);
     switch (bc) {

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -4,7 +4,8 @@
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
-//     i=3
+//     i=4
+//     jit-state: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //       %{{cond}} = icmp...
@@ -13,7 +14,7 @@
 //     guardfail:...
 //     ...
 //     --- End jit-pre-opt ---
-//     jit-state: stop-tracing
+//     i=3
 //     i=2
 //     jit-state: enter-jit-code
 //     i=1
@@ -30,7 +31,7 @@
 
 int main(int argc, char **argv) {
   YkLocation loc = yk_location_new();
-  int i = 3;
+  int i = 4;
   int j = 300;
   NOOPT_VAL(i);
   NOOPT_VAL(j);

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -4,7 +4,8 @@
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   stderr:
 //     jit-state: start-tracing
-//     i=3
+//     i=4
+//     jit-state: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //       switch i32 %{{cond}}, label %{{default-bb}} [
@@ -16,7 +17,7 @@
 //     guardfail:...
 //     ...
 //     --- End jit-pre-opt ---
-//     jit-state: stop-tracing
+//     i=3
 //     i=2
 //     jit-state: enter-jit-code
 //     i=1
@@ -33,7 +34,7 @@
 
 int main(int argc, char **argv) {
   YkLocation loc = yk_location_new();
-  int i = 3;
+  int i = 4;
   NOOPT_VAL(i);
   while (i > 0) {
     yk_control_point(&loc);

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -15,10 +15,18 @@ use ykrt::{Location, MT};
 use ykutil;
 
 // The "dummy control point" that is replaced in an LLVM pass.
-// FIXME for now the "location identifiers" are assumed to be `int`.
 #[no_mangle]
 pub extern "C" fn yk_control_point(_loc: *mut Location) {
     // Intentionally empty.
+}
+
+// The "real" control point, that is called once the interpreter has been patched by ykllvm.
+#[no_mangle]
+pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_void) {
+    debug_assert!(!ctrlp_vars.is_null());
+    if !loc.is_null() {
+        MT::transition_location(unsafe { &*loc }, ctrlp_vars);
+    }
 }
 
 #[no_mangle]
@@ -46,28 +54,11 @@ pub extern "C" fn __yk_debug_print(s: *const c_char) {
     eprintln!("{}", unsafe { CStr::from_ptr(s) }.to_str().unwrap());
 }
 
-/// Decides what action to take (if any) upon encountering a location.
-#[no_mangle]
-pub extern "C" fn __ykrt_transition_location(loc: *mut Location) -> usize {
-    MT::transition_location_simple(loc)
-}
-
-/// Stores the pointer to JITted code for the location `loc`.
-#[no_mangle]
-pub extern "C" fn __ykrt_set_loc_code_ptr(loc: *mut Location, code: *const c_void) {
-    ykrt::MT::set_loc_code_ptr(loc, code)
-}
-
 /// The following module contains exports only used for testing from external C code.
 /// These symbols are not shipped as part of the main API.
 #[cfg(feature = "c_testing")]
 mod c_testing {
-    use libc::c_void;
-    use std::{hint::black_box, os::raw::c_char, ptr};
-    use yktrace::{start_tracing, stop_tracing, BlockMap, IRTrace, TracingKind};
-
-    const SW_TRACING: usize = 0;
-    const HW_TRACING: usize = 1;
+    use yktrace::BlockMap;
 
     #[no_mangle]
     pub extern "C" fn __yktrace_hwt_mapper_blockmap_new() -> *mut BlockMap {
@@ -82,61 +73,5 @@ mod c_testing {
     #[no_mangle]
     pub extern "C" fn __yktrace_hwt_mapper_blockmap_len(bm: *mut BlockMap) -> usize {
         unsafe { &*bm }.len()
-    }
-
-    #[no_mangle]
-    pub unsafe extern "C" fn __yktrace_start_tracing(kind: usize) {
-        let kind = black_box(kind);
-        let kind: TracingKind = match kind {
-            SW_TRACING => TracingKind::SoftwareTracing,
-            HW_TRACING => TracingKind::HardwareTracing,
-            _ => panic!(),
-        };
-        start_tracing(kind)
-    }
-
-    #[no_mangle]
-    pub extern "C" fn __yktrace_stop_tracing() -> *mut IRTrace {
-        Box::into_raw(Box::new(stop_tracing().unwrap())) as *mut _
-    }
-
-    #[no_mangle]
-    pub extern "C" fn __yktrace_irtrace_len(trace: *mut IRTrace) -> usize {
-        unsafe { &*trace }.len()
-    }
-
-    /// Fetches the function name (`res_func`) and the block index (`res_bb`) at position `idx` in
-    /// `trace`.
-    #[no_mangle]
-    pub extern "C" fn __yktrace_irtrace_get(
-        trace: *mut IRTrace,
-        idx: usize,
-        res_func: *mut *const c_char,
-        res_bb: *mut usize,
-    ) {
-        let trace = unsafe { &*trace };
-        let blk = trace.get(idx).unwrap();
-        if let Some(blk) = blk {
-            unsafe {
-                *res_func = blk.func_name().as_ptr();
-                *res_bb = blk.bb();
-            }
-        } else {
-            // The block was unmappable.
-            unsafe {
-                *res_func = ptr::null();
-                *res_bb = 0;
-            }
-        }
-    }
-
-    #[no_mangle]
-    pub extern "C" fn __yktrace_drop_irtrace(trace: *mut IRTrace) {
-        unsafe { Box::from_raw(trace) };
-    }
-
-    #[no_mangle]
-    pub extern "C" fn __yktrace_irtrace_compile(trace: *mut IRTrace) -> *const c_void {
-        unsafe { &*trace }.compile()
     }
 }

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -22,7 +22,7 @@ uint64_t getNewTraceIdx() {
 }
 
 #define TRACE_FUNC_PREFIX "__yk_compiled_trace_"
-#define YK_NEW_CONTROL_POINT "yk_new_control_point"
+#define YK_NEW_CONTROL_POINT "__ykrt_control_point"
 #define YK_CONTROL_POINT_ARG_IDX 1
 
 // Dump an error message and an LLVM value to stderr and exit with failure.
@@ -826,10 +826,6 @@ public:
       BasicBlock *BB;
       std::tie(F, BB) = getLLVMAOTFuncAndBlock(&IB);
 
-      if (F->getName() == YK_NEW_CONTROL_POINT) {
-        continue;
-      }
-
       assert(LastCompletedBlocks.size() >= 1);
       LastCompletedBlocks.back() = NextCompletedBlock;
       NextCompletedBlock = BB;
@@ -889,6 +885,7 @@ public:
               break;
             }
           } else if (CF->getName() == YK_NEW_CONTROL_POINT) {
+            ExpectUnmappable = true; // control point is always opaque.
             if (NewControlPointCall == nullptr) {
               NewControlPointCall = &*CI;
             } else {

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -15,3 +15,6 @@ yktrace = { path = "../yktrace" }
 
 [build-dependencies]
 regex = "1.5.4"
+
+[features]
+jit_state_debug = []

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -1,6 +1,6 @@
 //! The mapper translates a PT trace into an IR trace.
 
-use crate::{IRBlock, CONTROL_POINT_SYM};
+use crate::IRBlock;
 use byteorder::{NativeEndian, ReadBytesExt};
 use hwtracer::{HWTracerError, Trace};
 use intervaltree::{self, IntervalTree};
@@ -108,52 +108,6 @@ impl HWTMapper {
         }
     }
 
-    /// Collapse consecutive control point blocks (including any unmappable internals) into one
-    /// control point entry. Unmappable holes exist because the generated control point calls out to
-    /// Rust code for which we have no IR.
-    ///
-    /// For example, if the trace is:
-    ///
-    /// ```ignore
-    /// [bb1, bb2, bb3, ctrlp, ctrlp, ?, ctrlp, bb4]
-    /// ```
-    ///
-    /// (where `bbN` is a mappable block, `ctrlp` is a block in the control point, and `?` is
-    /// unmappable blocks), then this function would canonicalise the trace to:
-    ///
-    /// ```ignore
-    /// [bb1, bb2, bb3, ctrlp, bb4]
-    /// ```
-    fn canonicalise_control_point(mut irblocks: Vec<IRBlock>) -> Vec<IRBlock> {
-        let mut ret_irblocks: Vec<IRBlock> = Vec::new();
-        let ctrlp_sym_c = CString::new(CONTROL_POINT_SYM).unwrap();
-
-        // The trace starts inside the control point, as that's where tracing is enabled.
-        debug_assert_eq!(irblocks[0].func_name, ctrlp_sym_c);
-
-        let mut in_ctrlp = false;
-        for ib in irblocks.drain(..) {
-            if in_ctrlp {
-                // Determine if we have exited from the control point (bearing in mind that the
-                // control point executes external, and thus unmappable, code).
-                if !ib.is_unmappable() && ib.func_name != ctrlp_sym_c {
-                    in_ctrlp = false;
-                    ret_irblocks.push(ib);
-                }
-            } else {
-                // Determine if we have entered the control point.
-                if ib.func_name == ctrlp_sym_c {
-                    in_ctrlp = true;
-                }
-                ret_irblocks.push(ib);
-            }
-        }
-
-        // The trace must end inside the control point, as that's where tracing is disabled.
-        debug_assert!(in_ctrlp);
-        ret_irblocks
-    }
-
     /// Maps each entry of a hardware trace back to the IR block from which it was compiled.
     pub(super) fn map_trace(
         mut self,
@@ -203,8 +157,6 @@ impl HWTMapper {
                 ret_irblocks.pop();
             }
         }
-
-        let ret_irblocks = Self::canonicalise_control_point(ret_irblocks);
 
         #[cfg(debug_assertions)]
         {
@@ -310,91 +262,5 @@ impl HWTMapper {
             }
         }
         ret
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{CString, HWTMapper, IRBlock};
-
-    #[test]
-    fn canonicalise_control_point1() {
-        let trace = vec![
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 2),
-            IRBlock::control_point(),
-        ];
-        let expect = vec![
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 2),
-            IRBlock::control_point(),
-        ];
-        assert_eq!(HWTMapper::canonicalise_control_point(trace), expect);
-    }
-
-    #[test]
-    fn canonicalise_control_point2() {
-        let trace = vec![
-            IRBlock::control_point(),
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::new(CString::new("main").unwrap(), 3),
-            IRBlock::new(CString::new("main").unwrap(), 4),
-            IRBlock::unmappable(),
-            IRBlock::new(CString::new("main").unwrap(), 4),
-            IRBlock::control_point(),
-            IRBlock::control_point(),
-            IRBlock::unmappable(),
-            IRBlock::unmappable(),
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::new(CString::new("main").unwrap(), 3),
-            IRBlock::new(CString::new("main").unwrap(), 5),
-            IRBlock::control_point(),
-        ];
-        let expect = vec![
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::new(CString::new("main").unwrap(), 3),
-            IRBlock::new(CString::new("main").unwrap(), 4),
-            IRBlock::unmappable(),
-            IRBlock::new(CString::new("main").unwrap(), 4),
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::new(CString::new("main").unwrap(), 3),
-            IRBlock::new(CString::new("main").unwrap(), 5),
-            IRBlock::control_point(),
-        ];
-        assert_eq!(HWTMapper::canonicalise_control_point(trace), expect);
-    }
-
-    #[test]
-    fn canonicalise_control_point3() {
-        let trace = vec![IRBlock::control_point()];
-        let expect = vec![IRBlock::control_point()];
-        assert_eq!(HWTMapper::canonicalise_control_point(trace), expect);
-    }
-
-    #[test]
-    fn canonicalise_control_point4() {
-        let trace = vec![
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::control_point(),
-            IRBlock::control_point(),
-            IRBlock::unmappable(),
-            IRBlock::control_point(),
-            IRBlock::unmappable(),
-        ];
-        let expect = vec![
-            IRBlock::control_point(),
-            IRBlock::new(CString::new("main").unwrap(), 1),
-            IRBlock::control_point(),
-        ];
-        assert_eq!(HWTMapper::canonicalise_control_point(trace), expect);
     }
 }


### PR DESCRIPTION
This commit is a rough and ready attempt at hooking in the full-blown `transition_location()` logic.

I've only tested it with one test "simple.c". This works with small adjustments to the test.

Lots of code goes away, which is good.

Don't review this deeply, but is this roughly what we were talking about?

If so, @ltratt before I continue, there are some questions annotated `LAURIE: `.

~I'll have a draft companion PR in a moment too.~ Here is the companion: https://github.com/ykjit/ykllvm/pull/17.