### PR TITLE
Make compilation happen in parallel.

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -18,4 +18,4 @@ lang_tester = "0.7.0"
 once_cell = "1.8.0"
 tempfile = "3.2.0"
 ykcapi = { path = "../ykcapi", features = ["c_testing"] }
-ykrt = { path = "../ykrt", features = ["jit_state_debug"] }
+ykrt = { path = "../ykrt", features = ["jit_state_debug", "c_testing"] }

--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=5

--- a/c_tests/tests/intrinsics.c
+++ b/c_tests/tests/intrinsics.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     jit-state: stop-tracing

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=5

--- a/c_tests/tests/ptr_global.c
+++ b/c_tests/tests/ptr_global.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...
 //     i=25

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=5

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     pc=0, mem=12

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     pc=0, mem=4

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=4

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=4

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -8,10 +8,19 @@
 
 #![feature(bench_black_box)]
 #![feature(c_variadic)]
+#![feature(once_cell)]
 
+#[cfg(feature = "c_testing")]
+use std::env;
 use std::ffi::c_void;
+#[cfg(feature = "c_testing")]
+use std::lazy::SyncLazy;
 use ykrt::{Location, MT};
 use ykutil;
+
+#[cfg(feature = "c_testing")]
+static SERIALISE_COMPILATION: SyncLazy<bool> =
+    SyncLazy::new(|| &env::var("YKD_SERIALISE_COMPILATION").unwrap_or("0".to_owned()) == "1");
 
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]
@@ -24,7 +33,15 @@ pub extern "C" fn yk_control_point(_loc: *mut Location) {
 pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_void) {
     debug_assert!(!ctrlp_vars.is_null());
     if !loc.is_null() {
-        MT::transition_location(unsafe { &*loc }, ctrlp_vars);
+        let loc = unsafe { &*loc };
+        MT::transition_location(loc, ctrlp_vars);
+
+        #[cfg(feature = "c_testing")]
+        {
+            if *SERIALISE_COMPILATION {
+                loc.block_if_compiling();
+            }
+        }
     }
 }
 

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -18,3 +18,4 @@ regex = "1.5.4"
 
 [features]
 jit_state_debug = []
+c_testing = []


### PR DESCRIPTION
This change makes compilation occur on a thread and provides infrastructure for tests to serialise compilation via the `YKD_SERIALISE_COMPILATION` environment variable (which is only available when the `c_testing` feature is used).

This is a little more complicated that it perhaps needs to be, as the compilation thread doesn't have the ability to update a `Location`'s state itself when compilation has completed. Perhaps we should look into this shortly, but I think that should be a separate PR.

I've yet to devise a test which doesn't use `YKD_SERIALISE_COMPILATION`. It's not clear if it's possible to test anything meaninful with the full determinism of threads.

All tests pass, with zero changes to them other than adding the env var.

Additional to commit message: this approach adds no extra code to the interpreter loop that would have to be potentially filtered out from the trace later.

Fixes #458 