### PR TITLE
Use `std::sync::LazySync` instead of `once_cell::sync::Lazy`.

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -15,7 +15,6 @@ regex = "1.5.4"
 
 [dev-dependencies]
 lang_tester = "0.7.0"
-once_cell = "1.8.0"
 tempfile = "3.2.0"
 ykcapi = { path = "../ykcapi", features = ["c_testing"] }
 ykrt = { path = "../ykrt", features = ["jit_state_debug", "c_testing"] }

--- a/c_tests/run.rs
+++ b/c_tests/run.rs
@@ -1,6 +1,8 @@
+#![feature(once_cell)]
+
 use lang_tester::LangTester;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::lazy::SyncLazy;
 use std::{
     collections::HashMap,
     env,
@@ -14,7 +16,7 @@ use tempfile::TempDir;
 const COMMENT: &str = "//";
 
 const TEMPDIR_SUBST: &'static str = "%%TEMPDIR%%";
-static EXTRA_LINK: Lazy<HashMap<&'static str, Vec<ExtraLinkage>>> = Lazy::new(|| {
+static EXTRA_LINK: SyncLazy<HashMap<&'static str, Vec<ExtraLinkage>>> = SyncLazy::new(|| {
     let mut map = HashMap::new();
     map.insert(
         "call_ext_in_obj.c",

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 num_cpus = "1.13.0"
-once_cell = "1.8.0"
 parking_lot = "0.11.1"
 parking_lot_core = "0.8.3"
 strum = { version = "0.21.0", features = ["derive"] }

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -1,6 +1,7 @@
 //! Interpreter-facing API to the Yk meta-tracer.
 
 #![cfg_attr(test, feature(test))]
+#![feature(once_cell)]
 
 mod location;
 pub(crate) mod mt;

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -15,9 +15,9 @@ use std::{
 };
 
 use num_cpus;
-use once_cell::sync::Lazy;
 use parking_lot::{Condvar, Mutex, MutexGuard};
 use parking_lot_core::SpinWait;
+use std::lazy::SyncLazy;
 
 use crate::location::{HotLocation, Location, LocationInner, ThreadIdInner};
 use yktrace::{start_tracing, stop_tracing, CompiledTrace, IRTrace, TracingKind};
@@ -34,7 +34,7 @@ type AtomicHotThreshold = AtomicU32;
 // FIXME: just for parity with existing tests for now.
 const DEFAULT_HOT_THRESHOLD: HotThreshold = 0;
 
-static GLOBAL_MT: Lazy<MT> = Lazy::new(|| MT::new());
+static GLOBAL_MT: SyncLazy<MT> = SyncLazy::new(|| MT::new());
 thread_local! {static THREAD_MTTHREAD: MTThread = MTThread::new();}
 
 #[derive(Clone)]

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -15,7 +15,6 @@ intervaltree = "0.2.6"
 leb128 = "0.2.4"
 libc = "0.2.97"
 memmap2 = "0.3.0"
-once_cell = "1.8.0"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 ykllvmwrap = { path = "../ykllvmwrap" }
 ykutil = { path = "../ykutil" }

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -7,7 +7,7 @@ use intervaltree::{self, IntervalTree};
 use libc::c_void;
 use memmap2;
 use object::{Object, ObjectSection};
-use once_cell::sync::Lazy;
+use std::lazy::SyncLazy;
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -20,7 +20,7 @@ use ykllvmwrap::symbolizer::Symbolizer;
 use ykutil::addr::{code_vaddr_to_off, off_to_vaddr_main_obj};
 
 const BLOCK_MAP_SEC: &str = ".llvm_bb_addr_map";
-static BLOCK_MAP: Lazy<BlockMap> = Lazy::new(|| BlockMap::new());
+static BLOCK_MAP: SyncLazy<BlockMap> = SyncLazy::new(|| BlockMap::new());
 
 /// The information for one LLVM MachineBasicBlock, as per:
 /// https://llvm.org/docs/Extensions.html#sht-llvm-bb-addr-map-section-basic-block-address-map

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -1,5 +1,7 @@
 //! Utilities for collecting and decoding traces.
 
+#![feature(once_cell)]
+
 mod errors;
 use libc::c_void;
 use std::{

--- a/ykutil/Cargo.toml
+++ b/ykutil/Cargo.toml
@@ -9,5 +9,4 @@ license = "Apache-2.0 OR MIT"
 libc = "0.2.97"
 memmap2 = "0.3.0"
 object = "0.25.3"
-once_cell = "1.8.0"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }

--- a/ykutil/src/lib.rs
+++ b/ykutil/src/lib.rs
@@ -1,4 +1,6 @@
 //! Miscellaneous utilities.
 
+#![feature(once_cell)]
+
 pub mod addr;
 pub mod obj;

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -2,24 +2,25 @@
 
 use memmap2::Mmap;
 use object::{self, Object, ObjectSection, Section};
-use once_cell::sync::Lazy;
+use std::lazy::SyncLazy;
 use std::{convert::TryFrom, env, fs};
 
 /// The current executable mmaped into the address space.
 ///
 /// PERF: Consider making the segment containing .llvmbc loadable so that ld.so loads it
 /// automatically when spawning the process.
-static EXE_MMAP: Lazy<Mmap> = Lazy::new(|| {
+static EXE_MMAP: SyncLazy<Mmap> = SyncLazy::new(|| {
     let pathb = env::current_exe().unwrap();
     let file = fs::File::open(&pathb.as_path()).unwrap();
     unsafe { memmap2::Mmap::map(&file).unwrap() }
 });
 
 /// The current executable parsed to an `object::File`.
-static EXE_OBJ: Lazy<object::File> = Lazy::new(|| object::File::parse(&**EXE_MMAP).unwrap());
+static EXE_OBJ: SyncLazy<object::File> =
+    SyncLazy::new(|| object::File::parse(&**EXE_MMAP).unwrap());
 
 /// The .llvmbc section of the current executable.
-static LLVMBC: Lazy<Section> = Lazy::new(|| EXE_OBJ.section_by_name(".llvmbc").unwrap());
+static LLVMBC: SyncLazy<Section> = SyncLazy::new(|| EXE_OBJ.section_by_name(".llvmbc").unwrap());
 
 /// Returns a pointer to (and the size of) the raw LLVM bitcode encoded in the .llvmbc section of
 /// the current binary.


### PR DESCRIPTION
This way we can strip back our dependencies a little.