### PR TITLE
Tidy up try_lock

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -270,9 +270,8 @@ impl Location {
     /// nonsensical); or another thread held the lock.
     pub(super) fn try_lock(&self) -> Option<LocationInner> {
         let mut ls = self.load(Ordering::Relaxed);
-        // FIXME: this could be in the counting state
         loop {
-            if ls.is_locked() {
+            if ls.is_counting() || ls.is_locked() {
                 return None;
             }
             let new_ls = ls.with_lock();

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -225,8 +225,8 @@ impl MT {
             // There's no point contending with other threads, so in general we don't want to
             // continually try grabbing the lock.
             match loc.try_lock() {
-                Ok(x) => ls = x,
-                Err(_) => {
+                Some(x) => ls = x,
+                None => {
                     // If this thread is tracing we need to grab the lock so that we can stop
                     // tracing, otherwise we return to the interpreter.
                     if mtt.tracing.get().is_none() {


### PR DESCRIPTION
Needs https://github.com/ykjit/yk/pull/465 to be merged first.

This PR tidies up `Location::try_lock`, first changing its return type from `Result<T, ()>` to `Option<T>` (https://github.com/ykjit/yk/commit/7e1b16ccd5395ad51af41c631fbaf0dbd54c0390) and then fixing a FIXME (https://github.com/ykjit/yk/commit/1ff03450d97869efc7ea91e5083503c76a015728).