### PR TITLE
Remove the SERIALISE_COMPILATION spinlock.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -11,20 +11,12 @@
 #![feature(once_cell)]
 
 use std::convert::TryInto;
-#[cfg(feature = "c_testing")]
-use std::env;
 use std::ffi::c_void;
-#[cfg(feature = "c_testing")]
-use std::lazy::SyncLazy;
 use std::process;
 use std::{ptr, slice};
 use ykrt::{Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
 use ykutil;
-
-#[cfg(feature = "c_testing")]
-static SERIALISE_COMPILATION: SyncLazy<bool> =
-    SyncLazy::new(|| &env::var("YKD_SERIALISE_COMPILATION").unwrap_or("0".to_owned()) == "1");
 
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]
@@ -39,13 +31,6 @@ pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_vo
     if !loc.is_null() {
         let loc = unsafe { &*loc };
         MT::transition_location(loc, ctrlp_vars);
-
-        #[cfg(feature = "c_testing")]
-        {
-            if *SERIALISE_COMPILATION {
-                loc.block_if_compiling();
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This commit moves the "serialise computation" concept from ykcapi to ykrt, where we change `queue_compile_job` to block compilation until it's complete. Thus when `queue_compile_job` returns, its not only compiled a `Location`, but it's updated it to the `Compiled` state too.

As well as simplifying the code, removing the spinlock has a noticeable performance impact: roughly speaking, the test suite's wall-clock time decreases by about 40% (from ~14s to ~8.5s) and the total CPU time (across all cores) decreases by about 50%.