### PR TITLE
Resolve linkage issue.

### DIFF
--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -13,7 +13,6 @@ libc = "0.2.97"
 ykllvmwrap = { path = "../ykllvmwrap" }
 ykrt = { path = "../ykrt" }
 yktrace = { path = "../yktrace" }
-ykutil = { path = "../ykutil" }
 yksmp = { path = "../yksmp" }
 
 [features]

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -16,7 +16,6 @@ use std::process;
 use std::{ptr, slice};
 use ykrt::{Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
-use ykutil;
 
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]
@@ -56,16 +55,6 @@ pub extern "C" fn yk_location_new() -> Location {
 #[no_mangle]
 pub extern "C" fn yk_location_drop(loc: Location) {
     drop(loc)
-}
-
-/// Return a pointer to (and the size of) the .llvmbc section of the current executable.
-#[no_mangle]
-pub extern "C" fn __ykutil_get_llvmbc_section(res_addr: *mut *const c_void, res_size: *mut usize) {
-    let (addr, size) = ykutil::obj::llvmbc_section();
-    unsafe {
-        *res_addr = addr as *const c_void;
-        *res_size = size;
-    }
 }
 
 /// Reads out registers spilled to the stack of the previous frame during the deoptimisation

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -16,5 +16,7 @@ extern "C" {
         faddr_keys: *const *const c_char,
         faddr_vals: *const *const c_void,
         len: size_t,
+        llvmbc_data: *const u8,
+        llvmbc_len: size_t,
     ) -> *const c_void;
 }

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -12,10 +12,10 @@ extern "C" {
     pub fn __ykllvmwrap_irtrace_compile(
         func_names: *const *const c_char,
         bbs: *const size_t,
-        len: size_t,
+        trace_len: size_t,
         faddr_keys: *const *const c_char,
         faddr_vals: *const *const c_void,
-        len: size_t,
+        faddr_len: size_t,
         llvmbc_data: *const u8,
         llvmbc_len: size_t,
     ) -> *const c_void;

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -257,7 +257,7 @@ extern "C" void *compileModule(string TraceName, Module *M,
 //
 // Returns a pointer to the compiled function.
 extern "C" void *__ykllvmwrap_irtrace_compile(
-    char *FuncNames[], size_t BBs[], size_t Len, char *FAddrKeys[],
+    char *FuncNames[], size_t BBs[], size_t TraceLen, char *FAddrKeys[],
     void *FAddrVals[], size_t FAddrLen, void *BitcodeData, size_t BitcodeLen) {
   DebugIRPrinter DIP;
 
@@ -272,8 +272,8 @@ extern "C" void *__ykllvmwrap_irtrace_compile(
   Module *JITMod;
   std::string TraceName;
   std::map<GlobalValue *, void *> GlobalMappings;
-  std::tie(JITMod, TraceName, GlobalMappings) =
-      createModule(AOTMod, FuncNames, BBs, Len, FAddrKeys, FAddrVals, FAddrLen);
+  std::tie(JITMod, TraceName, GlobalMappings) = createModule(
+      AOTMod, FuncNames, BBs, TraceLen, FAddrKeys, FAddrVals, FAddrLen);
   DIP.print(DebugIR::JITPreOpt, JITMod);
 #ifndef NDEBUG
   llvm::verifyModule(*JITMod, &llvm::errs());

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -116,9 +116,9 @@ impl IRTrace {
     }
 
     pub fn compile(&self) -> *const c_void {
-        let len = self.len();
-        let mut func_names = Vec::with_capacity(len);
-        let mut bbs = Vec::with_capacity(len);
+        let trace_len = self.len();
+        let mut func_names = Vec::with_capacity(trace_len);
+        let mut bbs = Vec::with_capacity(trace_len);
         for blk in &self.blocks {
             if blk.is_unmappable() {
                 // The block was unmappable. Indicate this with a null function name.
@@ -143,7 +143,7 @@ impl IRTrace {
             ykllvmwrap::__ykllvmwrap_irtrace_compile(
                 func_names.as_ptr(),
                 bbs.as_ptr(),
-                len,
+                trace_len,
                 faddr_keys.as_ptr(),
                 faddr_vals.as_ptr(),
                 faddr_keys.len(),

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     ptr,
 };
 mod hwt;
+use ykutil::obj::llvmbc_section;
 
 pub use errors::InvalidTraceError;
 pub use hwt::mapper::BlockMap;
@@ -136,6 +137,8 @@ impl IRTrace {
             faddr_vals.push(*k.1);
         }
 
+        let (llvmbc_data, llvmbc_len) = llvmbc_section();
+
         let ret = unsafe {
             ykllvmwrap::__ykllvmwrap_irtrace_compile(
                 func_names.as_ptr(),
@@ -144,6 +147,8 @@ impl IRTrace {
                 faddr_keys.as_ptr(),
                 faddr_vals.as_ptr(),
                 faddr_keys.len(),
+                llvmbc_data,
+                llvmbc_len,
             )
         };
         assert_ne!(ret, ptr::null());


### PR DESCRIPTION
The first commit fixes #470. The second is a small tidy up. No functional change.

[Your test still doesn't work, it fails with `SIGILL`, but at least you don't get the linker issue. My guess would be that because you are driving `transition_location()` manually, when a trace eventually gets compiled, the trace compiler is going to look for a control point, and not find one, thus probably crashing something. I still think you need to move all of the tracing-related activities out of `transition_location` if you want to test the state machine, and only the state machine]