### PR TITLE
Towards a test suite

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -16,5 +16,5 @@ regex = "1.5.4"
 [dev-dependencies]
 lang_tester = "0.7.0"
 tempfile = "3.2.0"
-ykcapi = { path = "../ykcapi", features = ["c_testing", "jit_state_debug"] }
+ykcapi = { path = "../ykcapi", features = ["c_testing"] }
 ykrt = { path = "../ykrt", features = ["c_testing", "jit_state_debug"] }

--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -55,6 +55,7 @@
 const int add = 2;
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
   int res = 0;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/c_tests/tests/intrinsics.c
+++ b/c_tests/tests/intrinsics.c
@@ -37,6 +37,7 @@ void _yk_test(int i, int res) {
 int main(int argc, char **argv) {
   int res = 0;
   int src = 1000;
+  yk_set_hot_threshold(0);
   YkLocation loc = yk_location_new();
   int i = 3;
   NOOPT_VAL(res);

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -53,6 +53,7 @@
 int add;
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
   int res = 0;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/c_tests/tests/ptr_global.c
+++ b/c_tests/tests/ptr_global.c
@@ -21,6 +21,7 @@
 char *p = NULL;
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
   int i = 0;
   YkLocation loc = yk_location_new();
   p = argv[0];

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -59,6 +59,7 @@ void _yk_test(int i, int res) {
 }
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
   int res = 9998;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -70,6 +70,8 @@ int mem = 12;
 #define RESTART_IF_NOT_ZERO 2
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
+
   // A hard-coded program to execute.
   int prog[] = {DEC, DEC, DEC, RESTART_IF_NOT_ZERO, DEC, DEC};
   size_t prog_len = sizeof(prog) / sizeof(prog[0]);

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -70,6 +70,8 @@ int mem = 4;
 #define EXIT 3
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
+
   // A hard-coded program to execute.
   int prog[] = {NOP, NOP, DEC, RESTART_IF_NOT_ZERO, NOP, EXIT};
   size_t prog_len = sizeof(prog) / sizeof(prog[0]);

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -31,6 +31,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
   YkLocation loc = yk_location_new();
   int i = 3;
   int j = 300;

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -37,6 +37,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
+  yk_set_hot_threshold(0);
   YkLocation loc = yk_location_new();
   int i = 4;
   NOOPT_VAL(i);

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -16,5 +16,4 @@ yktrace = { path = "../yktrace" }
 yksmp = { path = "../yksmp" }
 
 [features]
-jit_state_debug = []
 c_testing = []

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -14,8 +14,9 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::process;
 use std::{ptr, slice};
-use ykrt::{Location, MT};
+use ykrt::{Location, TransitionLocation, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
+use yktrace::{start_tracing, stop_tracing};
 
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]
@@ -28,21 +29,30 @@ pub extern "C" fn yk_control_point(_loc: *mut Location) {
 pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_void) {
     debug_assert!(!ctrlp_vars.is_null());
     if !loc.is_null() {
+        let mt = MT::global();
         let loc = unsafe { &*loc };
-        if let Some(ctr) = MT::transition_location(loc) {
-            // FIXME: If we want to free compiled traces, we'll need to refcount (or use
-            // a GC) to know if anyone's executing that trace at the moment.
-            //
-            // FIXME: this loop shouldn't exist. Trace stitching should be implemented in
-            // the trace itself.
-            // https://github.com/ykjit/yk/issues/442
-            loop {
-                #[cfg(feature = "jit_state_debug")]
-                eprintln!("jit-state: enter-jit-code");
-                unsafe { &*ctr }.exec(ctrlp_vars);
-                #[cfg(feature = "jit_state_debug")]
-                eprintln!("jit-state: exit-jit-code");
+        match mt.transition_location(loc) {
+            TransitionLocation::NoAction => (),
+            TransitionLocation::Execute(ctr) => {
+                // FIXME: If we want to free compiled traces, we'll need to refcount (or use
+                // a GC) to know if anyone's executing that trace at the moment.
+                //
+                // FIXME: this loop shouldn't exist. Trace stitching should be implemented in
+                // the trace itself.
+                // https://github.com/ykjit/yk/issues/442
+                loop {
+                    #[cfg(feature = "jit_state_debug")]
+                    eprintln!("jit-state: enter-jit-code");
+                    unsafe { &*ctr }.exec(ctrlp_vars);
+                    #[cfg(feature = "jit_state_debug")]
+                    eprintln!("jit-state: exit-jit-code");
+                }
             }
+            TransitionLocation::StartTracing(kind) => start_tracing(kind),
+            TransitionLocation::StopTracing(hl) => match stop_tracing() {
+                Ok(ir_trace) => mt.queue_compile_job(ir_trace, hl),
+                Err(_) => todo!(),
+            },
         }
     }
 }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -14,7 +14,7 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::process;
 use std::{ptr, slice};
-use ykrt::{Location, MT};
+use ykrt::{HotThreshold, Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
 
 // The "dummy control point" that is replaced in an LLVM pass.
@@ -32,6 +32,12 @@ pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_vo
         let loc = unsafe { &*loc };
         mt.control_point(loc, ctrlp_vars);
     }
+}
+
+#[no_mangle]
+pub extern "C" fn yk_set_hot_threshold(hot_threshold: HotThreshold) {
+    let mt = MT::global();
+    mt.set_hot_threshold(hot_threshold);
 }
 
 #[no_mangle]

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -32,6 +32,9 @@ typedef uint32_t YkHotThreshold;
 // execute JITted code.
 void yk_control_point(YkLocation *);
 
+// Set the threshold at which `YkLocation`'s are considered hot.
+void yk_set_hot_threshold(YkHotThreshold);
+
 // Create a new `Location`.
 //
 // Note that a `Location` created by this call must not simply be discarded:

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -30,10 +30,6 @@ typedef uint32_t YkHotThreshold;
 // argument passed uniquely identifies the current location in the user's
 // program. A call to this function may cause yk to start/stop tracing, or to
 // execute JITted code.
-//
-// FIXME: should accept `YkLocation`, not `int`.
-// FIXME: once the above is fixed, talk about locations for which a loop cannot
-// start.
 void yk_control_point(YkLocation *);
 
 // Create a new `Location`.

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -7,4 +7,4 @@ mod location;
 pub(crate) mod mt;
 
 pub use self::location::Location;
-pub use self::mt::{HotThreshold, MT};
+pub use self::mt::{HotThreshold, TransitionLocation, MT};

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -7,4 +7,4 @@ mod location;
 pub(crate) mod mt;
 
 pub use self::location::Location;
-pub use self::mt::{HotThreshold, TransitionLocation, MT};
+pub use self::mt::{HotThreshold, MT};

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -422,11 +422,11 @@ impl LocationInner {
 
 /// An opaque struct used by `MTThreadInner` to help identify if a thread that started a trace is
 /// still active.
-pub struct ThreadIdInner;
+pub(crate) struct ThreadIdInner;
 
 /// A `Location`'s non-counting states.
 #[derive(EnumDiscriminants)]
-pub enum HotLocation {
+pub(crate) enum HotLocation {
     /// Points to executable machine code that can be executed instead of the interpreter for this
     /// HotLocation.
     Compiled(*const CompiledTrace),

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -287,7 +287,7 @@ impl Drop for Location {
     fn drop(&mut self) {
         let ls = self.load(Ordering::Relaxed);
         if !ls.is_counting() {
-            debug_assert!(!ls.is_locked());
+            debug_assert!(!ls.is_locked()); // FIXME: this could be locked
             self.lock().unwrap();
             let hl = unsafe { ls.hot_location() };
             if let HotLocation::Compiled(_) = hl {
@@ -422,11 +422,11 @@ impl LocationInner {
 
 /// An opaque struct used by `MTThreadInner` to help identify if a thread that started a trace is
 /// still active.
-pub(super) struct ThreadIdInner;
+pub struct ThreadIdInner;
 
 /// A `Location`'s non-counting states.
 #[derive(EnumDiscriminants)]
-pub(super) enum HotLocation {
+pub enum HotLocation {
     /// Points to executable machine code that can be executed instead of the interpreter for this
     /// HotLocation.
     Compiled(*const CompiledTrace),

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -34,8 +34,7 @@ pub type HotThreshold = u32;
 #[cfg(target_pointer_width = "64")]
 type AtomicHotThreshold = AtomicU32;
 
-// FIXME: just for parity with existing tests for now.
-const DEFAULT_HOT_THRESHOLD: HotThreshold = 0;
+const DEFAULT_HOT_THRESHOLD: HotThreshold = 50;
 
 static GLOBAL_MT: SyncLazy<MT> = SyncLazy::new(|| MT::new());
 thread_local! {static THREAD_MTTHREAD: MTThread = MTThread::new();}
@@ -75,6 +74,11 @@ impl MT {
     /// other threads and is thus potentially stale as soon as it is read.
     pub fn hot_threshold(&self) -> HotThreshold {
         self.inner.hot_threshold.load(Ordering::Relaxed)
+    }
+
+    /// Set the threshold at which `Location`'s are considered hot.
+    pub fn set_hot_threshold(&self, hot_threshold: HotThreshold) {
+        self.inner.hot_threshold.store(hot_threshold, Ordering::Relaxed);
     }
 
     /// Return this meta-tracer's maximum number of worker threads. Notice that this value can be

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -26,7 +26,7 @@ thread_local! {
 }
 
 /// The different ways by which we can collect a trace.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TracingKind {
     /// Software tracing.
     SoftwareTracing,


### PR DESCRIPTION
This PR moves us much of the way towards being able to restore a sensible test suite to `ykrt` (and, maybe, other yk crates). AFAICS, the problems we face(d) is that we had taken shortcuts in the APIs that we probably a) didn't realise we'd done b) thought were temporary. There's a lesson in there for us, I think: shortcuts, or temporary fixes, in APIs come back to bite us!

The good news is that by the end of this PR there is a *tiny* restoration of part of the old `Location` test suite. There's still more that needs to be done to make this scale up (e.g. having a thread local for `MTThread` means that we've accidentally lost the property that calls to a control point are fast; fixing that will require another API change), but I'm working on the "one step at a time" basis.

[Note: there is also one `FIXME` in here (`Location::drop`) that's a correctness issue. Fixing that will probably be part of another API change, so trying to do that now, or explain it in depth, isn't realistic.]