### PR TITLE
Start work on the stopgap interpreter.

### DIFF
--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -71,9 +71,5 @@ int main(int argc, char **argv) {
     res += 2;
     i--;
   }
-  abort(); // FIXME: unreachable due to aborting guard failure earlier.
-  NOOPT_VAL(res);
-  yk_location_drop(loc);
-
   return (EXIT_SUCCESS);
 }

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -14,6 +14,8 @@ ykllvmwrap = { path = "../ykllvmwrap" }
 ykrt = { path = "../ykrt" }
 yktrace = { path = "../yktrace" }
 yksmp = { path = "../yksmp" }
+ykutil = { path = "../ykutil" }
+llvm-sys = "130"
 
 [features]
 c_testing = []

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -25,6 +25,7 @@ use sginterp::{SGInterp, SGValue};
 const SM_REC_HEADER: usize = 3;
 
 mod llvmapihelper;
+mod llvmwrap;
 
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -20,6 +20,10 @@ use yksmp::{Location as SMLocation, StackMapParser};
 mod sginterp;
 use sginterp::{SGInterp, SGValue};
 
+/// The first three locations of an LLVM stackmap record, according to the source, are CC, Flags,
+/// Num Deopts, which need to be skipped when mapping the stackmap values back to AOT variables.
+const SM_REC_HEADER: usize = 3;
+
 mod llvmapihelper;
 
 // The "dummy control point" that is replaced in an LLVM pass.
@@ -159,7 +163,7 @@ pub extern "C" fn yk_stopgap(
 
     // Extract live values from the stackmap.
     // Skip first 3 locations as they don't relate to any of our live variables.
-    for (i, l) in locs.iter().skip(3).enumerate() {
+    for (i, l) in locs.iter().skip(SM_REC_HEADER).enumerate() {
         match l {
             SMLocation::Register(reg, size) => {
                 // FIXME: remove once we have a stopgap interpreter.

--- a/ykcapi/src/llvmapihelper.rs
+++ b/ykcapi/src/llvmapihelper.rs
@@ -19,7 +19,7 @@ pub unsafe fn get_instruction(bb: LLVMBasicBlockRef, instridx: u32) -> LLVMValue
     instr
 }
 
-pub unsafe fn parse_const(c: LLVMValueRef) -> SGValue {
+pub unsafe fn llvm_const_to_sgvalue(c: LLVMValueRef) -> SGValue {
     let ty = LLVMTypeOf(c);
     let kind = LLVMGetTypeKind(ty);
     match kind {

--- a/ykcapi/src/llvmapihelper.rs
+++ b/ykcapi/src/llvmapihelper.rs
@@ -1,0 +1,37 @@
+use crate::sginterp::SGValue;
+use llvm_sys::core::*;
+use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
+use llvm_sys::{LLVMTypeKind};
+
+pub unsafe fn get_basic_block(func: LLVMValueRef, bbidx: u32) -> LLVMBasicBlockRef {
+    let mut bb = LLVMGetFirstBasicBlock(func);
+    for _ in 0..bbidx {
+        bb = LLVMGetNextBasicBlock(bb);
+    }
+    bb
+}
+
+pub unsafe fn get_instruction(bb: LLVMBasicBlockRef, instridx: u32) -> LLVMValueRef {
+    let mut instr = LLVMGetFirstInstruction(bb);
+    for _ in 0..instridx {
+        instr = LLVMGetNextInstruction(instr);
+    }
+    instr
+}
+
+pub unsafe fn parse_const(c: LLVMValueRef) -> SGValue {
+    let ty = LLVMTypeOf(c);
+    let kind = LLVMGetTypeKind(ty);
+    match kind {
+        LLVMTypeKind::LLVMIntegerTypeKind => {
+            let width = LLVMGetIntTypeWidth(ty);
+            let val = LLVMConstIntGetZExtValue(c) as u64;
+            match width {
+                32 => SGValue::U32(val as u32),
+                64 => SGValue::U64(val),
+                _ => todo!(),
+            }
+        }
+        _ => todo!(),
+    }
+}

--- a/ykcapi/src/llvmwrap.rs
+++ b/ykcapi/src/llvmwrap.rs
@@ -1,0 +1,12 @@
+use llvm_sys::core::*;
+use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
+
+#[derive(PartialEq, Eq, Hash)]
+pub struct LocalVar(LLVMValueRef);
+
+impl LocalVar {
+    pub unsafe fn new(instr: LLVMValueRef) -> Self {
+      debug_assert!(!LLVMIsAInstruction(instr).is_null());
+      Self(instr)
+    }
+}

--- a/ykcapi/src/sginterp.rs
+++ b/ykcapi/src/sginterp.rs
@@ -1,0 +1,142 @@
+use llvm_sys::bit_reader::LLVMParseBitcodeInContext2;
+use llvm_sys::core::*;
+use llvm_sys::prelude::{LLVMModuleRef, LLVMValueRef};
+use llvm_sys::{LLVMOpcode};
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::mem::MaybeUninit;
+
+use crate::llvmapihelper::{self};
+
+/// Stopgap interpreter values.
+#[derive(Debug)]
+pub enum SGValue {
+    U32(u32),
+    U64(u64),
+}
+
+/// A frame holding live variables.
+struct Frame {
+    vars: HashMap<LLVMValueRef, SGValue>,
+}
+
+impl Frame {
+    fn new() -> Frame {
+        Frame {
+            vars: HashMap::new(),
+        }
+    }
+
+    /// Get the value of the variable `key` in this frame.
+    fn get(&self, key: &LLVMValueRef) -> Option<&SGValue> {
+        self.vars.get(key)
+    }
+
+    /// Insert new variable into this frame.
+    fn add(&mut self, key: LLVMValueRef, val: SGValue) {
+        self.vars.insert(key, val);
+    }
+}
+
+/// The stopgap interpreter. Used during guard failures to get back to the control point by
+/// interpreting LLVM IR.
+pub struct SGInterp {
+    /// LLVM IR module we are interpreting.
+    module: LLVMModuleRef,
+    /// Current frames.
+    frames: Vec<Frame>,
+    /// Current instruction being interpreted.
+    pc: LLVMValueRef,
+}
+
+impl SGInterp {
+    /// Create a new stopgap interpreter and initialise it to start interpretation at the location
+    /// given by a basic block index, instruction index, and function name.
+    /// FIXME: Support initalisation of multiple frames.
+    pub unsafe fn new(bbidx: u32, instridx: u32, fname: &CStr) -> SGInterp {
+        // Get AOT module IR and parse it.
+        let (addr, size) = ykutil::obj::llvmbc_section();
+        let membuf = LLVMCreateMemoryBufferWithMemoryRange(
+            addr as *const i8,
+            size,
+            "".as_ptr() as *const i8,
+            0,
+        );
+        let context = LLVMContextCreate();
+        let mut module: MaybeUninit<LLVMModuleRef> = MaybeUninit::uninit();
+        let module = {
+            LLVMParseBitcodeInContext2(context, membuf, module.as_mut_ptr());
+            module.assume_init()
+        };
+        // Create and initialise stop gap interpreter.
+        let func = LLVMGetNamedFunction(module, fname.as_ptr());
+        let bb = llvmapihelper::get_basic_block(func, bbidx);
+        let instr = llvmapihelper::get_instruction(bb, instridx);
+        SGInterp {
+            module,
+            frames: vec![Frame::new()],
+            pc: instr,
+        }
+    }
+
+    /// Add a live variable and its value to the current frame.
+    pub unsafe fn init_live(&mut self, bbidx: u32, instridx: u32, fname: &CStr, value: SGValue) {
+        let func = LLVMGetNamedFunction(self.module, fname.as_ptr());
+        let bb = llvmapihelper::get_basic_block(func, bbidx);
+        let instr = llvmapihelper::get_instruction(bb, instridx);
+        self.frames.last_mut().unwrap().add(instr, value);
+    }
+
+    /// Lookup the value of variable `var` in the current frame.
+    fn lookup(&self, var: &LLVMValueRef) -> Option<&SGValue> {
+        self.frames.last().unwrap().get(var)
+    }
+
+    /// Start interpretation of the initialised interpreter.
+    pub unsafe fn interpret(&mut self) {
+        // We start interpretation at the branch instruction that was turned into a guard. We need
+        // to re-interpret this instruction in order to find out which branch we need to follow.
+        loop {
+            match LLVMGetInstructionOpcode(self.pc) {
+                LLVMOpcode::LLVMBr => self.branch(self.pc),
+                LLVMOpcode::LLVMRet => self.ret(self.pc),
+                _ => todo!("{:?}", CStr::from_ptr(LLVMPrintValueToString(self.pc))),
+            }
+        }
+    }
+
+    /// Interpret branch instruction `instr`.
+    pub unsafe fn branch(&mut self, instr: LLVMValueRef) {
+        let cond = LLVMGetCondition(instr);
+        let val = self.lookup(&cond);
+        let res = match val.unwrap() {
+            SGValue::U32(v) => *v == 1,
+            SGValue::U64(v) => *v == 1,
+        };
+        let succ = if res {
+            LLVMGetSuccessor(instr, 0)
+        } else {
+            LLVMGetSuccessor(instr, 1)
+        };
+        self.pc = LLVMGetFirstInstruction(succ);
+    }
+
+    /// Interpret return instruction `instr`.
+    unsafe fn ret(&mut self, instr: LLVMValueRef) {
+        if self.frames.len() == 1 {
+            // We've reached the end of the interpreters main, so just get the return value and
+            // exit. This is possibly a hack, though I'm not sure what the correct behaviour is.
+            let op = LLVMGetOperand(instr, 0);
+            let val = if !LLVMIsAConstant(op).is_null() {
+                llvmapihelper::parse_const(op)
+            } else {
+                todo!()
+            };
+            let ret = match val {
+                SGValue::U32(v) => v as i32,
+                SGValue::U64(v) => v as i32,
+            };
+            std::process::exit(ret);
+        }
+    }
+}

--- a/ykcapi/src/sginterp.rs
+++ b/ykcapi/src/sginterp.rs
@@ -128,7 +128,7 @@ impl SGInterp {
             // exit. This is possibly a hack, though I'm not sure what the correct behaviour is.
             let op = LLVMGetOperand(instr, 0);
             let val = if !LLVMIsAConstant(op).is_null() {
-                llvmapihelper::parse_const(op)
+                llvmapihelper::llvm_const_to_sgvalue(op)
             } else {
                 todo!()
             };

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -50,7 +50,8 @@ void yk_location_drop(YkLocation);
 void yk_stopgap(void *addr, uintptr_t size, uintptr_t retaddr, void *rsp);
 
 #if defined(__x86_64)
-__attribute__((naked)) void __llvm_deoptimize(void *addr, uintptr_t size) {
+__attribute__((naked)) void __llvm_deoptimize(void *addr, uintptr_t size,
+                                              void *aotmap, void *curpos) {
   // Push all registers to the stack before they can be clobbered, so that we
   // can find their values after parsing in the stackmap. The order in which
   // we push the registers is equivalent to the Sys-V x86_64 ABI, which the
@@ -71,15 +72,16 @@ __attribute__((naked)) void __llvm_deoptimize(void *addr, uintptr_t size) {
       "push rcx\n"
       "push rdx\n"
       "push rax\n"
-      // Now we need to call yk_stopgap. The arguments need to be in RDI,
-      // RSI, RDX, and RCX. The first two arguments (stackmap address and
-      // stackmap size) are already where they need to be as we are just
-      // forwarding them from the current function's arguments. The remaining
-      // arguments (return address and current stack pointer) need to be in
-      // RDX and RCX. The return address was at [RSP] before the above
-      // pushes, so to find it we need to offset 8 bytes per push.
-      "mov rdx, [rsp+64]\n"
-      "mov rcx, rsp\n"
+      // Now we need to call yk_stopgap. The arguments need to be in RDI, RSI,
+      // RDX, RCX, R8, and R9. The first four arguments (stackmap address,
+      // stackmap size, live variable map, and current IR position) are already
+      // where they need to be as we are just forwarding them from the current
+      // function's arguments. The remaining arguments (return address and
+      // current stack pointer) need to be in R8 and R9. The return address was
+      // at [RSP] before the above pushes, so to find it we need to offset 8
+      // bytes per push.
+      "mov r8, [rsp+64]\n"
+      "mov r9, rsp\n"
       "sub rsp, 8\n"
       "call yk_stopgap\n"
       "add rsp, 64\n"


### PR DESCRIPTION
**This is a draft PR to discuss the design of the stopgap interpreter. It is not ready
for merging yet as there's still quite a few IR instructions to be implemented.**

This PR sets up the skeleton of the stopgap interpreter. The interpreter
interacts with the LLVM module via llvm-sys rather than using a more abstracted
(and user-friendly) interface like llvm-ir. The reason is that llvm-ir parses
modules in its entirety, even parts of the module the stopgap interpreter won't
touch. Using llvm-sys we only parse what we actually need to get back to the
control point.

In order to initialise the stopgap interpreter we need to create a mapping from
stackmap values to variables (i.e. instructions) in the AOT module. This is
being setup in `jitmodbuilder.cc` during guard creation and then passed through
to the stopgap interpreter via the deoptimisation call. We also need to pass
the position in the AOT module from where interpretation needs to start, which
we previously didn't do either.