### PR TITLE
Start moving away from a singleton `MT` object

### DIFF
--- a/c_tests/tests/blockmap.c
+++ b/c_tests/tests/blockmap.c
@@ -19,8 +19,9 @@ int main(int argc, char **argv) {
 // This isn't used as part of the test, but is required for this file to
 // compile with ykllvm.
 void unused() {
+  YkMT *mt = yk_mt_global();
   YkLocation loc = yk_location_new();
   while(true) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
   }
 }

--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -55,7 +55,8 @@
 const int add = 2;
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
   NOOPT_VAL(res);
   NOOPT_VAL(i);
   while (i > 0) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     res += add;
     i--;

--- a/c_tests/tests/control_point_in_nested_loop.c
+++ b/c_tests/tests/control_point_in_nested_loop.c
@@ -9,13 +9,14 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_global();
   int outers = 100;
   int inners = 100;
   NOOPT_VAL(outers);
   NOOPT_VAL(inners);
   for (int i = 0; i < outers; i++) {
     for (int j = 0; j < inners; j++) {
-      yk_control_point(NULL); // In a nested loop!
+      yk_control_point(mt, NULL); // In a nested loop!
     }
   }
   return (EXIT_SUCCESS);

--- a/c_tests/tests/control_point_not_in_loop.c
+++ b/c_tests/tests/control_point_not_in_loop.c
@@ -12,6 +12,7 @@
 #include <yk.h>
 
 int main(int argc, char **argv) {
-  yk_control_point(NULL); // Not in a loop!
+  YkMT *mt = yk_mt_global();
+  yk_control_point(mt, NULL); // Not in a loop!
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/intrinsics.c
+++ b/c_tests/tests/intrinsics.c
@@ -32,7 +32,8 @@
 int main(int argc, char **argv) {
   int res = 0;
   int src = 1000;
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;
   NOOPT_VAL(res);

--- a/c_tests/tests/intrinsics.c
+++ b/c_tests/tests/intrinsics.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
   NOOPT_VAL(i);
   NOOPT_VAL(src);
   while (i > 0) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     memcpy(&res, &src, 4);
     src--;
     i--;

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -53,7 +53,8 @@
 int add;
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
   NOOPT_VAL(res);
   NOOPT_VAL(i);
   while (i > 0) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     res += add;
     i--;

--- a/c_tests/tests/ptr_global.c
+++ b/c_tests/tests/ptr_global.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
   p = argv[0];
   NOOPT_VAL(i);
   while (*p != '\0') {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     i++;
     p++;

--- a/c_tests/tests/ptr_global.c
+++ b/c_tests/tests/ptr_global.c
@@ -21,7 +21,8 @@
 char *p = NULL;
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   int i = 0;
   YkLocation loc = yk_location_new();
   p = argv[0];

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -58,11 +58,13 @@ int main(int argc, char **argv) {
   yk_set_hot_threshold(mt, 0);
   int res = 9998;
   YkLocation loc = yk_location_new();
+  fflush(NULL);
   int i = 4;
+  NOOPT_VAL(loc);
   NOOPT_VAL(res);
   NOOPT_VAL(i);
   while (i > 0) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     res += 2;
     i--;

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -54,7 +54,8 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   int res = 9998;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -70,7 +70,8 @@ int mem = 12;
 #define RESTART_IF_NOT_ZERO 2
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
 
   // A hard-coded program to execute.
   int prog[] = {DEC, DEC, DEC, RESTART_IF_NOT_ZERO, DEC, DEC};

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
       exit(0);
     }
     YkLocation *loc = &locs[pc];
-    yk_control_point(loc);
+    yk_control_point(mt, loc);
     int bc = prog[pc];
     fprintf(stderr, "pc=%d, mem=%d\n", pc, mem);
     switch (bc) {

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
   while (true) {
     assert(pc < prog_len);
     YkLocation *loc = &locs[pc];
-    yk_control_point(loc);
+    yk_control_point(mt, loc);
     int bc = prog[pc];
     fprintf(stderr, "pc=%d, mem=%d\n", pc, mem);
     switch (bc) {

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -70,7 +70,8 @@ int mem = 4;
 #define EXIT 3
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
 
   // A hard-coded program to execute.
   int prog[] = {NOP, NOP, DEC, RESTART_IF_NOT_ZERO, NOP, EXIT};

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -31,7 +31,8 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;
   int j = 300;

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
   NOOPT_VAL(i);
   NOOPT_VAL(j);
   while (i > 0) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     switch (j) {
       case 100:

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   int i = 4;
   NOOPT_VAL(i);
   while (i > 0) {
-    yk_control_point(&loc);
+    yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     switch (i) {
       case 100:

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -37,7 +37,8 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  yk_set_hot_threshold(0);
+  YkMT *mt = yk_mt_global();
+  yk_set_hot_threshold(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 4;
   NOOPT_VAL(i);

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -24,16 +24,17 @@ pub extern "C" fn yk_mt_global() -> &'static MT {
 
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]
-pub extern "C" fn yk_control_point(_loc: *mut Location) {
+pub extern "C" fn yk_control_point(_mt: *mut MT, _loc: *mut Location) {
     // Intentionally empty.
 }
 
 // The "real" control point, that is called once the interpreter has been patched by ykllvm.
 #[no_mangle]
-pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_void) {
+pub extern "C" fn __ykrt_control_point(mt: *mut MT, loc: *mut Location, ctrlp_vars: *mut c_void) {
+    println!("{:?} {:?} {:?}", mt, loc, ctrlp_vars);
     debug_assert!(!ctrlp_vars.is_null());
     if !loc.is_null() {
-        let mt = MT::global();
+        let mt = unsafe { &*mt };
         let loc = unsafe { &*loc };
         mt.control_point(loc, ctrlp_vars);
     }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -17,6 +17,11 @@ use std::{ptr, slice};
 use ykrt::{HotThreshold, Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
 
+#[no_mangle]
+pub extern "C" fn yk_mt_global() -> &'static MT {
+    MT::global()
+}
+
 // The "dummy control point" that is replaced in an LLVM pass.
 #[no_mangle]
 pub extern "C" fn yk_control_point(_loc: *mut Location) {
@@ -35,8 +40,7 @@ pub extern "C" fn __ykrt_control_point(loc: *mut Location, ctrlp_vars: *mut c_vo
 }
 
 #[no_mangle]
-pub extern "C" fn yk_set_hot_threshold(hot_threshold: HotThreshold) {
-    let mt = MT::global();
+pub extern "C" fn yk_set_hot_threshold(mt: &MT, hot_threshold: HotThreshold) {
     mt.set_hot_threshold(hot_threshold);
 }
 

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -35,7 +35,7 @@ YkMT *yk_mt_global();
 // argument passed uniquely identifies the current location in the user's
 // program. A call to this function may cause yk to start/stop tracing, or to
 // execute JITted code.
-void yk_control_point(YkLocation *);
+void yk_control_point(YkMT *, YkLocation *);
 
 // Set the threshold at which `YkLocation`'s are considered hot.
 void yk_set_hot_threshold(YkMT *, YkHotThreshold);

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -26,6 +26,11 @@ typedef uint32_t YkHotThreshold;
 #error Unable to determine type of HotThreshold
 #endif
 
+typedef struct YkMT YkMT;
+
+// Return a pointer to MT instance.
+YkMT *yk_mt_global();
+
 // Notify yk that an iteration of an interpreter loop is about to start. The
 // argument passed uniquely identifies the current location in the user's
 // program. A call to this function may cause yk to start/stop tracing, or to
@@ -33,7 +38,7 @@ typedef uint32_t YkHotThreshold;
 void yk_control_point(YkLocation *);
 
 // Set the threshold at which `YkLocation`'s are considered hot.
-void yk_set_hot_threshold(YkHotThreshold);
+void yk_set_hot_threshold(YkMT *, YkHotThreshold);
 
 // Create a new `Location`.
 //

--- a/yksmp/tests/simple.c
+++ b/yksmp/tests/simple.c
@@ -1,4 +1,3 @@
-int main() {
   int x = 11;
   int y = 13;
   // Insert stackmap here.

--- a/yksmp/tests/simple.c
+++ b/yksmp/tests/simple.c
@@ -1,3 +1,4 @@
+int main() {
   int x = 11;
   int y = 13;
   // Insert stackmap here.


### PR DESCRIPTION
At the moment our API forces us to use a singleton `MT` instance which we fish out whenever we need it. This is not only slow (it's in a `SyncLazy`), but it will cause us problems if/when we want to allow more than one `MT` in a single process.

This PR starts to move us away from that. First, we expose a `YkMt` type (https://github.com/ykjit/yk/commit/6ec9342dc6f948e771b293c7423667f7a8b002da). Then we add this new type as a first parameter to control points (https://github.com/ykjit/yk/commit/50505751f20c1c50d0164d4b4d165694af4f0350). This second commit needs the companion PR https://github.com/ykjit/ykllvm/pull/21.

This PR *does not go all the way*: there's still a fair bit more work to do to get rid of the singleton `MT`. However, because of the annoyance of the companion PR, and because I doubt I'll get to the rest of this stuff for a few days, I think it's better to get this reviewed and, maybe if I've not gone too far wrong, merged (it might have a small effect on some of @ptersilie's current work?).

Note that in https://github.com/ykjit/yk/commit/50505751f20c1c50d0164d4b4d165694af4f0350 I have had to replace several *truly evil* magic constants with named constants: I can't promise that I've got these right, because they're not explained in any way. Please check those parts particularly carefully!