### PR TITLE
Push THREAD_MTTHREAD down off the fast path

### DIFF
--- a/c_tests/tests/blockmap.c
+++ b/c_tests/tests/blockmap.c
@@ -19,9 +19,11 @@ int main(int argc, char **argv) {
 // This isn't used as part of the test, but is required for this file to
 // compile with ykllvm.
 void unused() {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   YkLocation loc = yk_location_new();
   while(true) {
     yk_control_point(mt, &loc);
   }
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
 }

--- a/c_tests/tests/const_global.c
+++ b/c_tests/tests/const_global.c
@@ -55,7 +55,7 @@
 const int add = 2;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();
@@ -71,6 +71,7 @@ int main(int argc, char **argv) {
   abort(); // FIXME: unreachable due to aborting guard failure earlier.
   NOOPT_VAL(res);
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/control_point_in_nested_loop.c
+++ b/c_tests/tests/control_point_in_nested_loop.c
@@ -9,7 +9,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   int outers = 100;
   int inners = 100;
   NOOPT_VAL(outers);
@@ -19,5 +19,6 @@ int main(int argc, char **argv) {
       yk_control_point(mt, NULL); // In a nested loop!
     }
   }
+  yk_mt_drop(mt);
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/control_point_not_in_loop.c
+++ b/c_tests/tests/control_point_not_in_loop.c
@@ -12,7 +12,8 @@
 #include <yk.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_control_point(mt, NULL); // Not in a loop!
+  yk_mt_drop(mt);
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/intrinsics.c
+++ b/c_tests/tests/intrinsics.c
@@ -32,7 +32,7 @@
 int main(int argc, char **argv) {
   int res = 0;
   int src = 1000;
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
   NOOPT_VAL(res);
   assert(res == 996);
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/mutable_global.c
+++ b/c_tests/tests/mutable_global.c
@@ -53,7 +53,7 @@
 int add;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();
@@ -70,6 +70,7 @@ int main(int argc, char **argv) {
   abort(); // FIXME: unreachable due to aborting guard failure earlier.
   NOOPT_VAL(res);
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/ptr_global.c
+++ b/c_tests/tests/ptr_global.c
@@ -21,7 +21,7 @@
 char *p = NULL;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   int i = 0;
   YkLocation loc = yk_location_new();
@@ -37,6 +37,7 @@ int main(int argc, char **argv) {
   NOOPT_VAL(i);
   NOOPT_VAL(p);
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/simple.c
+++ b/c_tests/tests/simple.c
@@ -54,7 +54,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   int res = 9998;
   YkLocation loc = yk_location_new();
@@ -72,6 +72,7 @@ int main(int argc, char **argv) {
   abort(); // FIXME: unreachable due to aborting guard failure earlier.
   NOOPT_VAL(res);
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/simple_interp_loop1.c
+++ b/c_tests/tests/simple_interp_loop1.c
@@ -70,7 +70,7 @@ int mem = 12;
 #define RESTART_IF_NOT_ZERO 2
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
 
   // A hard-coded program to execute.
@@ -120,6 +120,7 @@ int main(int argc, char **argv) {
 
   for (int i = 0; i < prog_len; i++)
     yk_location_drop(locs[i]);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/simple_interp_loop2.c
+++ b/c_tests/tests/simple_interp_loop2.c
@@ -70,7 +70,7 @@ int mem = 4;
 #define EXIT 3
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
 
   // A hard-coded program to execute.
@@ -124,6 +124,7 @@ done:
 
   for (int i = 0; i < prog_len; i++)
     yk_location_drop(locs[i]);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/switch.c
+++ b/c_tests/tests/switch.c
@@ -31,7 +31,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;
@@ -55,6 +55,7 @@ int main(int argc, char **argv) {
   }
   abort(); // FIXME: unreachable due to aborting guard failure earlier.
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/c_tests/tests/switch_default.c
+++ b/c_tests/tests/switch_default.c
@@ -37,7 +37,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_global();
+  YkMT *mt = yk_mt_new();
   yk_set_hot_threshold(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 4;
@@ -58,6 +58,7 @@ int main(int argc, char **argv) {
   }
   abort(); // FIXME: unreachable due to aborting guard failure earlier.
   yk_location_drop(loc);
+  yk_mt_drop(mt);
 
   return (EXIT_SUCCESS);
 }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -20,8 +20,14 @@ use ykrt::{HotThreshold, Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
 
 #[no_mangle]
-pub extern "C" fn yk_mt_global() -> &'static MT {
-    MT::global()
+pub extern "C" fn yk_mt_new() -> *mut MT {
+    let mt = Box::new(MT::new());
+    Box::into_raw(mt)
+}
+
+#[no_mangle]
+pub extern "C" fn yk_mt_drop(mt: *mut MT) {
+    unsafe { Box::from_raw(mt) };
 }
 
 // The "dummy control point" that is replaced in an LLVM pass.

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -33,7 +33,6 @@ pub extern "C" fn yk_control_point(_mt: *mut MT, _loc: *mut Location) {
 // The "real" control point, that is called once the interpreter has been patched by ykllvm.
 #[no_mangle]
 pub extern "C" fn __ykrt_control_point(mt: *mut MT, loc: *mut Location, ctrlp_vars: *mut c_void) {
-    println!("{:?} {:?} {:?}", mt, loc, ctrlp_vars);
     debug_assert!(!ctrlp_vars.is_null());
     if !loc.is_null() {
         let mt = unsafe { &*mt };

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -28,8 +28,13 @@ typedef uint32_t YkHotThreshold;
 
 typedef struct YkMT YkMT;
 
-// Return a pointer to MT instance.
-YkMT *yk_mt_global();
+// Create a new `YkMT` instance.
+YkMT *yk_mt_new();
+
+// Drop a `YkMT` instance. This must be called at most once per `YkMT`
+// instance: calling this function more than once on a `YkMT` instance leads to
+// undefined behaviour.
+void yk_mt_drop(YkMT *);
 
 // Notify yk that an iteration of an interpreter loop is about to start. The
 // argument passed uniquely identifies the current location in the user's


### PR DESCRIPTION
This PR mostly aims to get `THREAD_MTTHREAD` off of the control point fast path (https://github.com/ykjit/yk/commit/e20071a8861940ce7410ada8603c05d124b432a2). However this requires an API change such that we rethink the relationship between `MT` and `MTThread` (https://github.com/ykjit/yk/commit/5457f8be379b948e3b1fb4f8b008c74ad4e2b886). As a sort-of bonus, I've also started better understanding how to test the location statemachine, so that's now slightly better tested (https://github.com/ykjit/yk/commit/823f7400e73e19321c20b71289dd3ed4042d0ac7), giving us a bit of confidence that we're not breaking too many things.

For full disclosure, this PR contains a genuine horror which you can see at https://github.com/ykjit/yk/commit/e20071a8861940ce7410ada8603c05d124b432a2#diff-9fa85f3ab0ab08c2bb4337dd17d47605f520c2780158e50e66eff7cd9dc1b29bR291: this is clearly terrible, but until there's a better test suite, I'm not overly confident about fixing this until the test suite is reextended.