### PR TITLE
A rough attempt at a "Trace Driver" test suite.

### DIFF
--- a/c_tests/Cargo.toml
+++ b/c_tests/Cargo.toml
@@ -10,11 +10,19 @@ name = "c_tests"
 path = "run.rs"
 harness = false
 
+[[test]]
+name = "trace_compiler_tests"
+path = "run_trace_compiler.rs"
+harness = false
+
 [dependencies]
+memmap2 = "0.5.2"
 regex = "1.5.4"
+yktrace = { path = "../yktrace", features = ["c_testing"] }
 
 [dev-dependencies]
 lang_tester = "0.7.0"
 tempfile = "3.2.0"
 ykcapi = { path = "../ykcapi", features = ["c_testing"] }
+ykllvmwrap = { path = "../ykllvmwrap", features = ["c_testing"] }
 ykrt = { path = "../ykrt", features = ["c_testing", "jit_state_debug"] }

--- a/c_tests/run_trace_compiler.rs
+++ b/c_tests/run_trace_compiler.rs
@@ -1,0 +1,57 @@
+//! Lang tester harness for trace compiler tests.
+
+#![feature(once_cell)]
+
+use lang_tester::LangTester;
+use regex::Regex;
+use std::{env, fs::read_to_string, path::PathBuf, process::Command};
+
+const COMMENT: &str = ";";
+
+fn main() {
+    println!("Running trace compiler tests...");
+
+    // Find the `run_trace_driver_test` binary in the target dir.
+    let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut run_tc_test = PathBuf::from(md);
+    run_tc_test.push("..");
+    run_tc_test.push("target");
+    #[cfg(cargo_profile = "release")]
+    run_tc_test.push("release");
+    #[cfg(cargo_profile = "debug")]
+    run_tc_test.push("debug");
+    run_tc_test.push("run_trace_compiler_test");
+
+    LangTester::new()
+        .test_dir("trace_compiler")
+        .test_file_filter(|p| {
+            if let Some(ext) = p.extension() {
+                ext == "ll"
+            } else {
+                false
+            }
+        })
+        .test_extract(move |p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
+                .skip_while(|l| !l.starts_with(COMMENT))
+                .take_while(|l| l.starts_with(COMMENT))
+                .map(|l| &l[COMMENT.len()..])
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .test_cmds(move |p| {
+            let mut run_tc_test = Command::new(run_tc_test.clone());
+            run_tc_test.arg(p);
+            vec![("Run-time", run_tc_test)]
+        })
+        .fm_options(|_, _, fmb| {
+            // Use `{{}}` to match non-literal strings in tests.
+            // E.g. use `%{{var}}` to capture the name of a variable.
+            let ptn_re = Regex::new(r"\{\{.+?\}\}").unwrap();
+            let text_re = Regex::new(r".+?\b").unwrap();
+            fmb.name_matcher(ptn_re, text_re)
+        })
+        .run();
+}

--- a/c_tests/src/bin/run_trace_compiler_test.rs
+++ b/c_tests/src/bin/run_trace_compiler_test.rs
@@ -1,0 +1,29 @@
+//! Trace compiler test runner.
+//!
+//! Each invocation of this program runs one of the trace compiler tests found in the
+//! `trace_driver` directory of this crate.
+
+use memmap2;
+use std::{collections::HashMap, env, ffi::CString, fs::File};
+use yktrace::{IRBlock, IRTrace};
+
+fn main() {
+    // Build the trace that we are going to have compiled.
+    let mut bbs = vec![IRBlock::unmappable()];
+    for bb in env::var("TRACE_DRIVER_BBS").unwrap().split(",") {
+        let mut elems = bb.split(":");
+        let func = elems.next().unwrap();
+        let bb_idx = elems.next().unwrap().parse::<usize>().unwrap();
+        bbs.push(IRBlock::new(CString::new(func).unwrap(), bb_idx));
+    }
+    let trace = IRTrace::new(bbs, HashMap::new());
+
+    // Map the `.ll` file into the address space so that we can give a pointer to it to the trace
+    // compiler. Normally (i.e. outside of testing), the trace compiler wouldn't deal with textual
+    // bitcode format, but it just so happens that LLVM's module loading APIs accept either format.
+    let ll_path = env::args().skip(1).next().unwrap();
+    let ll_file = File::open(ll_path).unwrap();
+    let mmap = unsafe { memmap2::Mmap::map(&ll_file).unwrap() };
+
+    trace.compile_for_tc_tests(mmap.as_ptr(), mmap.len());
+}

--- a/c_tests/trace_compiler/guard_eq.ll
+++ b/c_tests/trace_compiler/guard_eq.ll
@@ -1,0 +1,37 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: TRACE_DRIVER_BBS=main:0,main:1
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{0}} = alloca i32, align 4
+;        %{{1}} = icmp eq i32 1, 1
+;        br i1 %{{1}}, label %{{true}}, label %guardfail
+;
+;      guardfail:...
+;        call void (...) @llvm.experimental.deoptimize.isVoid(...
+;        ret void
+;
+;      {{true}}:...
+;        store i32 1, i32* %{{0}}, align 4
+;        ret void
+;      }
+;
+;      declare void @llvm.experimental.deoptimize.isVoid(...)
+;      --- End jit-pre-opt ---
+
+define void @main() {
+entry:
+    %0 = alloca i32
+    %1 = icmp eq i32 1, 1
+    br i1 %1, label %true, label %false
+
+true:
+    store i32 1, i32 * %0
+    unreachable
+
+false:
+    store i32 0, i32 * %0
+    unreachable
+}

--- a/c_tests/trace_compiler/small.ll
+++ b/c_tests/trace_compiler/small.ll
@@ -1,0 +1,17 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: TRACE_DRIVER_BBS=main:0
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{0}} = add i32 100, 100
+;        ret void
+;      }
+;      --- End jit-pre-opt ---
+
+define void @main() {
+entry:
+    %0 = add i32 100, 100
+    unreachable
+}

--- a/c_tests/trace_compiler/smallest.ll
+++ b/c_tests/trace_compiler/smallest.ll
@@ -1,0 +1,15 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: TRACE_DRIVER_BBS=main:0
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        ret void
+;      }
+;      --- End jit-pre-opt ---
+
+define void @main() {
+entry:
+    unreachable
+}

--- a/c_tests/trace_compiler/two_blocks.ll
+++ b/c_tests/trace_compiler/two_blocks.ll
@@ -1,0 +1,22 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: TRACE_DRIVER_BBS=main:0,main:1
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{0}} = add i32 1, 1
+;        %{{1}} = add i32 2, 2
+;        ret void
+;      }
+;      --- End jit-pre-opt ---
+
+define void @main() {
+entry:
+    %0 = add i32 1, 1
+    br label %bb2
+
+bb2:
+    %1 = add i32 2, 2
+    unreachable
+}

--- a/ykllvmwrap/Cargo.toml
+++ b/ykllvmwrap/Cargo.toml
@@ -12,3 +12,6 @@ ykutil = { path = "../ykutil" }
 
 [build-dependencies]
 cc = "1.0.68"
+
+[features]
+c_testing = []

--- a/ykllvmwrap/build.rs
+++ b/ykllvmwrap/build.rs
@@ -24,6 +24,10 @@ fn main() {
         .flag("-Wno-unused-parameter")
         .cpp(true);
 
+    // If building with testing support, define a macro so we can conditionally compile stuff.
+    #[cfg(feature = "c_testing")]
+    comp.flag("-DYK_TESTING");
+
     // Set the C NDEBUG macro if Cargo is building in release mode. This ensures that assertions
     // (and other things we guard with NDEBUG) only happen in debug builds.
     if env::var("PROFILE").unwrap() == "release" {

--- a/ykllvmwrap/src/jitmodbuilder.h
+++ b/ykllvmwrap/src/jitmodbuilder.h
@@ -9,4 +9,10 @@ using namespace llvm;
 std::tuple<Module *, std::string, std::map<GlobalValue *, void *>>
 createModule(Module *AOTMod, char *FuncNames[], size_t BBs[], size_t TraceLen,
              char *FAddrKeys[], void *FAddrVals[], size_t FAddrLen);
+#ifdef YK_TESTING
+std::tuple<Module *, std::string, std::map<GlobalValue *, void *>>
+createModuleForTraceDriver(Module *AOTMod, char *FuncNames[], size_t BBs[],
+                           size_t TraceLen, char *FAddrKeys[],
+                           void *FAddrVals[], size_t FAddrLen);
+#endif // YK_TESTING
 #endif

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -19,4 +19,16 @@ extern "C" {
         llvmbc_data: *const u8,
         llvmbc_len: size_t,
     ) -> *const c_void;
+
+    #[cfg(feature = "c_testing")]
+    pub fn __ykllvmwrap_irtrace_compile_for_tc_tests(
+        func_names: *const *const c_char,
+        bbs: *const size_t,
+        trace_len: size_t,
+        faddr_keys: *const *const c_char,
+        faddr_vals: *const *const c_void,
+        faddr_len: size_t,
+        llvmbc_data: *const u8,
+        llvmbc_len: size_t,
+    ) -> *const c_void;
 }

--- a/ykutil/Cargo.toml
+++ b/ykutil/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = "0.2.97"
-memmap2 = "0.3.0"
+memmap2 = "0.5.2"
 object = "0.25.3"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }


### PR DESCRIPTION
This is a draft. Don't bother to review the code -- it needs tidying. I'm raising this to see if we are headed in the right direction.

The way this works:
 - The user provides a lang test, containing a LLVM module.
 - Unlike before, the provided module can be really bare-bones, devoid of lengthy control_point machinery. Just blocks containing instructions they want to simulate a trace through.
 - The user can liberally use `unreachable` terminators, for example in blocks that are intended to be at the end of a trace, or for blocks which will never be traced.
 - In the lang test, the user sets `env-var: TRACE_DRIVER_BBS=...` to "drive" the test down one given path of the CFG of the provided module. The value is a comma separated list of `func:bb` pairs, and `bb` is a block index (not it's name in the module yet. we could make it so tha t the user could use the name of the block, but this would require more work, as we'd have to parse the module and build a map of name->idx).
 - The trace compiler compiles the specified trace, faking control point machinery as necessary.
 - The user's test does the `env-var: YKD_PRINT_IR=...` trick as usual and matches the expected outcome at the desired stage in the pipeline (e.g. `jit-pre-opt`).

A good place to start is [this simple two-block test](https://github.com/ykjit/yk/compare/master...vext01:trace-driver-tests-v2#diff-89bfaa8f17998eedc6def69d274e139c435e845e664e7a0712883cfe65053f9e).

Once you've digested that, take a look at [this more involved test](https://github.com/ykjit/yk/compare/master...vext01:trace-driver-tests-v2#diff-d63cae56313cd4fdaa8939bc91feeaef1ae2c431f064e7d5d70e20003316ca3f), which checks that a conditional branch instruction gets an appropriate guard inserted.

Things for a later PR:
 - rename the `c_tests` directory, as this now contains more than C tests.
 - rename the `c_testing` feature as well.

Any comments on the design?