### PR TITLE
Rename remaining references to "trace driver tests".

### DIFF
--- a/tests/langtest_trace_compiler.rs
+++ b/tests/langtest_trace_compiler.rs
@@ -11,7 +11,7 @@ const COMMENT: &str = ";";
 fn main() {
     println!("Running trace compiler tests...");
 
-    // Find the `run_trace_driver_test` binary in the target dir.
+    // Find the `run_trace_compiler_test` binary in the target dir.
     let md = env::var("CARGO_MANIFEST_DIR").unwrap();
     let mut run_tc_test = PathBuf::from(md);
     run_tc_test.push("..");

--- a/tests/src/bin/run_trace_compiler_test.rs
+++ b/tests/src/bin/run_trace_compiler_test.rs
@@ -1,7 +1,7 @@
 //! Trace compiler test runner.
 //!
 //! Each invocation of this program runs one of the trace compiler tests found in the
-//! `trace_driver` directory of this crate.
+//! `trace_compiler` directory of this crate.
 
 use memmap2;
 use std::{collections::HashMap, env, ffi::CString, fs::File};
@@ -10,7 +10,7 @@ use yktrace::{IRBlock, IRTrace};
 fn main() {
     // Build the trace that we are going to have compiled.
     let mut bbs = vec![IRBlock::unmappable()];
-    for bb in env::var("TRACE_DRIVER_BBS").unwrap().split(",") {
+    for bb in env::var("YKT_TRACE_BBS").unwrap().split(",") {
         let mut elems = bb.split(":");
         let func = elems.next().unwrap();
         let bb_idx = elems.next().unwrap().parse::<usize>().unwrap();

--- a/tests/trace_compiler/guard_eq.ll
+++ b/tests/trace_compiler/guard_eq.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: TRACE_DRIVER_BBS=main:0,main:1
+;   env-var: YKT_TRACE_BBS=main:0,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...

--- a/tests/trace_compiler/small.ll
+++ b/tests/trace_compiler/small.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: TRACE_DRIVER_BBS=main:0
+;   env-var: YKT_TRACE_BBS=main:0
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...

--- a/tests/trace_compiler/smallest.ll
+++ b/tests/trace_compiler/smallest.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: TRACE_DRIVER_BBS=main:0
+;   env-var: YKT_TRACE_BBS=main:0
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...

--- a/tests/trace_compiler/two_blocks.ll
+++ b/tests/trace_compiler/two_blocks.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: TRACE_DRIVER_BBS=main:0,main:1
+;   env-var: YKT_TRACE_BBS=main:0,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...


### PR DESCRIPTION
This was a working name, which eventually became "trace compiler tests"
in PR #485.

I've renamed the variable `TRACE_DRIVER_BBS` to `YKT_TRACE_BBS`, where
`YKT` stands for "YK testing".

I didn't use the `YKD` prefix because, whilst the existing `YKD_*`
variables are used in testing, they can also be used more generally for
debugging the system. `YKT_TRACE_BBS`, on the other hand, can only ever
apply to a very specfic test scenario (trace driver tests).