### PR TITLE
Add a test for external calls.

### DIFF
--- a/tests/trace_compiler/call_ext.ll
+++ b/tests/trace_compiler/call_ext.ll
@@ -1,0 +1,23 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: YKT_TRACE_BBS=main:0
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{uid}} = call i32 @getuid()
+;        ret void
+;      }
+;
+;      declare i32 @getuid()
+;      --- End jit-pre-opt ---
+
+; Check that calls to external functions are properly declared in the trace.
+
+declare dso_local i32 @getuid()
+
+define void @main() {
+entry:
+    %0 = call i32 @getuid()
+    unreachable
+}

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -164,7 +164,8 @@ impl IRTrace {
     pub fn compile_for_tc_tests(&self, llvmbc_data: *const u8, llvmbc_len: usize) {
         let (func_names, bbs, trace_len) = self.encode_trace();
 
-        // FIXME: Populate these later as-needed (using additional hashmap argument).
+        // These would only need to be populated if we were to load the resulting compiled code
+        // into the address space, which for trace compiler tests, we don't.
         let faddr_keys = Vec::new();
         let faddr_vals = Vec::new();
 


### PR DESCRIPTION
I had expected to have to populate the function address map, as
mentioned in a FIXME I had inserted earlier. However, it turns out
that'd only be necessary if we were going to actually load the compiled
trace into the test's memory space (where we'd then get a linker error).

We don't actually do that with trace compiler tests (nor would it make
sense to, since we've faked all of the control point machinery), so the
function address map can in fact remain empty.