### PR TITLE
Test guards for `switch` instructions.

### DIFF
--- a/tests/trace_compiler/guard_switch_default.ll
+++ b/tests/trace_compiler/guard_switch_default.ll
@@ -1,0 +1,45 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: YKT_TRACE_BBS=main:0,main:1
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{4}} = add i32 0, 999
+;        switch i32 %{{4}}, label %{{5}} [
+;          i32 0, label %guardfail
+;          i32 1, label %guardfail
+;          i32 2, label %guardfail
+;        ]
+;
+;      guardfail:                                        ; preds = %3, %3, %3
+;        ...
+;
+;      {{5}}:...
+;        %6 = add i32 %4, 2
+;        ret void
+;        ...
+;      --- End jit-pre-opt ---
+
+; Check that an appropriate guard is inserted if a trace takes the default
+; switch case.
+
+define void @main() {
+entry:
+    %0 = add i32 0, 999
+    switch i32 %0, label %bb_default [i32 0, label %bb_zero
+                                      i32 1, label %bb_one
+                                      i32 2, label %bb_two]
+bb_default:
+    %1 = add i32 %0, 2
+    unreachable
+
+bb_zero:
+    unreachable
+
+bb_one:
+    unreachable
+
+bb_two:
+    unreachable
+}

--- a/tests/trace_compiler/guard_switch_non_default.ll
+++ b/tests/trace_compiler/guard_switch_non_default.ll
@@ -1,0 +1,43 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: YKT_TRACE_BBS=main:0,main:4
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{4}} = add i32 0, 2
+;        %{{5}} = icmp eq i32 %{{4}}, 2
+;        br i1 %{{5}}, label %{{6}}, label %guardfail
+;
+;       guardfail:...
+;        ...
+;
+;      {{6}}:...
+;        %{{7}} = add i32 %{{4}}, 1
+;        ret void
+;      }
+;      ...
+;      --- End jit-pre-opt ---
+
+; Check that an appropriate guard is inserted if a trace takes a non-default
+; switch case.
+
+define void @main() {
+entry:
+    %0 = add i32 0, 2
+    switch i32 %0, label %bb_default [i32 0, label %bb_zero
+                                      i32 1, label %bb_one
+                                      i32 2, label %bb_two]
+bb_default:
+    unreachable
+
+bb_zero:
+    unreachable
+
+bb_one:
+    unreachable
+
+bb_two:
+    %1 = add i32 %0, 1
+    unreachable
+}

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -1102,9 +1102,10 @@ createModule(Module *AOTMod, char *FuncNames[], size_t BBs[], size_t TraceLen,
 
 #ifdef YK_TESTING
 tuple<Module *, string, std::map<GlobalValue *, void *>>
-createModuleForTraceDriver(Module *AOTMod, char *FuncNames[], size_t BBs[],
-                           size_t TraceLen, char *FAddrKeys[],
-                           void *FAddrVals[], size_t FAddrLen) {
+createModuleForTraceCompilerTests(Module *AOTMod, char *FuncNames[],
+                                  size_t BBs[], size_t TraceLen,
+                                  char *FAddrKeys[], void *FAddrVals[],
+                                  size_t FAddrLen) {
   JITModBuilder JB = JITModBuilder::CreateMocked(
       AOTMod, FuncNames, BBs, TraceLen, FAddrKeys, FAddrVals, FAddrLen);
   auto JITMod = JB.createModule();

--- a/ykllvmwrap/src/jitmodbuilder.h
+++ b/ykllvmwrap/src/jitmodbuilder.h
@@ -11,8 +11,9 @@ createModule(Module *AOTMod, char *FuncNames[], size_t BBs[], size_t TraceLen,
              char *FAddrKeys[], void *FAddrVals[], size_t FAddrLen);
 #ifdef YK_TESTING
 std::tuple<Module *, std::string, std::map<GlobalValue *, void *>>
-createModuleForTraceDriver(Module *AOTMod, char *FuncNames[], size_t BBs[],
-                           size_t TraceLen, char *FAddrKeys[],
-                           void *FAddrVals[], size_t FAddrLen);
+createModuleForTraceCompilerTests(Module *AOTMod, char *FuncNames[],
+                                  size_t BBs[], size_t TraceLen,
+                                  char *FAddrKeys[], void *FAddrVals[],
+                                  size_t FAddrLen);
 #endif // YK_TESTING
 #endif

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -309,8 +309,8 @@ extern "C" void *__ykllvmwrap_irtrace_compile(
 extern "C" void *__ykllvmwrap_irtrace_compile_for_tc_tests(
     char *FuncNames[], size_t BBs[], size_t TraceLen, char *FAddrKeys[],
     void *FAddrVals[], size_t FAddrLen, void *BitcodeData, size_t BitcodeLen) {
-  return compileIRTrace(createModuleForTraceDriver, FuncNames, BBs, TraceLen,
-                        FAddrKeys, FAddrVals, FAddrLen, BitcodeData,
+  return compileIRTrace(createModuleForTraceCompilerTests, FuncNames, BBs,
+                        TraceLen, FAddrKeys, FAddrVals, FAddrLen, BitcodeData,
                         BitcodeLen);
 }
 #endif


### PR DESCRIPTION
We've already tested the guards we get from a regular `br` instruction. These tests are for the `switch` instruction.

[and also some renamings i missed earlier].