### PR TITLE
Add trace compiler tests for mutable and immutable globals.

### DIFF
--- a/tests/trace_compiler/global_immut.ll
+++ b/tests/trace_compiler/global_immut.ll
@@ -1,0 +1,23 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: YKT_TRACE_BBS=main:0
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        %{{0}} = load i32, i32* @g, align 4
+;        %{{1}} = add i32 %{{0}}, 1
+;        ret void
+;      }
+;      --- End jit-pre-opt ---
+
+; Check the trace compiler correctly handles a not-mutated global.
+
+@g = global i32 5
+
+define void @main() {
+entry:
+    %0 = load i32, i32* @g
+    %1 = add i32 %0, 1
+    unreachable
+}

--- a/tests/trace_compiler/global_mut.ll
+++ b/tests/trace_compiler/global_mut.ll
@@ -1,0 +1,21 @@
+; Run-time:
+;   env-var: YKD_PRINT_IR=jit-pre-opt
+;   env-var: YKT_TRACE_BBS=main:0
+;   stderr:
+;      --- Begin jit-pre-opt ---
+;      ...
+;      define internal void @__yk_compiled_trace_0(...
+;        store i32 1, i32* @g, align 4
+;        ret void
+;      }
+;      --- End jit-pre-opt ---
+
+; Check the trace compiler correctly handles a mutated global.
+
+@g = global i32 5
+
+define void @main() {
+entry:
+    store i32 1, i32* @g
+    unreachable
+}


### PR DESCRIPTION
For mutable globals, which can't be optimised away, I had to add a small
hack to get the trace through the compiler without getting symbol
errors.