### PR TITLE
Various fixes suggested by Clippy.

### DIFF
--- a/tests/src/bin/run_trace_compiler_test.rs
+++ b/tests/src/bin/run_trace_compiler_test.rs
@@ -25,5 +25,5 @@ fn main() {
     let ll_file = File::open(ll_path).unwrap();
     let mmap = unsafe { memmap2::Mmap::map(&ll_file).unwrap() };
 
-    trace.compile_for_tc_tests(mmap.as_ptr(), mmap.len());
+    unsafe { trace.compile_for_tc_tests(mmap.as_ptr(), mmap.len()) };
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@ fn ignore_dir(entry: &DirEntry) -> bool {
 fn clang_format() {
     for entry in WalkDir::new(".")
         .into_iter()
-        .filter_entry(|e| ignore_dir(e))
+        .filter_entry(ignore_dir)
         .filter_map(|e| e.ok())
     {
         if !entry.file_type().is_file() {

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -1,5 +1,7 @@
 // Exporting parts of the LLVM C++ API not present in the LLVM C API.
 
+#![allow(clippy::new_without_default)]
+
 // FIXME: C++ exceptions may unwind over the Rust FFI?
 // https://github.com/ykjit/yk/issues/426
 

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, feature(bench_black_box))]
 #![feature(once_cell)]
+#![allow(clippy::type_complexity)]
+#![allow(clippy::new_without_default)]
 
 mod location;
 pub(crate) mod mt;

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -38,8 +38,9 @@ const DEFAULT_HOT_THRESHOLD: HotThreshold = 50;
 thread_local! {static THREAD_MTTHREAD: MTThread = MTThread::new();}
 
 #[cfg(feature = "yk_testing")]
-static SERIALISE_COMPILATION: SyncLazy<bool> =
-    SyncLazy::new(|| &env::var("YKD_SERIALISE_COMPILATION").unwrap_or("0".to_owned()) == "1");
+static SERIALISE_COMPILATION: SyncLazy<bool> = SyncLazy::new(|| {
+    &env::var("YKD_SERIALISE_COMPILATION").unwrap_or_else(|_| "0".to_owned()) == "1"
+});
 
 #[derive(Clone)]
 /// A meta-tracer. Note that this is conceptually a "front-end" to the actual meta-tracer akin to

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 //! Note that LLVM currently only supports stackmaps for 64 bit architectures. Once they support
 //! others we will need to either make this parser more dynamic or create a new one for each
 //! architecture.
@@ -97,7 +99,7 @@ impl StackMapParser<'_> {
         v
     }
 
-    fn read_records(&mut self, num: u64, consts: &Vec<u64>) -> Vec<Record> {
+    fn read_records(&mut self, num: u64, consts: &[u64]) -> Vec<Record> {
         let mut v = Vec::new();
         for _ in 0..num {
             let _id = self.read_u64();
@@ -116,7 +118,7 @@ impl StackMapParser<'_> {
         v
     }
 
-    fn read_locations(&mut self, num: u16, consts: &Vec<u64>) -> Vec<Location> {
+    fn read_locations(&mut self, num: u16, consts: &[u64]) -> Vec<Location> {
         let mut v = Vec::new();
         for _ in 0..num {
             let kind = self.read_u8();

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -20,7 +20,7 @@ use ykllvmwrap::symbolizer::Symbolizer;
 use ykutil::addr::{code_vaddr_to_off, off_to_vaddr_main_obj};
 
 const BLOCK_MAP_SEC: &str = ".llvm_bb_addr_map";
-static BLOCK_MAP: SyncLazy<BlockMap> = SyncLazy::new(|| BlockMap::new());
+static BLOCK_MAP: SyncLazy<BlockMap> = SyncLazy::new(BlockMap::new);
 
 /// The information for one LLVM MachineBasicBlock, as per:
 /// https://llvm.org/docs/Extensions.html#sht-llvm-bb-addr-map-section-basic-block-address-map
@@ -152,10 +152,8 @@ impl HWTMapper {
             }
         }
         // Strip any trailing unmappable blocks.
-        if !ret_irblocks.is_empty() {
-            if ret_irblocks.last().unwrap().is_unmappable() {
-                ret_irblocks.pop();
-            }
+        if !ret_irblocks.is_empty() && ret_irblocks.last().unwrap().is_unmappable() {
+            ret_irblocks.pop();
         }
 
         #[cfg(debug_assertions)]

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -1,6 +1,7 @@
 //! Utilities for collecting and decoding traces.
 
 #![feature(once_cell)]
+#![allow(clippy::new_without_default)]
 
 mod errors;
 use libc::c_void;
@@ -62,7 +63,7 @@ impl IRBlock {
     }
 
     pub fn func_name(&self) -> &CStr {
-        &self.func_name.as_c_str()
+        self.func_name.as_c_str()
     }
 
     pub fn bb(&self) -> usize {
@@ -161,7 +162,7 @@ impl IRTrace {
     }
 
     #[cfg(feature = "yk_testing")]
-    pub fn compile_for_tc_tests(&self, llvmbc_data: *const u8, llvmbc_len: usize) {
+    pub unsafe fn compile_for_tc_tests(&self, llvmbc_data: *const u8, llvmbc_len: usize) {
         let (func_names, bbs, trace_len) = self.encode_trace();
 
         // These would only need to be populated if we were to load the resulting compiled code
@@ -169,18 +170,16 @@ impl IRTrace {
         let faddr_keys = Vec::new();
         let faddr_vals = Vec::new();
 
-        let ret = unsafe {
-            ykllvmwrap::__ykllvmwrap_irtrace_compile_for_tc_tests(
-                func_names.as_ptr(),
-                bbs.as_ptr(),
-                trace_len,
-                faddr_keys.as_ptr(),
-                faddr_vals.as_ptr(),
-                faddr_keys.len(),
-                llvmbc_data,
-                llvmbc_len,
-            )
-        };
+        let ret = ykllvmwrap::__ykllvmwrap_irtrace_compile_for_tc_tests(
+            func_names.as_ptr(),
+            bbs.as_ptr(),
+            trace_len,
+            faddr_keys.as_ptr(),
+            faddr_vals.as_ptr(),
+            faddr_keys.len(),
+            llvmbc_data,
+            llvmbc_len,
+        );
         assert_ne!(ret, ptr::null());
     }
 }


### PR DESCRIPTION
This doesn't fix all of Clippy's reasonable-looking warnings, but it does at least do most of the easy ones.