### PR TITLE
Simplify location transition

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -3,7 +3,7 @@
 use std::{
     convert::TryFrom,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicPtr, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -442,5 +442,5 @@ pub(crate) enum HotLocation {
     /// traced again.
     DontTrace,
     /// This HotLocation started a trace which is ongoing.
-    Tracing(Option<Arc<()>>),
+    Tracing(Arc<AtomicPtr<HotLocation>>),
 }

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -429,10 +429,6 @@ impl LocationInner {
     }
 }
 
-/// An opaque struct used by `MTThreadInner` to help identify if a thread that started a trace is
-/// still active.
-pub(crate) struct ThreadIdInner;
-
 /// A `Location`'s non-counting states.
 #[derive(EnumDiscriminants)]
 pub(crate) enum HotLocation {
@@ -446,5 +442,5 @@ pub(crate) enum HotLocation {
     /// traced again.
     DontTrace,
     /// This HotLocation started a trace which is ongoing.
-    Tracing(Option<Arc<ThreadIdInner>>),
+    Tracing(Option<Arc<()>>),
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -20,7 +20,7 @@ use num_cpus;
 use parking_lot::{Condvar, Mutex, MutexGuard};
 use std::lazy::SyncLazy;
 
-use crate::location::{HotLocation, Location, LocationInner, ThreadIdInner};
+use crate::location::{HotLocation, Location, LocationInner};
 use yktrace::{start_tracing, stop_tracing, CompiledTrace, IRTrace, TracingKind};
 
 // The HotThreshold must be less than a machine word wide for [`Location::Location`] to do its
@@ -371,7 +371,7 @@ pub struct MTThread {
     /// this Arc's strong count will be incremented. If, after this thread drops, this Arc's strong
     /// count remains > 0, it means that it was in the process of tracing a loop, implying that
     /// there is (or, at least, was at some point) a Location stuck in PHASE_TRACING.
-    tid: Arc<ThreadIdInner>,
+    tid: Arc<()>,
     /// If this thread is tracing, store a pointer to the `HotLocation`: this allows us to
     /// differentiate which thread is actually tracing the location.
     tracing: Cell<Option<*const ()>>,
@@ -382,7 +382,7 @@ pub struct MTThread {
 impl MTThread {
     fn new() -> Self {
         MTThread {
-            tid: Arc::new(ThreadIdInner),
+            tid: Arc::new(()),
             tracing: Cell::new(None),
             _dont_send_or_sync_me: PhantomData,
         }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -3,14 +3,12 @@
 #[cfg(feature = "yk_testing")]
 use std::env;
 use std::{
-    cell::Cell,
     cmp,
     collections::VecDeque,
     ffi::c_void,
     marker::PhantomData,
-    ptr,
     sync::{
-        atomic::{AtomicU32, AtomicUsize, Ordering},
+        atomic::{AtomicPtr, AtomicU32, AtomicUsize, Ordering},
         Arc,
     },
     thread,
@@ -178,7 +176,7 @@ impl MT {
                 return TransitionLocation::NoAction;
             } else {
                 return THREAD_MTTHREAD.with(|mtt| {
-                    if mtt.tracing.get().is_some() {
+                    if !mtt.tracing.load(Ordering::Relaxed).is_null() {
                         // This thread is already tracing another Location, so either another
                         // thread needs to trace this Location or this thread needs to wait
                         // until the current round of tracing has completed. Either way,
@@ -188,7 +186,8 @@ impl MT {
                         // To avoid racing with another thread that may also try starting to trace this
                         // location at the same time, we need to initialise and lock the Location, which we
                         // perform in a single step.
-                        let hl_ptr = Box::into_raw(Box::new(HotLocation::Tracing(None)));
+                        let hl_ptr =
+                            Box::into_raw(Box::new(HotLocation::Tracing(Arc::clone(&mtt.tracing))));
                         let new_ls = LocationInner::new().with_hotlocation(hl_ptr).with_lock();
                         debug_assert!(!ls.is_locked());
                         match loc.compare_exchange(ls, new_ls, Ordering::Acquire, Ordering::Relaxed)
@@ -196,11 +195,9 @@ impl MT {
                             Ok(_) => {
                                 // We've initialised this Location and obtained the lock, so we can now
                                 // start tracing for real.
-                                let tid = Arc::clone(&mtt.tid);
                                 #[cfg(feature = "jit_state_debug")]
                                 eprintln!("jit-state: start-tracing");
-                                *unsafe { new_ls.hot_location() } = HotLocation::Tracing(Some(tid));
-                                mtt.tracing.set(Some(hl_ptr as *const ()));
+                                mtt.tracing.store(hl_ptr, Ordering::Relaxed);
                                 loc.unlock();
                                 TransitionLocation::StartTracing(self.tracing_kind())
                             }
@@ -234,7 +231,7 @@ impl MT {
                 None => {
                     // If this thread is tracing we need to grab the lock so that we can stop
                     // tracing, otherwise we return to the interpreter.
-                    if THREAD_MTTHREAD.with(|mtt| mtt.tracing.get().is_none()) {
+                    if THREAD_MTTHREAD.with(|mtt| mtt.tracing.load(Ordering::Relaxed).is_null()) {
                         return TransitionLocation::NoAction;
                     }
                     match loc.lock() {
@@ -248,7 +245,6 @@ impl MT {
                 }
             }
             let hl = unsafe { ls.hot_location() };
-            let hl_ptr = hl as *mut _ as *mut ();
             match hl {
                 HotLocation::Compiled(ctr) => {
                     loc.unlock();
@@ -270,15 +266,16 @@ impl MT {
                     loc.unlock();
                     return r;
                 }
-                HotLocation::Tracing(opt) => {
+                HotLocation::Tracing(tarc) => {
                     // FIXME: This is the sort of hack that keeps me awake at night: we really want
                     // to return from the outer function, and to modify `hl`, but can't because
                     // we're in a closure. The integer return value allows us to perform the
                     // control flow we want.
                     let r = THREAD_MTTHREAD.with(|mtt| {
-                        if let Some(other_hl_ptr) = mtt.tracing.get() {
+                        let thread_hl_ptr = mtt.tracing.load(Ordering::Relaxed);
+                        if !thread_hl_ptr.is_null() {
                             // This thread is tracing something...
-                            if !ptr::eq(hl_ptr, other_hl_ptr) {
+                            if !Arc::ptr_eq(tarc, &mtt.tracing) {
                                 // but not this Location.
                                 loc.unlock();
                                 // Should be `return TransitionLocation::NoAction`
@@ -286,11 +283,7 @@ impl MT {
                             } else {
                                 // This thread is tracing this location: we must, therefore, have
                                 // finished tracing the loop.
-                                //
-                                // We must ensure that the `Arc<ThreadId>` inside `opt` is dropped so that
-                                // other threads won't think this thread has died while tracing.
-                                mtt.tracing.set(None);
-                                opt.take();
+                                mtt.tracing.store(std::ptr::null_mut(), Ordering::Relaxed);
                                 2
                             }
                         } else {
@@ -303,7 +296,7 @@ impl MT {
                         2 => (),
                         3 => {
                             // This thread isn't tracing anything.
-                            if Arc::strong_count(&opt.as_ref().unwrap()) == 1 {
+                            if Arc::strong_count(tarc) == 1 {
                                 // Another thread was tracing this location but it's terminated.
                                 // FIXME: we should probably have some sort of occasional retry
                                 // heuristic rather than simply saying "never try tracing this
@@ -367,14 +360,22 @@ struct MTInner {
 /// Meta-tracer per-thread state. Note that this struct is neither `Send` nor `Sync`: it can only
 /// be accessed from within a single thread.
 pub struct MTThread {
-    /// An Arc whose pointer address uniquely identifies this thread. When a Location is traced,
-    /// this Arc's strong count will be incremented. If, after this thread drops, this Arc's strong
-    /// count remains > 0, it means that it was in the process of tracing a loop, implying that
-    /// there is (or, at least, was at some point) a Location stuck in PHASE_TRACING.
-    tid: Arc<()>,
-    /// If this thread is tracing, store a pointer to the `HotLocation`: this allows us to
-    /// differentiate which thread is actually tracing the location.
-    tracing: Cell<Option<*const ()>>,
+    /// Is this thread currently tracing something? If so, the [AtomicPtr] points to the
+    /// [HotLocation] currently being traced. If not, the [AtomicPtr] is `null`. Note that no
+    /// reads/writes must depend on the [AtomicPtr], so all loads/stores can be
+    /// [Ordering::Relaxed].
+    ///
+    /// We wrap the [AtomicPtr] in an [Arc] to serve a second purpose: when we start tracing, we
+    /// `clone` the [Arc] and store it in [HotLocation::Tracing]. This allows another thread to
+    /// tell whether the thread that started tracing a [Location] is still alive or not by
+    /// inspecting its strong count (if the strong count is equal to 1 then the thread died while
+    /// tracing). Note that this relies on thread local storage dropping the [MTThread] instance
+    /// and (by implication) dropping the [Arc] and decrementing its strong count. Unfortunately,
+    /// there is no guarantee that thread local storage will be dropped when a thread dies (and
+    /// there is also significant platform variation in regard to dropping thread locals), so this
+    /// mechanism can't be fully relied upon: however, we can't monitor thread death in any other
+    /// reasonable way, so this will have to do.
+    tracing: Arc<AtomicPtr<HotLocation>>,
     // Raw pointers are neither send nor sync.
     _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
@@ -382,8 +383,7 @@ pub struct MTThread {
 impl MTThread {
     fn new() -> Self {
         MTThread {
-            tid: Arc::new(()),
-            tracing: Cell::new(None),
+            tracing: Arc::new(AtomicPtr::new(std::ptr::null_mut())),
             _dont_send_or_sync_me: PhantomData,
         }
     }


### PR DESCRIPTION
This PR simplifies the location transition code bit by bit, using the test suite from #496 to give us reasonable confidence that we aren't introducing too many new bugs. You might notice that this PR deletes more code than it adds!