### PR TITLE
Add a concept of "trace failure threshold"

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -8,7 +8,7 @@ use std::{
     },
 };
 
-use crate::mt::HotThreshold;
+use crate::mt::{HotThreshold, TraceFailureThreshold};
 use parking_lot::Mutex;
 use parking_lot_core::{
     park, unpark_one, ParkResult, SpinWait, UnparkResult, UnparkToken, DEFAULT_PARK_TOKEN,
@@ -431,6 +431,7 @@ impl LocationInner {
 
 pub(crate) struct HotLocation {
     pub(crate) kind: HotLocationKind,
+    pub(crate) trace_failure: TraceFailureThreshold,
 }
 
 /// A `Location`'s non-counting states.


### PR DESCRIPTION
The aim of this PR (achieved in the final commit https://github.com/ykjit/yk/commit/14dd81bb7f883d18720f331a418f51c4762660d4) is to allow us to retry tracing a `Location` several times if it doesn't succeed, before giving up forever and marking it `DontTrace`.

In order to get to that point, we first change the `HotLocation` enum into a struct roughly from:

```rust
enum HotLocation { ... }
```

to:

```rust
enum HotLocationKind { ... }
struct HotLocation {
  kind: HotLocationKind
}
```

This allows us to store information such as "how often has this location failed tracing" in the `HotLocation` struct.