### PR TITLE
jit_state_env fix and a build system sanity check.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -22,6 +22,14 @@ export PATH=${CARGO_HOME}/bin/:$PATH
 
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 
+# There are some feature-gated testing/debugging switches which slow the JIT
+# down a bit. Check that if we build the system without tests, those features
+# are not enabled.
+for mode in "" "--release"; do \
+    cargo -Z unstable-options build ${mode} --build-plan -p ykcapi | \
+        awk '/yk_testing/ { ec=1 } /jit_state_debug/ { ec=1 } END {exit ec}'; \
+done
+
 cargo fmt --all -- --check
 
 # Build LLVM for the C tests.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,6 +23,6 @@ yktrace = { path = "../yktrace", features = ["yk_testing"] }
 [dev-dependencies]
 lang_tester = "0.7.1"
 tempfile = "3.3.0"
-ykcapi = { path = "../ykcapi", features = ["yk_testing"] }
+ykcapi = { path = "../ykcapi", features = ["yk_testing", "jit_state_debug"] }
 ykllvmwrap = { path = "../ykllvmwrap", features = ["yk_testing"] }
 ykrt = { path = "../ykrt", features = ["yk_testing", "jit_state_debug"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,6 +23,6 @@ yktrace = { path = "../yktrace", features = ["yk_testing"] }
 [dev-dependencies]
 lang_tester = "0.7.1"
 tempfile = "3.3.0"
-ykcapi = { path = "../ykcapi", features = ["yk_testing", "jit_state_debug"] }
+ykcapi = { path = "../ykcapi", features = ["yk_testing", "yk_jitstate_debug"] }
 ykllvmwrap = { path = "../ykllvmwrap", features = ["yk_testing"] }
-ykrt = { path = "../ykrt", features = ["yk_testing", "jit_state_debug"] }
+ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }

--- a/tests/tests/call_ext_in_obj.c
+++ b/tests/tests/call_ext_in_obj.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     4

--- a/tests/tests/const_global.c
+++ b/tests/tests/const_global.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=4

--- a/tests/tests/fib.c
+++ b/tests/tests/fib.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     4:21

--- a/tests/tests/funcptrarg_noir.c
+++ b/tests/tests/funcptrarg_noir.c
@@ -1,7 +1,7 @@
-// Compiler:
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
 //     --- Begin jit-pre-opt ---

--- a/tests/tests/funcptrarg_pretrace.c
+++ b/tests/tests/funcptrarg_pretrace.c
@@ -1,7 +1,7 @@
-// Compiler:
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
 //     --- Begin jit-pre-opt ---

--- a/tests/tests/indirect_branch.c
+++ b/tests/tests/indirect_branch.c
@@ -1,8 +1,7 @@
 // ignore: guards for indirect branches not implemented.
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
 

--- a/tests/tests/intrinsics.c
+++ b/tests/tests/intrinsics.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     jit-state: stop-tracing

--- a/tests/tests/mutable_global.c
+++ b/tests/tests/mutable_global.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=4

--- a/tests/tests/ptr_global.c
+++ b/tests/tests/ptr_global.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
 //     i=25

--- a/tests/tests/recursion.c
+++ b/tests/tests/recursion.c
@@ -1,9 +1,8 @@
 // ignore: optimisation levels >0 need more intrinsics support.
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     4:0

--- a/tests/tests/recursion.c.O0
+++ b/tests/tests/recursion.c.O0
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     4:0

--- a/tests/tests/simple.c
+++ b/tests/tests/simple.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=4

--- a/tests/tests/simple_interp_loop1.c
+++ b/tests/tests/simple_interp_loop1.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     pc=0, mem=12

--- a/tests/tests/simple_interp_loop2.c
+++ b/tests/tests/simple_interp_loop2.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     pc=0, mem=4

--- a/tests/tests/switch.c
+++ b/tests/tests/switch.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=3

--- a/tests/tests/switch_default.c
+++ b/tests/tests/switch_default.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
 //     i=4

--- a/tests/tests/void_ret.c
+++ b/tests/tests/void_ret.c
@@ -1,8 +1,7 @@
-// Compiler:
-//   env-var: YKD_PRINT_JITSTATE=1
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
 //     jit-state: enter-jit-code

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -17,3 +17,4 @@ yksmp = { path = "../yksmp" }
 
 [features]
 yk_testing = []
+jit_state_debug = []

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -17,4 +17,4 @@ yksmp = { path = "../yksmp" }
 
 [features]
 yk_testing = []
-jit_state_debug = []
+yk_jitstate_debug = []

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -122,7 +122,7 @@ pub extern "C" fn yk_stopgap(
     rsp: *const c_void,
 ) {
     // FIXME: remove once we have a stopgap interpreter.
-    #[cfg(feature = "jit_state_debug")]
+    #[cfg(feature = "yk_jitstate_debug")]
     print_jit_state("stopgap");
     // Restore saved registers from the stack.
     let registers = Registers::from_ptr(rsp);

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::process;
 use std::{ptr, slice};
-use ykrt::{HotThreshold, Location, MT};
+use ykrt::{print_jit_state, HotThreshold, Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
 
 #[no_mangle]
@@ -122,7 +122,8 @@ pub extern "C" fn yk_stopgap(
     rsp: *const c_void,
 ) {
     // FIXME: remove once we have a stopgap interpreter.
-    eprintln!("jit-state: stopgap");
+    #[cfg(feature = "jit_state_debug")]
+    print_jit_state("stopgap");
     // Restore saved registers from the stack.
     let registers = Registers::from_ptr(rsp);
 

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -10,13 +10,10 @@ num_cpus = "1.13.1"
 parking_lot = "0.12.0"
 parking_lot_core = "0.9.1"
 strum = { version = "0.23.0", features = ["derive"] }
-yktrace = { path = "../yktrace", default-features = false, features = ["yk_testing"] }
+yktrace = { path = "../yktrace" }
 
 [build-dependencies]
 regex = "1.5.4"
-
-[dev-dependencies]
-ykrt = { path = ".", features = ["yk_testing"] }
 
 [features]
 jit_state_debug = []

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -16,5 +16,5 @@ yktrace = { path = "../yktrace" }
 regex = "1.5.4"
 
 [features]
-jit_state_debug = []
+yk_jitstate_debug = []
 yk_testing = []

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -14,11 +14,11 @@ pub(crate) mod mt;
 pub use self::location::Location;
 pub use self::mt::{HotThreshold, MT};
 
-#[cfg(feature = "jit_state_debug")]
+#[cfg(feature = "yk_jitstate_debug")]
 static JITSTATE_DEBUG: SyncLazy<bool> = SyncLazy::new(|| env::var("YKD_PRINT_JITSTATE").is_ok());
 
 /// Print select JIT events to stderr for testing/debugging purposes.
-#[cfg(feature = "jit_state_debug")]
+#[cfg(feature = "yk_jitstate_debug")]
 pub fn print_jit_state(state: &str) {
     if *JITSTATE_DEBUG {
         eprintln!("jit-state: {}", state);

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -6,8 +6,21 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]
 
+use std::{env, lazy::SyncLazy};
+
 mod location;
 pub(crate) mod mt;
 
 pub use self::location::Location;
 pub use self::mt::{HotThreshold, MT};
+
+#[cfg(feature = "jit_state_debug")]
+static JITSTATE_DEBUG: SyncLazy<bool> = SyncLazy::new(|| env::var("YKD_PRINT_JITSTATE").is_ok());
+
+/// Print select JIT events to stderr for testing/debugging purposes.
+#[cfg(feature = "jit_state_debug")]
+pub fn print_jit_state(state: &str) {
+    if *JITSTATE_DEBUG {
+        eprintln!("jit-state: {}", state);
+    }
+}

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -164,21 +164,21 @@ impl MT {
                 // the trace itself.
                 // https://github.com/ykjit/yk/issues/442
                 loop {
-                    #[cfg(feature = "jit_state_debug")]
+                    #[cfg(feature = "yk_jitstate_debug")]
                     print_jit_state("enter-jit-code");
                     unsafe { &*ctr }.exec(ctrlp_vars);
-                    #[cfg(feature = "jit_state_debug")]
+                    #[cfg(feature = "yk_jitstate_debug")]
                     print_jit_state("exit-jit-code");
                 }
             }
             TransitionLocation::StartTracing(kind) => {
-                #[cfg(feature = "jit_state_debug")]
+                #[cfg(feature = "yk_jitstate_debug")]
                 print_jit_state("start-tracing");
                 start_tracing(kind);
             }
             TransitionLocation::StopTracing(x) => match stop_tracing() {
                 Ok(ir_trace) => {
-                    #[cfg(feature = "jit_state_debug")]
+                    #[cfg(feature = "yk_jitstate_debug")]
                     print_jit_state("stop-tracing");
                     self.queue_compile_job(ir_trace, x);
                 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -18,7 +18,10 @@ use num_cpus;
 use parking_lot::{Condvar, Mutex, MutexGuard};
 use std::lazy::SyncLazy;
 
-use crate::location::{HotLocation, HotLocationKind, Location, LocationInner};
+use crate::{
+    location::{HotLocation, HotLocationKind, Location, LocationInner},
+    print_jit_state,
+};
 use yktrace::{start_tracing, stop_tracing, CompiledTrace, IRTrace, TracingKind};
 
 // The HotThreshold must be less than a machine word wide for [`Location::Location`] to do its
@@ -162,21 +165,21 @@ impl MT {
                 // https://github.com/ykjit/yk/issues/442
                 loop {
                     #[cfg(feature = "jit_state_debug")]
-                    eprintln!("jit-state: enter-jit-code");
+                    print_jit_state("enter-jit-code");
                     unsafe { &*ctr }.exec(ctrlp_vars);
                     #[cfg(feature = "jit_state_debug")]
-                    eprintln!("jit-state: exit-jit-code");
+                    print_jit_state("exit-jit-code");
                 }
             }
             TransitionLocation::StartTracing(kind) => {
                 #[cfg(feature = "jit_state_debug")]
-                eprintln!("jit-state: start-tracing");
+                print_jit_state("start-tracing");
                 start_tracing(kind);
             }
             TransitionLocation::StopTracing(x) => match stop_tracing() {
                 Ok(ir_trace) => {
                     #[cfg(feature = "jit_state_debug")]
-                    eprintln!("jit-state: stop-tracing");
+                    print_jit_state("stop-tracing");
                     self.queue_compile_job(ir_trace, x);
                 }
                 Err(_) => todo!(),


### PR DESCRIPTION
The first commit ensures that the system checks `YKD_PRINT_JITSTATE` again.

The second is something that has been on my mind for a  while. There are two cargo features in our system which we need for testing and debugging, and which slow the system down:
 - `yk_testing`
 - `jit_state_debug`
 
It occurs to me that by building only what is necessary to use (but not test or debug) the JIT, we should never pull in those features, otherwise we incur unnecessary slowdowns.

["building only what is necessary to use (but not test or debug) the JIT" is defined as: building only the ykcapi shared object, and without enabling extra features on the command line]

The second commit ensures this, and adds a check to CI to make sure we always maintain this property.

I'm raising this a draft, as I have a question: should "yk_testing" and "jit_state_debug" be merged into one?

By default these features are only ever enabled together, but that's not to say that a user might not want to use jit state debugging without testing support...

Thoughts?