### PR TITLE
Rename yk_set_hot_threshold to yk_hot_threshold_set.

### DIFF
--- a/tests/tests/call_ext_in_obj.c
+++ b/tests/tests/call_ext_in_obj.c
@@ -27,7 +27,7 @@ extern int call_me_add(int);
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   int i = 3;

--- a/tests/tests/call_ext_simple.c
+++ b/tests/tests/call_ext_simple.c
@@ -22,7 +22,7 @@
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   int ch = '1';

--- a/tests/tests/const_global.c
+++ b/tests/tests/const_global.c
@@ -56,7 +56,7 @@ const int add = 2;
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/tests/tests/fib.c
+++ b/tests/tests/fib.c
@@ -41,7 +41,7 @@ __attribute__((noinline)) int fib(int num) {
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   int i = 4;

--- a/tests/tests/funcptrarg_noir.c
+++ b/tests/tests/funcptrarg_noir.c
@@ -27,7 +27,7 @@ int bar(size_t (*func)(const char *)) {
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   int z = 0, i = 2;

--- a/tests/tests/funcptrarg_pretrace.c
+++ b/tests/tests/funcptrarg_pretrace.c
@@ -27,7 +27,7 @@
 
 int bar(size_t (*func)(const char *)) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   size_t pre = func("abc");

--- a/tests/tests/intrinsics.c
+++ b/tests/tests/intrinsics.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
   int res = 0;
   int src = 1000;
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;
   NOOPT_VAL(res);

--- a/tests/tests/mutable_global.c
+++ b/tests/tests/mutable_global.c
@@ -54,7 +54,7 @@ int add;
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/tests/tests/ptr_global.c
+++ b/tests/tests/ptr_global.c
@@ -22,7 +22,7 @@ char *p = NULL;
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   int i = 0;
   YkLocation loc = yk_location_new();
   p = argv[0];

--- a/tests/tests/recursion.c
+++ b/tests/tests/recursion.c
@@ -38,7 +38,7 @@ __attribute__((noinline)) int f(int num) {
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   int i = 4;

--- a/tests/tests/simple.c
+++ b/tests/tests/simple.c
@@ -55,7 +55,7 @@
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   int res = 9998;
   YkLocation loc = yk_location_new();
   fflush(NULL);

--- a/tests/tests/simple_interp_loop1.c
+++ b/tests/tests/simple_interp_loop1.c
@@ -72,7 +72,7 @@ int mem = 12;
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
 
   // A hard-coded program to execute.
   int prog[] = {DEC, DEC, DEC, RESTART_IF_NOT_ZERO, DEC, DEC};

--- a/tests/tests/simple_interp_loop2.c
+++ b/tests/tests/simple_interp_loop2.c
@@ -72,7 +72,7 @@ int mem = 4;
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
 
   // A hard-coded program to execute.
   int prog[] = {NOP, NOP, DEC, RESTART_IF_NOT_ZERO, NOP, EXIT};

--- a/tests/tests/switch.c
+++ b/tests/tests/switch.c
@@ -32,7 +32,7 @@
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;
   int j = 300;

--- a/tests/tests/switch_default.c
+++ b/tests/tests/switch_default.c
@@ -38,7 +38,7 @@
 
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 4;
   NOOPT_VAL(i);

--- a/tests/tests/void_ret.c
+++ b/tests/tests/void_ret.c
@@ -26,7 +26,7 @@ void __attribute__((noinline)) f() {
 int main(int argc, char **argv) {
 
   YkMT *mt = yk_mt_new();
-  yk_set_hot_threshold(mt, 0);
+  yk_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
   int i = 4;

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -48,7 +48,7 @@ pub extern "C" fn __ykrt_control_point(mt: *mut MT, loc: *mut Location, ctrlp_va
 }
 
 #[no_mangle]
-pub extern "C" fn yk_set_hot_threshold(mt: &MT, hot_threshold: HotThreshold) {
+pub extern "C" fn yk_hot_threshold_set(mt: &MT, hot_threshold: HotThreshold) {
     mt.set_hot_threshold(hot_threshold);
 }
 

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -43,7 +43,7 @@ void yk_mt_drop(YkMT *);
 void yk_control_point(YkMT *, YkLocation *);
 
 // Set the threshold at which `YkLocation`'s are considered hot.
-void yk_set_hot_threshold(YkMT *, YkHotThreshold);
+void yk_hot_threshold_set(YkMT *, YkHotThreshold);
 
 // Create a new `Location`.
 //


### PR DESCRIPTION
This reflects the ordering of other functions in the C API.

Perhaps we should also rename `set_hot_threshold` to `hot_threshold_set` in the Rust API too?