### PR TITLE
Fix silent failure of clang-format on the C test suite.

### DIFF
--- a/tests/tests/.clang-format
+++ b/tests/tests/.clang-format
@@ -1,2 +1,2 @@
 # Some lang_tester comment lines have to be long.
-ReflowComments=false
+ReflowComments: false

--- a/tests/tests/blockmap.c
+++ b/tests/tests/blockmap.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
 void unused() {
   YkMT *mt = yk_mt_new();
   YkLocation loc = yk_location_new();
-  while(true) {
+  while (true) {
     yk_control_point(mt, &loc);
   }
   yk_location_drop(loc);

--- a/tests/tests/control_point_in_nested_loop.c
+++ b/tests/tests/control_point_in_nested_loop.c
@@ -3,8 +3,8 @@
 
 // Check that the system is OK with the control point being in a nested loop.
 
-#include <stdlib.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <yk.h>
 #include <yk_testing.h>
 

--- a/tests/tests/control_point_not_in_loop.c
+++ b/tests/tests/control_point_not_in_loop.c
@@ -7,8 +7,8 @@
 
 // Check that the system crashes if the control point is not in a loop.
 
-#include <stdlib.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <yk.h>
 
 int main(int argc, char **argv) {

--- a/tests/tests/indirect_branch.c
+++ b/tests/tests/indirect_branch.c
@@ -25,11 +25,11 @@ int main(int argc, char **argv) {
     yk_control_point(loc);
     fprintf(stderr, "i=%d\n", i);
     goto *dispatch[idx];
-label1:
+  label1:
     abort(); // unreachable.
-label2:
+  label2:
     abort(); // unreachable.
-label3:
+  label3:
     i--;
   }
   abort(); // FIXME: unreachable due to aborting guard failure earlier.

--- a/tests/tests/switch.c
+++ b/tests/tests/switch.c
@@ -41,15 +41,15 @@ int main(int argc, char **argv) {
     yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     switch (j) {
-      case 100:
-        i = 997;
-      case 200:
-        i = 998;
-      case 300:
-        i--;
-        break;
-      default:
-        i = 999;
+    case 100:
+      i = 997;
+    case 200:
+      i = 998;
+    case 300:
+      i--;
+      break;
+    default:
+      i = 999;
     }
   }
   abort(); // FIXME: unreachable due to aborting guard failure earlier.

--- a/tests/tests/switch_default.c
+++ b/tests/tests/switch_default.c
@@ -45,14 +45,14 @@ int main(int argc, char **argv) {
     yk_control_point(mt, &loc);
     fprintf(stderr, "i=%d\n", i);
     switch (i) {
-      case 100:
-        fprintf(stderr, "one hundred\n");
-      case 200:
-        fprintf(stderr, "two hundred\n");
-      case 300:
-        fprintf(stderr, "three hundred\n");
-      default:
-        i--;
+    case 100:
+      fprintf(stderr, "one hundred\n");
+    case 200:
+      fprintf(stderr, "two hundred\n");
+    case 300:
+      fprintf(stderr, "three hundred\n");
+    default:
+      i--;
     }
   }
   abort(); // FIXME: unreachable due to aborting guard failure earlier.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,11 +24,14 @@ fn clang_format() {
         if let Some(ext) = entry.path().extension() {
             match ext.to_str().unwrap() {
                 "h" | "c" | "cpp" | "cc" => {
-                    Command::new("clang-format")
+                    let res = Command::new("clang-format")
                         .arg("-i")
                         .arg(entry.path())
                         .output()
                         .expect("Failed to execute xtask: cfmt");
+                    if !res.status.success() {
+                        panic!("clang-format failed on {}", entry.path().to_str().unwrap());
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
The problem is twofold:

 - The clang-format config file for the C suite is invalid and causes
   clang-format to exit with error status.

 - The xtask program running clang-format doesn't check the exit status,
   so we have been failing silently.

This change fixes those, and fixes bad formatting that slipped through
as a result of the bugs.