### PR TITLE
Our JITted traces use the C ABI and are unsafe.

### DIFF
--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -234,8 +234,12 @@ impl CompiledTrace {
     pub fn exec(&self, ctrlp_vars: *mut c_void) {
         #[cfg(feature = "yk_testing")]
         assert_ne!(self.entry as *const (), std::ptr::null());
-        let f = unsafe { mem::transmute::<_, fn(*mut c_void, *const c_void, usize)>(self.entry) };
-        (f)(ctrlp_vars, self.smptr, self.smsize)
+        unsafe {
+            let f = mem::transmute::<_, unsafe extern "C" fn(*mut c_void, *const c_void, usize)>(
+                self.entry,
+            );
+            f(ctrlp_vars, self.smptr, self.smsize)
+        }
     }
 }
 


### PR DESCRIPTION
I noticed that we are erroneously calling our traces with the Rust ABI.
It's working by chance.

[There's a bit of churn in the diff, but essentially I just added `unsafe extern "C"` to the place where we cast the pointer to the code to a callable function]

[See [here](https://github.com/ykjit/yk/blob/7d4e6d084ae5daa25ceeddee108634e7f9ea56d2/ykllvmwrap/src/jitmodbuilder.cc#L391) for proof that our trace code is C ABI]