### PR TITLE
Fix a prototype (found while compiling Lua with Yk support)

### DIFF
--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -29,7 +29,7 @@ typedef uint32_t YkHotThreshold;
 typedef struct YkMT YkMT;
 
 // Create a new `YkMT` instance.
-YkMT *yk_mt_new();
+YkMT *yk_mt_new(void);
 
 // Drop a `YkMT` instance. This must be called at most once per `YkMT`
 // instance: calling this function more than once on a `YkMT` instance leads to


### PR DESCRIPTION
Silences:

```
yk.h:32:16: warning: this function declaration is not a prototype [-Wstrict-prototypes]
YkMT *yk_mt_new();
               ^
                void
1 warning generated.
```