### PR TITLE
Implement missing stuff required to run ykcbf.

### DIFF
--- a/tests/tests/blockmap.c
+++ b/tests/tests/blockmap.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
 //
 // FIXME: This only returns an integer due to a shortcoming of the stopgap interpreter:
 // https://github.com/ykjit/yk/issues/537
-int unused() {
+uint32_t unused() {
   YkMT *mt = yk_mt_new();
   YkLocation loc = yk_location_new();
   while (true) {


### PR DESCRIPTION
And put back the `bf.c` test derived from ykcbf.

This is just a collection of changes implementing missing stop-gap
interpreter features.