### PR TITLE
Fix stopgapping out of nested functions.

### DIFF
--- a/tests/c/arg_mapping_callee.c
+++ b/tests/c/arg_mapping_callee.c
@@ -1,4 +1,3 @@
-// ignore: Requires stackmap support for nested functions.
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
@@ -13,7 +12,7 @@
 //     2:5
 //     jit-state: enter-jit-code
 //     1:5
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that using an argument (of a non-main() function) in a trace works.
@@ -24,7 +23,7 @@
 #include <yk.h>
 #include <yk_testing.h>
 
-void f(int x) {
+int f(int x) {
   YkMT *mt = yk_mt_new();
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
@@ -39,6 +38,7 @@ void f(int x) {
 
   yk_location_drop(loc);
   yk_mt_drop(mt);
+  return 0;
 }
 
 int main(int argc, char **argv) {

--- a/tests/c/bf.c
+++ b/tests/c/bf.c
@@ -6,7 +6,7 @@
 //     jit-state: enter-jit-code
 //     jit-state: exit-jit-code
 //     ...
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 //   stdout:
 //     Hello World!

--- a/tests/c/call_ext_in_obj.c
+++ b/tests/c/call_ext_in_obj.c
@@ -12,7 +12,7 @@
 //     3
 //     jit-state: enter-jit-code
 //     2
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that we can call a function without IR from another object (.o) file.

--- a/tests/c/choice.c
+++ b/tests/c/choice.c
@@ -1,4 +1,3 @@
-// ignore: Requires stackmap support for nested functions.
 // Compiler:
 // Run-time:
 //   env-var: YKD_PRINT_JITSTATE=1
@@ -15,7 +14,7 @@
 //     2: 47
 //     jit-state: enter-jit-code
 //     1: 47
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that tracing a cascading "if...else if...else" works.

--- a/tests/c/const_global.c
+++ b/tests/c/const_global.c
@@ -38,9 +38,7 @@
 //     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=1
-//     jit-state: stopgap
-//     ...
-//     Indirect: 8...
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that using a global constant works.

--- a/tests/c/direct_recursion.c
+++ b/tests/c/direct_recursion.c
@@ -1,4 +1,4 @@
-// ignore: Requires stackmap support for nested functions.
+// ignore: Requires function calls in stopgap interpreter.
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/fib.c
+++ b/tests/c/fib.c
@@ -1,4 +1,4 @@
-// ignore: Requires stackmap support for nested functions.
+// ignore: Requires function calls in stopgap interpreter.
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/interp_inside_call2.c
+++ b/tests/c/interp_inside_call2.c
@@ -1,32 +1,47 @@
 // Run-time:
-//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_PRINT_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     jit-state: start-tracing
-//     3: 5
+//     ...
 //     jit-state: stop-tracing
-//     --- Begin jit-pre-opt ---
 //     ...
-//     %{{res}} = add nsw i32...
-//     ...
-//     --- End jit-pre-opt ---
-//     2: 5
 //     jit-state: enter-jit-code
-//     1: 5
+//     ...
 //     jit-state: enter-stopgap
 //     ...
+//     jit-state: exit-stopgap
+//  stdout:
+//     ...
+//     i: 5 ret: 12
+//     ...
+//     i: 2 ret: 9
+//     i: 1 ret: 108
 
-// Check that function calls with arguments do the right thing
+// Check that we can stopgap outside of nested, inlined calls.
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <yk.h>
 #include <yk_testing.h>
 
+__attribute__((noinline)) int h(int a, int b) {
+  if (a > 1) {
+    return a + b;
+  } else {
+    return a + b + 100;
+  }
+}
+
+__attribute__((noinline)) int g(int a, int b) {
+  int c = b + 2;
+  return h(a, c);
+}
+
 __attribute__((noinline)) int f(int a, int b) {
-  int c = a + b;
-  return c;
+  int c = b + 1;
+  return g(a, c);
 }
 
 int main(int argc, char **argv) {
@@ -34,13 +49,13 @@ int main(int argc, char **argv) {
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
-  int i = 3, two = 2, three = 3;
+  int i = 5;
+  int ret = 0;
   NOOPT_VAL(i);
   while (i > 0) {
     yk_mt_control_point(mt, &loc);
-    NOOPT_VAL(two);
-    NOOPT_VAL(three);
-    fprintf(stderr, "%d: %d\n", i, f(two, three));
+    ret = f(i, argc + 3);
+    printf("i: %d ret: %d\n", i, ret);
     i--;
   }
 

--- a/tests/c/mutable_global.c
+++ b/tests/c/mutable_global.c
@@ -38,7 +38,7 @@
 //     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=1
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that using a global works.

--- a/tests/c/simple.c
+++ b/tests/c/simple.c
@@ -39,11 +39,9 @@
 //     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=1
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
-//     Indirect: 10004...
-//     Indirect: 10006...
-//     ...
+//     jit-state: exit-stopgap
 //   stdout:
 //     exit
 

--- a/tests/c/simple_interp_loop2.c
+++ b/tests/c/simple_interp_loop2.c
@@ -50,8 +50,9 @@
 //     pc=1, mem=1
 //     pc=2, mem=1
 //     pc=3, mem=0
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
+//     jit-state: exit-stopgap
 //     pc=4, mem=0
 //     pc=5, mem=0
 

--- a/tests/c/switch.c
+++ b/tests/c/switch.c
@@ -17,7 +17,7 @@
 //     i=2
 //     jit-state: enter-jit-code
 //     i=1
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that tracing a non-default switch arm works correctly.

--- a/tests/c/switch_default.c
+++ b/tests/c/switch_default.c
@@ -23,7 +23,7 @@
 //     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     i=1
-//     jit-state: stopgap
+//     jit-state: enter-stopgap
 //     ...
 
 // Check that tracing the default arm of a switch works correctly.

--- a/tests/trace_compiler/mutual_recursion.ll
+++ b/tests/trace_compiler/mutual_recursion.ll
@@ -8,14 +8,14 @@
 ;      ...
 ;      define {{type}} @__yk_compiled_trace_0(%0* %0, i64* %1, i64 %2) {
 ;        %4 = icmp eq i32 1, 0
-;        br i1 %4, label %guardfail, label %20
+;        br i1 %4, label %guardfail, label %{{rtnbb}}
 ;
 ;      guardfail:                                        ; preds = %3
 ;        ...
 ;        %{{cprtn}} = call {{type}} (...) @llvm.experimental.deoptimize.{{type}}(i64* %1, i64 %2...
 ;        ret {{type}} %{{cprtn}}
 ;
-;      20:                                               ; preds = %3
+;      {{rtnbb}}:                                               ; preds = %3
 ;        call void @f(i32 0)
 ;        ret {{type}}...
 ;      }

--- a/yksgi/src/llvmbridge.rs
+++ b/yksgi/src/llvmbridge.rs
@@ -165,6 +165,10 @@ impl Value {
         unsafe { !LLVMIsASwitchInst(self.0).is_null() }
     }
 
+    pub fn is_call(&self) -> bool {
+        unsafe { !LLVMIsACallInst(self.0).is_null() }
+    }
+
     pub fn get_type(&self) -> Type {
         unsafe { Type(LLVMTypeOf(self.0)) }
     }
@@ -204,7 +208,7 @@ pub fn llvm_const_to_sgvalue(c: Value) -> SGValue {
             LLVMValueKind::LLVMConstantPointerNullValueKind => SGValue::new(0, ty),
             _ => todo!(),
         },
-        _ => todo!(),
+        _ => todo!("{:?}", c.as_str()),
     }
 }
 


### PR DESCRIPTION
Until now our stopgap interpreter was only able to recover from a guard
failure if it happened at the top level of the compiled interpreter.
This commit adds the neccessary extra information to the guards so that
the interpreter can recover even when the guard failure happens deep
inside a nested (and in the JIT inlined) function.