### PR TITLE
Teach the stop-gap interpreter how to call AOT functions.

### DIFF
--- a/tests/c/stopgap_call_int_ret.c
+++ b/tests/c/stopgap_call_int_ret.c
@@ -1,0 +1,48 @@
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     f: 3
+//     jit-state: enter-jit-code
+//     ...
+//     jit-state: enter-stopgap
+//     ...
+//     f: 2
+//     jit-state: exit-stopgap
+//     ...
+
+// Check the stop-gap interpreter can call out to AOT-compiled functions.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+__attribute((__noinline__)) int f(int i) {
+  fprintf(stderr, "f: %d\n", i);
+  return i - 1;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new();
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    if (i == 4) {
+      fprintf(stderr, "main: %d\n", i--);
+    } else
+      i = f(i);
+  }
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/stopgap_call_many_args.c
+++ b/tests/c/stopgap_call_many_args.c
@@ -1,0 +1,48 @@
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     f: 3:4:5:6:7
+//     jit-state: enter-jit-code
+//     ...
+//     jit-state: enter-stopgap
+//     ...
+//     f: 2:3:4:5:6
+//     jit-state: exit-stopgap
+//     ...
+
+// Check the stop-gap interpreter can call out to AOT-compiled functions.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+__attribute((__noinline__)) void f(int a, int b, int c, int d, int e) {
+  fprintf(stderr, "f: %d:%d:%d:%d:%d\n", a, b, c, d, e);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new();
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    if (i == 4)
+      fprintf(stderr, "main: %d\n", i);
+    else
+      f(i, i + 1, i + 2, i + 3, i + 4);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/stopgap_call_void_ret.c
+++ b/tests/c/stopgap_call_void_ret.c
@@ -1,0 +1,46 @@
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     f: 3
+//     jit-state: enter-jit-code
+//     ...
+//     jit-state: enter-stopgap
+//     ...
+//     f: 2
+//     jit-state: exit-stopgap
+//     ...
+
+// Check the stop-gap interpreter can call out to AOT-compiled functions.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+__attribute((__noinline__)) void f(int i) { fprintf(stderr, "f: %d\n", i); }
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new();
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    if (i == 4)
+      fprintf(stderr, "main: %d\n", i);
+    else
+      f(i);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/yksgi/Cargo.toml
+++ b/yksgi/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = "0.2.97"
+libffi = "3.0.0"
 ykutil = { path = "../ykutil" }
 llvm-sys = "130"
 

--- a/yksgi/src/lib.rs
+++ b/yksgi/src/lib.rs
@@ -1,10 +1,14 @@
+use libc::dlsym;
+use libffi::middle::{arg as ffi_arg, Arg as FFIArg, Builder as FFIBuilder, CodePtr as FFICodePtr};
 use llvm_sys::core::*;
 use llvm_sys::target::{LLVMABISizeOfType, LLVMOffsetOfElement};
 use llvm_sys::{LLVMOpcode, LLVMTypeKind};
+use std::alloc::{alloc, dealloc, Layout};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::{c_void, CStr};
 use std::ptr;
+use std::slice;
 
 mod llvmbridge;
 use llvmbridge::{get_aot_original, BasicBlock, Module, Type, Value};
@@ -317,16 +321,13 @@ impl SGInterp {
     /// Implement call instructions. Returns `true` if the control point has been reached,
     /// `false` otherwise.
     unsafe fn call(&mut self) -> bool {
-        let func = LLVMGetCalledValue(self.pc.get());
-        if !LLVMIsAInlineAsm(func).is_null() {
+        let func = self.pc.get_called_value();
+        if func.is_inline_asm() {
             // FIXME: Implement calls to inline asm. Just skip them for now, as our tests won't run
             // otherwise.
             return false;
         }
-        let mut size = 0;
-        let name = CStr::from_ptr(LLVMGetValueName2(func, &mut size))
-            .to_str()
-            .unwrap();
+        let name = func.get_name();
         if ALWAYS_SKIP_FUNCS.contains(&name) {
             // There's no point calling these functions inside the stopgap interpreter so just skip
             // them.
@@ -364,8 +365,61 @@ impl SGInterp {
             // FIXME: When we see the control point we are done and can just return.
             return true;
         } else {
-            // FIXME: Properly implement calls.
-            todo!("{:?}", self.pc.as_str())
+            // We are going to do a native call via libffi, starting with looking up the address of
+            // the callee in the virtual address space.
+            //
+            // OPT: This could benefit from caching, and we may already know the address of the
+            // callee if we inlined it when preparing traces:
+            // https://github.com/ykjit/yk/issues/544
+            debug_assert!(func.is_function());
+            let fptr = dlsym(ptr::null_mut(), name.as_ptr() as *const i8);
+            if fptr == ptr::null_mut() {
+                todo!("couldn't find symbol: {}", name);
+            }
+
+            if func.is_vararg_function() {
+                todo!("calling a varargs function");
+            }
+
+            // Now build the calling interface and collect the values of the callee's arguments.
+            let mut builder = FFIBuilder::new();
+            let num_args = usize::try_from(self.pc.get_num_arg_operands()).unwrap();
+            let arg_lay = Layout::array::<u64>(num_args).unwrap();
+            let arg_mem = alloc(Layout::array::<u64>(num_args).unwrap());
+            let mut arg_mem_p = arg_mem.cast::<u64>();
+            for i in 0..num_args {
+                // The first N operands are the first N operands of the function being called.
+                let arg = self.pc.get_operand(u32::try_from(i).unwrap());
+                builder = builder.arg(arg.get_type().ffi_type());
+                *arg_mem_p = self.var_lookup(&arg).val;
+                arg_mem_p = arg_mem_p.add(1);
+            }
+            builder = builder.res(self.pc.get_type().ffi_type());
+            let cif = builder.into_cif(); // OPT: cache CIFs for repeated calls to same func sig.
+
+            // Actually do the call.
+            let ret_ty = self.pc.get_type();
+            let arg_slice = slice::from_raw_parts_mut::<u64>(arg_mem as *mut u64, num_args);
+            let ffi_arg_vals: Vec<FFIArg> = arg_slice.iter().map(|a| ffi_arg(a)).collect();
+            if ret_ty.is_integer() {
+                // FIXME: https://github.com/ykjit/yk/issues/536
+                match ret_ty.get_int_width() {
+                    32 => {
+                        let rv = cif.call::<u32>(FFICodePtr(fptr), &ffi_arg_vals) as u64;
+                        self.var_set(self.pc, SGValue::new(rv, ret_ty));
+                    }
+                    _ => todo!(),
+                }
+            } else if ret_ty.is_void() {
+                cif.call::<()>(FFICodePtr(fptr), &ffi_arg_vals);
+            } else {
+                todo!("{:?}", ret_ty.as_str());
+            };
+            // `ffi_arg_vals` contains raw pointers to `arg_mem`, so we had better drop those
+            // before we deallocate `arg_mem`.
+            drop(ffi_arg_vals);
+            dealloc(arg_mem, arg_lay);
+            return false;
         }
     }
 


### PR DESCRIPTION
When encountering a call instruction, we don't interpret the callee, but
instead call the AOT version of the function. This should be faster.

We do this via libffi bindings to Rust, as we need the ability to call
addresses whose interfaces not known until runtime.