### PR TITLE
Drop mutexes in the `Compiling` state properly.

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -306,10 +306,10 @@ impl Drop for Location {
                 // trace that's pointed to. There should be a ref count that we decrement and free
                 // memory if it reaches zero.
                 self.unlock();
-            } else if let HotLocationKind::Compiling(ref mtx) = hl.kind {
-                drop(mtx);
-                self.unlock();
-            } else if let HotLocationKind::DontTrace | HotLocationKind::Tracing(_) = hl.kind {
+            } else if let HotLocationKind::Compiling(_)
+            | HotLocationKind::DontTrace
+            | HotLocationKind::Tracing(_) = hl.kind
+            {
                 self.unlock();
                 unsafe {
                     Box::from_raw(hl);


### PR DESCRIPTION
Previously we were calling `drop(&Arc<Mutex<...>>)` which is a no-op. The fix is relatively easy: we treat the `Compiling` state as the other states which have allocated a `Box`, turning it back into a  `Box` which is then implicitly dropped.