### PR TITLE
Compilation could fail

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -386,7 +386,10 @@ impl MT {
                 Ok(x) => x,
                 Err(e) => todo!("{e:?}"),
             };
-            let codeptr = irtrace.compile();
+            let codeptr = match irtrace.compile() {
+                Ok(x) => x,
+                Err(e) => todo!("{e:?}"),
+            };
             let ct = Box::new(CompiledTrace::new(codeptr));
             // FIXME: although we've now put the compiled trace into the `HotLocation`, there's
             // no guarantee that the `Location` for which we're compiling will ever be executed

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -382,6 +382,8 @@ impl MT {
         mtx: Arc<Mutex<Option<Box<CompiledTrace>>>>,
     ) {
         let do_compile = move || {
+            // FIXME: if mapping or tracing fails we don't want to abort, but in order to do that,
+            // we'll need to move the location into something other than the Compiling state.
             let irtrace = match utrace.map() {
                 Ok(x) => x,
                 Err(e) => todo!("{e:?}"),

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -9,6 +9,7 @@ use libc::c_void;
 use std::{
     cell::RefCell,
     collections::HashMap,
+    error::Error,
     ffi::{CStr, CString},
     ptr,
 };
@@ -135,7 +136,7 @@ impl IRTrace {
         (func_names, bbs, trace_len)
     }
 
-    pub fn compile(&self) -> *const c_void {
+    pub fn compile(&self) -> Result<*const c_void, Box<dyn Error>> {
         let (func_names, bbs, trace_len) = self.encode_trace();
 
         let mut faddr_keys = Vec::new();
@@ -160,7 +161,7 @@ impl IRTrace {
             )
         };
         assert_ne!(ret, ptr::null());
-        ret
+        Ok(ret)
     }
 
     #[cfg(feature = "yk_testing")]


### PR DESCRIPTION
Compilation could fail so return a `Result`. This is a case of "we'll need this in the API in the future so save ourselves doing lots of refactoring in the future". I'm not even fully sure what we should do when compilation-in-a-thread fails....