### PR TITLE
Deoptimise minimally needed live values.

### DIFF
--- a/tests/trace_compiler/direct_recursion.ll
+++ b/tests/trace_compiler/direct_recursion.ll
@@ -28,9 +28,11 @@
 
 define void @f(i32 %0) {
     %2 = icmp eq i32 %0, 0
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i1 %2)
     br i1 %2, label %done, label %recurse
 recurse:
     %3 = sub i32 %0, 1
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0, i32 %3)
     call void @f(i32 %3)
     br label %done
 done:
@@ -39,6 +41,8 @@ done:
 
 define void @main() {
 entry:
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0)
     call void @f(i32 2)
     ret void
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/guard_eq.ll
+++ b/tests/trace_compiler/guard_eq.ll
@@ -27,6 +27,7 @@ define void @main() {
 entry:
     %0 = alloca i32
     %1 = icmp eq i32 1, 1
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32* %0, i1 %1)
     br i1 %1, label %true, label %false
 
 true:
@@ -37,3 +38,4 @@ false:
     store i32 0, i32 * %0
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/guard_switch_default.ll
+++ b/tests/trace_compiler/guard_switch_default.ll
@@ -27,6 +27,7 @@
 define void @main() {
 entry:
     %0 = add i32 0, 999
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
     switch i32 %0, label %bb_default [i32 0, label %bb_zero
                                       i32 1, label %bb_one
                                       i32 2, label %bb_two]
@@ -43,3 +44,4 @@ bb_one:
 bb_two:
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/guard_switch_non_default.ll
+++ b/tests/trace_compiler/guard_switch_non_default.ll
@@ -25,6 +25,7 @@
 define void @main() {
 entry:
     %0 = add i32 0, 2
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
     switch i32 %0, label %bb_default [i32 0, label %bb_zero
                                       i32 1, label %bb_one
                                       i32 2, label %bb_two]
@@ -41,3 +42,4 @@ bb_two:
     %1 = add i32 %0, 1
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/guards_collapse.ll
+++ b/tests/trace_compiler/guards_collapse.ll
@@ -28,10 +28,12 @@ define void @main() {
 entry:
     %v = load volatile i32 , i32 * @g
     %cond1 = icmp slt i32 %v, 999
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %v)
     br i1 %cond1, label %true1, label %falses
 
 true1:
     %cond2 = icmp slt i32 %v, 1000
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     br i1 %cond2, label %true2, label %falses
 
 true2:
@@ -40,3 +42,4 @@ true2:
 falses:
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/mutual_recursion.ll
+++ b/tests/trace_compiler/mutual_recursion.ll
@@ -27,8 +27,10 @@
 
 define void @f(i32 %0) {
     %2 = icmp eq i32 %0, 0
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i1 %2)
     br i1 %2, label %done, label %recurse
 recurse:
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     call void @g()
     br label %done
 done:
@@ -36,12 +38,15 @@ done:
 }
 
 define void @g() {
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     call void @f(i32 0)
     ret void
 }
 
 define void @main() {
 entry:
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     call void @f(i32 1)
     ret void
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/phi.ll
+++ b/tests/trace_compiler/phi.ll
@@ -23,6 +23,7 @@ define void @main() {
 entry:
     %0 = add i32 0, 0
     %1 = icmp eq i32 %0, 0
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0, i1 %1)
     br i1 %1, label %true, label %false
 
 true:
@@ -37,3 +38,4 @@ join:
     %4 = add i32 %3, 2
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)


### PR DESCRIPTION
Companion PR: https://github.com/ykjit/ykllvm/pull/41

The previous algorithm to collect live values for deoptimisation inside
a trace overapproximated so much that large traces could take minutes to
build. This was due the linear nature of the trace which meant no longer
used values would stay live (from the perspective of the algorithm)
so the bigger the trace the more values would end up in the later
guard failures.

Instead of the overapproximation we now lookup live values inside the
AOT module, using the recently added stackmap calls. At each guard
failure, we lookup the corresponding stackmap call inside AOTMod,
extract the live values, and translate them to their corresponding
JITMod values. These are the exact live values that we need to
deoptimise.