### PR TITLE
Avoid current_exe() and path canonicalisation when mapping.

### DIFF
--- a/ykutil/Cargo.toml
+++ b/ykutil/Cargo.toml
@@ -10,3 +10,6 @@ libc = "0.2.117"
 memmap2 = "0.5.2"
 object = "0.28.3"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
+
+[build-dependencies]
+cc = "1.0.72"

--- a/ykutil/build.rs
+++ b/ykutil/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut comp = cc::Build::new();
+    comp.file("src/find_main.c");
+    comp.compile("find_main");
+}

--- a/ykutil/src/find_main.c
+++ b/ykutil/src/find_main.c
@@ -1,0 +1,10 @@
+/*
+ * Find the address of main.
+ *
+ * This is done in C due to this Rust bug:
+ * https://github.com/rust-lang/rust/issues/101906
+ */
+
+extern int main(int argc, char **argv);
+
+void *find_main() { return main; }

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -1,9 +1,31 @@
 //! Utilities for dealing with object files.
 
+use libc::{c_void, dladdr, Dl_info};
 use memmap2::Mmap;
 use object::{self, Object, ObjectSection, Section};
-use std::sync::LazyLock;
-use std::{convert::TryFrom, env, fs};
+use std::{
+    convert::TryFrom, env, ffi::CStr, fs, mem::MaybeUninit, path::PathBuf, ptr, sync::LazyLock,
+};
+
+extern "C" {
+    fn find_main() -> *const c_void;
+}
+
+/// The path to the currently running binary.
+///
+/// This relies on there being an exported symbol for `main()`.
+pub static SELF_BIN_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
+    let addr = unsafe { find_main() };
+    if addr == ptr::null_mut() as *mut c_void {
+        panic!("couldn't find address of main()");
+    }
+    let mut info = MaybeUninit::<Dl_info>::uninit();
+    if unsafe { dladdr(addr, info.as_mut_ptr()) } == 0 {
+        panic!("couldn't find Dl_info for main()");
+    }
+    let info = unsafe { info.assume_init() };
+    PathBuf::from(unsafe { CStr::from_ptr(info.dli_fname) }.to_str().unwrap())
+});
 
 /// The current executable mmaped into the address space.
 ///


### PR DESCRIPTION
This basically works by `replacing std::env::current_exe()` by querying the linker for the object containing `main()` and using that path exclusively.

This has the knock-on effect that we no longer have one mechanism giving us a non-canonical path (`dladdr(3)`, when asking where a virtual address came from), and one mechanism giving us (possibly) an absolute path (`std::env::current_exe()`). Therefore we no longer need to canonicalise paths, which is a win in itself because canonicalisation hits the filesystem, slowing us down.

Running numwarp.bf on the input `1234`:

BEFORE:
```
1: sh -c "echo \"1234\" |  ./bf_simple_yk lang_tests/numwarp.bf"
            Mean        Std.Dev.    Min         Median      Max
real        1.638       0.011       1.623       1.642       1.654
user        1.241       0.014       1.218       1.244       1.256
sys         0.348       0.014       0.331       0.344       0.369
```

AFTER:
```
1: sh -c "echo \"1234\" |  ./bf_simple_yk lang_tests/numwarp.bf"
            Mean        Std.Dev.    Min         Median      Max
real        1.479       0.007       1.471       1.474       1.489
user        1.194       0.013       1.172       1.197       1.208
sys         0.235       0.016       0.210       0.233       0.259
```

So about 10% quicker, which is close enough to the ~7% cost of canonicalisation that I measured using perf.

(this is with Lukas' experimental PT cache and guard compression diffs applied, as without those, the cost of canonicalisation is swamped by other inefficiencies).