### PR TITLE
Fish the LLVM bitcode out of the address space.

### DIFF
--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -142,6 +142,8 @@ fn mk_compiler(exe: &Path, src: &Path, opt: &str, extra_objs: &[PathBuf]) -> Com
         "-Wl,--mllvm=--yk-insert-stackmaps",
         // Ensure we can unambiguously map back to LLVM IR blocks.
         "-Wl,--mllvm=--yk-block-disambiguate",
+        // Have the `.llvmbc` section loaded into memory by the loader.
+        "-Wl,--mllvm=--yk-alloc-llvmbc-section",
         // Emit a basic block map section. Used for block mapping.
         "-Wl,--lto-basic-block-sections=labels",
         // FIXME: https://github.com/ykjit/yk/issues/381

--- a/ykutil/Cargo.toml
+++ b/ykutil/Cargo.toml
@@ -7,8 +7,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = "0.2.117"
-memmap2 = "0.5.2"
-object = "0.28.3"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 
 [build-dependencies]

--- a/ykutil/src/lib.rs
+++ b/ykutil/src/lib.rs
@@ -1,5 +1,6 @@
 //! Miscellaneous utilities.
 
+#![feature(link_llvm_intrinsics)]
 #![feature(once_cell)]
 
 pub mod addr;

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -1,11 +1,7 @@
 //! Utilities for dealing with object files.
 
 use libc::{c_void, dladdr, Dl_info};
-use memmap2::Mmap;
-use object::{self, Object, ObjectSection, Section};
-use std::{
-    convert::TryFrom, env, ffi::CStr, fs, mem::MaybeUninit, path::PathBuf, ptr, sync::LazyLock,
-};
+use std::{ffi::CStr, mem::MaybeUninit, path::PathBuf, ptr, sync::LazyLock};
 
 extern "C" {
     fn find_main() -> *const c_void;
@@ -27,27 +23,24 @@ pub static SELF_BIN_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     PathBuf::from(unsafe { CStr::from_ptr(info.dli_fname) }.to_str().unwrap())
 });
 
-/// The current executable mmaped into the address space.
-///
-/// PERF: Consider making the segment containing .llvmbc loadable so that ld.so loads it
-/// automatically when spawning the process.
-static EXE_MMAP: LazyLock<Mmap> = LazyLock::new(|| {
-    let pathb = env::current_exe().unwrap();
-    let file = fs::File::open(&pathb.as_path()).unwrap();
-    unsafe { memmap2::Mmap::map(&file).unwrap() }
-});
+/// The `llvm.embedded.module` symbol in the `.llvmbc` section.
+#[repr(C)]
+struct EmbeddedModule {
+    /// The length of the bitcode.
+    len: usize,
+    /// The start of the bitcode itself.
+    first_byte_of_bitcode: u8,
+}
 
-/// The current executable parsed to an `object::File`.
-static EXE_OBJ: LazyLock<object::File> =
-    LazyLock::new(|| object::File::parse(&**EXE_MMAP).unwrap());
+// ykllvm adds the `SHF_ALLOC` flag to the `.llvmbc` section so that the loader puts it into our
+// address space at load time.
+extern "C" {
+    #[link_name = "llvm.embedded.module"]
+    static LLVMBC: EmbeddedModule;
+}
 
-/// The .llvmbc section of the current executable.
-static LLVMBC: LazyLock<Section> = LazyLock::new(|| EXE_OBJ.section_by_name(".llvmbc").unwrap());
-
-/// Returns a pointer to (and the size of) the raw LLVM bitcode encoded in the .llvmbc section of
-/// the current binary.
+/// Returns a pointer to (and the size of) the raw LLVM bitcode in the current address space.
 pub fn llvmbc_section() -> (*const u8, usize) {
-    let sec_ptr = LLVMBC.data().unwrap().as_ptr();
-    let sec_size = usize::try_from(LLVMBC.size()).unwrap();
-    (sec_ptr, sec_size)
+    let bc = unsafe { &LLVMBC };
+    (&bc.first_byte_of_bitcode as *const u8, bc.len)
 }


### PR DESCRIPTION
ykllvm now puts the LLVM bitcode into a loaded section, so we can take it out of our address space instead of loading it from disk.

This doesn't speed anything up, but it does eliminate a use of `current_exe()` and also a couple of dependency crates.