### PR TITLE
Load the basic block map from the address space.

### DIFF
--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -144,6 +144,8 @@ fn mk_compiler(exe: &Path, src: &Path, opt: &str, extra_objs: &[PathBuf]) -> Com
         "-Wl,--mllvm=--yk-block-disambiguate",
         // Have the `.llvmbc` section loaded into memory by the loader.
         "-Wl,--mllvm=--yk-alloc-llvmbc-section",
+        // Have the `.llvm_bb_addr_map` section loaded into memory by the loader.
+        "-Wl,--mllvm=--yk-alloc-llvmbbaddrmap-section",
         // Emit a basic block map section. Used for block mapping.
         "-Wl,--lto-basic-block-sections=labels",
         // FIXME: https://github.com/ykjit/yk/issues/381

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -31,4 +31,11 @@ extern "C" {
         llvmbc_data: *const u8,
         llvmbc_len: size_t,
     ) -> *const c_void;
+
+    pub fn __ykllvmwrap_find_bbmaps(
+        bitcode_data: *const u8,
+        bitcode_len: usize,
+        start_addr: *mut size_t,
+        end_addr: *mut size_t,
+    ) -> bool;
 }

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -14,15 +14,9 @@ hwtracer = { git = "https://github.com/ykjit/hwtracer" }
 intervaltree = "0.2.7"
 leb128 = "0.2.5"
 libc = "0.2.117"
-memmap2 = "0.5.2"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 ykllvmwrap = { path = "../ykllvmwrap" }
 ykutil = { path = "../ykutil" }
-
-[dependencies.object]
-version = "0.28.3"
-default-features = false
-features = ["read_core", "elf"]
 
 [dev-dependencies]
 fm = "0.2.1"

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![feature(once_cell)]
 #![feature(naked_functions)]
+#![feature(ptr_sub_ptr)]
 #![allow(clippy::new_without_default)]
 
 mod errors;


### PR DESCRIPTION
ykllvm now inserts symbols to help us find the `.llvm_bb_addr_map` data.

[companion to https://github.com/ykjit/ykllvm/pull/47]