### PR TITLE
Add a helper to make it easy to run a C test in gdb.

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,13 +16,14 @@ path = "langtest_trace_compiler.rs"
 harness = false
 
 [dependencies]
+clap = { features = ["derive"], version = "4.0.11" }
 memmap2 = "0.5.2"
 regex = "1.5.4"
+tempfile = "3.3.0"
 yktrace = { path = "../yktrace", features = ["yk_testing"] }
 
 [dev-dependencies]
 lang_tester = "0.7.1"
-tempfile = "3.3.0"
 ykcapi = { path = "../ykcapi", features = ["yk_testing", "yk_jitstate_debug"] }
 ykllvmwrap = { path = "../ykllvmwrap", features = ["yk_testing"] }
 ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -2,141 +2,15 @@
 
 use lang_tester::LangTester;
 use regex::Regex;
-use std::sync::LazyLock;
 use std::{
-    collections::HashMap,
-    env,
     fs::read_to_string,
-    io::{self, Write},
     path::{Path, PathBuf},
     process::Command,
 };
 use tempfile::TempDir;
+use tests::{mk_compiler, EXTRA_LINK};
 
 const COMMENT: &str = "//";
-
-const TEMPDIR_SUBST: &'static str = "%%TEMPDIR%%";
-static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = LazyLock::new(|| {
-    let mut map = HashMap::new();
-
-    // These tests get an extra, separately compiled (thus opaque to LTO), object file linked in.
-    for test_file in &[
-        "call_ext_in_obj.c",
-        "loopy_funcs_not_inlined_by_default.c",
-        "not_loopy_funcs_inlined_by_default.c",
-        "unroll_safe_implies_noinline.c",
-        "unroll_safe_inlines.c",
-        "yk_unroll_safe_vs_yk_outline.c",
-    ] {
-        map.insert(
-            *test_file,
-            vec![ExtraLinkage::new(
-                "%%TEMPDIR%%/call_me.o",
-                &[
-                    "clang",
-                    "-c",
-                    "-O0",
-                    "extra_linkage/call_me.c",
-                    "-o",
-                    "%%TEMPDIR%%/call_me.o",
-                ],
-            )],
-        );
-    }
-    map
-});
-
-/// Describes an extra object file to link to a C test.
-struct ExtraLinkage<'a> {
-    /// The name of the object file to be generated.
-    output_file: &'a str,
-    /// The command that generates the object file.
-    gen_cmd: &'a [&'a str],
-}
-
-impl<'a> ExtraLinkage<'a> {
-    fn new(output_file: &'a str, gen_cmd: &'a [&'a str]) -> Self {
-        Self {
-            output_file,
-            gen_cmd,
-        }
-    }
-
-    /// Run the command to generate the object in `tempdir` and return the absolute path to the
-    /// generated object.
-    fn generate_obj(&self, tempdir: &Path) -> PathBuf {
-        let mut cmd = Command::new(self.gen_cmd[0]);
-        let tempdir_s = tempdir.to_str().unwrap();
-        for arg in self.gen_cmd[1..].iter() {
-            cmd.arg(arg.replace(TEMPDIR_SUBST, tempdir_s));
-        }
-        let out = cmd.output().unwrap();
-        assert!(tempdir.exists());
-        if !out.status.success() {
-            io::stdout().write_all(&out.stdout).unwrap();
-            io::stderr().write_all(&out.stderr).unwrap();
-            panic!();
-        }
-        let mut ret = PathBuf::from(tempdir);
-        ret.push(&self.output_file.replace(TEMPDIR_SUBST, tempdir_s));
-        ret
-    }
-}
-
-/// Make a compiler command that compiles `src` to `exe` using the optimisation flag `opt`.
-/// `extra_objs` is a collection of other object files to link.
-fn mk_compiler(exe: &Path, src: &Path, opt: &str, extra_objs: &[PathBuf]) -> Command {
-    let mut compiler = Command::new("clang");
-    compiler.env("YKD_PRINT_IR", "1");
-
-    let yk_config = [
-        &env::var("CARGO_MANIFEST_DIR").unwrap(),
-        "..",
-        "ykcapi",
-        "scripts",
-        "yk-config",
-    ]
-    .iter()
-    .collect::<PathBuf>();
-
-    #[cfg(cargo_profile = "debug")]
-    let mode = "debug";
-    #[cfg(cargo_profile = "release")]
-    let mode = "release";
-
-    let yk_config_out = Command::new(yk_config)
-        .args(&[mode, "--cflags", "--cppflags", "--ldflags", "--libs"])
-        .output()
-        .expect("failed to execute yk-config");
-    if !yk_config_out.status.success() {
-        panic!("yk-config exited with non-zero status");
-    }
-    let yk_flags = String::from_utf8(yk_config_out.stdout).unwrap();
-
-    // yk-config never returns arguments containing spaces, so we can split by space here. If this
-    // ever changes, then we should build arguments as an "unparsed" string and parse that to `sh
-    // -c` and let the shell do the parsing.
-    let yk_flags = yk_flags.trim().split(" ");
-    compiler.args(yk_flags);
-
-    compiler.args(&[
-        opt,
-        // If this is a debug build, include debug info in the test binary.
-        #[cfg(debug_assertions)]
-        "-g",
-        // Be strict.
-        "-Werror",
-        "-Wall",
-        // Some tests are multi-threaded via the pthread API.
-        "-pthread",
-        // The input and output files.
-        "-o",
-        exe.to_str().unwrap(),
-        src.to_str().unwrap(),
-    ]);
-    compiler.args(extra_objs);
-    compiler
-}
 
 fn run_suite(opt: &'static str) {
     println!("Running C tests with {}...", opt);

--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -1,0 +1,94 @@
+//! A tool to run a C test under gdb.
+
+use clap::Parser;
+use std::{env, path::PathBuf, process::Command};
+use tempfile::TempDir;
+use tests::{mk_compiler, EXTRA_LINK};
+
+/// Run a C test under gdb.
+#[derive(Parser, Debug)]
+#[command(about, long_about = None)]
+struct Args {
+    /// The test to attach gdb to.
+    test_file: PathBuf,
+
+    /// Run the test with `YKD_PRINT_IR` set to the specified value.
+    #[arg(short, long)]
+    print_ir: Option<String>,
+
+    /// Run the test with `YKD_PRINT_JITSTATE=1`
+    #[arg(short = 'j', long)]
+    print_jitstate: bool,
+
+    /// Run the test with `YKD_SERIALISE_COMPILATION=1`
+    #[arg(short, long)]
+    serialise_compilation: bool,
+
+    /// Set breakpoints at the first `N` compiled traces.
+    #[arg(short = 'b', long)]
+    num_breaks: Option<usize>,
+
+    /// Don't immediately run the program.
+    #[arg(short = 'n', long)]
+    wait_at_prompt: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let test_path = PathBuf::from(
+        [&md, "c", &args.test_file.to_str().unwrap()]
+            .iter()
+            .collect::<PathBuf>(),
+    );
+    let tempdir = TempDir::new().unwrap();
+
+    // Compile the test.
+    //
+    // Some tests expect to have extra objects linked.
+    let extra_objs = EXTRA_LINK
+        .get(&test_path.to_str().unwrap())
+        .unwrap_or(&Vec::new())
+        .iter()
+        .map(|e| e.generate_obj(tempdir.path()))
+        .collect::<Vec<PathBuf>>();
+
+    let binstem = PathBuf::from(args.test_file.file_stem().unwrap());
+    let binpath = [tempdir.path(), &binstem].iter().collect::<PathBuf>();
+    let mut cmd = mk_compiler(&binpath, &test_path, "-O0", &extra_objs);
+    if !cmd.spawn().unwrap().wait().unwrap().success() {
+        panic!("compilation failed");
+    }
+
+    // Now we have a test binary in a temporary directory, prepare an invocation of gdb, setting
+    // environment variables as necessary.
+    let mut gdb = Command::new("gdb");
+    gdb.arg(&binpath).env("YKD_TRACE_DEBUGINFO", "1");
+
+    if args.serialise_compilation {
+        gdb.env("YKD_SERIALISE_COMPILATION", "1");
+    }
+
+    if args.print_jitstate {
+        gdb.env("YKD_PRINT_JITSTATE", "1");
+    }
+
+    if let Some(irs) = args.print_ir {
+        gdb.env("YKD_PRINT_IR", irs);
+    }
+
+    if let Some(num_breaks) = args.num_breaks {
+        gdb.args(["-ex", "set breakpoint pending on"]); // don't prompt for pending breaks.
+        for i in 0..num_breaks {
+            gdb.args(["-ex", &format!("b __yk_compiled_trace_{i}")]);
+        }
+    }
+
+    if !args.wait_at_prompt {
+        gdb.args(["-ex", "run"]);
+    }
+
+    // Run gdb!
+    gdb.spawn().unwrap().wait().unwrap();
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,133 @@
+#![feature(once_cell)]
+
+use std::{
+    collections::HashMap,
+    env,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::Command,
+    sync::LazyLock,
+};
+
+const TEMPDIR_SUBST: &'static str = "%%TEMPDIR%%";
+pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+
+    // These tests get an extra, separately compiled (thus opaque to LTO), object file linked in.
+    for test_file in &[
+        "call_ext_in_obj.c",
+        "loopy_funcs_not_inlined_by_default.c",
+        "not_loopy_funcs_inlined_by_default.c",
+        "unroll_safe_implies_noinline.c",
+        "unroll_safe_inlines.c",
+        "yk_unroll_safe_vs_yk_outline.c",
+    ] {
+        map.insert(
+            *test_file,
+            vec![ExtraLinkage::new(
+                "%%TEMPDIR%%/call_me.o",
+                &[
+                    "clang",
+                    "-c",
+                    "-O0",
+                    "extra_linkage/call_me.c",
+                    "-o",
+                    "%%TEMPDIR%%/call_me.o",
+                ],
+            )],
+        );
+    }
+    map
+});
+
+/// Describes an extra object file to link to a C test.
+pub struct ExtraLinkage<'a> {
+    /// The name of the object file to be generated.
+    output_file: &'a str,
+    /// The command that generates the object file.
+    gen_cmd: &'a [&'a str],
+}
+
+impl<'a> ExtraLinkage<'a> {
+    fn new(output_file: &'a str, gen_cmd: &'a [&'a str]) -> Self {
+        Self {
+            output_file,
+            gen_cmd,
+        }
+    }
+
+    /// Run the command to generate the object in `tempdir` and return the absolute path to the
+    /// generated object.
+    pub fn generate_obj(&self, tempdir: &Path) -> PathBuf {
+        let mut cmd = Command::new(self.gen_cmd[0]);
+        let tempdir_s = tempdir.to_str().unwrap();
+        for arg in self.gen_cmd[1..].iter() {
+            cmd.arg(arg.replace(TEMPDIR_SUBST, tempdir_s));
+        }
+        let out = cmd.output().unwrap();
+        assert!(tempdir.exists());
+        if !out.status.success() {
+            io::stdout().write_all(&out.stdout).unwrap();
+            io::stderr().write_all(&out.stderr).unwrap();
+            panic!();
+        }
+        let mut ret = PathBuf::from(tempdir);
+        ret.push(&self.output_file.replace(TEMPDIR_SUBST, tempdir_s));
+        ret
+    }
+}
+
+/// Make a compiler command that compiles `src` to `exe` using the optimisation flag `opt`.
+/// `extra_objs` is a collection of other object files to link.
+pub fn mk_compiler(exe: &Path, src: &Path, opt: &str, extra_objs: &[PathBuf]) -> Command {
+    let mut compiler = Command::new("clang");
+    compiler.env("YKD_PRINT_IR", "1");
+
+    let yk_config = [
+        &env::var("CARGO_MANIFEST_DIR").unwrap(),
+        "..",
+        "ykcapi",
+        "scripts",
+        "yk-config",
+    ]
+    .iter()
+    .collect::<PathBuf>();
+
+    #[cfg(cargo_profile = "debug")]
+    let mode = "debug";
+    #[cfg(cargo_profile = "release")]
+    let mode = "release";
+
+    let yk_config_out = Command::new(yk_config)
+        .args(&[mode, "--cflags", "--cppflags", "--ldflags", "--libs"])
+        .output()
+        .expect("failed to execute yk-config");
+    if !yk_config_out.status.success() {
+        panic!("yk-config exited with non-zero status");
+    }
+    let yk_flags = String::from_utf8(yk_config_out.stdout).unwrap();
+
+    // yk-config never returns arguments containing spaces, so we can split by space here. If this
+    // ever changes, then we should build arguments as an "unparsed" string and parse that to `sh
+    // -c` and let the shell do the parsing.
+    let yk_flags = yk_flags.trim().split(" ");
+    compiler.args(yk_flags);
+
+    compiler.args(&[
+        opt,
+        // If this is a debug build, include debug info in the test binary.
+        #[cfg(debug_assertions)]
+        "-g",
+        // Be strict.
+        "-Werror",
+        "-Wall",
+        // Some tests are multi-threaded via the pthread API.
+        "-pthread",
+        // The input and output files.
+        "-o",
+        exe.to_str().unwrap(),
+        src.to_str().unwrap(),
+    ]);
+    compiler.args(extra_objs);
+    compiler
+}


### PR DESCRIPTION
Lukas and I waste so much time getting gdb attached to tests.

How about this?

```
ben12$ cargo xtask gdb-c-test --help          
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/xtask gdb-c-test --help`
Run a C test under gdb

Usage: gdb_c_test [OPTIONS] <TEST_FILE>

Arguments:
  <TEST_FILE>  The test to attach gdb to

Options:
  -p, --print-ir <PRINT_IR>      Run the test with `YKD_PRINT_IR` set to the specified value
  -j, --print-jitstate           Run the test with `YKD_PRINT_JITSTATE=1`
  -s, --serialise-compilation    Run the test with `YKD_SERIALISE_COMPILATION=1`
  -b, --num-breaks <NUM_BREAKS>  Set breakpoints at the first `N` compiled traces
  -n, --wait-at-prompt           Don't immediately run the program
  -h, --help                     Print help information
```

So let's run the `simple.c` test with serialised compilation, setting breakpoints for the first three compiled traces, and printing the jitstate:

```
ben12$ cargo xtask gdb-c-test -s -b3 -j simple.c
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/xtask gdb-c-test -s -b3 -j simple.c`
GNU gdb (Debian 10.1-1.7) 10.1.90.20210103-git
...
Reading symbols from /tmp/.tmpB6HD3q/simple...
Function "__yk_compiled_trace_0" not defined.
Breakpoint 1 (__yk_compiled_trace_0) pending.
Function "__yk_compiled_trace_1" not defined.
Breakpoint 2 (__yk_compiled_trace_1) pending.
Function "__yk_compiled_trace_2" not defined.
Breakpoint 3 (__yk_compiled_trace_2) pending.
Starting program: /tmp/.tmpB6HD3q/simple 
DW_FORM_rnglistx index pointing outside of .debug_rnglists offset array [in module /home/vext01/research/yk/target/debug/deps/libykcapi.so]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
jit-state: start-tracing
[New Thread 0x7ffff451f700 (LWP 228187)]
i=4
[Thread 0x7ffff451f700 (LWP 228187) exited]
jit-state: stop-tracing
i=3
jit-state: enter-jit-code

Thread 1 "simple" hit Breakpoint 1, __yk_compiled_trace_0 () at .tmpyYkwiJ:4
4         %5 = load ptr, ptr %0, align 8, !dbg !20
(gdb)
```

Note I didn't even have to type "run", it just starts the program. If you don't want that, you can pass `-n`.

[I can imagine a scenario where you want to break on exactly the Nth trace (and not the ones before). We can add a flag for that later if the need comes]

I'm on the fence with the second commit (the xtask hook). It's a bit annoying due to the unstable `bindeps` support (see the comment). All the xtask hook does is make:

```
cargo run --bin gdb_c_test -- <args>
```

into:

```
cargo xtask gdb-c-test <args>
```

I wonder if it's worth it?

@ptersilie interested to see what you think.