### PR TITLE
Adjust to recent stackmap call position change.

### DIFF
--- a/tests/trace_compiler/direct_recursion.ll
+++ b/tests/trace_compiler/direct_recursion.ll
@@ -33,8 +33,8 @@ define void @f(i32 %0) {
     br i1 %2, label %done, label %recurse
 recurse:
     %3 = sub i32 %0, 1
-    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0, i32 %3)
     call void @f(i32 %3)
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0, i32 %3)
     br label %done
 done:
     ret void
@@ -42,8 +42,8 @@ done:
 
 define void @main() {
 entry:
-    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0)
     call void @f(i32 2)
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0)
     ret void
 }
 declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/inline_ret.ll
+++ b/tests/trace_compiler/inline_ret.ll
@@ -23,6 +23,8 @@ define void @main() {
 entry:
     %0 = add i32 1, 1
     %1 = call i32 @f()
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     %2 = add i32 %0, %1
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/inline_ret_args.ll
+++ b/tests/trace_compiler/inline_ret_args.ll
@@ -25,6 +25,8 @@ define void @main() {
 entry:
     %0 = add i32 1, 1
     %1 = call i32 @f(i32 %0, i32 2)
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
     %2 = add i32 %1, 3
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/inline_simplest.ll
+++ b/tests/trace_compiler/inline_simplest.ll
@@ -23,6 +23,8 @@ define void @main() {
 entry:
     %0 = add i32 1, 1
     call void @f()
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
     %1 = add i32 %0, 2
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/mutual_recursion.ll
+++ b/tests/trace_compiler/mutual_recursion.ll
@@ -31,23 +31,23 @@ define void @f(i32 %0) {
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i1 %2)
     br i1 %2, label %done, label %recurse
 recurse:
-    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     call void @g()
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     br label %done
 done:
     ret void
 }
 
 define void @g() {
-    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     call void @f(i32 0)
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     ret void
 }
 
 define void @main() {
 entry:
-    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     call void @f(i32 1)
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     ret void
 }
 declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/tests/trace_compiler/no_trace_annotation.ll
+++ b/tests/trace_compiler/no_trace_annotation.ll
@@ -26,6 +26,8 @@ attributes #0 = { "yk_outline" "noinline"}
 define void @main() {
 entry:
     call void @call_me()
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     unreachable
 }
+declare void @llvm.experimental.stackmap(i64, i32, ...)
 

--- a/ykcapi/scripts/yk-config
+++ b/ykcapi/scripts/yk-config
@@ -74,6 +74,7 @@ handle_arg() {
 
             # Use the Yk extensions to the blockmap section.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-extended-llvmbbaddrmap-section"
+            OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-stackmap-offset-fix"
 
             # Have the `.llvmbc` and `.llvm_bb_addr_map` sections loaded into
             # memory by the loader.

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -385,6 +385,7 @@ class JITModBuilder {
           VMap[Arg] = getMappedValue(Var);
         }
       }
+      LastSMCall = cast<CallBase>(CI->getNextNonDebugInstruction());
       ActiveFrames.push_back(
           {CurBBIdx, CurInstrIdx, CI->getFunction()->getName(), LastSMCall});
       CallDepth += 1;


### PR DESCRIPTION
Stackmap calls now appear after (not before) a call, so we need to adjust our code accordingly.

Companion PR: https://github.com/ykjit/ykllvm/pull/52