### PR TITLE
Implement the ability to skip over foreign code.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -18,6 +18,9 @@ intervaltree = "0.2.7"
 byteorder = "1.4.3"
 leb128 = "0.2.5"
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+iced-x86 = { version = "1.18.0", features = ["decoder"]}
+
 [build-dependencies]
 cc = "1.0.62"
 rerun_except = "0.1.2"

--- a/hwtracer/src/block.rs
+++ b/hwtracer/src/block.rs
@@ -16,7 +16,10 @@ pub enum Block {
         /// Virtual address of *any* byte of the last instruction in this block.
         last_instr: BlockAddr,
     },
-    /// An unkonwn address range.
+    /// An unknown virtual address range.
+    ///
+    /// This is required because decoders don't have perfect knowledge about every block
+    /// in the virtual address space.
     Unknown,
 }
 
@@ -46,8 +49,12 @@ impl Block {
         }
     }
 
-    pub fn unknown() -> Self {
-        Self::Unknown
+    /// Returns `true` if `self` represents an unknown virtual address range.
+    pub fn is_unknown(&self) -> bool {
+        match self {
+            Self::Unknown => true,
+            _ => false,
+        }
     }
 
     /// If `self` represents a known address range, returns the address range, otherwise `None`.

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -1,4 +1,41 @@
 //! The Yk PT trace decoder.
+//!
+//! The decoder works in two modes:
+//!
+//!  - compiler-assisted decoding
+//!  - disassembly-based decoding
+//!
+//! The former mode is for decoding portions of the trace that are for "native code" (code compiled
+//! by ykllvm). Code built with ykllvm gets static control flow information embedded in the end
+//! binary in a special section. Along with dynamic information provided by the PT packet stream,
+//! we have everything we need to decode these parts of the trace without disassembling
+//! instructions. This is the preferred mode of decoding.
+//!
+//! The latter mode is a fallback for decoding portions of the trace that are for "foreign code"
+//! (code not built with ykllvm). For foreign code there is no static control flow edge information
+//! available, so to decode these parts of the trace we have to disassemble the instruction stream
+//! (like libipt does).
+//!
+//! You may now be asking: why not just skip the parts of the trace that are for foreign code?
+//! After all, if a portion of code wasn't built with ykllvm, then we won't have IR for it anyway,
+//! meaning that the JIT is unable to inline it and we'd have to emit a call into the JIT trace.
+//! Why bother decoding the bit of the trace we don't actually care about?
+//!
+//! The problem is, it's not always easy to identify which parts of a PT trace are for native or
+//! foreign code: it's easy if the CPU that doesn't implement the deferred TIP optimisation (see
+//! the Intel 64 and IA32 Architectures Software Developer's Manual, Vol 3, Section  32.4.2.3).
+//!
+//! Deferred TIPs mean that TNT decisions can come in "out of order" with TIP updates. For example,
+//! a packet stream `[TNT(0,1), TIP(addr), TNT(1,0)]` may be optimised to `[TNT(0, 1, 1, 0),
+//! TIP(addr)]`. If the TIP update to `addr` is the return from foreign code, then when we resume
+//! compiler-assisted decoding then we need only the last two TNT decisions in the buffer
+//! (discarding the first two as we skip over foreign code). The problem is that without successor
+//! block information about the foreign code we can't know how how many TNT decisions correspond
+//! with the foreign code, and thus how many decisions to discard.
+//!
+//! We therefore have to disassemble foreign code, popping TNT decisions as we encounter
+//! conditional branch instructions. We can still use compiler-assisted decoding for portions of
+//! code that are compiled with ykllvm.
 
 use crate::{
     decode::TraceDecoder,
@@ -6,16 +43,21 @@ use crate::{
     llvm_blockmap::{BlockMapEntry, SuccessorKind, LLVM_BLOCK_MAP},
     Block, Trace,
 };
-use intervaltree;
+use iced_x86;
+use intervaltree::IntervalTree;
+use phdrs;
 use std::{
     collections::VecDeque,
     convert::TryFrom,
     fmt::{self, Debug},
-    path::PathBuf,
+    ops::Range,
+    path::{Path, PathBuf},
+    slice,
+    sync::LazyLock,
 };
 use ykutil::{
-    addr::{code_vaddr_to_off, off_to_vaddr},
-    obj::SELF_BIN_PATH,
+    self,
+    obj::{PHDR_MAIN_OBJ, SELF_BIN_PATH},
 };
 
 mod packet_parser;
@@ -38,29 +80,151 @@ impl TraceDecoder for YkPTTraceDecoder {
         let itr = YkPTBlockIterator {
             errored: false,
             parser: PacketParser::new(trace.bytes()),
-            cur_loc: ObjLoc::OtherObjOrUnknown,
+            cur_loc: ObjLoc::OtherObjOrUnknown(None),
             tnts: VecDeque::new(),
+            comprets: CompressedReturns::new(),
             pge: false,
         };
         Box::new(itr)
     }
 }
 
+/// The virtual address ranges of segments that we may need to disassemble.
+static CODE_SEGS: LazyLock<CodeSegs> = LazyLock::new(|| {
+    let mut segs = Vec::new();
+    for obj in phdrs::objects() {
+        let obj_base = obj.addr();
+        for hdr in obj.iter_phdrs() {
+            if (hdr.flags() & libc::PF_W) == 0 {
+                let vaddr = usize::try_from(obj_base + hdr.vaddr()).unwrap();
+                let memsz = usize::try_from(hdr.memsz()).unwrap();
+                let key = vaddr..(vaddr + memsz);
+                segs.push((key.clone(), ()));
+            }
+        }
+    }
+    let tree = segs.into_iter().collect::<IntervalTree<usize, ()>>();
+    CodeSegs { tree }
+});
+
+/// The number of compressed returns that a CPU implementing Intel Processor Trace can keep track
+/// of. This is a bound baked into the hardware, but the decoder needs to be aware of it for its
+/// compressed return stack.
+const PT_MAX_COMPRETS: usize = 64;
+
+/// A data structure providing convenient access to virtual address ranges and memory slices for
+/// segments.
+///
+/// FIXME: For now this assumes that no dlopen()/dlclose() is happening.
+struct CodeSegs {
+    tree: IntervalTree<usize, ()>,
+}
+
+impl CodeSegs {
+    /// Obtain the virtual address range and a slice of memory for the segment containing the
+    /// specified virtual address.
+    fn seg<'s: 'a, 'a>(&'s self, vaddr: usize) -> Segment<'a> {
+        let mut hits = self.tree.query(vaddr..(vaddr + 1));
+        match hits.next() {
+            Some(x) => {
+                // Segments can't overlap.
+                debug_assert_eq!(hits.next(), None);
+
+                let slice = unsafe {
+                    slice::from_raw_parts(x.range.start as *const u8, x.range.end - x.range.start)
+                };
+                Segment {
+                    vaddrs: &x.range,
+                    slice,
+                }
+            }
+            None => todo!(), // Has an object been loaded or unloaded at runtime?
+        }
+    }
+}
+
+/// The virtual address range of and memory slice of one ELF segment.
+struct Segment<'a> {
+    /// The virtual address range of the segment.
+    vaddrs: &'a Range<usize>,
+    /// A memory slice for the segment.
+    slice: &'a [u8],
+}
+
 /// Represents a location in the instruction stream of the traced binary.
 #[derive(Eq, PartialEq)]
 enum ObjLoc {
-    /// A known location in the "main binary object" of the program.
+    /// A known byte offset in the "main binary object" of the program.
     MainObj(u64),
-    /// Either a location not in the "main binary object", or an unknown location.
-    OtherObjOrUnknown,
+    /// Anything else, as a virtual address (if known).
+    OtherObjOrUnknown(Option<usize>),
 }
 
 impl Debug for ObjLoc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::MainObj(v) => write!(f, "MainObj[0x{:x}]", v),
-            Self::OtherObjOrUnknown => write!(f, "OtherObjOrUnknown"),
+            Self::MainObj(v) => write!(f, "ObjLoc::MainObj(0x{:x})", v),
+            Self::OtherObjOrUnknown(e) => {
+                if let Some(e) = e {
+                    write!(f, "ObjLoc::OtherObjOrUnknown(0x{:x})", e)
+                } else {
+                    write!(f, "ObjLoc::OtherObjOrUnknown(???)")
+                }
+            }
         }
+    }
+}
+
+/// The return addresses that can appear on the compressed return stack.
+#[derive(Debug, Clone)]
+enum CompRetAddr {
+    /// A regular return address (as a virtual address).
+    VAddr(usize),
+    /// Return to directly after the callsite at the given offset in the main object binary.
+    ///
+    /// This exists because when we do compiler-assisted decoding, we don't disassemble the
+    /// instruction stream, and thus we don't know how long the call instruction is, and hence nor
+    /// the address of the instruction to return to. That's actually OK, because compiler-assisted
+    /// decoding needs only to know after which call to continue decoding after.
+    AfterCall(u64),
+}
+
+/// The compressed return stack (required for the compressed returns optimisation implemented by
+/// some Intel CPUs).
+///
+/// In short, the call-chains of most programs are "well-behaved" in that their calls and returns
+/// are properly nested. In such scenarios, it's not necessary for each return from a function to
+/// report a fresh target IP (return address) via a PT packet, since the return address can be
+/// inferred from an earlier callsite.
+///
+/// For more information, consult Section 34.4.2.2 of the Intel 64 and IA-32 Architectures Software
+/// Developer’s Manual, Volume 3 (under the "Indirect Transfer Compression for Returns")
+/// sub-heading.
+struct CompressedReturns {
+    rets: VecDeque<CompRetAddr>,
+}
+
+impl CompressedReturns {
+    fn new() -> Self {
+        Self {
+            rets: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, ret: CompRetAddr) {
+        debug_assert!(self.rets.len() <= PT_MAX_COMPRETS);
+
+        // The stack is fixed-size. When the stack is full and a new entry is pushed, the oldest
+        // entry is evicted.
+        if self.rets.len() == PT_MAX_COMPRETS {
+            self.rets.pop_front();
+        }
+
+        self.rets.push_back(ret);
+    }
+
+    fn pop(&mut self) -> Option<CompRetAddr> {
+        self.rets.pop_back()
     }
 }
 
@@ -75,12 +239,34 @@ struct YkPTBlockIterator<'t> {
     /// A vector of "taken/not-taken" (TNT) decisions. These arrive in batches and get buffered
     /// here in a FIFO fashion (oldest decision at head poistion).
     tnts: VecDeque<bool>,
+    /// The compressed return stack.
+    comprets: CompressedReturns,
     /// When true, packet generation is enabled (we've seen a `TIP.PGE` packet, but no
     /// corresponding `TIP.PGD` yet).
     pge: bool,
 }
 
 impl<'t> YkPTBlockIterator<'t> {
+    /// Convert a file offset to a virtual address.
+    fn off_to_vaddr(&self, obj: &Path, off: u64) -> Result<usize, HWTracerError> {
+        match ykutil::addr::off_to_vaddr(obj, off) {
+            Some(vaddr) => Ok(vaddr),
+            None => Err(HWTracerError::TraceParseError(
+                "failed to convert an offset to a virtual address".to_owned(),
+            )),
+        }
+    }
+
+    /// Convert a virtual address to a file offset.
+    fn vaddr_to_off(&self, vaddr: usize) -> Result<(PathBuf, u64), HWTracerError> {
+        match ykutil::addr::code_vaddr_to_off(vaddr) {
+            Some(tup) => Ok(tup),
+            None => Err(HWTracerError::TraceParseError(
+                "failed to convert a virtual address to an offset".to_owned(),
+            )),
+        }
+    }
+
     /// Looks up the blockmap entry for the given offset in the "main object binary".
     fn lookup_blockmap_entry(
         &self,
@@ -97,126 +283,358 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     // Lookup a block from an offset in the "main binary" (i.e. not from a shared object).
-    fn lookup_block_from_main_bin_offset(&self, off: u64) -> Block {
+    fn lookup_block_from_main_bin_offset(&mut self, off: u64) -> Result<Block, HWTracerError> {
         if let Some(ent) = self.lookup_blockmap_entry(off) {
-            Block::from_vaddr_range(
-                u64::try_from(off_to_vaddr(&PathBuf::from(""), ent.range.start).unwrap()).unwrap(),
-                u64::try_from(off_to_vaddr(&PathBuf::from(""), ent.range.end).unwrap()).unwrap(),
-            )
+            Ok(Block::from_vaddr_range(
+                u64::try_from(self.off_to_vaddr(&PHDR_MAIN_OBJ, ent.range.start)?).unwrap(),
+                u64::try_from(self.off_to_vaddr(&PHDR_MAIN_OBJ, ent.range.end)?).unwrap(),
+            ))
         } else {
-            Block::unknown()
+            Ok(Block::Unknown)
         }
     }
 
-    fn do_next(&mut self) -> Result<Option<Block>, HWTracerError> {
+    fn do_next(&mut self) -> Result<Block, HWTracerError> {
         // Read as far ahead as we can using static successor info encoded into the blockmap.
-        if let ObjLoc::MainObj(b_off) = self.cur_loc {
-            // We know where we are in the main object binary, so there's a chance that there's a
-            // blockmap entry for this location.
-            if let Some(ent) = self.lookup_blockmap_entry(b_off.to_owned()) {
-                // If there are calls in the block that come *after* the current position in the
-                // block, then we will need to follow those before we look at the successor info.
-                if let Some(call_info) = ent
-                    .value
-                    .call_offs()
-                    .iter()
-                    .find(|c| c.callsite_off() >= b_off)
-                {
-                    let target = call_info.target_off();
-                    if let Some(target_off) = target {
-                        self.cur_loc = ObjLoc::MainObj(target_off);
-                        return Ok(Some(self.lookup_block_from_main_bin_offset(target_off)));
-                    } else {
-                        // Call target isn't known statically.
-                        self.cur_loc = ObjLoc::OtherObjOrUnknown;
-                        return Ok(Some(Block::unknown()));
-                    }
-                }
+        match self.cur_loc {
+            ObjLoc::MainObj(b_off) => {
+                // We know where we are in the main object binary, so there's a chance that there's
+                // a blockmap entry for this location (not all code from the main object binary
+                // necessarily has blockmap info. e.g. PLT resolution routines).
+                if let Some(ent) = self.lookup_blockmap_entry(b_off.to_owned()) {
+                    // If there are calls in the block that come *after* the current position in the
+                    // block, then we will need to follow those before we look at the successor info.
+                    if let Some(call_info) = ent
+                        .value
+                        .call_offs()
+                        .iter()
+                        .find(|c| c.callsite_off() >= b_off)
+                    {
+                        self.comprets
+                            .push(CompRetAddr::AfterCall(call_info.callsite_off()));
 
-                // If we get here, there were no further calls to follow in the block, so we
-                // consult the static successor information.
-                match ent.value.successor() {
-                    SuccessorKind::Unconditional { target } => {
+                        let target = call_info.target_off();
                         if let Some(target_off) = target {
-                            self.cur_loc = ObjLoc::MainObj(*target_off);
-                            return Ok(Some(self.lookup_block_from_main_bin_offset(*target_off)));
+                            self.cur_loc = ObjLoc::MainObj(target_off);
+                            return self.lookup_block_from_main_bin_offset(target_off);
                         } else {
-                            // Divergent control flow.
-                            todo!();
+                            // Call target isn't known statically. Find it from a TIP packet.
+                            self.seek_tip()?;
+                            return match self.cur_loc {
+                                ObjLoc::MainObj(off) => self.lookup_block_from_main_bin_offset(off),
+                                ObjLoc::OtherObjOrUnknown(_) => Ok(Block::Unknown),
+                            };
                         }
                     }
-                    SuccessorKind::Conditional {
-                        taken_target,
-                        not_taken_target,
-                    } => {
-                        // If we don't have any TNT choices buffered, get more.
-                        if self.tnts.is_empty() && !self.seek_tnt()? {
-                            // The packet stream was exhausted.
-                            return Ok(None);
-                        }
-                        // Find where to go next based on whether the trace took the branch or not.
-                        //
-                        // The `unwrap()` is guaranteed to succeed because the above call to
-                        // `seek_tnt()` has populated `self.tnts()`.
-                        let target_off = if self.tnts.pop_front().unwrap() {
-                            *taken_target
-                        } else {
-                            if let Some(ntt) = not_taken_target {
-                                *ntt
+
+                    // If we get here, there were no further calls to follow in the block, so we
+                    // consult the static successor information.
+                    match ent.value.successor() {
+                        SuccessorKind::Unconditional { target } => {
+                            if let Some(target_off) = target {
+                                self.cur_loc = ObjLoc::MainObj(*target_off);
+                                return self.lookup_block_from_main_bin_offset(*target_off);
                             } else {
                                 // Divergent control flow.
                                 todo!();
                             }
-                        };
-                        self.cur_loc = ObjLoc::MainObj(target_off);
-                        return Ok(Some(self.lookup_block_from_main_bin_offset(target_off)));
+                        }
+                        SuccessorKind::Conditional {
+                            taken_target,
+                            not_taken_target,
+                        } => {
+                            // If we don't have any TNT choices buffered, get more.
+                            if self.tnts.is_empty() {
+                                self.seek_tnt()?;
+                            }
+
+                            // Find where to go next based on whether the trace took the branch or not.
+                            //
+                            // The `unwrap()` is guaranteed to succeed because the above call to
+                            // `seek_tnt()` has populated `self.tnts()`.
+                            let target_off = if self.tnts.pop_front().unwrap() {
+                                *taken_target
+                            } else {
+                                if let Some(ntt) = not_taken_target {
+                                    *ntt
+                                } else {
+                                    // Divergent control flow.
+                                    todo!();
+                                }
+                            };
+                            self.cur_loc = ObjLoc::MainObj(target_off);
+                            return self.lookup_block_from_main_bin_offset(target_off);
+                        }
+                        SuccessorKind::Return => {
+                            if self.is_return_compressed()? {
+                                // This unwrap cannot fail if the CPU has implemented compressed
+                                // returns correctly.
+                                let off = match self.comprets.pop().unwrap() {
+                                    CompRetAddr::AfterCall(off) => off + 1,
+                                    CompRetAddr::VAddr(vaddr) => {
+                                        let (obj, off) = self.vaddr_to_off(vaddr)?;
+                                        debug_assert!(obj == *SELF_BIN_PATH);
+                                        off
+                                    }
+                                };
+
+                                self.cur_loc = ObjLoc::MainObj(off + 1);
+                                return self.lookup_block_from_main_bin_offset(off + 1);
+                            } else {
+                                // A regular uncompressed return that relies on a TIP update.
+                                //
+                                // Note that `is_return_compressed()` has already updated
+                                // `self.cur_loc()`.
+                                match self.cur_loc {
+                                    ObjLoc::MainObj(off) => {
+                                        return Ok(self.lookup_block_from_main_bin_offset(off)?)
+                                    }
+                                    _ => return Ok(Block::Unknown),
+                                };
+                            }
+                        }
+                        SuccessorKind::Dynamic => {
+                            // We can only know the successor via a TIP update in a packet.
+                            //
+                            // FIXME: can't test without fixing indirect branch support for the
+                            // block disambiguator pass in ykllvm.
+                            //
+                            // Test already written: tests/hwtracer_ykpt/indirect_jump.c
+                            todo!();
+                        }
                     }
-                    SuccessorKind::Dynamic => {
-                        // We can only know the successor via a TIP update in a packet. Fall
-                        // through to `self.seek_tip()`.
-                        self.cur_loc = ObjLoc::OtherObjOrUnknown;
-                    }
+                } else {
+                    self.cur_loc =
+                        ObjLoc::OtherObjOrUnknown(Some(self.off_to_vaddr(&PHDR_MAIN_OBJ, b_off)?));
+                    return Ok(Block::Unknown);
                 }
-            } else {
-                // In the absence of blockmap info, we cannot know the successor block.
-                self.cur_loc = ObjLoc::OtherObjOrUnknown;
-                return Ok(Some(Block::unknown()));
             }
+            ObjLoc::OtherObjOrUnknown(vaddr) => self.skip_foreign(vaddr),
         }
-
-        // If we get here then we can't statically figure out where to go next. A packet is going
-        // to have to tell us what to do.
-        self.seek_tip()
     }
 
-    /// Keep decoding packets until we have some TNT decisions buffered.
-    fn seek_tnt(&mut self) -> Result<bool, HWTracerError> {
-        while self.tnts.is_empty() {
-            let pkt = self.packet()?; // Potentially populates `self.tnts`.
-            if pkt.is_none() {
-                return Ok(false); // Packet stream exhausted.
-            }
+    /// Returns the target virtual address for a branch instruction.
+    fn branch_target_vaddr(&self, inst: &iced_x86::Instruction) -> u64 {
+        match inst.op0_kind() {
+            iced_x86::OpKind::NearBranch16 => inst.near_branch16().into(),
+            iced_x86::OpKind::NearBranch32 => inst.near_branch32().into(),
+            iced_x86::OpKind::NearBranch64 => inst.near_branch64(),
+            iced_x86::OpKind::FarBranch16 | iced_x86::OpKind::FarBranch32 => panic!(),
+            _ => unreachable!(),
         }
-        Ok(true)
     }
 
-    /// Keep decoding packets until we receive a TIP update.
-    fn seek_tip(&mut self) -> Result<Option<Block>, HWTracerError> {
-        debug_assert_eq!(self.cur_loc, ObjLoc::OtherObjOrUnknown);
+    // Determines if a return from a function was compressed in the packet stream.
+    //
+    // In the event that the return is compressed, the taken decision is popped from `self.tnts`.
+    fn is_return_compressed(&mut self) -> Result<bool, HWTracerError> {
+        let compressed = if !self.tnts.is_empty() {
+            // As the Intel manual explains, when a return is *not* compressed, the CPU's TNT
+            // buffers are flushed, so if we have any buffered TNT decisions, then this must be a
+            // *compressed* return.
+            true
+        } else {
+            // This *may* be a compressed return. If the next event packet carries a TIP update
+            // then this was an uncompressed return, otherwise it was compressed.
+            let pkt = self.seek_tnt_or_tip()?;
+            pkt.tnts().is_some()
+        };
+
+        if compressed {
+            // If the return was compressed, we must we consume one "taken=true" decision from the
+            // TNT buffer. The unwrap cannot fail becuase the above code ensures that `self.tnts`
+            // is not empty.
+            let taken = self.tnts.pop_front().unwrap();
+            debug_assert!(taken);
+        }
+
+        Ok(compressed)
+    }
+
+    fn disassemble(&mut self, start_vaddr: usize) -> Result<Block, HWTracerError> {
+        let mut seg = CODE_SEGS.seg(start_vaddr);
+        let mut dis =
+            iced_x86::Decoder::with_ip(64, seg.slice, u64::try_from(seg.vaddrs.start).unwrap(), 0);
+        dis.set_ip(u64::try_from(start_vaddr).unwrap());
+        dis.set_position(start_vaddr - seg.vaddrs.start)
+            .map_err(|_| HWTracerError::DisasmFail("failed to set position".to_owned()))?;
+        let mut reposition: bool = false;
+
         loop {
-            if self.packet()?.is_some() {
-                if let ObjLoc::MainObj(off) = self.cur_loc {
-                    return Ok(Some(self.lookup_block_from_main_bin_offset(off)));
+            let vaddr = usize::try_from(dis.ip()).unwrap();
+            let (obj, off) = self.vaddr_to_off(vaddr)?;
+
+            if obj == *SELF_BIN_PATH {
+                let block = self.lookup_block_from_main_bin_offset(off)?;
+                if !block.is_unknown() {
+                    // We are back to "native code" and can resume compiler-assisted decoding.
+                    self.cur_loc = ObjLoc::MainObj(off);
+                    return Ok(block);
                 }
-            } else {
-                return Ok(None); // No more packets.
+            }
+
+            if !seg.vaddrs.contains(&vaddr) {
+                // The next instruction is outside of the current segment. Switch segment and make
+                // a new decoder for it.
+                seg = CODE_SEGS.seg(vaddr);
+                let seg_start_u64 = u64::try_from(seg.vaddrs.start).unwrap();
+                dis = iced_x86::Decoder::with_ip(64, seg.slice, seg_start_u64, 0);
+                dis.set_ip(u64::try_from(vaddr).unwrap());
+                reposition = true;
+            }
+
+            if reposition {
+                dis.set_position(vaddr - seg.vaddrs.start)
+                    .map_err(|_| HWTracerError::DisasmFail("failed to reposition".to_owned()))?;
+                reposition = false;
+            }
+
+            let inst = dis.decode();
+            match inst.flow_control() {
+                iced_x86::FlowControl::Next => (),
+                iced_x86::FlowControl::Return => {
+                    // We don't expect to see any 16-bit far returns.
+                    debug_assert!(is_ret_near(&inst));
+
+                    let ret_vaddr = if self.is_return_compressed()? {
+                        // This unwrap cannot fail if the CPU correctly implements compressed
+                        // returns.
+                        match self.comprets.pop().unwrap() {
+                            CompRetAddr::VAddr(vaddr) => vaddr,
+                            CompRetAddr::AfterCall(off) => {
+                                self.off_to_vaddr(&PHDR_MAIN_OBJ, off + 1)?
+                            }
+                        }
+                    } else {
+                        match self.cur_loc {
+                            ObjLoc::MainObj(off) => self.off_to_vaddr(&PHDR_MAIN_OBJ, off)?,
+                            ObjLoc::OtherObjOrUnknown(opt_vaddr) => match opt_vaddr {
+                                Some(vaddr) => vaddr,
+                                None => unreachable!(),
+                            },
+                        }
+                    };
+                    dis.set_ip(u64::try_from(ret_vaddr).unwrap());
+                    reposition = true;
+                }
+                iced_x86::FlowControl::IndirectBranch | iced_x86::FlowControl::IndirectCall => {
+                    self.seek_tip()?;
+                    let vaddr = match self.cur_loc {
+                        ObjLoc::MainObj(off) => self.off_to_vaddr(&PHDR_MAIN_OBJ, off)?,
+                        ObjLoc::OtherObjOrUnknown(opt_vaddr) => match opt_vaddr {
+                            Some(vaddr) => vaddr,
+                            None => unreachable!(),
+                        },
+                    };
+
+                    if inst.flow_control() == iced_x86::FlowControl::IndirectCall {
+                        if usize::try_from(inst.next_ip()).unwrap() == vaddr {
+                            todo!("zero length call");
+                        }
+                        debug_assert!(!inst.is_call_far());
+                        self.comprets
+                            .push(CompRetAddr::VAddr(usize::try_from(inst.next_ip()).unwrap()));
+                    }
+
+                    dis.set_ip(u64::try_from(vaddr).unwrap());
+                    reposition = true;
+                }
+                iced_x86::FlowControl::ConditionalBranch => {
+                    // Ensure we have TNT decisions buffered.
+                    if self.tnts.is_empty() {
+                        self.seek_tnt()?;
+                    }
+                    // unwrap() cannot fail as the above code ensures we have decisions buffered.
+                    if self.tnts.pop_front().unwrap() {
+                        dis.set_ip(self.branch_target_vaddr(&inst));
+                        reposition = true;
+                    }
+                }
+                iced_x86::FlowControl::UnconditionalBranch => {
+                    dis.set_ip(self.branch_target_vaddr(&inst));
+                    reposition = true;
+                }
+                iced_x86::FlowControl::Call => {
+                    if inst.code() == iced_x86::Code::Syscall {
+                        // Do nothing. We have disabled kernel tracing in hwtracer, so
+                        // entering/leaving a syscall will generate packet generation
+                        // disable/enable events (`TIP.PGD`/`TIP.PGE` packets) which are handled by
+                        // the decoder elsewhere.
+                    } else {
+                        let target_vaddr = self.branch_target_vaddr(&inst);
+                        if target_vaddr == inst.next_ip() {
+                            // FIXME: Intel PT treats this case specially.
+                            todo!();
+                        }
+                        // We don't expect to see any 16-bit mode far calls in modernity.
+                        debug_assert!(!inst.is_call_far());
+                        self.comprets
+                            .push(CompRetAddr::VAddr(usize::try_from(inst.next_ip()).unwrap()));
+                        dis.set_ip(target_vaddr);
+                        reposition = true;
+                    }
+                }
+                _ => todo!(),
+            }
+        }
+    }
+
+    /// Skip over "foreign code" for which we have no blockmap info for.
+    fn skip_foreign(&mut self, start_vaddr: Option<usize>) -> Result<Block, HWTracerError> {
+        let start_vaddr = match start_vaddr {
+            Some(v) => v,
+            None => {
+                // We don't statically know where to start, so we rely on a TIP update to tell us.
+                self.seek_tip()?;
+                match self.cur_loc {
+                    ObjLoc::OtherObjOrUnknown(Some(vaddr)) => vaddr,
+                    ObjLoc::OtherObjOrUnknown(None) => {
+                        // The above `seek_tip()` ensures this can't happen!
+                        unreachable!();
+                    }
+                    ObjLoc::MainObj(off) => self.off_to_vaddr(&PHDR_MAIN_OBJ, off)?,
+                }
+            }
+        };
+        self.disassemble(start_vaddr)
+    }
+
+    /// Keep decoding packets until we encounter a TNT packet.
+    fn seek_tnt(&mut self) -> Result<(), HWTracerError> {
+        loop {
+            let pkt = self.packet()?; // Potentially populates `self.tnts`.
+            if pkt.tnts().is_some() {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Keep decoding packets until we encounter one with a TIP update.
+    fn seek_tip(&mut self) -> Result<(), HWTracerError> {
+        loop {
+            if self.packet()?.target_ip().is_some() {
+                // Note that self.packet() will have update `self.cur_loc`.
+                return Ok(());
+            }
+        }
+    }
+
+    /// Keep decoding packets until we encounter either a TNT packet or one with a TIP update.
+    ///
+    /// The packet is returned so that the consumer can determine which kind of packet was
+    /// encountered.
+    fn seek_tnt_or_tip(&mut self) -> Result<Packet, HWTracerError> {
+        loop {
+            let pkt = self.packet()?;
+            if pkt.target_ip().is_some() || pkt.tnts().is_some() {
+                return Ok(pkt);
             }
         }
     }
 
     /// Fetch the next packet and update iterator state.
-    fn packet(&mut self) -> Result<Option<Packet>, HWTracerError> {
-        if let Some(pkt_or_err) = self.parser.next() {
+    fn packet(&mut self) -> Result<Packet, HWTracerError> {
+        let ret = if let Some(pkt_or_err) = self.parser.next() {
             let pkt = pkt_or_err?;
 
             // Update `self.pge` if necessary.
@@ -235,19 +653,10 @@ impl<'t> YkPTBlockIterator<'t> {
             // Update `self.target_ip` if necessary.
             if let Some(vaddr) = pkt.target_ip() {
                 if self.pge {
-                    match code_vaddr_to_off(vaddr) {
-                        Some((obj, off)) if obj == *SELF_BIN_PATH => {
-                            self.cur_loc = ObjLoc::MainObj(off)
-                        }
-                        _ => self.cur_loc = ObjLoc::OtherObjOrUnknown,
-                    }
-
-                    // At this point any remaining buffered TNTs would be ones for past control
-                    // flow decisions that we were unable to make use of due to imperfect
-                    // knowledge of the control flow. E.g. execution passed through code that
-                    // wasn't compiled by ykllvm, so we get TNT packets, but no static successor
-                    // info to use them against.
-                    self.tnts.clear();
+                    self.cur_loc = match self.vaddr_to_off(vaddr)? {
+                        (obj, off) if obj == *SELF_BIN_PATH => ObjLoc::MainObj(off),
+                        _ => ObjLoc::OtherObjOrUnknown(Some(vaddr)),
+                    };
                 }
             }
 
@@ -256,10 +665,12 @@ impl<'t> YkPTBlockIterator<'t> {
                 self.tnts.extend(bits);
             }
 
-            Ok(Some(pkt))
+            Ok(pkt)
         } else {
-            Ok(None)
-        }
+            Err(HWTracerError::NoMorePackets)
+        };
+
+        ret
     }
 }
 
@@ -269,8 +680,8 @@ impl<'t> Iterator for YkPTBlockIterator<'t> {
     fn next(&mut self) -> Option<Self::Item> {
         if !self.errored {
             match self.do_next() {
-                Ok(Some(blk)) => Some(Ok(blk)),
-                Ok(None) => None,
+                Ok(blk) => Some(Ok(blk)),
+                Err(HWTracerError::NoMorePackets) => None, // Signals end of iterator.
                 Err(e) => {
                     self.errored = true;
                     Some(Err(e))
@@ -279,6 +690,18 @@ impl<'t> Iterator for YkPTBlockIterator<'t> {
         } else {
             None
         }
+    }
+}
+
+/// iced_x86 should be providing this:
+/// https://github.com/icedland/iced/issues/366
+fn is_ret_near(inst: &iced_x86::Instruction) -> bool {
+    debug_assert_eq!(inst.flow_control(), iced_x86::FlowControl::Return);
+    use iced_x86::Code::*;
+    match inst.code() {
+        Retnd | Retnd_imm16 | Retnq | Retnq_imm16 | Retnw | Retnw_imm16 => true,
+        Retfd | Retfd_imm16 | Retfq | Retfq_imm16 | Retfw | Retfw_imm16 => false,
+        _ => unreachable!(), // anything else isn't a return instruction.
     }
 }
 

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -30,6 +30,10 @@ pub enum HWTracerError {
     Unknown,
     /// Failed to decode trace.
     TraceParseError(String),
+    /// A disassembly-related error.
+    DisasmFail(String),
+    /// End of hardware decoder packet stream.
+    NoMorePackets,
     /// Any other error.
     Custom(Box<dyn Error>),
 }
@@ -58,6 +62,8 @@ impl Display for HWTracerError {
             HWTracerError::BadConfig(ref s) => write!(f, "{}", s),
             HWTracerError::Custom(ref bx) => write!(f, "{}", bx),
             HWTracerError::TraceParseError(ref s) => write!(f, "failed to parse trace: {}", s),
+            HWTracerError::NoMorePackets => write!(f, "End of packet stream"),
+            HWTracerError::DisasmFail(ref s) => write!(f, "failed to disassemble: {}", s),
             HWTracerError::Unknown => write!(f, "Unknown error"),
         }
     }
@@ -82,6 +88,8 @@ impl Error for HWTracerError {
             HWTracerError::Custom(ref bx) => Some(bx.as_ref()),
             HWTracerError::TraceParseError(_) => None,
             HWTracerError::Unknown => None,
+            HWTracerError::NoMorePackets => None,
+            HWTracerError::DisasmFail(_) => None,
         }
     }
 }

--- a/hwtracer/src/llvm_blockmap.rs
+++ b/hwtracer/src/llvm_blockmap.rs
@@ -28,7 +28,9 @@ pub enum SuccessorKind {
         /// The offset of the "not taken" successor, or `None` if control flow is divergent.
         not_taken_target: Option<u64>,
     },
-    /// A control flow edge known only at runtime, e.g. a return or an indirect branch.
+    /// A return edge.
+    Return,
+    /// Any other control flow edge known only at runtime, e.g. an indirect branch.
     Dynamic,
 }
 
@@ -148,7 +150,7 @@ impl BlockMap {
                     corr_bbs.push(leb128::read::unsigned(&mut crsr).unwrap());
                 }
 
-                // Read call offsets.
+                // Read call information.
                 let num_calls = leb128::read::unsigned(&mut crsr).unwrap();
                 let mut call_offs = Vec::new();
                 for _ in 0..num_calls {
@@ -181,7 +183,8 @@ impl BlockMap {
                         taken_target: crsr.read_u64::<NativeEndian>().unwrap(),
                         not_taken_target: read_maybe_divergent_target(&mut crsr),
                     },
-                    2 => SuccessorKind::Dynamic,
+                    2 => SuccessorKind::Return,
+                    3 => SuccessorKind::Dynamic,
                     _ => unreachable!(),
                 };
 

--- a/tests/extra_linkage/fudge.s
+++ b/tests/extra_linkage/fudge.s
@@ -1,0 +1,8 @@
+.global fudge_return_address
+.intel_syntax
+
+# Function that returns to the address stored in its first argument.
+fudge_return_address:
+    pop rax
+    push rdi
+    ret

--- a/tests/hwtracer_ykpt/foreign.c
+++ b/tests/hwtracer_ykpt/foreign.c
@@ -1,0 +1,23 @@
+// Run-time:
+
+#include <assert.h>
+#include <stdio.h>
+#include <yk_testing.h>
+
+extern int call_me_add(int); // opaque to the JIT.
+
+int main(void) {
+  int i = 0;
+  NOOPT_VAL(i);
+
+  void *tc = __hwykpt_start_collector();
+  i++;
+  i = call_me_add(i);
+  i++;
+  void *trace = __hwykpt_stop_collector(tc);
+
+  NOOPT_VAL(i);
+  assert(i == 3);
+
+  __hwykpt_libipt_vs_ykpt(trace);
+}

--- a/tests/hwtracer_ykpt/indirect_call.c
+++ b/tests/hwtracer_ykpt/indirect_call.c
@@ -1,0 +1,20 @@
+// Run-time:
+//   stderr:
+//     ggg
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <yk_testing.h>
+
+__attribute__((noinline)) void f(void) { fprintf(stderr, "fff\n"); }
+
+__attribute__((noinline)) void g(void) { fprintf(stderr, "ggg\n"); }
+
+int main(void) {
+  void (*callee)(void) = &g;
+  NOOPT_VAL(callee);
+  void *tc = __hwykpt_start_collector();
+  callee(); // indirect call
+  void *trace = __hwykpt_stop_collector(tc);
+  __hwykpt_libipt_vs_ykpt(trace);
+}

--- a/tests/hwtracer_ykpt/indirect_jump.c
+++ b/tests/hwtracer_ykpt/indirect_jump.c
@@ -1,0 +1,35 @@
+// ignore: Requires ykllvm support for indirect jumps.
+// Run-time:
+//   stderr:
+//    l2
+//    l1
+//    l3
+
+// FIXME: The BlockDisambiguate pass in ykllvm currently crashes on
+// indirect jumps due to unimplemented logic.
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <yk_testing.h>
+
+int main(void) {
+  void *t1 = &&l1;
+  void *t2 = &&l2;
+  void *t3 = &&l3;
+  NOOPT_VAL(t1);
+  NOOPT_VAL(t2);
+  NOOPT_VAL(t3);
+
+  void *tc = __hwykpt_start_collector();
+  goto *t2;
+l1:
+  fprintf(stderr, "l1\n");
+  goto *t3;
+l2:
+  fprintf(stderr, "l2\n");
+  goto *t1;
+l3:
+  fprintf(stderr, "l3\n");
+  void *trace = __hwykpt_stop_collector(tc);
+  __hwykpt_libipt_vs_ykpt(trace);
+}

--- a/tests/hwtracer_ykpt/simple_loop.c
+++ b/tests/hwtracer_ykpt/simple_loop.c
@@ -1,0 +1,21 @@
+// Run-time:
+
+#include <stdio.h>
+#include <yk_testing.h>
+
+int main(void) {
+  int i = 4;
+  int x = 0;
+  NOOPT_VAL(i);
+  NOOPT_VAL(x);
+
+  void *tc = __hwykpt_start_collector();
+  while (i > 0) {
+    printf("i=%d, x=%d\n", i, x);
+    x += 2;
+    i--;
+  }
+  void *trace = __hwykpt_stop_collector(tc);
+
+  __hwykpt_libipt_vs_ykpt(trace);
+}

--- a/tests/hwtracer_ykpt/stifle_compressed_ret.c
+++ b/tests/hwtracer_ykpt/stifle_compressed_ret.c
@@ -1,0 +1,28 @@
+// Run-time:
+//   stderr:
+//     before
+//     always reached
+
+#include <assert.h>
+#include <stdio.h>
+#include <yk_testing.h>
+
+// This function returns to the address passed in, which in turn prevents Intel
+// PT from compressing the return back to main.
+extern void fudge_return_address(void *);
+
+int main(void) {
+  void *ra = &&ret_here;
+  NOOPT_VAL(ra);
+
+  fprintf(stderr, "before\n");
+  void *tc = __hwykpt_start_collector();
+  fudge_return_address(ra);
+  fprintf(stderr, "never reached\n");
+
+ret_here:
+  fprintf(stderr, "always reached\n");
+  void *trace = __hwykpt_stop_collector(tc);
+
+  __hwykpt_libipt_vs_ykpt(trace);
+}

--- a/tests/hwtracer_ykpt/syscall.c
+++ b/tests/hwtracer_ykpt/syscall.c
@@ -1,0 +1,27 @@
+// Run-time:
+//   stderr:
+//     hello
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <yk_testing.h>
+
+#define THE_STRING "hello\n"
+
+int main(void) {
+  size_t remain = strlen(THE_STRING);
+  NOOPT_VAL(remain);
+
+  void *tc = __hwykpt_start_collector();
+
+  while (remain) {
+    int wrote = write(STDERR_FILENO, THE_STRING, strlen(THE_STRING));
+    if (wrote == -1)
+      exit(EXIT_FAILURE);
+    remain -= wrote;
+  }
+
+  void *trace = __hwykpt_stop_collector(tc);
+  __hwykpt_libipt_vs_ykpt(trace);
+}

--- a/tests/langtest_hwtracer_ykpt.rs
+++ b/tests/langtest_hwtracer_ykpt.rs
@@ -3,14 +3,54 @@
 use lang_tester::LangTester;
 use regex::Regex;
 use std::{
+    collections::HashMap,
     fs::read_to_string,
     path::{Path, PathBuf},
     process::Command,
+    sync::LazyLock,
 };
 use tempfile::TempDir;
 use tests::mk_compiler;
+use tests::ExtraLinkage;
 
 const COMMENT: &str = "//";
+
+pub static EXTRA_LINK_HWTRACER_YKPT: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> =
+    LazyLock::new(|| {
+        let mut map = HashMap::new();
+
+        // These tests get an extra, separately compiled (thus opaque to LTO), object file linked in.
+        map.insert(
+            "foreign.c",
+            vec![ExtraLinkage::new(
+                "%%TEMPDIR%%/call_me.o",
+                &[
+                    "clang",
+                    "-c",
+                    "-O0",
+                    "extra_linkage/call_me.c",
+                    "-o",
+                    "%%TEMPDIR%%/call_me.o",
+                ],
+            )],
+        );
+        map.insert(
+            "stifle_compressed_ret.c",
+            vec![ExtraLinkage::new(
+                "%%TEMPDIR%%/fudge.o",
+                &[
+                    "clang",
+                    "-c",
+                    "-O0",
+                    "extra_linkage/fudge.s",
+                    "-o",
+                    "%%TEMPDIR%%/fudge.o",
+                ],
+            )],
+        );
+
+        map
+    });
 
 fn run_suite(opt: &'static str) {
     println!("Running hwtracer_ykpt tests with {}...", opt);
@@ -44,7 +84,16 @@ fn run_suite(opt: &'static str) {
             exe.push(&tempdir);
             exe.push(p.file_stem().unwrap());
 
-            let mut compiler = mk_compiler(&exe, p, opt, &[], false);
+            // Decide if we have extra objects to link to the test.
+            let key = p.file_name().unwrap().to_str().unwrap();
+            let extra_objs = EXTRA_LINK_HWTRACER_YKPT
+                .get(key)
+                .unwrap_or(&Vec::new())
+                .iter()
+                .map(|l| l.generate_obj(tempdir.path()))
+                .collect::<Vec<PathBuf>>();
+
+            let mut compiler = mk_compiler(&exe, p, opt, &extra_objs, false);
             compiler.arg("-ltests");
             let runtime = Command::new(exe.clone());
             vec![("Compiler", compiler), ("Run-time", runtime)]

--- a/tests/langtest_hwtracer_ykpt.rs
+++ b/tests/langtest_hwtracer_ykpt.rs
@@ -13,7 +13,7 @@ use tests::mk_compiler;
 const COMMENT: &str = "//";
 
 fn run_suite(opt: &'static str) {
-    println!("Running C tests with {}...", opt);
+    println!("Running hwtracer_ykpt tests with {}...", opt);
 
     let filter: fn(&Path) -> bool = |p| {
         if let Some(ext) = p.extension() {

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -56,9 +56,15 @@ pub extern "C" fn __hwykpt_libipt_vs_ykpt(trace: *mut Box<dyn Trace>) {
     let mut ykpt_mapper = HWTMapper::new(&mut ykpt_itr);
 
     let mut last = None;
-    while let Some(got) = ipt_mapper.next(last.as_ref()) {
-        let got = got.unwrap();
-        let expect = ykpt_mapper.next(last.as_ref()).unwrap().unwrap();
+    loop {
+        let next = ipt_mapper.next(last.as_ref());
+        if next.is_none() {
+            break;
+        }
+        let expect = next.unwrap();
+
+        let expect = expect.unwrap();
+        let got = ykpt_mapper.next(last.as_ref()).unwrap().unwrap();
         assert_eq!(expect, got);
         last = Some(got);
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -52,7 +52,7 @@ pub struct ExtraLinkage<'a> {
 }
 
 impl<'a> ExtraLinkage<'a> {
-    fn new(output_file: &'a str, gen_cmd: &'a [&'a str]) -> Self {
+    pub fn new(output_file: &'a str, gen_cmd: &'a [&'a str]) -> Self {
         Self {
             output_file,
             gen_cmd,

--- a/ykutil/src/addr.rs
+++ b/ykutil/src/addr.rs
@@ -102,12 +102,9 @@ pub fn vaddr_to_sym_and_obj(vaddr: usize) -> Result<SymbolInObject, ()> {
 #[cfg(test)]
 mod tests {
     use super::{code_vaddr_to_off, off_to_vaddr, vaddr_to_sym_and_obj, MaybeUninit};
+    use crate::obj::PHDR_MAIN_OBJ;
     use libc::{dladdr, dlsym, Dl_info};
-    use std::{
-        ffi::CString,
-        path::{Path, PathBuf},
-        ptr,
-    };
+    use std::{ffi::CString, path::PathBuf, ptr};
 
     #[test]
     fn map_libc() {
@@ -147,15 +144,10 @@ mod tests {
     fn round_trip_main() {
         let func_vaddr = round_trip_main as *const fn();
         let (_obj, off) = code_vaddr_to_off(func_vaddr as usize).unwrap();
-
-        // On Linux, the main object's name in the program headers is the empty string.
-        #[cfg(target_os = "linux")]
-        let main_obj = Path::new("");
-
-        #[cfg(not(target_os = "linux"))]
-        todo!(); // We may get away with using `_obj` returned from `code_vaddr_to_off()` above?
-
-        assert_eq!(off_to_vaddr(&main_obj, off).unwrap(), func_vaddr as usize);
+        assert_eq!(
+            off_to_vaddr(&PHDR_MAIN_OBJ, off).unwrap(),
+            func_vaddr as usize
+        );
     }
 
     #[test]

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -3,6 +3,12 @@
 use libc::{c_void, dladdr, Dl_info};
 use std::{ffi::CStr, mem::MaybeUninit, path::PathBuf, ptr, sync::LazyLock};
 
+// The name of the main object as it appears in the program headers.
+//
+// On Linux this is the empty string.
+#[cfg(target_os = "linux")]
+pub static PHDR_MAIN_OBJ: LazyLock<PathBuf> = LazyLock::new(|| PathBuf::new());
+
 extern "C" {
     fn find_main() -> *const c_void;
 }


### PR DESCRIPTION
Long story short: this requires disassembling the instruction stream. Read the module comment at the top of `hwtracer/src/decode/ykpt/mod.rs` for the whole story.

Companion PR: https://github.com/ykjit/ykllvm/pull/54