### PR TITLE
Make the ykpt trace decoder the default.

### DIFF
--- a/hwtracer/examples/hwtracer_example.rs
+++ b/hwtracer/examples/hwtracer_example.rs
@@ -1,11 +1,17 @@
 use hwtracer::Trace;
-use hwtracer::{collect::TraceCollectorBuilder, decode::TraceDecoderBuilder};
+use hwtracer::{
+    collect::TraceCollectorBuilder,
+    decode::{TraceDecoderBuilder, TraceDecoderKind},
+};
 use std::time::SystemTime;
 
 /// Prints the addresses of the first `qty` blocks in a trace along with it's name and
 /// computation result.
 fn print_trace(trace: Box<dyn Trace>, name: &str, result: u32, qty: usize) {
-    let dec = TraceDecoderBuilder::new().build().unwrap();
+    let dec = TraceDecoderBuilder::new()
+        .kind(TraceDecoderKind::LibIPT)
+        .build()
+        .unwrap();
     let count = dec.iter_blocks(&*trace).count();
     println!("{}: num_blocks={}, result={}", name, count, result);
 

--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -16,8 +16,8 @@ use ykpt::YkPTTraceDecoder;
 
 #[derive(Clone, Copy, Debug, EnumIter)]
 pub enum TraceDecoderKind {
-    LibIPT,
     YkPT,
+    LibIPT,
 }
 
 impl TraceDecoderKind {

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -394,12 +394,13 @@ impl<'t> YkPTBlockIterator<'t> {
             }
             SuccessorKind::Dynamic => {
                 // We can only know the successor via a TIP update in a packet.
-                //
-                // FIXME: can't test without fixing indirect branch support for the
-                // block disambiguator pass in ykllvm.
-                //
-                // Test already written: tests/hwtracer_ykpt/indirect_jump.c
-                todo!();
+                self.seek_tip()?;
+                match self.cur_loc {
+                    ObjLoc::MainObj(off) => {
+                        return Ok(self.lookup_block_from_main_bin_offset(off)?)
+                    }
+                    _ => return Ok(Block::Unknown),
+                };
             }
         }
     }

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -332,7 +332,7 @@ impl<'t> YkPTBlockIterator<'t> {
             SuccessorKind::Unconditional { target } => {
                 if let Some(target_off) = target {
                     self.cur_loc = ObjLoc::MainObj(*target_off);
-                    return self.lookup_block_from_main_bin_offset(*target_off);
+                    self.lookup_block_from_main_bin_offset(*target_off)
                 } else {
                     // Divergent control flow.
                     todo!();
@@ -362,7 +362,7 @@ impl<'t> YkPTBlockIterator<'t> {
                     }
                 };
                 self.cur_loc = ObjLoc::MainObj(target_off);
-                return self.lookup_block_from_main_bin_offset(target_off);
+                self.lookup_block_from_main_bin_offset(target_off)
             }
             SuccessorKind::Return => {
                 if self.is_return_compressed()? {
@@ -378,29 +378,25 @@ impl<'t> YkPTBlockIterator<'t> {
                     };
 
                     self.cur_loc = ObjLoc::MainObj(off + 1);
-                    return self.lookup_block_from_main_bin_offset(off + 1);
+                    self.lookup_block_from_main_bin_offset(off + 1)
                 } else {
                     // A regular uncompressed return that relies on a TIP update.
                     //
                     // Note that `is_return_compressed()` has already updated
                     // `self.cur_loc()`.
                     match self.cur_loc {
-                        ObjLoc::MainObj(off) => {
-                            return Ok(self.lookup_block_from_main_bin_offset(off)?)
-                        }
-                        _ => return Ok(Block::Unknown),
-                    };
+                        ObjLoc::MainObj(off) => Ok(self.lookup_block_from_main_bin_offset(off)?),
+                        _ => Ok(Block::Unknown),
+                    }
                 }
             }
             SuccessorKind::Dynamic => {
                 // We can only know the successor via a TIP update in a packet.
                 self.seek_tip()?;
                 match self.cur_loc {
-                    ObjLoc::MainObj(off) => {
-                        return Ok(self.lookup_block_from_main_bin_offset(off)?)
-                    }
-                    _ => return Ok(Block::Unknown),
-                };
+                    ObjLoc::MainObj(off) => Ok(self.lookup_block_from_main_bin_offset(off)?),
+                    _ => Ok(Block::Unknown),
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes the last remaining failing test and sets our decoder as the default.

(The comment about a necessary compiler change was incorrect. Removed)