### PR TITLE
Handle FUP/TIP.* packets that pair with MODE.* packets.

### DIFF
--- a/hwtracer/src/decode/ykpt/packet_parser/mod.rs
+++ b/hwtracer/src/decode/ykpt/packet_parser/mod.rs
@@ -39,7 +39,8 @@ impl PacketParserState {
                 PacketKind::CYC,
                 PacketKind::LongTNT,
                 PacketKind::PSB,
-                PacketKind::MODE,
+                PacketKind::MODEExec,
+                PacketKind::MODETSX,
                 PacketKind::CBR,
                 PacketKind::TIPPGE,
                 PacketKind::TIPPGD,
@@ -48,7 +49,8 @@ impl PacketParserState {
                 PacketKind::PAD,
                 PacketKind::CBR,
                 PacketKind::FUP,
-                PacketKind::MODE,
+                PacketKind::MODEExec,
+                PacketKind::MODETSX,
                 PacketKind::PSBEND,
             ],
         }
@@ -121,7 +123,8 @@ impl<'t> PacketParser<'t> {
             PacketKind::CBR => read_to_packet!(CBRPacket, self.bits, Packet::CBR),
             PacketKind::PSBEND => read_to_packet!(PSBENDPacket, self.bits, Packet::PSBEND),
             PacketKind::PAD => read_to_packet!(PADPacket, self.bits, Packet::PAD),
-            PacketKind::MODE => read_to_packet!(MODEPacket, self.bits, Packet::MODE),
+            PacketKind::MODEExec => read_to_packet!(MODEExecPacket, self.bits, Packet::MODEExec),
+            PacketKind::MODETSX => read_to_packet!(MODETSXPacket, self.bits, Packet::MODETSX),
             PacketKind::TIPPGE => {
                 read_to_packet_tip!(TIPPGEPacket, self.bits, Packet::TIPPGE, self.prev_tip)
             }
@@ -204,7 +207,8 @@ impl<'t> Iterator for PacketParser<'t> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.bits.is_empty() {
-            Some(self.parse_packet())
+            let p = self.parse_packet();
+            Some(p)
         } else {
             None
         }


### PR DESCRIPTION
The Intel manual explains that if MODE.* packets precede a TIP.* or a FUP packet, then the FUP packet is consumed.

These cases communicate the execution mode of the CPU (WRT 16/32/64-bit mode, and transaction state) and are emitted when the mode changes, but also in PSB+ sequences (a decoder may have missed a prior mode change due to being desynchronised)

This differs from the case (that we've already partially handled), where a FUP packet indicates an interruption in the regular control flow of the instruction stream.

This change ensures that we can handle MODE changes. Fixes one class of non-deterministic crashes.

While here, properly parse the fields of MODE.* packets and check that we only ever see 64-bit mode.