### PR TITLE
Fixes due to upstream LLVM sync.

### DIFF
--- a/tests/c/varargs.c
+++ b/tests/c/varargs.c
@@ -25,6 +25,7 @@
 // Check that basic trace compilation works.
 
 #include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/c/varargs_inlined.c
+++ b/tests/c/varargs_inlined.c
@@ -25,6 +25,7 @@
 // Check that basic trace compilation works.
 
 #include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Most of this is due to `llvm::Optional` being removed in favour of C++'s `std::optional`.