### PR TITLE
Run tests for both PT decoders.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -24,3 +24,6 @@ iced-x86 = { version = "1.18.0", features = ["decoder"]}
 [build-dependencies]
 cc = "1.0.62"
 rerun_except = "0.1.2"
+
+[features]
+yk_testing = []

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = "3.3.0"
 yktrace = { path = "../yktrace", features = ["yk_testing"] }
 
 [dev-dependencies]
+hwtracer = { path = "../hwtracer", features = ["yk_testing"] }
 lang_tester = "0.7.1"
 ykcapi = { path = "../ykcapi", features = ["yk_testing", "yk_jitstate_debug"] }
 ykllvmwrap = { path = "../ykllvmwrap", features = ["yk_testing"] }

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -12,8 +12,11 @@ use tests::{mk_compiler, EXTRA_LINK};
 
 const COMMENT: &str = "//";
 
-fn run_suite(opt: &'static str) {
-    println!("Running C tests with {}...", opt);
+fn run_suite(opt: &'static str, force_decoder: &'static str) {
+    println!(
+        "Running C tests with opt level {} and forcing the {} decoder...",
+        opt, force_decoder
+    );
 
     // Tests with the filename prefix `debug_` are only run in debug builds.
     #[cfg(cargo_profile = "release")]
@@ -70,7 +73,8 @@ fn run_suite(opt: &'static str) {
                 .collect::<Vec<PathBuf>>();
 
             let compiler = mk_compiler(&exe, p, opt, &extra_objs, true);
-            let runtime = Command::new(exe.clone());
+            let mut runtime = Command::new(exe.clone());
+            runtime.env("YKD_FORCE_TRACE_DECODER", force_decoder);
             vec![("Compiler", compiler), ("Run-time", runtime)]
         })
         .fm_options(|_, _, fmb| {
@@ -89,5 +93,6 @@ fn main() {
     // reconstruction. This isn't a huge problem as in the future we will keep two versions of the
     // interpreter around and only swap to -O0 when tracing and run on higher optimisation levels
     // otherwise.
-    run_suite("-O0");
+    run_suite("-O0", "libipt");
+    run_suite("-O0", "ykpt");
 }


### PR DESCRIPTION
[wrote this branch a week or two ago and forgot about it! may also help tracking down non-deterministic bugs]

We run the C suite twice, once for each PT decoder.

(It doesn't make sense to do so in the other suites as they either explicitly test one specific decoder, or don't use PT to get a trace)

In order to select which decoder to use we introduce the `YKD_FORCE_TRACE_DECODER` env var. This is strictly a debugging/testing facility. Eventually we will add an API that allows the interpreter authors to select a decoder if they wish (but not now).