### PR TITLE
Implement a simple immutable program header cache.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0 OR MIT"
 libc = "0.2.80"
 lazy_static = "1.4.0"
 tempfile = "3.1.0"
-phdrs = { git = "https://github.com/softdevteam/phdrs" }
 strum = { version = "0.24.1", features = ["derive", "strum_macros"] }
 strum_macros = "0.24.3"
 deku = "0.15.0"

--- a/hwtracer/src/decode/libipt/mod.rs
+++ b/hwtracer/src/decode/libipt/mod.rs
@@ -170,6 +170,7 @@ mod tests {
     use libc::{c_int, size_t, PF_X, PT_LOAD};
     use std::{convert::TryFrom, env, os::fd::AsRawFd, process::Command, ptr};
     use tempfile::NamedTempFile;
+    use ykutil::obj::PHDR_OBJECT_CACHE;
 
     extern "C" {
         fn hwt_ipt_dump_vdso(fd: c_int, vaddr: u64, len: size_t, err: &PerfPTCError) -> bool;
@@ -200,7 +201,7 @@ mod tests {
         let vdso_tempfile = NamedTempFile::new().unwrap();
 
         let exe = env::current_exe().unwrap();
-        for obj in phdrs::objects() {
+        for obj in PHDR_OBJECT_CACHE.iter() {
             let obj_name = obj.name().to_str().unwrap();
             let mut filename = if cfg!(target_os = "linux") && obj_name == "" {
                 exe.to_str().unwrap()
@@ -208,7 +209,7 @@ mod tests {
                 obj_name
             };
 
-            for hdr in obj.iter_phdrs() {
+            for hdr in obj.phdrs().iter() {
                 if hdr.type_() != PT_LOAD || hdr.flags() & PF_X == 0 {
                     continue; // Only look at loadable and executable segments.
                 }

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -45,7 +45,6 @@ use crate::{
 };
 use iced_x86;
 use intervaltree::IntervalTree;
-use phdrs;
 use std::{
     collections::VecDeque,
     convert::TryFrom,
@@ -57,7 +56,7 @@ use std::{
 };
 use ykutil::{
     self,
-    obj::{PHDR_MAIN_OBJ, SELF_BIN_PATH},
+    obj::{PHDR_MAIN_OBJ, PHDR_OBJECT_CACHE, SELF_BIN_PATH},
 };
 
 mod packet_parser;
@@ -94,9 +93,9 @@ impl TraceDecoder for YkPTTraceDecoder {
 /// The virtual address ranges of segments that we may need to disassemble.
 static CODE_SEGS: LazyLock<CodeSegs> = LazyLock::new(|| {
     let mut segs = Vec::new();
-    for obj in phdrs::objects() {
+    for obj in PHDR_OBJECT_CACHE.iter() {
         let obj_base = obj.addr();
-        for hdr in obj.iter_phdrs() {
+        for hdr in obj.phdrs() {
             if (hdr.flags() & libc::PF_W) == 0 {
                 let vaddr = usize::try_from(obj_base + hdr.vaddr()).unwrap();
                 let memsz = usize::try_from(hdr.memsz()).unwrap();

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -12,7 +12,6 @@ gimli = "0.26.1"
 hwtracer = { path = "../hwtracer" }
 intervaltree = "0.2.7"
 libc = "0.2.117"
-phdrs = { git = "https://github.com/softdevteam/phdrs" }
 tempfile = "3.3.0"
 ykllvmwrap = { path = "../ykllvmwrap" }
 ykutil = { path = "../ykutil" }

--- a/ykutil/src/addr.rs
+++ b/ykutil/src/addr.rs
@@ -1,9 +1,8 @@
 //! Address utilities.
 
-use crate::obj::SELF_BIN_PATH;
+use crate::obj::{PHDR_OBJECT_CACHE, SELF_BIN_PATH};
 use cached::proc_macro::cached;
 use libc::{self, c_void, Dl_info};
-use phdrs::objects;
 use std::mem::MaybeUninit;
 use std::{
     convert::{From, TryFrom},
@@ -91,7 +90,7 @@ pub fn vaddr_to_obj_and_off(vaddr: usize) -> Option<(PathBuf, u64)> {
     let containing_obj = PathBuf::from(info.dli_fname.unwrap().to_str().unwrap());
 
     // Find the corresponding byte offset of the virtual address in the object.
-    for obj in &objects() {
+    for obj in PHDR_OBJECT_CACHE.iter() {
         let obj_name = obj.name();
         let obj_name: &Path = if unsafe { *obj_name.as_ptr() } == 0 {
             SELF_BIN_PATH.as_path()
@@ -115,7 +114,7 @@ pub fn vaddr_to_obj_and_off(vaddr: usize) -> Option<(PathBuf, u64)> {
 /// in the same form as it appears in the program header table. This function makes no attempt to
 /// canonicalise equivalent, but different (in terms of string equality) object paths.
 pub fn off_to_vaddr(containing_obj: &Path, off: u64) -> Option<usize> {
-    for obj in &objects() {
+    for obj in PHDR_OBJECT_CACHE.iter() {
         if Path::new(obj.name().to_str().unwrap()) != containing_obj {
             continue;
         }

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -2,7 +2,113 @@
 
 use crate::addr::dladdr;
 use libc::c_void;
-use std::{path::PathBuf, ptr, sync::LazyLock};
+#[cfg(target_pointer_width = "64")]
+use libc::{
+    Elf64_Addr as Elf_Addr, Elf64_Off as Elf_Off, Elf64_Word as Elf_Word, Elf64_Xword as Elf_Xword,
+};
+use phdrs;
+use std::{
+    ffi::{CStr, CString},
+    path::PathBuf,
+    ptr,
+    sync::LazyLock,
+};
+
+/// A thread-safe (containing no raw pointers) version of `phdrs::ProgramHeader`.
+pub struct ProgramHeader {
+    flags: Elf_Word,
+    type_: Elf_Word,
+    vaddr: Elf_Addr,
+    memsz: Elf_Xword,
+    filesz: Elf_Xword,
+    offset: Elf_Off,
+}
+
+impl From<&phdrs::ProgramHeader> for ProgramHeader {
+    fn from(phdr: &phdrs::ProgramHeader) -> Self {
+        Self {
+            flags: phdr.flags(),
+            type_: phdr.type_(),
+            vaddr: phdr.vaddr(),
+            memsz: phdr.memsz(),
+            filesz: phdr.filesz(),
+            offset: phdr.offset(),
+        }
+    }
+}
+
+impl ProgramHeader {
+    pub fn flags(&self) -> Elf_Word {
+        self.flags
+    }
+
+    pub fn type_(&self) -> Elf_Word {
+        self.type_
+    }
+
+    pub fn vaddr(&self) -> Elf_Addr {
+        self.vaddr
+    }
+
+    pub fn memsz(&self) -> Elf_Xword {
+        self.memsz
+    }
+
+    pub fn filesz(&self) -> Elf_Xword {
+        self.filesz
+    }
+
+    pub fn offset(&self) -> Elf_Off {
+        self.offset
+    }
+}
+
+/// A thread-safe (containing no raw pointers) version of `phdrs::Object`.
+pub struct Object {
+    /// The base address of the object.
+    addr: Elf_Addr,
+    /// The name of the object.
+    name: CString,
+    /// Vector of program headers.
+    phdrs: Vec<ProgramHeader>,
+}
+
+impl Object {
+    pub fn addr(&self) -> Elf_Addr {
+        self.addr
+    }
+
+    pub fn name(&self) -> &CStr {
+        &self.name
+    }
+
+    pub fn phdrs(&self) -> &Vec<ProgramHeader> {
+        &self.phdrs
+    }
+}
+
+impl From<&phdrs::Object> for Object {
+    fn from(pobj: &phdrs::Object) -> Self {
+        Self {
+            addr: pobj.addr(),
+            name: pobj.name().to_owned(),
+            phdrs: pobj.iter_phdrs().map(|ref p| p.into()).collect::<Vec<_>>(),
+        }
+    }
+}
+
+/// A program header cache.
+///
+/// This stashes the result of `dl_iterate_phdr(3)` (via the `phdr` crate), thus avoiding a (slow)
+/// chain of C callbacks each time we want to inspect the program headers.
+///
+/// Since (for now) we assume that there can be no dlopen/dlclose, the cache is immutable.
+pub static PHDR_OBJECT_CACHE: LazyLock<Vec<Object>> = LazyLock::new(|| {
+    phdrs::objects()
+        .iter()
+        .map(|p| p.into())
+        .collect::<Vec<Object>>()
+});
 
 // The name of the main object as it appears in the program headers.
 //


### PR DESCRIPTION
Improves performance quite a bit for compiler-assisted trace decoding on larger traces.

E.g. the trace-decode-native/100000 benchmark drops from ~250ms to ~40ms.

before:
![a](https://user-images.githubusercontent.com/604955/216642662-20b0cffb-35c8-4362-ae2e-ba39008ac3df.svg)

after:
![a2](https://user-images.githubusercontent.com/604955/216642679-fb7f279a-0044-4cc9-8fc8-3fcfa37dc756.svg)

disassembly-based trace-decoding is improved a little too:

before:
![a3](https://user-images.githubusercontent.com/604955/216642918-2774a8fe-bef2-40f7-ae89-9dea6bbde40f.svg)

after:
![a4](https://user-images.githubusercontent.com/604955/216642939-c0e49af0-0f39-4754-afac-8a9eca4c6cc5.svg)

(based on these benchmarks, we are now faster than libipt)

The next bottlenecks are packet decoding and interval tree lookups. I have a plan for the latter.