### PR TITLE
unsafe impl Send/Sync

### DIFF
--- a/hwtracer/src/decode/libipt/mod.rs
+++ b/hwtracer/src/decode/libipt/mod.rs
@@ -209,7 +209,7 @@ mod tests {
                 obj_name
             };
 
-            for hdr in obj.phdrs().iter() {
+            for hdr in obj.iter_phdrs() {
                 if hdr.type_() != PT_LOAD || hdr.flags() & PF_X == 0 {
                     continue; // Only look at loadable and executable segments.
                 }

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -95,7 +95,7 @@ static CODE_SEGS: LazyLock<CodeSegs> = LazyLock::new(|| {
     let mut segs = Vec::new();
     for obj in PHDR_OBJECT_CACHE.iter() {
         let obj_base = obj.addr();
-        for hdr in obj.phdrs() {
+        for hdr in obj.iter_phdrs() {
             if (hdr.flags() & libc::PF_W) == 0 {
                 let vaddr = usize::try_from(obj_base + hdr.vaddr()).unwrap();
                 let memsz = usize::try_from(hdr.memsz()).unwrap();

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -3,97 +3,56 @@
 use crate::addr::dladdr;
 use libc::c_void;
 #[cfg(target_pointer_width = "64")]
-use libc::{
-    Elf64_Addr as Elf_Addr, Elf64_Off as Elf_Off, Elf64_Word as Elf_Word, Elf64_Xword as Elf_Xword,
-};
+use libc::Elf64_Addr as Elf_Addr;
 use phdrs;
 use std::{
     ffi::{CStr, CString},
+    ops::Deref,
     path::PathBuf,
     ptr,
     sync::LazyLock,
 };
 
-/// A thread-safe (containing no raw pointers) version of `phdrs::ProgramHeader`.
-pub struct ProgramHeader {
-    flags: Elf_Word,
-    type_: Elf_Word,
-    vaddr: Elf_Addr,
-    memsz: Elf_Xword,
-    filesz: Elf_Xword,
-    offset: Elf_Off,
-}
+/// A thread-safe wrapper around `phdrs::ProgramHeader`.
+///
+/// Because the headers are given out by the loader, and for now we assume no use of `dlclose()`,
+/// we can safely use `unsafe impl` for `Send ` and `Sync`.
+pub struct ProgramHeader(pub phdrs::ProgramHeader);
+
+unsafe impl Send for ProgramHeader {}
+unsafe impl Sync for ProgramHeader {}
 
 impl From<&phdrs::ProgramHeader> for ProgramHeader {
     fn from(phdr: &phdrs::ProgramHeader) -> Self {
-        Self {
-            flags: phdr.flags(),
-            type_: phdr.type_(),
-            vaddr: phdr.vaddr(),
-            memsz: phdr.memsz(),
-            filesz: phdr.filesz(),
-            offset: phdr.offset(),
-        }
+        Self(phdr.to_owned())
     }
 }
 
-impl ProgramHeader {
-    pub fn flags(&self) -> Elf_Word {
-        self.flags
-    }
+impl Deref for ProgramHeader {
+    type Target = phdrs::ProgramHeader;
 
-    pub fn type_(&self) -> Elf_Word {
-        self.type_
-    }
-
-    pub fn vaddr(&self) -> Elf_Addr {
-        self.vaddr
-    }
-
-    pub fn memsz(&self) -> Elf_Xword {
-        self.memsz
-    }
-
-    pub fn filesz(&self) -> Elf_Xword {
-        self.filesz
-    }
-
-    pub fn offset(&self) -> Elf_Off {
-        self.offset
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
-/// A thread-safe (containing no raw pointers) version of `phdrs::Object`.
-pub struct Object {
-    /// The base address of the object.
-    addr: Elf_Addr,
-    /// The name of the object.
-    name: CString,
-    /// Vector of program headers.
-    phdrs: Vec<ProgramHeader>,
-}
+/// A thread-safe wrapper around `phdrs::Object`.
+pub struct Object(phdrs::Object);
 
-impl Object {
-    pub fn addr(&self) -> Elf_Addr {
-        self.addr
-    }
+unsafe impl Send for Object {}
+unsafe impl Sync for Object {}
 
-    pub fn name(&self) -> &CStr {
-        &self.name
-    }
+impl Deref for Object {
+    type Target = phdrs::Object;
 
-    pub fn phdrs(&self) -> &Vec<ProgramHeader> {
-        &self.phdrs
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
 impl From<&phdrs::Object> for Object {
     fn from(pobj: &phdrs::Object) -> Self {
-        Self {
-            addr: pobj.addr(),
-            name: pobj.name().to_owned(),
-            phdrs: pobj.iter_phdrs().map(|ref p| p.into()).collect::<Vec<_>>(),
-        }
+        Self(pobj.to_owned())
     }
 }
 


### PR DESCRIPTION
This is (something hopefully close to) @jacob-hughes' suggestion to use `Send` and `Sync` for a couple of types which I'd manually mirrored.

Nothing is ever simple. The first commit message justifies some design decisions and there's some `.to_owned()` that I couldn't convince myself I could safely get rid of.