### PR TITLE
Ensure C++ stuff gets rebuilt when .cpp or .h files change.

### DIFF
--- a/ykllvmwrap/Cargo.toml
+++ b/ykllvmwrap/Cargo.toml
@@ -12,6 +12,7 @@ ykutil = { path = "../ykutil" }
 
 [build-dependencies]
 cc = "1.0.72"
+rerun_except = "1.0.0"
 
 [features]
 yk_testing = []

--- a/ykllvmwrap/build.rs
+++ b/ykllvmwrap/build.rs
@@ -1,6 +1,10 @@
+use rerun_except::rerun_except;
 use std::{env, process::Command};
 
 fn main() {
+    // Ensure changing C++ source files or headers retriggers a build.
+    rerun_except(&[]).unwrap();
+
     // Compile our wrappers with the right LLVM C++ flags.
     let cxxflags_out = Command::new("llvm-config")
         .arg("--cxxflags")


### PR DESCRIPTION
I'm sure you've seen it where you change something in ykllvmwrap, and re-run the tests and old code is run...