### PR TITLE
Handle setjmp/longjmp.

### DIFF
--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -1,0 +1,48 @@
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     jit-state: stop-tracing
+//     jit-state: trace-compilation-aborted
+//     ...
+
+// Tests that we can deal with setjmp/longjmp.
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+jmp_buf buf;
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new();
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    int r = setjmp(buf);
+    if (r != 10) {
+      longjmp(buf, 10);
+    }
+    fprintf(stderr, "i=%d\n", i);
+    res += 2;
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -1411,6 +1411,13 @@ public:
             ResumeAfter = make_tuple(CurInstrIdx, CI);
             break;
           } else {
+            StringRef S = CF->getName();
+            if (S == "_setjmp" || S == "_longjmp") {
+              // FIXME: We currently can't deal with traces containing
+              // setjmp/longjmp, so for now simply abort this trace.
+              // See: https://github.com/ykjit/yk/issues/610
+              return nullptr;
+            }
             handleCallInst(CI, CF, CurBBIdx, CurInstrIdx);
             break;
           }

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -397,6 +397,11 @@ void *compileIRTrace(FN Func, char *FuncNames[], size_t BBs[], size_t TraceLen,
   std::tie(JITMod, TraceName, GlobalMappings, AOTMappingVec) =
       Func(AOTMod, FuncNames, BBs, TraceLen, FAddrKeys, FAddrVals, FAddrLen);
 
+  // If we failed to build the trace, return null.
+  if (JITMod == nullptr) {
+    return nullptr;
+  }
+
   DIP.print(DebugIR::JITPreOpt, JITMod);
 #ifndef NDEBUG
   llvm::verifyModule(*JITMod, &llvm::errs());

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -192,8 +192,11 @@ impl IRTrace {
                 di_tmpname_c,
             )
         };
-        assert_ne!(ret, ptr::null());
-        Ok((ret, di_tmp))
+        if ret == ptr::null() {
+            Err("Could not compile trace.".into())
+        } else {
+            Ok((ret, di_tmp))
+        }
     }
 
     #[cfg(feature = "yk_testing")]


### PR DESCRIPTION
We currently can't deal with setjmp/longjmp. For now ignore traces containing these calls so we don't crash.