### PR TITLE
Make the mapper eager.

### DIFF
--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -47,29 +47,30 @@ pub extern "C" fn __hwykpt_libipt_vs_ykpt(trace: *mut Box<dyn Trace>) {
         .build()
         .unwrap();
     let mut ipt_itr = ipt_tdec.iter_blocks(&**trace);
-    let mut ipt_mapper = HWTMapper::new(&mut ipt_itr);
+    let mut ipt_mapper = HWTMapper::new();
+    let ipt_irblocks = ipt_mapper.map_trace(&mut ipt_itr).unwrap();
+    let mut ipt_irb_itr = ipt_irblocks.iter();
 
     let ykpt_tdec = TraceDecoderBuilder::new()
         .kind(TraceDecoderKind::YkPT)
         .build()
         .unwrap();
     let mut ykpt_itr = ykpt_tdec.iter_blocks(&**trace);
-    let mut ykpt_mapper = HWTMapper::new(&mut ykpt_itr);
+    let mut ykpt_mapper = HWTMapper::new();
+    let ykpt_irblocks = ykpt_mapper.map_trace(&mut ykpt_itr).unwrap();
+    let mut ykpt_irb_itr = ykpt_irblocks.iter();
 
-    let mut last = None;
     loop {
-        let next = ipt_mapper.next(last.as_ref());
+        let next = ipt_irb_itr.next();
         if next.is_none() {
             break;
         }
         let expect = next.unwrap();
 
-        let expect = expect.unwrap();
-        let got = ykpt_mapper.next(last.as_ref()).unwrap().unwrap();
+        let got = ykpt_irb_itr.next().unwrap();
         assert_eq!(expect, got);
-        last = Some(got);
     }
-    assert!(ykpt_mapper.next(last.as_ref()).is_none());
+    assert!(ykpt_irb_itr.next().is_none());
 }
 
 /// Decode the specified trace and iterate over the resulting blocks.

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -54,19 +54,11 @@ impl UnmappedTrace for PTTrace {
     fn map(self: Box<Self>, decoder: TraceDecoderKind) -> Result<IRTrace, InvalidTraceError> {
         let tdec = TraceDecoderBuilder::new().kind(decoder).build().unwrap();
         let mut itr = tdec.iter_blocks(self.0.as_ref());
-        let mut mt = HWTMapper::new(&mut *itr);
-        let mut mapped = Vec::new();
+        let mut mt = HWTMapper::new();
 
-        let mut last = None;
-        while let Some(res) = mt.next(last) {
-            if let Ok(blk) = res {
-                mapped.push(blk);
-                last = mapped.last();
-            } else {
-                return Err(InvalidTraceError::InternalError);
-            }
-        }
-
+        let mapped = mt
+            .map_trace(&mut *itr)
+            .map_err(|_| InvalidTraceError::InternalError)?;
         if mapped.is_empty() {
             return Err(InvalidTraceError::EmptyTrace);
         }


### PR DESCRIPTION
Prior to this change, the mapper was a pseudo-iterator with a `next()` but using a non-standard interface requiring the consumer to pass in the last value the iterator yielded. This was required in order to collapse consecutive unmappable blocks, and to omit the initial unmappable prefix (both assumptions the trace compiler makes).

This interface is not only odd, but it is hindering my work on allowing foreign code to call back to mappable code.

This change makes the mapper eagerly collect the mapped trace, instead of working like an iterator. By doing so, we kill the weird interface and simplify the code quite a bit.

At first I was hesitant to make this change: I'm biased towards iterators, as they can often be made to use less memory than collecting. But upon inspection, both consumers of this interface (yktrace and one of the test suites) simply collect the trace anyway, so there's really no need for the mapper to be an iterator.