### PR TITLE
Fix some memory leaks.

### DIFF
--- a/ykfr/Cargo.toml
+++ b/ykfr/Cargo.toml
@@ -12,7 +12,6 @@ ykutil = { path = "../ykutil" }
 yksmp = { path = "../yksmp" }
 llvm-sys = "140"
 memmap2 = "0.5.2"
-capstone = "0.11.0"
 
 [dependencies.object]
 version = "0.28.3"

--- a/ykfr/src/lib.rs
+++ b/ykfr/src/lib.rs
@@ -379,7 +379,7 @@ impl FrameReconstructor {
         // correct amount.
         unsafe {
             rsp = rsp.sub(USIZEOF_POINTER);
-            ptr::write(rsp as *mut usize, memsize - USIZEOF_POINTER);
+            ptr::write(rsp as *mut usize, memsize);
         }
 
         // Mark the memory read-only and return its pointer.


### PR DESCRIPTION
7851c981e0db7055882d7d76258c97553c1f04d3 fixes a large memory leak that lead to some lua programs running out of memory.

c8d861e9f874243c1b8c537d0597262e3bfe3f28 fixes a smaller leak. Interestingly, analysing program execution with heaptrack doesn't seem to find this leak. I wonder if this has to do with `The munmap() function shall remove any mappings for those entire  pages containing  any  part  of  the address space...`. Which I read as: if the allocation is smaller than a page, then it would be freed wholly regardless of the size argument being passed to `munmap`.