### PR TITLE
Add clangd support for our C++ code.

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    CompilationDatabase: target/

--- a/ykllvmwrap/Cargo.toml
+++ b/ykllvmwrap/Cargo.toml
@@ -12,7 +12,9 @@ ykutil = { path = "../ykutil" }
 
 [build-dependencies]
 cc = "1.0.72"
+glob = "0.3.1"
 rerun_except = "1.0.0"
+tempfile = "3.4.0"
 
 [features]
 yk_testing = []

--- a/ykllvmwrap/build.rs
+++ b/ykllvmwrap/build.rs
@@ -1,5 +1,48 @@
+use glob::glob;
 use rerun_except::rerun_except;
-use std::{env, process::Command};
+use std::{
+    env,
+    fs::File,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
+use tempfile::TempDir;
+
+/// Collect the compilation commands found (one per-file) in `tmpdir` and generate a
+/// `compile_commands.json` file for clangd to use.
+fn write_clangd_json(tmpdir: &Path) {
+    let mut entries = Vec::new();
+    let mdir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    for path in glob(&format!("{}/*", tmpdir.to_str().unwrap())).unwrap() {
+        let mut infile = File::open(path.unwrap()).unwrap();
+        let mut buf = String::new();
+        infile.read_to_string(&mut buf).unwrap();
+        let buf = buf.trim();
+
+        // The `cc` crate always puts the source file on the end.
+        let ccfile = buf.split(" ").last().unwrap();
+        assert!(ccfile.starts_with("src/") && ccfile.ends_with(".cc"));
+
+        let mut entry = String::new();
+        entry.push_str("  {\n");
+        entry.push_str(&format!("    \"directory\": \"{mdir}\",\n"));
+        entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
+        entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
+        entry.push_str("  }");
+        entries.push(entry);
+    }
+
+    // Write JSON to Rust target dir.
+    let outpath = [&mdir, "..", "target", "compile_commands.json"]
+        .iter()
+        .collect::<PathBuf>();
+    let mut outfile = File::create(outpath).unwrap();
+    write!(outfile, "[\n").unwrap();
+    write!(outfile, "{}", entries.join(",\n")).unwrap();
+    write!(outfile, "\n]\n").unwrap();
+}
 
 fn main() {
     // Ensure changing C++ source files or headers retriggers a build.
@@ -24,7 +67,6 @@ fn main() {
     comp.file("src/ykllvmwrap.cc")
         .file("src/jitmodbuilder.cc")
         .file("src/memman.cc")
-        .compiler("clang++")
         // Lots of unused parameters in the LLVM headers.
         .flag("-Wno-unused-parameter")
         .cpp(true);
@@ -38,7 +80,18 @@ fn main() {
     if env::var("PROFILE").unwrap() == "release" {
         comp.flag("-DNDEBUG");
     }
+
+    // We use a compiler wrapper to capture compilation commands and generate a
+    // `compile_commands.json` database for clangd.
+    let td = TempDir::new().unwrap();
+    env::set_var("YKLLVMWRAP_JSON_TEMP", td.path());
+    comp.compiler("./wrap-clang++.sh");
+
+    // Actually do the compilation.
     comp.compile("ykllvmwrap");
+
+    // Generate `compile_commands.json`.
+    write_clangd_json(td.path());
 
     // Ensure that downstream crates performing linkage use the right -L and -l flags.
     let lib_dir = Command::new("llvm-config")

--- a/ykllvmwrap/wrap-clang++.sh
+++ b/ykllvmwrap/wrap-clang++.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# A wrapper around the C++ compiler to capture compilation commands performed
+# by `build.rs`. This allows us to generate a `compile_commands.json` file for
+# clangd, which in turn gives us LSP support for our C++ code!
+
+set -e
+
+echo "clang++ $@" > $(mktemp -p ${YKLLVMWRAP_JSON_TEMP})
+
+clang++ $@


### PR DESCRIPTION
Jump to definition now works reliably, even into LLVM headers.