### PR TITLE
Add clangd support for the C test suite.

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,0 @@
-CompileFlags:
-    CompilationDatabase: target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "hwtracer",
     "tests",
+    "ykbuild",
     "ykcapi",
     "ykllvmwrap",
     "ykrt",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,6 +31,7 @@ libc = "0.2.139"
 memmap2 = "0.5.2"
 regex = "1.5.4"
 tempfile = "3.3.0"
+ykbuild = { path = "../ykbuild" }
 yktrace = { path = "../yktrace", features = ["yk_testing"] }
 
 [dev-dependencies]

--- a/tests/benches/bench.rs
+++ b/tests/benches/bench.rs
@@ -27,7 +27,7 @@ fn compile_runner(tempdir: &TempDir) -> PathBuf {
     exe.push(&tempdir);
     exe.push(src.file_stem().unwrap());
 
-    let mut compiler = mk_compiler(&exe, &src, "-O0", &[], false);
+    let mut compiler = mk_compiler("clang", &exe, &src, "-O0", &[], false);
     compiler.arg("-ltests");
     let out = compiler.output().unwrap();
     check_output(&out);

--- a/tests/c/.clangd
+++ b/tests/c/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    CompilationDatabase: ../../target/compile_commands/c_tests/

--- a/tests/langtest_hwtracer_ykpt.rs
+++ b/tests/langtest_hwtracer_ykpt.rs
@@ -93,7 +93,7 @@ fn run_suite(opt: &'static str) {
                 .map(|l| l.generate_obj(tempdir.path()))
                 .collect::<Vec<PathBuf>>();
 
-            let mut compiler = mk_compiler(&exe, p, opt, &extra_objs, false);
+            let mut compiler = mk_compiler("clang", &exe, p, opt, &extra_objs, false);
             compiler.arg("-ltests");
             let runtime = Command::new(exe.clone());
             vec![("Compiler", compiler), ("Run-time", runtime)]

--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -56,7 +56,7 @@ fn main() {
 
     let binstem = PathBuf::from(args.test_file.file_stem().unwrap());
     let binpath = [tempdir.path(), &binstem].iter().collect::<PathBuf>();
-    let mut cmd = mk_compiler(&binpath, &test_path, "-O0", &extra_objs, true);
+    let mut cmd = mk_compiler("clang", &binpath, &test_path, "-O0", &extra_objs, true);
     if !cmd.spawn().unwrap().wait().unwrap().success() {
         panic!("compilation failed");
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -85,13 +85,14 @@ impl<'a> ExtraLinkage<'a> {
 ///
 /// If `patch_cp` is `false` then the argument to patch the control point is omitted.
 pub fn mk_compiler(
+    compiler: &str,
     exe: &Path,
     src: &Path,
     opt: &str,
     extra_objs: &[PathBuf],
     patch_cp: bool,
 ) -> Command {
-    let mut compiler = Command::new("clang");
+    let mut compiler = Command::new(compiler);
     compiler.env("YKD_PRINT_IR", "1");
 
     let yk_config = [
@@ -128,6 +129,7 @@ pub fn mk_compiler(
     let yk_flags = yk_flags.trim().split(" ");
     compiler.args(yk_flags);
 
+    compiler.args(extra_objs);
     compiler.args(&[
         opt,
         // If this is a debug build, include debug info in the test binary.
@@ -143,6 +145,5 @@ pub fn mk_compiler(
         exe.to_str().unwrap(),
         src.to_str().unwrap(),
     ]);
-    compiler.args(extra_objs);
     compiler
 }

--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ykbuild"
+version = "0.1.0"
+authors = ["The Yk Developers"]
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+glob = "0.3.1"
+tempfile = "3.3.0"

--- a/ykbuild/src/lib.rs
+++ b/ykbuild/src/lib.rs
@@ -1,0 +1,143 @@
+//! Utilities for the yk build system.
+
+use glob::glob;
+use std::{
+    env,
+    fs::{create_dir_all, File},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+use tempfile::TempDir;
+
+fn manifest_dir() -> String {
+    env::var("CARGO_MANIFEST_DIR").unwrap()
+}
+
+/// A language that clangd understands.
+pub enum CCLang {
+    C,
+    CPP,
+}
+
+impl CCLang {
+    fn extensions(&self) -> &'static [&'static str] {
+        match self {
+            Self::C => &["c"],
+            Self::CPP => &["cpp", "cxx", "cc"],
+        }
+    }
+
+    pub fn compiler_wrapper(&self) -> PathBuf {
+        let script = match self {
+            Self::C => "wrap-clang.sh",
+            Self::CPP => "wrap-clang++.sh",
+        };
+        [&manifest_dir(), "..", "ykbuild", script]
+            .iter()
+            .collect::<PathBuf>()
+    }
+}
+
+/// Generate a clangd compilation databases to give LSP support for Yk's C/C++ code.
+///
+/// This provides a compiler wrapper which captures the compilation commands and a way to write
+/// them into a `compile_commands.json` file that can be used by clangd.
+///
+/// This only exists in part due to:
+/// https://github.com/rust-lang/cc-rs/issues/497
+///
+/// but also so that we can use clangd on our lang_tester suites.
+///
+/// Steps for use:
+///
+/// - Call `CCGenerator::new()` with the desired parameters.
+///
+/// - Compile your C/C++ code with the compiler wrapper returned by `CCLang::compiler_wrapper()`
+///   with the environment returned by `CCGenerator::build_env()` applied. Note that the source
+///   file to be compiled MUST be the last argument of the compiler invocation!
+///
+/// - Once all compilation is complete, the consumer can generate the JSON file by calling
+///   `generate()`.
+///
+/// By default `clangd` will only search parent directories of source files for databases, so it
+/// will not find the generated databases in the Rust `target` directory. You will need to
+/// strategically place `.clangd` configuration files like the following:
+///
+/// ```ignore
+/// CompileFlags:
+///     CompilationDatabase: ../target/compile_commands/<db_subdir>/
+/// ```
+pub struct CCGenerator {
+    db_subdir: String,
+    dir_field: String,
+    tmpdir: TempDir,
+}
+
+impl CCGenerator {
+    /// Create a compiler commands database generator.
+    ///
+    ///  - `db_subdir` specifies the subdirectory of `target/compiler_commands/` to put the
+    ///    generated JSON file into.
+    ///
+    ///  - `dir_field` specifies the string to use for the `directory` fields inside the generated
+    ///    JSON file. See: https://clang.llvm.org/docs/JSONCompilationDatabase.html
+    pub fn new(db_subdir: &str, dir_field: &str) -> Self {
+        Self {
+            db_subdir: db_subdir.to_owned(),
+            dir_field: dir_field.to_owned(),
+            tmpdir: TempDir::new().unwrap(),
+        }
+    }
+
+    /// Returns the key and value that must be applied to the wrapped compiler's environment.
+    pub fn build_env(&self) -> (&str, &str) {
+        ("YK_CC_TEMPDIR", self.tmpdir.path().to_str().unwrap())
+    }
+
+    /// Call when the build is done to generate the `build_commands.json` file.
+    pub fn generate(self) {
+        let mut entries = Vec::new();
+
+        for path in glob(&format!("{}/*", self.tmpdir.path().to_str().unwrap())).unwrap() {
+            let mut infile = File::open(path.unwrap()).unwrap();
+            let mut buf = String::new();
+            infile.read_to_string(&mut buf).unwrap();
+            let buf = buf.trim();
+
+            // We assume (and assert) that the source file is the last argument.
+            let ccfile = buf.split(" ").last().unwrap();
+            assert!(CCLang::C
+                .extensions()
+                .iter()
+                .chain(CCLang::CPP.extensions())
+                .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
+            let mut entry = String::new();
+            entry.push_str("  {\n");
+            entry.push_str(&format!("    \"directory\": \"{}\",\n", self.dir_field));
+            entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
+            entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
+            entry.push_str("  }");
+            entries.push(entry);
+        }
+
+        let out_dir = [
+            &manifest_dir(),
+            "..",
+            "target",
+            "compile_commands",
+            &self.db_subdir,
+        ]
+        .iter()
+        .collect::<PathBuf>();
+        create_dir_all(out_dir.clone()).unwrap();
+
+        // Write JSON to Rust target dir.
+        let outpath = [&out_dir, Path::new("compile_commands.json")]
+            .iter()
+            .collect::<PathBuf>();
+        let mut outfile = File::create(outpath).unwrap();
+        write!(outfile, "[\n").unwrap();
+        write!(outfile, "{}", entries.join(",\n")).unwrap();
+        write!(outfile, "\n]\n").unwrap();
+    }
+}

--- a/ykbuild/wrap-clang++.sh
+++ b/ykbuild/wrap-clang++.sh
@@ -6,6 +6,6 @@
 
 set -e
 
-echo "clang++ $@" > $(mktemp -p ${YKLLVMWRAP_JSON_TEMP})
+echo "clang++ $@" > $(mktemp -p ${YK_CC_TEMPDIR})
 
 clang++ $@

--- a/ykbuild/wrap-clang.sh
+++ b/ykbuild/wrap-clang.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# This is like `wrap-clang++`, just for C code.
+
+set -e
+
+echo "clang $@" > $(mktemp -p ${YK_CC_TEMPDIR})
+
+clang $@

--- a/ykllvmwrap/.clangd
+++ b/ykllvmwrap/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    CompilationDatabase: ../target/compile_commands/ykllvmwrap/

--- a/ykllvmwrap/Cargo.toml
+++ b/ykllvmwrap/Cargo.toml
@@ -12,9 +12,8 @@ ykutil = { path = "../ykutil" }
 
 [build-dependencies]
 cc = "1.0.72"
-glob = "0.3.1"
 rerun_except = "1.0.0"
-tempfile = "3.4.0"
+ykbuild = { path = "../ykbuild" }
 
 [features]
 yk_testing = []


### PR DESCRIPTION
This generalises generation of `compile_command.json` files and uses that to add support for clangd to the C test suite.