### PR TITLE
Handle OVF packets.

### DIFF
--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -656,6 +656,10 @@ impl<'t> YkPTBlockIterator<'t> {
         let ret = if let Some(pkt_or_err) = self.parser.next() {
             let mut pkt = pkt_or_err?;
 
+            if pkt.kind() == PacketKind::OVF {
+                return Err(HWTracerError::HWBufferOverflow);
+            }
+
             if pkt.kind() == PacketKind::FUP && self.pge && !self.unbound_modes {
                 // FIXME: https://github.com/ykjit/yk/issues/593
                 //

--- a/hwtracer/src/decode/ykpt/packet_parser/mod.rs
+++ b/hwtracer/src/decode/ykpt/packet_parser/mod.rs
@@ -45,6 +45,7 @@ impl PacketParserState {
                 PacketKind::TIPPGE,
                 PacketKind::TIPPGD,
                 PacketKind::EXSTOP,
+                PacketKind::OVF,
             ],
             Self::PSBPlus => &[
                 PacketKind::PAD,
@@ -53,6 +54,7 @@ impl PacketParserState {
                 PacketKind::MODEExec,
                 PacketKind::MODETSX,
                 PacketKind::PSBEND,
+                PacketKind::OVF,
             ],
         }
     }
@@ -142,6 +144,7 @@ impl<'t> PacketParser<'t> {
             }
             PacketKind::CYC => read_to_packet!(CYCPacket, self.bits, Packet::CYC),
             PacketKind::EXSTOP => read_to_packet!(EXSTOPPacket, self.bits, Packet::EXSTOP),
+            PacketKind::OVF => read_to_packet!(OVFPacket, self.bits, Packet::OVF),
         };
         if let Ok((remain, pkt)) = parse_res {
             self.bits = remain;

--- a/hwtracer/src/decode/ykpt/packet_parser/packets.rs
+++ b/hwtracer/src/decode/ykpt/packet_parser/packets.rs
@@ -361,6 +361,11 @@ pub(in crate::decode::ykpt) struct EXSTOPPacket {
     magic2: u8,
 }
 
+/// Overflow (OVF) packet.
+#[derive(Debug, PartialEq, DekuRead)]
+#[deku(magic = b"\x02\xf3")]
+pub(in crate::decode::ykpt) struct OVFPacket {}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(in crate::decode::ykpt) enum PacketKind {
     PSB,
@@ -377,6 +382,7 @@ pub(in crate::decode::ykpt) enum PacketKind {
     FUP,
     CYC,
     EXSTOP,
+    OVF,
 }
 
 impl PacketKind {
@@ -393,7 +399,8 @@ impl PacketKind {
             | Self::ShortTNT
             | Self::LongTNT
             | Self::CYC
-            | Self::EXSTOP => false,
+            | Self::EXSTOP
+            | Self::OVF => false,
         }
     }
 
@@ -412,7 +419,8 @@ impl PacketKind {
             | Self::TIP
             | Self::TIPPGD
             | Self::TIPPGE
-            | Self::EXSTOP => false,
+            | Self::EXSTOP
+            | Self::OVF => false,
         }
     }
 }
@@ -437,6 +445,7 @@ pub(in crate::decode::ykpt) enum Packet {
     FUP(FUPPacket, Option<usize>),
     CYC(CYCPacket),
     EXSTOP(EXSTOPPacket),
+    OVF(OVFPacket),
 }
 
 impl Packet {
@@ -456,7 +465,8 @@ impl Packet {
             | Self::ShortTNT(_)
             | Self::LongTNT(_)
             | Self::CYC(_)
-            | Self::EXSTOP(_) => None,
+            | Self::EXSTOP(_)
+            | Self::OVF(_) => None,
         }
     }
 
@@ -476,6 +486,7 @@ impl Packet {
             Self::FUP(..) => PacketKind::FUP,
             Self::CYC(_) => PacketKind::CYC,
             Self::EXSTOP(_) => PacketKind::EXSTOP,
+            Self::OVF(_) => PacketKind::OVF,
         }
     }
 
@@ -499,7 +510,8 @@ impl Packet {
             | Self::TIP(_, _)
             | Self::FUP(_, _)
             | Self::CYC(_)
-            | Self::EXSTOP(_) => None,
+            | Self::EXSTOP(_)
+            | Self::OVF(_) => None,
         }
     }
 }


### PR DESCRIPTION
We can't recover from an overflow, so we propagate an error.

Fixes #623 

[I made no effort to differentiate this kind of overflow from a software-based overflow where we didn't read the aux buffer fast enough]