### PR TITLE
For now crash if we encounter setjmp or _setjmp in unmapped code.

### DIFF
--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -1,0 +1,40 @@
+// Run-time:
+//   status: error
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     jit-state: start-tracing
+//     set jump point
+//     jumped!
+//     jit-state: stop-tracing
+//     ...
+
+// Check that we bork on a call to setjmp in unmapped code.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+void unmapped_setjmp(void);
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new();
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    unmapped_setjmp();
+    i--;
+  }
+
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/extra_linkage/call_me.c
+++ b/tests/extra_linkage/call_me.c
@@ -1,7 +1,24 @@
+#include <setjmp.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "yk_testing.h"
+
 int call_me(int x) { return 5; }
 
 int call_me_add(int x) { return x + 1; }
 
 int call_callback(int (*callback)(int, int), int x, int y) {
   return callback(x, y);
+}
+
+jmp_buf jbuf;
+void unmapped_setjmp(void) {
+  if (setjmp(jbuf) == 0) {
+    fprintf(stderr, "set jump point\n");
+    NOOPT_VAL(jbuf);
+    longjmp(jbuf, 1);
+  } else {
+    fprintf(stderr, "jumped!\n");
+  }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -18,6 +18,7 @@ pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = Lazy
     // These tests get an extra, separately compiled (thus opaque to LTO), object file linked in.
     for test_file in &[
         "call_ext_in_obj.c",
+        "unmapped_setjmp.c",
         "loopy_funcs_not_inlined_by_default.c",
         "not_loopy_funcs_inlined_by_default.c",
         "reentrant.c",
@@ -31,6 +32,7 @@ pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = Lazy
                 "%%TEMPDIR%%/call_me.o",
                 &[
                     "clang",
+                    "-I../ykcapi",
                     "-c",
                     "-O0",
                     "extra_linkage/call_me.c",


### PR DESCRIPTION
Unfortunately we can only check this in the ykpt decoder, and only if the call is direct. It's better than nothing.