### PR TITLE
Tweak MT::new() and freinds

### DIFF
--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -24,7 +24,8 @@ pub enum TraceDecoderKind {
 }
 
 impl TraceDecoderKind {
-    /// Returns the default kind of decoder for the current platform.
+    /// Returns the default kind of decoder for the current platform or `None` if this platform
+    /// does not support tracing.
     pub fn default_for_platform() -> Option<Self> {
         Self::iter().find(|&kind| Self::match_platform(&kind).is_ok())
     }

--- a/tests/c/arg_mapping_callee.c
+++ b/tests/c/arg_mapping_callee.c
@@ -24,7 +24,7 @@
 #include <yk_testing.h>
 
 int f(int x) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/bf.c
+++ b/tests/c/bf.c
@@ -114,7 +114,7 @@ int main(void) {
     err(1, "out of memory");
   char *cells_end = cells + CELLS_LEN;
 
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 5);
 
   size_t prog_len = sizeof(INPUT_PROG);

--- a/tests/c/bfbug.c
+++ b/tests/c/bfbug.c
@@ -152,7 +152,7 @@ int main(void) {
     err(1, "out of memory");
   char *cells_end = cells + CELLS_LEN;
 
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 5);
 
   size_t prog_len = sizeof(INPUT_PROG);

--- a/tests/c/blockmap.c
+++ b/tests/c/blockmap.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
 // FIXME: This only returns an integer due to a shortcoming of the stopgap interpreter:
 // https://github.com/ykjit/yk/issues/537
 uint32_t unused() {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   YkLocation loc = yk_location_new();
   while (true) {
     yk_mt_control_point(mt, &loc);

--- a/tests/c/call_args.c
+++ b/tests/c/call_args.c
@@ -30,7 +30,7 @@ __attribute__((noinline)) int f(int a, int b) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/call_ext_in_obj.c
+++ b/tests/c/call_ext_in_obj.c
@@ -25,7 +25,7 @@
 extern int call_me_add(int);
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/call_ext_simple.c
+++ b/tests/c/call_ext_simple.c
@@ -21,7 +21,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/calls_double.c
+++ b/tests/c/calls_double.c
@@ -18,7 +18,7 @@
 __attribute__((noinline)) int f(int a) { return a; }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/choice.c
+++ b/tests/c/choice.c
@@ -34,7 +34,7 @@ __attribute__((noinline)) int f(int x) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/conditionals.c
+++ b/tests/c/conditionals.c
@@ -16,7 +16,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/const_global.c
+++ b/tests/c/const_global.c
@@ -53,7 +53,7 @@
 const int add = 2;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();

--- a/tests/c/constant_ret.c
+++ b/tests/c/constant_ret.c
@@ -29,7 +29,7 @@
 __attribute__((noinline)) int f() { return 30; }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/constexpr.c
+++ b/tests/c/constexpr.c
@@ -36,7 +36,7 @@ __attribute__((noinline)) char foo(char *str) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/control_point_in_nested_loop.c
+++ b/tests/c/control_point_in_nested_loop.c
@@ -9,7 +9,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   int outers = 100;
   int inners = 100;
   NOOPT_VAL(outers);

--- a/tests/c/control_point_not_in_loop.c
+++ b/tests/c/control_point_not_in_loop.c
@@ -12,7 +12,7 @@
 #include <yk.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_control_point(mt, NULL); // Not in a loop!
   yk_mt_drop(mt);
   return (EXIT_SUCCESS);

--- a/tests/c/debug_debuginfo.c
+++ b/tests/c/debug_debuginfo.c
@@ -17,7 +17,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/direct_recursion.c
+++ b/tests/c/direct_recursion.c
@@ -37,7 +37,7 @@ __attribute__((noinline)) int f(int num) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/fib.c
+++ b/tests/c/fib.c
@@ -40,7 +40,7 @@ __attribute__((noinline)) int fib(int num) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/funcptrarg_hasir.c
+++ b/tests/c/funcptrarg_hasir.c
@@ -26,7 +26,7 @@ int bar(int (*func)(int)) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/funcptrarg_noir.c
+++ b/tests/c/funcptrarg_noir.c
@@ -26,7 +26,7 @@ int bar(size_t (*func)(const char *)) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/funcptrarg_pretrace.c
+++ b/tests/c/funcptrarg_pretrace.c
@@ -26,7 +26,7 @@
 #include <yk_testing.h>
 
 int bar(size_t (*func)(const char *)) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/inline_asm.c
+++ b/tests/c/inline_asm.c
@@ -23,7 +23,7 @@
 
 int main(int argc, char **argv) {
 
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/internal_linkage_same_obj.c
+++ b/tests/c/internal_linkage_same_obj.c
@@ -16,7 +16,7 @@ static int call_me(int x) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/interp_inside_call.c
+++ b/tests/c/interp_inside_call.c
@@ -35,7 +35,7 @@ __attribute__((noinline)) int f(int a, int b) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/interp_inside_call2.c
+++ b/tests/c/interp_inside_call2.c
@@ -45,7 +45,7 @@ __attribute__((noinline)) int f(int a, int b) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/intrinsic_noinline.c
+++ b/tests/c/intrinsic_noinline.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
   for (int i = 0; i < 100; i++) {
     src[i] = argc * i;
   }
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 5;

--- a/tests/c/intrinsics.c
+++ b/tests/c/intrinsics.c
@@ -31,7 +31,7 @@
 int main(int argc, char **argv) {
   int res = 0;
   int src = 1000;
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;

--- a/tests/c/lifetime_intrinsics.c
+++ b/tests/c/lifetime_intrinsics.c
@@ -24,7 +24,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/loopy_funcs_not_inlined_by_default.c
+++ b/tests/c/loopy_funcs_not_inlined_by_default.c
@@ -39,7 +39,7 @@ void never_inline_into_trace(int x) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/many_threads_many_locs.c
+++ b/tests/c/many_threads_many_locs.c
@@ -47,7 +47,7 @@ static void *trace(void *arg) {
 }
 
 int main() {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
 
 #ifdef linux

--- a/tests/c/many_threads_one_loc.c
+++ b/tests/c/many_threads_one_loc.c
@@ -59,7 +59,7 @@ static void *trace(void *arg) {
 
 int main() {
   YkLocation loc = yk_location_new();
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
 
 #ifdef linux

--- a/tests/c/mutable_global.c
+++ b/tests/c/mutable_global.c
@@ -53,7 +53,7 @@
 int add;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   int res = 0;
   YkLocation loc = yk_location_new();

--- a/tests/c/mutual_recursion.c
+++ b/tests/c/mutual_recursion.c
@@ -55,7 +55,7 @@ __attribute__((noinline)) void f(int num) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/nested_writetoptr.c
+++ b/tests/c/nested_writetoptr.c
@@ -54,7 +54,7 @@ __attribute__((noinline)) void foo(int i) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/no_trace_annotation.c
+++ b/tests/c/no_trace_annotation.c
@@ -46,7 +46,7 @@ __attribute__((yk_outline)) void call_me(void) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/no_trace_annotation2.c
+++ b/tests/c/no_trace_annotation2.c
@@ -52,7 +52,7 @@ __attribute__((yk_outline)) void call_me(void) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/noopts.c
+++ b/tests/c/noopts.c
@@ -36,7 +36,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/not_loopy_funcs_inlined_by_default.c
+++ b/tests/c/not_loopy_funcs_inlined_by_default.c
@@ -32,7 +32,7 @@ int call_me(int x); // from extra_linkage/call_me.c
 __attribute__((noinline)) void inline_into_trace(int x) { call_me(x); }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/ptr_global.c
+++ b/tests/c/ptr_global.c
@@ -21,7 +21,7 @@
 char *p = NULL;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   int i = 0;
   YkLocation loc = yk_location_new();

--- a/tests/c/qsort.c
+++ b/tests/c/qsort.c
@@ -48,7 +48,7 @@ __attribute__((noinline)) void print_elems(int elems[]) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/reentrant.c
+++ b/tests/c/reentrant.c
@@ -35,7 +35,7 @@ int call_callback(int (*callback)(int, int), int x, int y);
 __attribute((noinline)) int callback(int x, int y) { return (x + y) / 2; }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/rel_path.c
+++ b/tests/c/rel_path.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     // NOREACH
   }
 
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/resume_and_branch.c
+++ b/tests/c/resume_and_branch.c
@@ -22,7 +22,7 @@
 __attribute__((noinline)) void f(int x) { fprintf(stderr, "x=%d\n", x); }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/return_char.c
+++ b/tests/c/return_char.c
@@ -27,7 +27,7 @@
 #include <yk_testing.h>
 
 __attribute__((noinline)) char f() {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/return_void.c
+++ b/tests/c/return_void.c
@@ -30,7 +30,7 @@
 #include <yk_testing.h>
 
 __attribute__((noinline)) void f() {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -21,7 +21,7 @@
 jmp_buf buf;
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/simple.c
+++ b/tests/c/simple.c
@@ -55,7 +55,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/simple_interp_loop1.c
+++ b/tests/c/simple_interp_loop1.c
@@ -70,7 +70,7 @@ int mem = 12;
 #define RESTART_IF_NOT_ZERO 2
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
 
   // A hard-coded program to execute.

--- a/tests/c/simple_interp_loop2.c
+++ b/tests/c/simple_interp_loop2.c
@@ -75,7 +75,7 @@ int mem = 4;
 #define EXIT 3
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
 
   // A hard-coded program to execute.

--- a/tests/c/simple_nested.c
+++ b/tests/c/simple_nested.c
@@ -65,7 +65,7 @@ int foo(int arg) {
 int bar(int arg) { return foo(arg); }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/smmultisrc.c
+++ b/tests/c/smmultisrc.c
@@ -56,7 +56,7 @@ __attribute__((yk_unroll_safe)) int tunpack(void *L, int argc) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/smmultisrc2.c
+++ b/tests/c/smmultisrc2.c
@@ -54,7 +54,7 @@ __attribute__((yk_unroll_safe)) int tunpack(void *L, int argc) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/stopgap_call_int_ret.c
+++ b/tests/c/stopgap_call_int_ret.c
@@ -29,7 +29,7 @@ __attribute((__noinline__)) int f(int i) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/stopgap_call_many_args.c
+++ b/tests/c/stopgap_call_many_args.c
@@ -29,7 +29,7 @@ __attribute((__noinline__)) void f(int a, int b, int c, int d, int e) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/stopgap_call_void_ret.c
+++ b/tests/c/stopgap_call_void_ret.c
@@ -26,7 +26,7 @@
 __attribute((__noinline__)) void f(int i) { fprintf(stderr, "f: %d\n", i); }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/strarray.c
+++ b/tests/c/strarray.c
@@ -41,7 +41,7 @@ static const char *const fruits[] = {"apple", "banana", "tomato", "cucumber",
                                      "pepper"};
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/struct_phi.c
+++ b/tests/c/struct_phi.c
@@ -13,7 +13,7 @@ struct s {
 };
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/struct_simple.c
+++ b/tests/c/struct_simple.c
@@ -29,7 +29,7 @@ struct s {
 };
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/switch.c
+++ b/tests/c/switch.c
@@ -30,7 +30,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 3;

--- a/tests/c/switch_default.c
+++ b/tests/c/switch_default.c
@@ -36,7 +36,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
   int i = 4;

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -21,7 +21,7 @@
 void unmapped_setjmp(void);
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/unroll_safe_implies_noinline.c
+++ b/tests/c/unroll_safe_implies_noinline.c
@@ -29,7 +29,7 @@ __attribute__((yk_unroll_safe)) void never_aot_inline(int x) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/unroll_safe_inlines.c
+++ b/tests/c/unroll_safe_inlines.c
@@ -39,7 +39,7 @@ __attribute__((yk_unroll_safe, noinline)) void inline_into_trace(int x) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/varargs.c
+++ b/tests/c/varargs.c
@@ -45,7 +45,7 @@ int varargfunc(int len, ...) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/varargs_inlined.c
+++ b/tests/c/varargs_inlined.c
@@ -45,7 +45,7 @@ int varargfunc(int len, ...) {
 int foo(int argc) { return varargfunc(3, argc, 2, 3); }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/void_ret.c
+++ b/tests/c/void_ret.c
@@ -24,7 +24,7 @@ void __attribute__((noinline)) f() {
 
 int main(int argc, char **argv) {
 
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/tests/c/yk_unroll_safe_vs_yk_outline.c
+++ b/tests/c/yk_unroll_safe_vs_yk_outline.c
@@ -36,7 +36,7 @@ never_inline_into_trace(int x) {
 }
 
 int main(int argc, char **argv) {
-  YkMT *mt = yk_mt_new();
+  YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -25,7 +25,7 @@ use yksmp::{Location as SMLocation, StackMapParser};
 
 #[no_mangle]
 pub extern "C" fn yk_mt_new() -> *mut MT {
-    let mt = Box::new(MT::new());
+    let mt = Box::new(MT::new().unwrap());
     Box::into_raw(mt)
 }
 

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -13,9 +13,10 @@
 #[cfg(feature = "yk_testing")]
 mod testing;
 
+use libc;
 use std::arch::asm;
 use std::convert::{TryFrom, TryInto};
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void, CString};
 use std::{ptr, slice};
 use ykfr::{self, FrameReconstructor};
 #[cfg(feature = "yk_jitstate_debug")]
@@ -24,9 +25,23 @@ use ykrt::{HotThreshold, Location, MT};
 use yksmp::{Location as SMLocation, StackMapParser};
 
 #[no_mangle]
-pub extern "C" fn yk_mt_new() -> *mut MT {
-    let mt = Box::new(MT::new().unwrap());
-    Box::into_raw(mt)
+pub extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *mut MT {
+    match MT::new() {
+        Ok(mt) => Box::into_raw(Box::new(mt)),
+        Err(e) => {
+            if err_msg.is_null() {
+                panic!("{}", e);
+            }
+            let s = CString::new(e.to_string()).unwrap();
+            let b = s.to_bytes_with_nul();
+            let buf = unsafe { libc::malloc(b.len()) as *mut i8 };
+            unsafe {
+                buf.copy_from(b.as_ptr() as *const i8, b.len());
+            }
+            unsafe { *err_msg = buf };
+            ptr::null_mut()
+        }
+    }
 }
 
 #[no_mangle]

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -28,8 +28,14 @@ typedef uint32_t YkHotThreshold;
 
 typedef struct YkMT YkMT;
 
-// Create a new `YkMT` instance.
-YkMT *yk_mt_new(void);
+// Create a new `YkMT` instance. If this fails then:
+//   * If `err_msg` is `NULL`, this function will abort.
+//   * If `err_msg` is not `NULL`:
+//       1. A malloc()d string with an error message explaining the failure
+//          will be placed in `*err_msg`. It is the callers duty to free this
+//          string.
+//       2. `yk_mt_new` will return `NULL`.
+YkMT *yk_mt_new(char **err_msg);
 
 // Drop a `YkMT` instance. This must be called at most once per `YkMT`
 // instance: calling this function more than once on a `YkMT` instance leads to


### PR DESCRIPTION
This PR tweaks `MT` creation/initialisation a bit. The main thing is to allow `MT::new()` to signal failure (https://github.com/ykjit/yk/commit/988ddbe64815583e40242f9e2c2e985aefb12377). This also allows us to change `yk_mt_new` (https://github.com/ykjit/yk/commit/2900bd5380a19b789a26004d57a990810849d7b7).