### PR TITLE
Unignore some tests.

### DIFF
--- a/tests/c/bf.c
+++ b/tests/c/bf.c
@@ -1,4 +1,3 @@
-// ignore: runs too fast to check what should be checked. reenable when the PT decoder is faster
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1

--- a/tests/c/bfbug.c
+++ b/tests/c/bfbug.c
@@ -1,4 +1,4 @@
-// ignore: runs too fast to check what should be checked. reenable when the PT decoder is faster
+// ignore: Consistently hits `Assertion `!CallStack.curMappableFrame()' failed`
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1

--- a/tests/c/conditionals.c
+++ b/tests/c/conditionals.c
@@ -1,4 +1,3 @@
-// ignore: Requires global variable stderr in stopgap.
 // Run-time:
 //   env-var: YKD_PRINT_JITSTATE=1
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/constexpr.c
+++ b/tests/c/constexpr.c
@@ -1,4 +1,3 @@
-// ignore: Requires struct._IO_FILE in stopgap.
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_PRINT_JITSTATE=1

--- a/tests/c/funcptrarg_hasir.c
+++ b/tests/c/funcptrarg_hasir.c
@@ -1,4 +1,3 @@
-// ignore: Requires global variable stderr in stopgap.
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1

--- a/tests/c/internal_linkage_same_obj.c
+++ b/tests/c/internal_linkage_same_obj.c
@@ -1,4 +1,3 @@
-// ignore: opt levels > -O0 require more intrinstics support from ykllvm
 
 // Check that we can call a static function with internal linkage from the same
 // compilation unit.

--- a/tests/c/mutual_recursion.c
+++ b/tests/c/mutual_recursion.c
@@ -1,4 +1,3 @@
-// ignore: causes an assertion failure in stop-gap code.
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt,aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/reentrant.c
+++ b/tests/c/reentrant.c
@@ -1,4 +1,3 @@
-// ignore: can't trace reentrant code yet. see below.
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_IR=jit-pre-opt

--- a/tests/c/struct_phi.c
+++ b/tests/c/struct_phi.c
@@ -1,4 +1,3 @@
-// ignore: Can only reliably make a PHI node at -O0.
 
 // Check that we can handle struct field accesses where the field is
 // initialised via a phi node.


### PR DESCRIPTION
Some of these had incorrect reasons given for ignoring them.

Interestingly, `bfbug.c` seems to cause our "nondeterministic" bug to happen deterministically (well, it happened 5 times in a row, and that's more failures than I've seen in the other sometime-failing test!).

I also noticed that `smmultisrc.c` occasionally fails with:

```
src/jitmodbuilder.cc:1543: Module *JITModBuilder::createModule(): Assertion `UR->StackAdjust > 0' failed.
```