### PR TITLE
Fix build when using an LLVM without assertions enabled.

### DIFF
--- a/ykllvmwrap/src/jitmodbuilder.cc
+++ b/ykllvmwrap/src/jitmodbuilder.cc
@@ -286,7 +286,7 @@ public:
 // Dump an error message and an LLVM value to stderr and exit with failure.
 void dumpValueAndExit(const char *Msg, Value *V) {
   errs() << Msg << ": ";
-  V->dump();
+  V->print(errs());
   exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
`Value::dump()` is guarded like this:

```
#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
```

Rather than requiring the user to build LLVM in a certain way, use `Value::print()` to `stderr` instead (which is all `dump()` does anyway).

Fixes #640