### PR TITLE
Remove various parts of dead code.

### DIFF
--- a/hwtracer/src/llvm_blockmap.rs
+++ b/hwtracer/src/llvm_blockmap.rs
@@ -56,8 +56,6 @@ impl CallInfo {
 /// The information for one LLVM `MachineBasicBlock`.
 #[derive(Debug)]
 pub struct BlockMapEntry {
-    /// Function offset.
-    f_off: u64,
     /// Indices of corresponding BasicBlocks.
     corr_bbs: Vec<u64>,
     /// Successor information.
@@ -69,10 +67,6 @@ pub struct BlockMapEntry {
 impl BlockMapEntry {
     pub fn corr_bbs(&self) -> &Vec<u64> {
         &self.corr_bbs
-    }
-
-    pub fn f_off(&self) -> u64 {
-        self.f_off
     }
 
     pub fn successor(&self) -> &SuccessorKind {
@@ -134,9 +128,8 @@ impl BlockMap {
         while crsr.position() < u64::try_from(bbaddrmap_data.len()).unwrap() {
             let _version = crsr.read_u8().unwrap();
             let _feature = crsr.read_u8().unwrap();
-            let f_off = crsr.read_u64::<NativeEndian>().unwrap();
+            let mut last_off = crsr.read_u64::<NativeEndian>().unwrap();
             let n_blks = leb128::read::unsigned(&mut crsr).unwrap();
-            let mut last_off = f_off;
             for _ in 0..n_blks {
                 let mut corr_bbs = Vec::new();
                 let b_off = leb128::read::unsigned(&mut crsr).unwrap();
@@ -193,7 +186,6 @@ impl BlockMap {
                 elems.push((
                     (lo..hi),
                     BlockMapEntry {
-                        f_off,
                         corr_bbs,
                         call_offs,
                         succ,

--- a/ykfr/src/llvmbridge.rs
+++ b/ykfr/src/llvmbridge.rs
@@ -1,5 +1,4 @@
 use crate::SGValue;
-use libffi::middle::Type as FFIType;
 use llvm_sys::core::*;
 use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMModuleRef, LLVMTypeRef, LLVMValueRef};
 use llvm_sys::target::{LLVMGetModuleDataLayout, LLVMTargetDataRef};
@@ -77,10 +76,6 @@ impl Type {
         Type(tref)
     }
 
-    pub fn get(&self) -> LLVMTypeRef {
-        self.0
-    }
-
     pub fn get_element_type(&self) -> Self {
         unsafe { Type::new(LLVMGetElementType(self.0)) }
     }
@@ -112,29 +107,6 @@ impl Type {
     pub fn get_int_width(&self) -> u32 {
         debug_assert!(self.is_integer());
         unsafe { LLVMGetIntTypeWidth(self.0) }
-    }
-
-    pub fn as_str(&self) -> &CStr {
-        unsafe { CStr::from_ptr(LLVMPrintTypeToString(self.0)) }
-    }
-
-    /// Converts an LLVM type into a libffi type.
-    pub fn ffi_type(&self) -> FFIType {
-        match self.kind() {
-            LLVMTypeKind::LLVMIntegerTypeKind => {
-                // FIXME: https://github.com/ykjit/yk/issues/536
-                match unsafe { LLVMGetIntTypeWidth(self.0) } {
-                    8 => FFIType::u8(),
-                    16 => FFIType::u16(),
-                    32 => FFIType::u32(),
-                    64 => FFIType::u64(),
-                    _ => todo!(),
-                }
-            }
-            LLVMTypeKind::LLVMVoidTypeKind => FFIType::void(),
-            LLVMTypeKind::LLVMPointerTypeKind => FFIType::pointer(),
-            _ => todo!("{:?}", self.as_str()),
-        }
     }
 }
 

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -23,7 +23,6 @@ pub struct Record {
     pub offset: u64,
     pub live_vars: Vec<LiveVar>,
     pub size: u64,
-    pub pinfo: Option<PrologueInfo>,
 }
 
 #[derive(Debug)]
@@ -174,7 +173,6 @@ impl StackMapParser<'_> {
                 offset,
                 live_vars,
                 size: 0,
-                pinfo: None,
             });
         }
         v

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -147,17 +147,6 @@ impl IRTrace {
         self.blocks.len()
     }
 
-    // Get the block at the specified position.
-    // Returns None if there is no block at this index. Returns Some(None) if the block at that
-    // index couldn't be mapped.
-    pub fn get(&self, idx: usize) -> Option<Option<&IRBlock>> {
-        // usize::MAX is a reserved index.
-        debug_assert_ne!(idx, usize::MAX);
-        self.blocks
-            .get(idx)
-            .map(|b| if b.is_unmappable() { None } else { Some(b) })
-    }
-
     fn encode_trace(&self) -> (Vec<*const i8>, Vec<usize>, usize) {
         let trace_len = self.len();
         let mut func_names = Vec::with_capacity(trace_len);


### PR DESCRIPTION
Mostly found (indirectly) by `depub`.