### PR TITLE
Use dynamic linking to ykllvm.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -53,6 +53,7 @@ cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
     -DLLVM_ENABLE_ASSERTIONS=On \
     -DLLVM_ENABLE_PROJECTS="lld;clang" \
     -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
+    -DBUILD_SHARED_LIBS=ON \
     -GNinja \
     ../llvm
 cmake --build .

--- a/docs/src/dev/getting_started.md
+++ b/docs/src/dev/getting_started.md
@@ -26,6 +26,7 @@ cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
     -DCMAKE_BUILD_TYPE=release \
     -DLLVM_ENABLE_ASSERTIONS=On \
     -DLLVM_ENABLE_PROJECTS="lld;clang" \
+    -DBUILD_SHARED_LIBS=ON \
     -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
     ../llvm
 make -j `nproc` install

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -43,6 +43,9 @@ ykcapi = { path = "../ykcapi", features = ["yk_testing", "yk_jitstate_debug"] }
 ykllvmwrap = { path = "../ykllvmwrap", features = ["yk_testing"] }
 ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }
 
+[build-dependencies]
+ykbuild = { path = "../ykbuild" }
+
 [[bench]]
 name = "bench"
 harness = false

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,8 +1,11 @@
 use std::env;
+use ykbuild;
 
 pub fn main() {
     // Expose the cargo profile to run.rs so that it can set the right link flags.
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=cargo_profile=\"{}\"", profile);
     }
+
+    ykbuild::apply_llvm_ld_library_path();
 }

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -16,7 +16,17 @@ ykrt = { path = "../ykrt" }
 yktrace = { path = "../yktrace" }
 yksmp = { path = "../yksmp" }
 ykfr = { path = "../ykfr" }
-llvm-sys = "130"
+
+[dependencies.llvm-sys]
+# note: using a git version to get llvm linkage features in llvm-sys (not in a
+# release at the time of writing)
+git = "https://gitlab.com/taricorp/llvm-sys.rs"
+rev = "678b3da2b2239ae12766c964e6e613c0d82b5f37"
+# because yk already links llvm elsewhere.
+features = ["no-llvm-linking"]
+
+[build-dependencies]
+ykbuild = { path = "../ykbuild" }
 
 [features]
 yk_testing = []

--- a/ykcapi/build.rs
+++ b/ykcapi/build.rs
@@ -1,0 +1,5 @@
+use ykbuild;
+
+pub fn main() {
+    ykbuild::apply_llvm_ld_library_path();
+}

--- a/ykcapi/scripts/yk-config
+++ b/ykcapi/scripts/yk-config
@@ -99,7 +99,15 @@ handle_arg() {
             OUTPUT="${OUTPUT} -L${DIR}/../../target/${mode}/deps"
 
             # Encode an rpath so that we don't have to set LD_LIBRARY_PATH.
+            #
+            # FIXME: Adding rpaths should probably be behind a flag. It's kind
+            # of rude to add local rpaths to interpreter binaries that
+            # downstreams may want to distribute.
             OUTPUT="${OUTPUT} -Wl,-rpath=${DIR}/../../target/${mode}/deps"
+            OUTPUT="${OUTPUT} -Wl,-rpath=$(llvm-config --link-shared --libdir)"
+            # Add a proper RPATH, not a RUNPATH:
+            # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1737608
+            OUTPUT="${OUTPUT} -Wl,--disable-new-dtags"
 
             # Improve the quality of profiling data.
             OUTPUT="${OUTPUT} -Wl,--no-rosegment"

--- a/ykfr/Cargo.toml
+++ b/ykfr/Cargo.toml
@@ -10,8 +10,15 @@ libc = "0.2.97"
 libffi = "3.0.0"
 ykutil = { path = "../ykutil" }
 yksmp = { path = "../yksmp" }
-llvm-sys = "140"
 memmap2 = "0.5.2"
+
+[dependencies.llvm-sys]
+# note: using a git version to get llvm linkage features in llvm-sys (not in a
+# release at the time of writing)
+git = "https://gitlab.com/taricorp/llvm-sys.rs"
+rev = "678b3da2b2239ae12766c964e6e613c0d82b5f37"
+# because yk already links llvm elsewhere.
+features = ["no-llvm-linking"]
 
 [dependencies.object]
 version = "0.28.3"

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -15,6 +15,7 @@ yktrace = { path = "../yktrace" }
 
 [build-dependencies]
 regex = "1.5.4"
+ykbuild = { path = "../ykbuild" }
 
 [features]
 yk_jitstate_debug = []

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -1,0 +1,5 @@
+use ykbuild;
+
+pub fn main() {
+    ykbuild::apply_llvm_ld_library_path();
+}


### PR DESCRIPTION
This includes routing all calls to `llvm-config` in build scripts through a new `ykbuild::llvm_config` function, so we can never miss `-link-shared`.

Companion to https://github.com/ykjit/ykllvm/pull/67

Fixes #636