### PR TITLE
Build ykllvm from submodule

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -38,8 +38,6 @@ test -d book
 cd ..
 
 # Build LLVM for the C tests.
-mkdir -p target && cd target
-git clone https://github.com/ykjit/ykllvm
 cd ykllvm
 mkdir build
 cd build
@@ -59,13 +57,17 @@ cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
 cmake --build .
 cmake --install .
 export PATH=`pwd`/../inst/bin:${PATH}
-cd ../../..
+cd ../../
 
 # Check that clang-format is installed.
 clang-format --version
 # Check C/C++ formatting using xtask.
 cargo xtask cfmt
-git diff --exit-code
+
+# This is used to check clang-tidy output, but the dirty submodule from building
+# ykllvm is also shown.
+# FIXME: Add build/ to .gitignore in ykllvm
+git diff --exit-code --ignore-submodules
 
 # Check that building `ykcapi` in isolation works. This is what we'd be doing
 # if we were building release binaries, as it would mean we get a system

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ykllvm"]
+	path = ykllvm
+	url = https://github.com/ykjit/ykllvm

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@ fn ignore_dir(entry: &DirEntry) -> bool {
     if entry.path().starts_with("./target")
         || entry.path().starts_with("./.cargo")
         || entry.path().starts_with("./.git")
+        || entry.path().starts_with("./ykllvm")
     {
         return false;
     }

--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.1.0"
 authors = ["The Yk Developers"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
+# The following makes ykbuild's cargo metadata available to any crate which
+# depends on it, providing depedents with the location of the ykllvm install dir.
+links = "ykbuild"
 
 [dependencies]
 glob = "0.3.1"
 tempfile = "3.3.0"
+
+[build-dependencies]
+cmake = "0.1"
+num_cpus = "1.0"
+which = "4.4.0"

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -1,0 +1,54 @@
+use std::env;
+use which::which;
+
+const YKLLVM: &str = "../ykllvm/llvm";
+const PROFILE: &str = "Release";
+
+fn main() {
+    if env::var("YKB_YKLLVM_INSTALL_DIR").is_ok() {
+        println!(
+            "cargo:ykllvm={}",
+            env::var("YKB_YKLLVM_INSTALL_DIR").unwrap()
+        );
+        return;
+    }
+
+    // Ninja builds are faster, so use this if it's available.
+    let use_ninja = which("ninja").is_ok();
+    let is_debug = env::var("PROFILE").unwrap() == "debug";
+    let nprocs = format!("-j {}", num_cpus::get());
+
+    let mut ykllvm = cmake::Config::new(YKLLVM);
+    ykllvm
+        .profile(PROFILE)
+        .generator(if use_ninja { "Ninja" } else { "Unix Makefiles" })
+        .define("LLVM_INSTALL_UTILS", "ON")
+        .define("BUILD_SHARED_LIBS", "ON")
+        .define("LLVM_ENABLE_PROJECTS", "lld;clang")
+        .define(
+            "LLVM_ENABLE_ASSERTIONS",
+            if is_debug { "ON" } else { "OFF" },
+        )
+        // Due to an LLVM bug, PIE breaks our mapper, and it's not enough to pass
+        // `-fno-pie` to clang for some reason:
+        // https://github.com/llvm/llvm-project/issues/57085
+        .define("CLANG_DEFAULT_PIE_ON_LINUX", "OFF")
+        .build_arg(nprocs);
+
+    if let Ok(args) = env::var("YKB_YKLLVM_BUILD_ARGS") {
+        for arg in args.split(",") {
+            if !arg.starts_with("-D") {
+                panic!("YKB_YKLLVM_BUILD_ARGS must only contain -D arguments");
+            }
+            let (k, v) = arg.strip_prefix("-D").unwrap().split_once("=").unwrap();
+            ykllvm.define(k, v);
+        }
+    }
+
+    let dsp = ykllvm.build();
+
+    // We need to be able to locate the ykllvm install llvm bins from other
+    // crates, so this sets a `DEP_YKBUILD_YKLLVM` env var which can be accessed
+    // from any other crate in the yk workspace.
+    println!("cargo:ykllvm={}/bin/", dsp.display())
+}

--- a/ykbuild/wrap-clang++.sh
+++ b/ykbuild/wrap-clang++.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+export PATH=${DEP_YKBUILD_YKLLVM}:${PATH}
+
 echo "clang++ $@" > $(mktemp -p ${YK_CC_TEMPDIR})
 
 clang++ $@

--- a/ykllvmwrap/Cargo.toml
+++ b/ykllvmwrap/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0 OR MIT"
 cc = "1.0.72"
 libc = "0.2.117"
 ykutil = { path = "../ykutil" }
+ykbuild = { path = "../ykbuild" }
 
 [build-dependencies]
 cc = "1.0.72"


### PR DESCRIPTION
This builds ykllvm using the build.rs script in ykbuild. Build args can
be passed to cmake using the `YKLLVM_BUILD` environment variable. For
example:

    `YKLLVM_BUILD_ARGS="-DLLVM_CACHE_BUILD=ON,-DLLVM_CCACHE_DIR=/opt/ccache" cargo build`

A release build of ykllvm is always built, however ykllvm will be built
with assertions when using cargo's debug profile.

If for whatever reason you want to point to your own version of ykllvm,
you can use the `YKLLVM_INSTALL_DIR=/path/to/ykllvm` environment variable
and ykllvm will not be built and deps such as ykllvmwrap will use the
`YKLLVM_INSTALL_DIR` path instead.
