### PR TITLE
Stackmaps now record a second additional location.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn yk_stopgap(
         assert!(locs.len() == 1);
         let l = locs.get(0).unwrap();
         match l {
-            SMLocation::Register(reg, _size, _off) => {
+            SMLocation::Register(reg, _size, _off, _extra) => {
                 let _val = unsafe { registers.get(*reg) };
                 todo!();
             }

--- a/ykfr/src/lib.rs
+++ b/ykfr/src/lib.rs
@@ -285,8 +285,13 @@ impl FrameReconstructor {
                 // written to the allocated memory. Other locations we haven't encountered yet, so
                 // will deal with them as they appear.
                 match l {
-                    SMLocation::Register(reg, _size, off) => {
+                    SMLocation::Register(reg, _size, off, extra) => {
                         registers[usize::from(*reg)] = val;
+                        if *extra != 0 {
+                            // The stackmap has recorded an additional register we need to write
+                            // this value to.
+                            registers[usize::try_from(*extra - 1).unwrap()] = val;
+                        }
                         if i == 0 {
                             // skip first frame
                             continue;

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -27,7 +27,7 @@ pub struct Record {
 
 #[derive(Debug)]
 pub enum Location {
-    Register(u16, u16, i32),
+    Register(u16, u16, i32, u16),
     Direct(u16, i32, u16),
     Indirect(u16, i32, u16),
     Constant(u32),
@@ -196,12 +196,12 @@ impl StackMapParser<'_> {
             self.read_u8();
             let size = self.read_u16();
             let dwreg = self.read_u16();
-            self.read_u16();
+            let extrareg = self.read_u16();
 
             let location = match kind {
                 0x01 => {
                     let offset = self.read_i32();
-                    Location::Register(dwreg, size, offset)
+                    Location::Register(dwreg, size, offset, extrareg)
                 }
                 0x02 => {
                     let offset = self.read_i32();


### PR DESCRIPTION
During optimisation we need to copy values to all extra locations provided by stackmaps.

Requires: https://github.com/ykjit/ykllvm/pull/68