### PR TITLE
Reduce the LLVM builds in CI from 3 to 2.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -37,9 +37,11 @@ mdbook build
 test -d book
 cd ..
 
-# We build our own LLVM-with-assertions to get access to clang-format. Since
-# we're going to such lengths, we then reuse this installation of LLVM when
-# doing non-`--build` releases below.
+# We could let yk build two copies of LLVM, but we also want to: check that
+# YKB_YKLLVM_INSTALL_DIR works; and we want access to clang-format from a build
+# of LLVM. So we first build our own LLVM-with-assertions, use the
+# YKB_YKLLVM_INSTALL_DIR variable to have yk use that, and use its
+# clang-format.
 mkdir -p ykllvm/build
 cd ykllvm/build
 # Due to an LLVM bug, PIE breaks our mapper, and it's not enough to pass
@@ -85,6 +87,8 @@ done
 cargo run --example hwtracer_example
 cargo run --release --example hwtracer_example
 
-# Run cargo bench, forcing yk to build its own LLVM-without-assertions.
+# We now want to test `cargo bench` which we also takes as an opportunity to
+# check that yk can build ykllvm, which requires unsetting
+# YKB_YKLLVM_INSTALL_DIR.
 unset YKB_YKLLVM_INSTALL_DIR
 cargo bench

--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -16,6 +16,7 @@ ykutil = { path = "../ykutil" }
 intervaltree = "0.2.7"
 byteorder = "1.4.3"
 leb128 = "0.2.5"
+ykbuild = { path = "../ykbuild" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 iced-x86 = { version = "1.18.0", features = ["decoder"]}

--- a/tests/benches/bench.rs
+++ b/tests/benches/bench.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use tempfile::TempDir;
 use tests::mk_compiler;
+use ykbuild::ccgen::CCLang;
 
 const SAMPLE_SIZE: usize = 50;
 const MEASUREMENT_TIME: Duration = Duration::from_secs(30);
@@ -27,7 +28,14 @@ fn compile_runner(tempdir: &TempDir) -> PathBuf {
     exe.push(tempdir);
     exe.push(src.file_stem().unwrap());
 
-    let mut compiler = mk_compiler("clang", &exe, &src, "-O0", &[], false);
+    let mut compiler = mk_compiler(
+        CCLang::C.compiler_wrapper().to_str().unwrap(),
+        &exe,
+        &src,
+        "-O0",
+        &[],
+        false,
+    );
     compiler.arg("-ltests");
     let out = compiler.output().unwrap();
     check_output(&out);

--- a/tests/langtest_hwtracer_ykpt.rs
+++ b/tests/langtest_hwtracer_ykpt.rs
@@ -12,6 +12,7 @@ use std::{
 use tempfile::TempDir;
 use tests::mk_compiler;
 use tests::ExtraLinkage;
+use ykbuild::ccgen::CCLang;
 
 const COMMENT: &str = "//";
 
@@ -93,7 +94,9 @@ fn run_suite(opt: &'static str) {
                 .map(|l| l.generate_obj(tempdir.path()))
                 .collect::<Vec<PathBuf>>();
 
-            let mut compiler = mk_compiler("clang", &exe, p, opt, &extra_objs, false);
+            let mut compiler = mk_compiler(
+                CCLang::C.compiler_wrapper().to_str().unwrap(),
+                &exe, p, opt, &extra_objs, false);
             compiler.arg("-ltests");
             let runtime = Command::new(exe.clone());
             vec![("Compiler", compiler), ("Run-time", runtime)]

--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use std::{env, path::PathBuf, process::Command};
 use tempfile::TempDir;
 use tests::{mk_compiler, EXTRA_LINK};
+use ykbuild::ccgen::CCLang;
 
 /// Run a C test under gdb.
 #[derive(Parser, Debug)]
@@ -54,7 +55,14 @@ fn main() {
 
     let binstem = PathBuf::from(args.test_file.file_stem().unwrap());
     let binpath = [tempdir.path(), &binstem].iter().collect::<PathBuf>();
-    let mut cmd = mk_compiler("clang", &binpath, &test_path, "-O0", &extra_objs, true);
+    let mut cmd = mk_compiler(
+        CCLang::C.compiler_wrapper().to_str().unwrap(),
+        &binpath,
+        &test_path,
+        "-O0",
+        &extra_objs,
+        true,
+    );
     if !cmd.spawn().unwrap().wait().unwrap().success() {
         panic!("compilation failed");
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
     process::Command,
     sync::LazyLock,
 };
+use ykbuild::llvm_bin_path;
 
 const TEMPDIR_SUBST: &str = "%%TEMPDIR%%";
 pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = LazyLock::new(|| {
@@ -114,9 +115,11 @@ pub fn mk_compiler(
 
     let yk_config_out = Command::new(yk_config)
         .args([mode, "--cflags", "--cppflags", "--ldflags", "--libs"])
+        .env("PATH", llvm_bin_path())
         .output()
         .expect("failed to execute yk-config");
     if !yk_config_out.status.success() {
+        io::stderr().write_all(&yk_config_out.stderr);
         panic!("yk-config exited with non-zero status");
     }
     let mut yk_flags = String::from_utf8(yk_config_out.stdout).unwrap();

--- a/ykbuild/src/lib.rs
+++ b/ykbuild/src/lib.rs
@@ -10,6 +10,9 @@ fn manifest_dir() -> String {
 
 pub fn llvm_config() -> Command {
     let mut c = Command::new("llvm-config");
+    if let (Ok(bin_dir), Ok(path)) = (env::var("YKB_YKLLVM_INSTALL_DIR"), env::var("PATH")) {
+        c.env("PATH", format!("{bin_dir}:{path}"));
+    }
     c.arg("--link-shared");
     c
 }

--- a/ykbuild/src/lib.rs
+++ b/ykbuild/src/lib.rs
@@ -8,12 +8,20 @@ fn manifest_dir() -> String {
     env::var("CARGO_MANIFEST_DIR").unwrap()
 }
 
+/// Return an extended PATH variable with the LLVM binary dir at its head.
+pub fn llvm_bin_path() -> String {
+    let path = env::var("PATH").expect("PATH environment variable not defined");
+    if let Ok(bin_dir) = env::var("YKB_YKLLVM_INSTALL_DIR") {
+        format!("{bin_dir}:{path}")
+    } else {
+        format!("{}:{path}", env::var("DEP_YKBUILD_YKLLVM").unwrap())
+    }
+}
+
 pub fn llvm_config() -> Command {
     let mut c = Command::new("llvm-config");
-    if let (Ok(bin_dir), Ok(path)) = (env::var("YKB_YKLLVM_INSTALL_DIR"), env::var("PATH")) {
-        c.env("PATH", format!("{bin_dir}:{path}"));
-    }
     c.arg("--link-shared");
+    c.env("PATH", llvm_bin_path());
     c
 }
 

--- a/ykbuild/wrap-clang.sh
+++ b/ykbuild/wrap-clang.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+echo dep: ${DEP_YKBUILD_YKLLVM}
+echo path: $PATH
 export PATH=${DEP_YKBUILD_YKLLVM}:${PATH}
 
 echo "clang $@" > $(mktemp -p ${YK_CC_TEMPDIR})

--- a/ykbuild/wrap-clang.sh
+++ b/ykbuild/wrap-clang.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+export PATH=${DEP_YKBUILD_YKLLVM}:${PATH}
+
 echo "clang $@" > $(mktemp -p ${YK_CC_TEMPDIR})
 
 clang $@

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 hwtracer = { path = "../hwtracer" }
 libc = "0.2.117"
+ykbuild = { path = "../ykbuild" }
 ykllvmwrap = { path = "../ykllvmwrap" }
 ykrt = { path = "../ykrt" }
 yktrace = { path = "../yktrace" }

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -11,6 +11,7 @@ num_cpus = "1.13.1"
 parking_lot = "0.12.0"
 parking_lot_core = "0.9.1"
 strum = { version = "0.23.0", features = ["derive"] }
+ykbuild = { path = "../ykbuild" }
 yktrace = { path = "../yktrace" }
 
 [build-dependencies]


### PR DESCRIPTION
**DRAFT PR: DO NOT MERGE**

I believe that we were building 3 versions of LLVM in CI: one in `.buildbot.sh` and once each for `cargo test` and `cargo test --release`.

This commit gets this down to 2 LLVM builds: an LLVM-with-assertions which we use with the relevant `YKB` env var; and an LLVM-without-assertions for `cargo bench`. The latter is also intended to test yk's ability to build ykllvm without having the env var set, so kills two birds with one stone.