### PR TITLE
Rename `YKB_YKLLVM_INSTALL_DIR` to `YKB_YKLLVM_BIN_DIR`.

### DIFF
--- a/docs/src/dev/env.md
+++ b/docs/src/dev/env.md
@@ -13,6 +13,18 @@ testing only. It is enabled whenever the `tests` crate is being compiled, so a
 regular `cargo build` in the root of the workspace will enable the feature (to
 build *without* the feature enabled, do `cargo build -p ykcapi`).
 
+## Build-time Variables
+
+### `YKB_YKLLVM_BIN_DIR`
+
+Under normal circumstances, yk builds a copy of its LLVM fork "ykllvm" and uses
+it to build interpreters. You can use your own ykllvm build by specifying the
+directory where the executables (e.g. `clang`, `llvm-config`, and so on) are
+stored with `YKB_YKLLVM_BIN_DIR`. yk does not check your installation for
+compatibility: it is your responsibility to ensure that your ykllvm build
+matches that expected by yk.
+
+
 ## Run-time Variables
 
 ### `YKD_FORCE_TRACE_DECODER`

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -5,11 +5,8 @@ const YKLLVM: &str = "../ykllvm/llvm";
 const PROFILE: &str = "Release";
 
 fn main() {
-    if env::var("YKB_YKLLVM_INSTALL_DIR").is_ok() {
-        println!(
-            "cargo:ykllvm={}",
-            env::var("YKB_YKLLVM_INSTALL_DIR").unwrap()
-        );
+    if env::var("YKB_YKLLVM_BIN_DIR").is_ok() {
+        println!("cargo:ykllvm={}", env::var("YKB_YKLLVM_BIN_DIR").unwrap());
         return;
     }
 


### PR DESCRIPTION
`YKB_YKLLVM_INSTALL_DIR` is ambiguous: is it the "common root" of the installation (e.g. `/usr/local`) or where the binaries are stored (e.g. `/usr/local/bin`). `YKB_YKLLVM_BIN_DIR` makes clear that it's the latter. As discussed on MM.