### PR TITLE
Shuffle tests each time they're run.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -69,7 +69,7 @@ cargo -Z unstable-options build --build-plan -p ykcapi | \
     awk '/yk_testing/ { ec=1 } /yk_jitstate_debug/ { ec=1 } END {exit ec}'
 
 for i in $(seq 10); do
-    cargo test
+    RUST_TEST_SHUFFLE=1 cargo test
 done
 
 # Run examples.
@@ -88,7 +88,7 @@ cargo -Z unstable-options build --release --build-plan -p ykcapi | \
 cargo build --release -p ykcapi
 
 for i in $(seq 10); do
-    cargo test --release
+    RUST_TEST_SHUFFLE=1 cargo test --release
 done
 
 cargo run --release --example hwtracer_example


### PR DESCRIPTION
This can help shake out subtle bugs where one test changes global state in a way that affects another test. This could also be specified with `--shuffle-tests` but then one has to specify `-Z unstable-options` whereas the environment var is backwards/forwards compatible.