### PR TITLE
Update dependencies.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = "1.4.0"
 tempfile = "3.1.0"
 strum = { version = "0.24.1", features = ["derive", "strum_macros"] }
 strum_macros = "0.24.3"
-deku = "0.15.0"
+deku = "0.16"
 ykutil = { path = "../ykutil" }
 intervaltree = "0.2.7"
 byteorder = "1.4.3"
@@ -22,7 +22,7 @@ iced-x86 = { version = "1.18.0", features = ["decoder"]}
 
 [build-dependencies]
 cc = "1.0.62"
-rerun_except = "0.1.2"
+rerun_except = "1"
 ykbuild = { path = "../ykbuild" }
 
 [features]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,7 +29,7 @@ harness = false
 clap = { features = ["derive"], version = "4.0.11" }
 hwtracer = { path = "../hwtracer", features = [ "yk_testing" ] }
 libc = "0.2.139"
-memmap2 = "0.5.2"
+memmap2 = "0.6"
 regex = "1.5.4"
 tempfile = "3.3.0"
 ykbuild = { path = "../ykbuild" }

--- a/ykfr/Cargo.toml
+++ b/ykfr/Cargo.toml
@@ -10,7 +10,7 @@ libc = "0.2.97"
 libffi = "3.0.0"
 ykutil = { path = "../ykutil" }
 yksmp = { path = "../yksmp" }
-memmap2 = "0.5.2"
+memmap2 = "0.6"
 
 [dependencies.llvm-sys]
 # note: using a git version to get llvm linkage features in llvm-sys (not in a
@@ -21,7 +21,7 @@ rev = "678b3da2b2239ae12766c964e6e613c0d82b5f37"
 features = ["no-llvm-linking"]
 
 [dependencies.object]
-version = "0.28.3"
+version = "0.31"
 default-features = false
 features = ["read_core", "elf"]
 

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -10,7 +10,7 @@ hwtracer = { path = "../hwtracer" }
 num_cpus = "1.13.1"
 parking_lot = "0.12.0"
 parking_lot_core = "0.9.1"
-strum = { version = "0.23.0", features = ["derive"] }
+strum = { version = "0.24.0", features = ["derive"] }
 yktrace = { path = "../yktrace" }
 
 [build-dependencies]

--- a/yksmp/Cargo.toml
+++ b/yksmp/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["The Yk Developers"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-object = "0.28.3"
+object = "0.31"

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-elf = "0.0.10"
+elf = "0.7"
 fxhash = "0.2.1"
-gimli = "0.26.1"
+gimli = "0.27"
 hwtracer = { path = "../hwtracer" }
 intervaltree = "0.2.7"
 libc = "0.2.117"

--- a/ykutil/Cargo.toml
+++ b/ykutil/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-cached = { version = "0.42.0", features = ["proc_macro"] }
+cached = { version = "0.43", features = ["proc_macro"] }
 libc = "0.2.117"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 


### PR DESCRIPTION
This passes a full test run. `cargo outdated -R` now shows everything is up to date.