### PR TITLE
Change `build_env` to return a `Vec`.

### DIFF
--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -3,7 +3,7 @@
 use rerun_except::rerun_except;
 use std::env;
 use std::path::PathBuf;
-use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
+use ykbuild::completion_wrapper::CompletionWrapper;
 
 const FEATURE_CHECKS_PATH: &str = "feature_checks";
 
@@ -24,8 +24,9 @@ fn main() {
 
     // Generate a `compile_commands.json` database for clangd.
     let ccg = CompletionWrapper::new("hwtracer", &env::var("CARGO_MANIFEST_DIR").unwrap());
-    env::set_var.call(ccg.build_env());
-    env::set_var("YK_COMPILER_PATH", ykllvm_bin("clang"));
+    for (k, v) in ccg.build_env() {
+        env::set_var(k, v);
+    }
     c_build.compiler(ccg.wrapper_path());
 
     // Check if we should build the perf collector.

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -49,9 +49,10 @@ fn run_suite(opt: &'static str, force_decoder: &'static str) {
 
     // Generate a `compile_commands.json` database for clangd.
     let ccg = CompletionWrapper::new("c_tests", &env::var("CARGO_MANIFEST_DIR").unwrap());
+    for (k, v) in ccg.build_env() {
+        env::set_var(k, v);
+    }
     let wrapper_path = ccg.wrapper_path().to_owned();
-    env::set_var.call(ccg.build_env());
-    env::set_var("YK_COMPILER_PATH", ykllvm_bin("clang"));
 
     LangTester::new()
         .test_dir("c")

--- a/yktracec/build.rs
+++ b/yktracec/build.rs
@@ -49,8 +49,9 @@ fn main() {
 
     // Generate a `compile_commands.json` database for clangd.
     let ccg = CompletionWrapper::new("ykllvmwrap", &env::var("CARGO_MANIFEST_DIR").unwrap());
-    env::set_var.call(ccg.build_env());
-    env::set_var("YK_COMPILER_PATH", ykllvm_bin("clang++"));
+    for (k, v) in ccg.build_env() {
+        env::set_var(k, v);
+    }
     comp.compiler(ccg.wrapper_path());
 
     // Actually do the compilation.


### PR DESCRIPTION
This allows us to put the necessary environment variables for the compiler wrapper in a single place.