### PR TITLE
 The `dir_field` parameter isn't necessary.

### DIFF
--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -23,7 +23,7 @@ fn main() {
     let mut c_build = cc::Build::new();
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new("hwtracer", &env::var("CARGO_MANIFEST_DIR").unwrap());
+    let ccg = CompletionWrapper::new("hwtracer");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -48,7 +48,7 @@ fn run_suite(opt: &'static str, force_decoder: &'static str) {
     let tempdir = TempDir::new().unwrap();
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new("c_tests", &env::var("CARGO_MANIFEST_DIR").unwrap());
+    let ccg = CompletionWrapper::new("c_tests");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }

--- a/ykbuild/src/completion_wrapper.rs
+++ b/ykbuild/src/completion_wrapper.rs
@@ -36,7 +36,6 @@ use tempfile::TempDir;
 /// ```
 pub struct CompletionWrapper {
     db_subdir: String,
-    dir_field: String,
     tmpdir: TempDir,
 }
 
@@ -45,13 +44,9 @@ impl CompletionWrapper {
     ///
     ///  - `db_subdir` specifies the subdirectory of `target/compiler_commands/` to put the
     ///    generated JSON file into.
-    ///
-    ///  - `dir_field` specifies the string to use for the `directory` fields inside the generated
-    ///    JSON file. See: https://clang.llvm.org/docs/JSONCompilationDatabase.html
-    pub fn new(db_subdir: &str, dir_field: &str) -> Self {
+    pub fn new(db_subdir: &str) -> Self {
         Self {
             db_subdir: db_subdir.to_owned(),
-            dir_field: dir_field.to_owned(),
             tmpdir: TempDir::new().unwrap(),
         }
     }
@@ -101,7 +96,10 @@ impl CompletionWrapper {
                 .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
             let mut entry = String::new();
             entry.push_str("  {\n");
-            entry.push_str(&format!("    \"directory\": \"{}\",\n", self.dir_field));
+            entry.push_str(&format!(
+                "    \"directory\": \"{}\",\n",
+                env::var("CARGO_MANIFEST_DIR").unwrap()
+            ));
             entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
             entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
             entry.push_str("  }");

--- a/yktracec/build.rs
+++ b/yktracec/build.rs
@@ -48,7 +48,7 @@ fn main() {
     }
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new("ykllvmwrap", &env::var("CARGO_MANIFEST_DIR").unwrap());
+    let ccg = CompletionWrapper::new("ykllvmwrap");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }


### PR DESCRIPTION
This is always going to be `CARGO_MANIFEST_DIR`, so we can reduce this
complexity from the API.

@vext01 We could also (in another PR) get rid of the `db_subdir` if we say it's always `CARGO_CRATE_NAME`. At the moment we wrap the `tests` crate -> `c_tests`: is that useful/necessary? I'm unsure.