### PR TITLE
Allow users to choose the compiler they want wrapped

### DIFF
--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -3,7 +3,7 @@
 use rerun_except::rerun_except;
 use std::env;
 use std::path::PathBuf;
-use ykbuild::completion_wrapper::CompletionWrapper;
+use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
 
 const FEATURE_CHECKS_PATH: &str = "feature_checks";
 
@@ -23,7 +23,7 @@ fn main() {
     let mut c_build = cc::Build::new();
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new("hwtracer");
+    let ccg = CompletionWrapper::new(ykllvm_bin("clang"), "hwtracer");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -48,7 +48,7 @@ fn run_suite(opt: &'static str, force_decoder: &'static str) {
     let tempdir = TempDir::new().unwrap();
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new("c_tests");
+    let ccg = CompletionWrapper::new(ykllvm_bin("clang"), "c_tests");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }

--- a/yktracec/build.rs
+++ b/yktracec/build.rs
@@ -48,7 +48,7 @@ fn main() {
     }
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new("ykllvmwrap");
+    let ccg = CompletionWrapper::new(ykllvm_bin("clang++"), "ykllvmwrap");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }


### PR DESCRIPTION
This restores some of the subtlety we lost with https://github.com/ykjit/yk/pull/686/files. As that PR showed, only yktracec wanted `clang++` wrapped: hwtracer and langtest_c want `clang` wrapped.