### PR TITLE
Flatten some of the configuration layers in hwtracer.

### DIFF
--- a/hwtracer/src/collect/perf/mod.rs
+++ b/hwtracer/src/collect/perf/mod.rs
@@ -235,19 +235,13 @@ impl Drop for PerfTrace {
 mod tests {
     use super::{PerfCollectorConfig, PerfThreadTraceCollector};
     use crate::{
-        collect::{
-            test_helpers, ThreadTraceCollector, TraceCollector, TraceCollectorBuilder,
-            TraceCollectorConfig, TraceCollectorKind,
-        },
+        collect::{perf::PerfTraceCollector, test_helpers, ThreadTraceCollector, TraceCollector},
         errors::HWTracerError,
         test_helpers::work_loop,
     };
 
     fn mk_collector() -> TraceCollector {
-        TraceCollectorBuilder::new()
-            .kind(TraceCollectorKind::Perf)
-            .build()
-            .unwrap()
+        TraceCollector::default_for_platform().unwrap()
     }
 
     #[test]
@@ -318,13 +312,13 @@ mod tests {
     /// Check that an invalid data buffer size causes an error.
     #[test]
     fn test_config_bad_data_bufsize() {
-        let mut bldr = TraceCollectorBuilder::new().kind(TraceCollectorKind::Perf);
-        match bldr.config() {
-            TraceCollectorConfig::Perf(ref mut ppt_conf) => ppt_conf.data_bufsize = 3,
-        }
-        match bldr.build() {
-            Err(HWTracerError::BadConfig(s)) => {
-                assert_eq!(s, "data_bufsize must be a positive power of 2");
+        let mut cfg = PerfCollectorConfig::default();
+        cfg.data_bufsize = 3;
+        match PerfTraceCollector::new(cfg) {
+            Err(HWTracerError::BadConfig(s))
+                if s == "data_bufsize must be a positive power of 2" =>
+            {
+                ()
             }
             _ => panic!(),
         }
@@ -333,13 +327,13 @@ mod tests {
     /// Check that an invalid aux buffer size causes an error.
     #[test]
     fn test_config_bad_aux_bufsize() {
-        let mut bldr = TraceCollectorBuilder::new().kind(TraceCollectorKind::Perf);
-        match bldr.config() {
-            TraceCollectorConfig::Perf(ref mut ppt_conf) => ppt_conf.aux_bufsize = 3,
-        }
-        match bldr.build() {
-            Err(HWTracerError::BadConfig(s)) => {
-                assert_eq!(s, "aux_bufsize must be a positive power of 2");
+        let mut cfg = PerfCollectorConfig::default();
+        cfg.aux_bufsize = 3;
+        match PerfTraceCollector::new(cfg) {
+            Err(HWTracerError::BadConfig(s))
+                if s == "aux_bufsize must be a positive power of 2" =>
+            {
+                ()
             }
             _ => panic!(),
         }

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -878,14 +878,14 @@ fn is_ret_near(inst: &iced_x86::Instruction) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::{
-        collect::TraceCollectorBuilder,
+        collect::TraceCollector,
         decode::{test_helpers, TraceDecoderKind},
     };
 
     #[ignore] // FIXME
     #[test]
     fn ten_times_as_many_blocks() {
-        let tc = TraceCollectorBuilder::new().build().unwrap();
+        let tc = TraceCollector::default_for_platform().unwrap();
         test_helpers::ten_times_as_many_blocks(tc, TraceDecoderKind::YkPT);
     }
 }

--- a/hwtracer/src/decode/ykpt/packet_parser/mod.rs
+++ b/hwtracer/src/decode/ykpt/packet_parser/mod.rs
@@ -231,14 +231,14 @@ impl<'t> Iterator for PacketParser<'t> {
 mod tests {
     use super::{packets::*, PacketParser};
     use crate::{
-        collect::{test_helpers::trace_closure, TraceCollectorBuilder},
+        collect::{test_helpers::trace_closure, TraceCollector},
         test_helpers::work_loop,
     };
 
     /// Parse the packets of a small trace, checking the basic structure of the decoded trace.
     #[test]
     fn parse_small_trace() {
-        let tc = TraceCollectorBuilder::new().build().unwrap();
+        let tc = TraceCollector::default_for_platform().unwrap();
         let trace = trace_closure(&tc, || work_loop(3));
 
         #[derive(Clone, Copy, Debug)]

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -1,4 +1,3 @@
-use crate::{collect::TraceCollectorKind, decode::TraceDecoderKind};
 use libc::{c_int, strerror};
 use std::error::Error;
 use std::ffi::{self, CStr};
@@ -12,10 +11,6 @@ pub enum HWTracerError {
     HWBufferOverflow,
     /// The hardware doesn't support a required feature.
     NoHWSupport(String),
-    /// This collector was not compiled in to hwtracer.
-    CollectorUnavailable(TraceCollectorKind),
-    /// This decoder was not compiled into hwtracer.
-    DecoderUnavailable(TraceDecoderKind),
     /// Permission denied.
     Permissions(String),
     /// Something went wrong in C code.
@@ -44,12 +39,6 @@ impl Display for HWTracerError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             HWTracerError::HWBufferOverflow => write!(f, "Hardware trace buffer overflow"),
-            HWTracerError::CollectorUnavailable(ref s) => {
-                write!(f, "Trace collector unavailble: {:?}", s)
-            }
-            HWTracerError::DecoderUnavailable(ref s) => {
-                write!(f, "Trace decoder unavailble: {:?}", s)
-            }
             HWTracerError::NoHWSupport(ref s) => write!(f, "{}", s),
             HWTracerError::Permissions(ref s) => write!(f, "{}", s),
             HWTracerError::Errno(n) => {
@@ -80,8 +69,6 @@ impl Error for HWTracerError {
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             HWTracerError::HWBufferOverflow => None,
-            HWTracerError::CollectorUnavailable(_) => None,
-            HWTracerError::DecoderUnavailable(_) => None,
             HWTracerError::NoHWSupport(_) => None,
             HWTracerError::Permissions(_) => None,
             HWTracerError::AlreadyCollecting => None,

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -12,17 +12,11 @@
 //! langtester suite) and then they call into this file to have assertions checked in Rust code.
 
 use hwtracer::decode::{TraceDecoderBuilder, TraceDecoderKind};
-use hwtracer::{
-    collect::{TraceCollector, TraceCollectorBuilder, TraceCollectorKind},
-    Trace,
-};
+use hwtracer::{collect::TraceCollector, Trace};
 
 #[no_mangle]
 pub extern "C" fn __hwykpt_start_collector() -> *mut TraceCollector {
-    let tc = TraceCollectorBuilder::new()
-        .kind(TraceCollectorKind::Perf)
-        .build()
-        .unwrap();
+    let tc = TraceCollector::default_for_platform().unwrap();
     tc.start_thread_collector().unwrap();
     Box::into_raw(Box::new(tc))
 }

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -3,7 +3,7 @@
 use super::{IRTrace, ThreadTracer, ThreadTracerImpl, UnmappedTrace};
 use crate::errors::InvalidTraceError;
 use hwtracer::{
-    collect::{TraceCollector, TraceCollectorBuilder},
+    collect::TraceCollector,
     decode::{TraceDecoderBuilder, TraceDecoderKind},
 };
 use std::sync::LazyLock;
@@ -13,7 +13,7 @@ pub use mapper::HWTMapper;
 
 static TRACE_COLLECTOR: LazyLock<TraceCollector> = LazyLock::new(|| {
     // FIXME: This just makes a default trace collector. We should allow configuration somehow.
-    TraceCollectorBuilder::new().build().unwrap()
+    TraceCollector::default_for_platform().unwrap()
 });
 
 /// Hardware thread tracer.


### PR DESCRIPTION
Before this commit, there are sort-of 4 layers of configuration necessary to get a tracer: this more-or-less gets things down to 1 layer (with the configuration aspect slightly separate).

In some ways this commit is a bit brutal, and more work is needed, but this seems like a good first step towards simplifying things and making them more idiomatic Rust.