### PR TITLE
Move `test_helpers` out to the more descriptive module `work_loop`.

### DIFF
--- a/hwtracer/src/collect/mod.rs
+++ b/hwtracer/src/collect/mod.rs
@@ -128,7 +128,7 @@ fn pt_supported() -> bool {
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    use crate::{collect::TraceCollector, errors::HWTracerError, test_helpers::work_loop, Trace};
+    use crate::{collect::TraceCollector, errors::HWTracerError, work_loop, Trace};
     use std::thread;
 
     /// Trace a closure that returns a u64.

--- a/hwtracer/src/collect/perf/mod.rs
+++ b/hwtracer/src/collect/perf/mod.rs
@@ -237,7 +237,7 @@ mod tests {
     use crate::{
         collect::{perf::PerfTraceCollector, test_helpers, ThreadTraceCollector, TraceCollector},
         errors::HWTracerError,
-        test_helpers::work_loop,
+        work_loop,
     };
 
     fn mk_collector() -> TraceCollector {

--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -105,7 +105,7 @@ mod test_helpers {
     use super::{TraceDecoder, TraceDecoderBuilder, TraceDecoderKind};
     use crate::{
         collect::{test_helpers::trace_closure, TraceCollector},
-        test_helpers::work_loop,
+        work_loop,
     };
 
     /// Trace two loops, one 10x larger than the other, then check the proportions match the number

--- a/hwtracer/src/decode/ykpt/packet_parser/mod.rs
+++ b/hwtracer/src/decode/ykpt/packet_parser/mod.rs
@@ -232,7 +232,7 @@ mod tests {
     use super::{packets::*, PacketParser};
     use crate::{
         collect::{test_helpers::trace_closure, TraceCollector},
-        test_helpers::work_loop,
+        work_loop,
     };
 
     /// Parse the packets of a small trace, checking the basic structure of the decoded trace.

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -12,6 +12,11 @@ pub mod decode;
 pub mod errors;
 pub mod llvm_blockmap;
 
+#[cfg(test)]
+mod work_loop;
+#[cfg(test)]
+use work_loop::work_loop;
+
 pub use errors::HWTracerError;
 use std::fmt::Debug;
 #[cfg(test)]
@@ -35,20 +40,4 @@ pub trait Trace: Debug + Send {
     /// The exact format varies depending on what kind of trace it is.
     #[cfg(test)]
     fn to_file(&self, file: &mut File);
-}
-
-#[cfg(test)]
-mod test_helpers {
-    use std::time::SystemTime;
-
-    /// A loop that does some work that we can use to build a trace.
-    #[inline(never)]
-    pub fn work_loop(iters: u64) -> u64 {
-        let mut res = 0;
-        for _ in 0..iters {
-            // Computation which stops the compiler from eliminating the loop.
-            res += SystemTime::now().elapsed().unwrap().subsec_nanos() as u64;
-        }
-        res
-    }
 }

--- a/hwtracer/src/work_loop.rs
+++ b/hwtracer/src/work_loop.rs
@@ -1,0 +1,12 @@
+use std::time::SystemTime;
+
+/// A loop that does some work that we can use to build a trace.
+#[inline(never)]
+pub fn work_loop(iters: u64) -> u64 {
+    let mut res = 0;
+    for _ in 0..iters {
+        // Computation which stops the compiler from eliminating the loop.
+        res += SystemTime::now().elapsed().unwrap().subsec_nanos() as u64;
+    }
+    res
+}


### PR DESCRIPTION
I tend to feel that `helper` as a name is too generic to be helpful, so I've made a specific `work_loop` module instead.

By shoving this code into its own module, we also make it less likely that external users who look at the source code will be burdened by `work_loop`.