### PR TITLE
Use clang and clang++ 13 for CI.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -46,6 +46,8 @@ cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
     -DLLVM_ENABLE_PROJECTS="lld;clang" \
     -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
     -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_C_COMPILER=/usr/bin/clang \
+    -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
     -GNinja \
     ../llvm
 cmake --build .
@@ -77,6 +79,7 @@ done
 # YKB_YKLLVM_BIN_DIR. In essence, we now repeat much of what we did above but
 # with `--release`.
 unset YKB_YKLLVM_BIN_DIR
+export YKB_YKLLVM_BUILD_ARGS="define:CMAKE_C_COMPILER=/usr/bin/clang,define:CMAKE_CXX_COMPILER=/usr/bin/clang++"
 
 cargo -Z unstable-options build --release --build-plan -p ykcapi | \
     awk '/yk_testing/ { ec=1 } /yk_jitstate_debug/ { ec=1 } END {exit ec}'

--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -2,8 +2,14 @@ FROM debian:bullseye
 ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci
 RUN apt-get update && \
-apt-get -y install build-essential curl procps file git cmake python3 \
+apt-get -y install clang-13 make curl procps file git cmake python3 \
     libtinfo-dev libzip-dev ninja-build
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-13 999
+RUN update-alternatives --set cc /usr/bin/clang-13
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-13 999
+RUN update-alternatives --set c++ /usr/bin/clang++-13
+RUN ln -sf /usr/bin/clang-13 /usr/bin/clang
+RUN ln -sf /usr/bin/clang-13 /usr/bin/clang++
 WORKDIR /ci
 RUN chown ${CI_UID}:${CI_UID} .
 COPY --chown=${CI_UID}:${CI_UID} . .


### PR DESCRIPTION
This solves an issue we are having where GCC crashes when building ykllvm.

This was more of a rabbit hole than expected, as after switching to the Debian clang and clang++, we saw the compilers crash when building yk!

Therefore in this change we are forcing the system compiler to be clang and clang++ 13 (also from Debian packages).

Unfortunately `update-alternatives` only manages `cc` and `c++` (and not `clang` and `clang++`, which some parts of our build explicitly call), so we resort to symlinking `clang-13` and `clang++-13` into `/usr/bin`.

It's not ideal, but since this script is designed to run only inside a CI docker image, I can live with it.

If we get any more trouble from old compiler versions we can get newer packages from the official LLVM apt repo: https://apt.llvm.org/