### PR TITLE
Don't run the benchmarks for as long as Criterion wants.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -87,4 +87,6 @@ for i in $(seq 10); do
     RUST_TEST_SHUFFLE=1 cargo test --release
 done
 
-cargo bench
+# We want to check that the benchmarks build and run correctly, but want to
+# ignore the results, so run them for the minimum possible time.
+cargo bench --bench bench -- --profile-time 1


### PR DESCRIPTION
In CI, we want the benchmarks to be built, and we want to check that they can run, but the results are meaningless. By setting `--profile-time 1` we lower the time for `cargo bench` from just over 4 minutes to just under 10 seconds. In other words, this commit reduces overall CI build time by a little under 10%!