### PR TITLE
Start simplifying the tracing API and making it more flexible

### DIFF
--- a/hwtracer/src/collect/mod.rs
+++ b/hwtracer/src/collect/mod.rs
@@ -3,7 +3,7 @@
 use crate::{errors::HWTracerError, Trace};
 use core::arch::x86_64::__cpuid_count;
 use libc::{size_t, sysconf, _SC_PAGESIZE};
-use std::{cell::RefCell, convert::TryFrom, sync::LazyLock};
+use std::{any::Any, convert::TryFrom, sync::LazyLock};
 
 #[cfg(collector_perf)]
 pub(crate) mod perf;
@@ -22,43 +22,16 @@ static PERF_DFLT_AUX_BUFSIZE: LazyLock<size_t> = LazyLock::new(|| {
 
 const PERF_DFLT_INITIAL_TRACE_BUFSIZE: size_t = 1024 * 1024; // 1MiB
 
-thread_local! {
-    /// When `Some` holds the `ThreadTraceCollector` that is collecting a trace of the current
-    /// thread.
-    static THREAD_TRACE_COLLECTOR: RefCell<Option<Box<dyn ThreadTracer>>> = RefCell::new(None);
-}
-
 pub trait Tracer: Send + Sync {
     /// Start collecting a trace of the current thread.
-    fn start_collector(&self) -> Result<(), HWTracerError> {
-        THREAD_TRACE_COLLECTOR.with(|inner| {
-            let mut inner = inner.borrow_mut();
-            if inner.is_some() {
-                Err(HWTracerError::AlreadyCollecting)
-            } else {
-                let thr_col = self.start()?;
-                *inner = Some(thr_col);
-                Ok(())
-            }
-        })
-    }
+    fn start_collector(&self) -> Result<Box<dyn ThreadTracer>, HWTracerError>;
 
     /// Stop collecting a trace of the current thread.
-    fn stop_collector(&self) -> Result<Box<dyn Trace>, HWTracerError> {
-        THREAD_TRACE_COLLECTOR.with(|inner| {
-            if let Some(thr_col) = inner.take() {
-                thr_col.stop()
-            } else {
-                Err(HWTracerError::AlreadyStopped)
-            }
-        })
-    }
-
-    fn start(&self) -> Result<Box<dyn ThreadTracer>, HWTracerError>;
+    fn stop_collector(&self, tt: Box<dyn ThreadTracer>) -> Result<Box<dyn Trace>, HWTracerError>;
 }
 
 pub trait ThreadTracer {
-    fn stop(self: Box<Self>) -> Result<Box<dyn Trace>, HWTracerError>;
+    fn as_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
 pub fn default_tracer_for_platform() -> Result<Box<dyn Tracer>, HWTracerError> {
@@ -101,7 +74,7 @@ impl Default for PerfCollectorConfig {
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    use crate::{collect::Tracer, errors::HWTracerError, work_loop, Trace};
+    use crate::{collect::Tracer, work_loop, Trace};
     use std::thread;
 
     /// Trace a closure that returns a u64.
@@ -109,9 +82,9 @@ pub(crate) mod test_helpers {
     where
         F: FnOnce() -> u64,
     {
-        tc.start_collector().unwrap();
+        let tt = tc.start_collector().unwrap();
         let res = f();
-        let trace = tc.stop_collector().unwrap();
+        let trace = tc.stop_collector(tt).unwrap();
         println!("traced closure with result: {}", res); // To avoid over-optimisation.
         trace
     }
@@ -134,35 +107,6 @@ pub(crate) mod test_helpers {
         for i in 0..10 {
             trace_closure(&tcs[i], || work_loop(500));
         }
-    }
-
-    /// Check that starting a trace collector twice (without stopping maktracing inbetween) makes
-    /// an appropriate error.
-    pub fn already_started(tc: Box<dyn Tracer>) {
-        tc.start_collector().unwrap();
-        match tc.start_collector() {
-            Err(HWTracerError::AlreadyCollecting) => (),
-            _ => panic!(),
-        };
-        tc.stop_collector().unwrap();
-    }
-
-    /// Check that an attempt to trace the same thread using different collectors fails.
-    pub fn already_started_different_collectors(tc1: Box<dyn Tracer>, tc2: Box<dyn Tracer>) {
-        tc1.start_collector().unwrap();
-        match tc2.start_collector() {
-            Err(HWTracerError::AlreadyCollecting) => (),
-            _ => panic!(),
-        };
-        tc1.stop_collector().unwrap();
-    }
-
-    /// Check that stopping an unstarted trace collector makes an appropriate error.
-    pub fn not_started(tc: Box<dyn Tracer>) {
-        match tc.stop_collector() {
-            Err(HWTracerError::AlreadyStopped) => (),
-            _ => panic!(),
-        };
     }
 
     /// Check that traces can be collected concurrently.

--- a/hwtracer/src/collect/mod.rs
+++ b/hwtracer/src/collect/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod perf;
 #[cfg(all(collector_perf, feature = "yk_testing"))]
 pub use perf::PerfTrace;
 #[cfg(collector_perf)]
-pub(crate) use perf::PerfTraceCollector;
+pub(crate) use perf::PerfTracer;
 
 const PERF_DFLT_DATA_BUFSIZE: size_t = 64;
 static PERF_DFLT_AUX_BUFSIZE: LazyLock<size_t> = LazyLock::new(|| {
@@ -25,44 +25,18 @@ const PERF_DFLT_INITIAL_TRACE_BUFSIZE: size_t = 1024 * 1024; // 1MiB
 thread_local! {
     /// When `Some` holds the `ThreadTraceCollector` that is collecting a trace of the current
     /// thread.
-    static THREAD_TRACE_COLLECTOR: RefCell<Option<Box<dyn ThreadTraceCollector>>> = RefCell::new(None);
+    static THREAD_TRACE_COLLECTOR: RefCell<Option<Box<dyn ThreadTracer>>> = RefCell::new(None);
 }
 
-/// The private innards of a `TraceCollector`.
-pub trait TraceCollectorImpl: Send + Sync {
-    unsafe fn thread_collector(&self) -> Box<dyn ThreadTraceCollector>;
-}
-
-/// The public interface offered by all trace collectors.
-pub struct TraceCollector {
-    col_impl: Box<dyn TraceCollectorImpl>,
-}
-
-impl TraceCollector {
-    #[cfg(debug_assertions)]
-    pub fn new(col_impl: Box<dyn TraceCollectorImpl>) -> Self {
-        Self { col_impl }
-    }
-
-    pub fn default_for_platform() -> Result<Self, HWTracerError> {
-        if pt_supported() {
-            Ok(Self {
-                col_impl: Box::new(PerfTraceCollector::new(PerfCollectorConfig::default())?),
-            })
-        } else {
-            todo!();
-        }
-    }
-
+pub trait Tracer: Send + Sync {
     /// Start collecting a trace of the current thread.
-    pub fn start_thread_collector(&self) -> Result<(), HWTracerError> {
+    fn start_collector(&self) -> Result<(), HWTracerError> {
         THREAD_TRACE_COLLECTOR.with(|inner| {
             let mut inner = inner.borrow_mut();
             if inner.is_some() {
                 Err(HWTracerError::AlreadyCollecting)
             } else {
-                let mut thr_col = unsafe { self.col_impl.thread_collector() };
-                thr_col.start_collector()?;
+                let thr_col = self.start()?;
                 *inner = Some(thr_col);
                 Ok(())
             }
@@ -70,30 +44,35 @@ impl TraceCollector {
     }
 
     /// Stop collecting a trace of the current thread.
-    pub fn stop_thread_collector(&self) -> Result<Box<dyn Trace>, HWTracerError> {
+    fn stop_collector(&self) -> Result<Box<dyn Trace>, HWTracerError> {
         THREAD_TRACE_COLLECTOR.with(|inner| {
-            let mut inner = inner.borrow_mut();
-            if let Some(thr_col) = &mut *inner {
-                let ret = thr_col.stop_collector();
-                *inner = None;
-                ret
+            if let Some(thr_col) = inner.take() {
+                thr_col.stop()
             } else {
                 Err(HWTracerError::AlreadyStopped)
             }
         })
     }
+
+    fn start(&self) -> Result<Box<dyn ThreadTracer>, HWTracerError>;
 }
 
-/// Represents a trace collection session for a single thread.
-pub trait ThreadTraceCollector {
-    /// Start recording a trace.
-    ///
-    /// Tracing continues until [stop_collector] is called.
-    fn start_collector(&mut self) -> Result<(), HWTracerError>;
-    /// Turns off the tracer.
-    ///
-    /// Tracing continues until [stop_collector] is called.
-    fn stop_collector(&mut self) -> Result<Box<dyn Trace>, HWTracerError>;
+pub trait ThreadTracer {
+    fn stop(self: Box<Self>) -> Result<Box<dyn Trace>, HWTracerError>;
+}
+
+pub fn default_tracer_for_platform() -> Result<Box<dyn Tracer>, HWTracerError> {
+    if pt_supported() {
+        Ok(Box::new(PerfTracer::new(PerfCollectorConfig::default())?))
+    } else {
+        todo!();
+    }
+}
+
+/// Checks if the CPU supports Intel Processor Trace.
+fn pt_supported() -> bool {
+    let res = unsafe { __cpuid_count(0x7, 0x0) };
+    (res.ebx & (1 << 25)) != 0
 }
 
 /// Configures the Perf collector.
@@ -120,44 +99,38 @@ impl Default for PerfCollectorConfig {
     }
 }
 
-/// Checks if the CPU supports Intel Processor Trace.
-fn pt_supported() -> bool {
-    let res = unsafe { __cpuid_count(0x7, 0x0) };
-    (res.ebx & (1 << 25)) != 0
-}
-
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    use crate::{collect::TraceCollector, errors::HWTracerError, work_loop, Trace};
+    use crate::{collect::Tracer, errors::HWTracerError, work_loop, Trace};
     use std::thread;
 
     /// Trace a closure that returns a u64.
-    pub fn trace_closure<F>(tc: &TraceCollector, f: F) -> Box<dyn Trace>
+    pub fn trace_closure<F>(tc: &Box<dyn Tracer>, f: F) -> Box<dyn Trace>
     where
         F: FnOnce() -> u64,
     {
-        tc.start_thread_collector().unwrap();
+        tc.start_collector().unwrap();
         let res = f();
-        let trace = tc.stop_thread_collector().unwrap();
+        let trace = tc.stop_collector().unwrap();
         println!("traced closure with result: {}", res); // To avoid over-optimisation.
         trace
     }
 
     /// Check that starting and stopping a trace collector works.
-    pub fn basic_collection(tc: TraceCollector) {
+    pub fn basic_collection(tc: Box<dyn Tracer>) {
         let trace = trace_closure(&tc, || work_loop(500));
         assert_ne!(trace.len(), 0);
     }
 
     /// Check that repeated usage of the same trace collector works.
-    pub fn repeated_collection(tc: TraceCollector) {
+    pub fn repeated_collection(tc: Box<dyn Tracer>) {
         for _ in 0..10 {
             trace_closure(&tc, || work_loop(500));
         }
     }
 
     /// Check that repeated collection using different collectors works.
-    pub fn repeated_collection_different_collectors(tcs: [TraceCollector; 10]) {
+    pub fn repeated_collection_different_collectors(tcs: [Box<dyn Tracer>; 10]) {
         for i in 0..10 {
             trace_closure(&tcs[i], || work_loop(500));
         }
@@ -165,35 +138,35 @@ pub(crate) mod test_helpers {
 
     /// Check that starting a trace collector twice (without stopping maktracing inbetween) makes
     /// an appropriate error.
-    pub fn already_started(tc: TraceCollector) {
-        tc.start_thread_collector().unwrap();
-        match tc.start_thread_collector() {
+    pub fn already_started(tc: Box<dyn Tracer>) {
+        tc.start_collector().unwrap();
+        match tc.start_collector() {
             Err(HWTracerError::AlreadyCollecting) => (),
             _ => panic!(),
         };
-        tc.stop_thread_collector().unwrap();
+        tc.stop_collector().unwrap();
     }
 
     /// Check that an attempt to trace the same thread using different collectors fails.
-    pub fn already_started_different_collectors(tc1: TraceCollector, tc2: TraceCollector) {
-        tc1.start_thread_collector().unwrap();
-        match tc2.start_thread_collector() {
+    pub fn already_started_different_collectors(tc1: Box<dyn Tracer>, tc2: Box<dyn Tracer>) {
+        tc1.start_collector().unwrap();
+        match tc2.start_collector() {
             Err(HWTracerError::AlreadyCollecting) => (),
             _ => panic!(),
         };
-        tc1.stop_thread_collector().unwrap();
+        tc1.stop_collector().unwrap();
     }
 
     /// Check that stopping an unstarted trace collector makes an appropriate error.
-    pub fn not_started(tc: TraceCollector) {
-        match tc.stop_thread_collector() {
+    pub fn not_started(tc: Box<dyn Tracer>) {
+        match tc.stop_collector() {
             Err(HWTracerError::AlreadyStopped) => (),
             _ => panic!(),
         };
     }
 
     /// Check that traces can be collected concurrently.
-    pub fn concurrent_collection(tc: TraceCollector) {
+    pub fn concurrent_collection(tc: Box<dyn Tracer>) {
         for _ in 0..10 {
             thread::scope(|s| {
                 let hndl = s.spawn(|| {

--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -104,13 +104,13 @@ impl TraceDecoderBuilder {
 mod test_helpers {
     use super::{TraceDecoder, TraceDecoderBuilder, TraceDecoderKind};
     use crate::{
-        collect::{test_helpers::trace_closure, TraceCollector},
+        collect::{test_helpers::trace_closure, Tracer},
         work_loop,
     };
 
     /// Trace two loops, one 10x larger than the other, then check the proportions match the number
     /// of block the trace passes through.
-    pub fn ten_times_as_many_blocks(tc: TraceCollector, decoder_kind: TraceDecoderKind) {
+    pub fn ten_times_as_many_blocks(tc: Box<dyn Tracer>, decoder_kind: TraceDecoderKind) {
         let trace1 = trace_closure(&tc, || work_loop(10));
         let trace2 = trace_closure(&tc, || work_loop(100));
 

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -878,14 +878,14 @@ fn is_ret_near(inst: &iced_x86::Instruction) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::{
-        collect::TraceCollector,
+        collect::default_tracer_for_platform,
         decode::{test_helpers, TraceDecoderKind},
     };
 
     #[ignore] // FIXME
     #[test]
     fn ten_times_as_many_blocks() {
-        let tc = TraceCollector::default_for_platform().unwrap();
+        let tc = default_tracer_for_platform().unwrap();
         test_helpers::ten_times_as_many_blocks(tc, TraceDecoderKind::YkPT);
     }
 }

--- a/hwtracer/src/decode/ykpt/packet_parser/mod.rs
+++ b/hwtracer/src/decode/ykpt/packet_parser/mod.rs
@@ -231,14 +231,14 @@ impl<'t> Iterator for PacketParser<'t> {
 mod tests {
     use super::{packets::*, PacketParser};
     use crate::{
-        collect::{test_helpers::trace_closure, TraceCollector},
+        collect::{default_tracer_for_platform, test_helpers::trace_closure},
         work_loop,
     };
 
     /// Parse the packets of a small trace, checking the basic structure of the decoded trace.
     #[test]
     fn parse_small_trace() {
-        let tc = TraceCollector::default_for_platform().unwrap();
+        let tc = default_tracer_for_platform().unwrap();
         let trace = trace_closure(&tc, || work_loop(3));
 
         #[derive(Clone, Copy, Debug)]

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -8,6 +8,7 @@ mod block;
 pub use block::Block;
 mod c_errors;
 pub mod collect;
+pub use collect::{default_tracer_for_platform, ThreadTracer, Tracer};
 pub mod decode;
 pub mod errors;
 pub mod llvm_blockmap;

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -12,7 +12,7 @@
 //! langtester suite) and then they call into this file to have assertions checked in Rust code.
 
 use hwtracer::{
-    collect::{default_tracer_for_platform, Tracer},
+    collect::{default_tracer_for_platform, ThreadTracer, Tracer},
     decode::{TraceDecoderBuilder, TraceDecoderKind},
     Trace,
 };
@@ -21,19 +21,21 @@ use std::ffi::c_void;
 #[no_mangle]
 /// The value returned by this function *must* be passed to [__hwykpt_stop_collector] or memory
 /// will leak.
-pub extern "C" fn __hwykpt_start_collector() -> *mut Box<dyn Tracer> {
-    let tc = default_tracer_for_platform().unwrap();
-    tc.start_collector().unwrap();
+pub extern "C" fn __hwykpt_start_collector() -> *mut (Box<dyn Tracer>, Box<dyn ThreadTracer>) {
+    let t = default_tracer_for_platform().unwrap();
+    let tt = t.start_collector().unwrap();
     // In order to pass the trait object over the FFI, we have to box it twice.
-    Box::into_raw(Box::new(tc))
+    Box::into_raw(Box::new((t, tt)))
 }
 
 #[no_mangle]
 /// The value passed to this function *must* have come from [ __hwykpt_start_collector]; doing
 /// otherwise leads to undefined behaviour.
-pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn Tracer>) -> *mut c_void {
-    let tc: Box<Box<dyn Tracer>> = unsafe { Box::from_raw(tc) };
-    let trace = tc.stop_collector().unwrap();
+pub extern "C" fn __hwykpt_stop_collector(
+    tc: *mut (Box<dyn Tracer>, Box<dyn ThreadTracer>),
+) -> *mut c_void {
+    let (t, tt): (Box<dyn Tracer>, Box<dyn ThreadTracer>) = *unsafe { Box::from_raw(tc) };
+    let trace = t.stop_collector(tt).unwrap();
     // We have to return a double-boxed trait object, as the inner Box is a fat pointer that
     // can't be passed across the C ABI.
     Box::into_raw(Box::new(trace)) as *mut c_void

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -11,23 +11,32 @@
 //! To that end, the test files in `tests/hwtracer_ykpt` are compiled into test binaries (as a
 //! langtester suite) and then they call into this file to have assertions checked in Rust code.
 
-use hwtracer::decode::{TraceDecoderBuilder, TraceDecoderKind};
-use hwtracer::{collect::TraceCollector, Trace};
+use hwtracer::{
+    collect::{default_tracer_for_platform, Tracer},
+    decode::{TraceDecoderBuilder, TraceDecoderKind},
+    Trace,
+};
+use std::ffi::c_void;
 
 #[no_mangle]
-pub extern "C" fn __hwykpt_start_collector() -> *mut TraceCollector {
-    let tc = TraceCollector::default_for_platform().unwrap();
-    tc.start_thread_collector().unwrap();
+/// The value returned by this function *must* be passed to [__hwykpt_stop_collector] or memory
+/// will leak.
+pub extern "C" fn __hwykpt_start_collector() -> *mut Box<dyn Tracer> {
+    let tc = default_tracer_for_platform().unwrap();
+    tc.start_collector().unwrap();
+    // In order to pass the trait object over the FFI, we have to box it twice.
     Box::into_raw(Box::new(tc))
 }
 
 #[no_mangle]
-pub extern "C" fn __hwykpt_stop_collector(tc: *mut TraceCollector) -> *mut Box<dyn Trace> {
-    let tc: Box<TraceCollector> = unsafe { Box::from_raw(tc) };
-    let trace = tc.stop_thread_collector().unwrap();
+/// The value passed to this function *must* have come from [ __hwykpt_start_collector]; doing
+/// otherwise leads to undefined behaviour.
+pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn Tracer>) -> *mut c_void {
+    let tc: Box<Box<dyn Tracer>> = unsafe { Box::from_raw(tc) };
+    let trace = tc.stop_collector().unwrap();
     // We have to return a double-boxed trait object, as the inner Box is a fat pointer that
     // can't be passed across the C ABI.
-    Box::into_raw(Box::new(trace))
+    Box::into_raw(Box::new(trace)) as *mut c_void
 }
 
 /// Decode the specified trace and iterate over the resulting blocks.

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -2,47 +2,50 @@
 
 use super::{IRTrace, ThreadTracer, UnmappedTrace};
 use crate::errors::InvalidTraceError;
-use hwtracer::{
-    collect::{default_tracer_for_platform, ThreadTracer as HWThreadTracer, Tracer},
-    decode::{TraceDecoderBuilder, TraceDecoderKind},
-};
+use hwtracer::decode::{TraceDecoderBuilder, TraceDecoderKind};
+use std::{error::Error, sync::Arc};
 
 pub mod mapper;
 pub use mapper::HWTMapper;
 
+pub struct HWTracer {
+    backend: Box<dyn hwtracer::Tracer>,
+}
+
+impl super::Tracer for HWTracer {
+    fn start_collector(self: Arc<Self>) -> Result<Box<dyn ThreadTracer>, Box<dyn Error>> {
+        Ok(Box::new(HWTThreadTracer {
+            tracer: Arc::clone(&self),
+            thread_tracer: Some(self.backend.start_collector()?),
+        }))
+    }
+}
+
+impl HWTracer {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        Ok(HWTracer {
+            backend: hwtracer::default_tracer_for_platform()?,
+        })
+    }
+}
+
 /// Hardware thread tracer.
 struct HWTThreadTracer {
-    tracer: Box<dyn Tracer>,
-    thread_tracer: Option<Box<dyn HWThreadTracer>>,
+    tracer: Arc<HWTracer>,
+    thread_tracer: Option<Box<dyn hwtracer::ThreadTracer>>,
 }
 
 impl ThreadTracer for HWTThreadTracer {
-    fn stop_collector(&mut self) -> Result<Box<dyn UnmappedTrace>, InvalidTraceError> {
+    fn stop_collector(mut self: Box<Self>) -> Result<Box<dyn UnmappedTrace>, InvalidTraceError> {
         match self
             .tracer
+            .backend
             .stop_collector(self.thread_tracer.take().unwrap())
         {
             Ok(t) => Ok(Box::new(PTTrace(t))),
             Err(e) => todo!("{e:?}"),
         }
     }
-}
-
-impl Drop for HWTThreadTracer {
-    fn drop(&mut self) {
-        if self.thread_tracer.is_some() {
-            self.stop_collector().ok();
-        }
-    }
-}
-
-pub(crate) fn start_tracing() -> Box<dyn ThreadTracer> {
-    let tracer = default_tracer_for_platform().unwrap();
-    let thread_tracer = Some(tracer.start_collector().unwrap());
-    Box::new(HWTThreadTracer {
-        tracer,
-        thread_tracer,
-    })
 }
 
 struct PTTrace(Box<dyn hwtracer::Trace>);

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -12,12 +12,12 @@ use libc::c_void;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 use std::{
-    cell::RefCell,
     collections::HashMap,
     env,
     error::Error,
     ffi::{c_char, c_int, CStr, CString},
     ptr,
+    sync::Arc,
 };
 pub mod hwt;
 use std::arch::asm;
@@ -25,33 +25,6 @@ use tempfile::NamedTempFile;
 use ykutil::obj::llvmbc_section;
 
 pub use errors::InvalidTraceError;
-
-thread_local! {
-    // When `Some`, contains the `ThreadTracer` for the current thread. When `None`, the current
-    // thread is not being traced.
-    //
-    // We hide the `ThreadTracer` in a thread local (rather than returning it to the consumer of
-    // yk). This ensures that the `ThreadTracer` itself cannot appear in traces.
-    pub static THREAD_TRACER: RefCell<Option<Box<dyn ThreadTracer>>> = const { RefCell::new(None) };
-}
-
-/// The different ways by which we can collect a trace.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum TracingKind {
-    /// Software tracing.
-    SoftwareTracing,
-    /// Hardware tracing via a branch tracer (e.g. Intel PT).
-    HardwareTracing,
-}
-
-impl Default for TracingKind {
-    /// Returns the default tracing kind.
-    fn default() -> Self {
-        // FIXME this should query the hardware for a suitable hardware tracer and failing that
-        // fall back on software tracing.
-        TracingKind::HardwareTracing
-    }
-}
 
 /// A globally unique block ID for an LLVM IR block.
 #[derive(Debug, Eq, PartialEq)]
@@ -390,30 +363,21 @@ impl Drop for CompiledTrace {
 unsafe impl Send for CompiledTrace {}
 unsafe impl Sync for CompiledTrace {}
 
+/// A tracer is an object which can start / stop collecting traces. It may have its own
+/// configuration, but that is dependent on the concrete tracer itself.
+pub trait Tracer: Send + Sync {
+    /// Start collecting a trace of the current thread.
+    fn start_collector(self: Arc<Self>) -> Result<Box<dyn ThreadTracer>, Box<dyn Error>>;
+}
+
 /// Represents a thread which is currently tracing.
 pub trait ThreadTracer {
     /// Stop collecting a trace of the current thread.
-    fn stop_collector(&mut self) -> Result<Box<dyn UnmappedTrace>, InvalidTraceError>;
+    fn stop_collector(self: Box<Self>) -> Result<Box<dyn UnmappedTrace>, InvalidTraceError>;
 }
 
-/// Start tracing on the current thread using the specified tracing kind.
-/// Each thread can have at most one active tracer; calling `start_tracing()` on a thread where
-/// there is already an active tracer leads to undefined behaviour.
-pub fn start_tracing(kind: TracingKind) {
-    let tt = match kind {
-        TracingKind::SoftwareTracing => todo!(),
-        TracingKind::HardwareTracing => hwt::start_tracing(),
-    };
-    THREAD_TRACER.with(|rc| *rc.borrow_mut() = Some(tt));
-}
-
-/// Stop tracing on the current thread. Calling this when the current thread is not already tracing
-/// leads to undefined behaviour.
-pub fn stop_tracing() -> Result<Box<dyn UnmappedTrace>, InvalidTraceError> {
-    THREAD_TRACER.with(|rc| {
-        let mut thread_tracer = rc.borrow_mut().take().unwrap();
-        thread_tracer.stop_collector()
-    })
+pub fn default_tracer_for_platform() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
+    Ok(Arc::new(hwt::HWTracer::new()?))
 }
 
 pub trait UnmappedTrace: Send {


### PR DESCRIPTION
This PR aims to start simplifying the internal tracing APIs and make them more flexible. It is best viewed as a "useful checkpoint" rather than "this ties up every loose end".

Before this PR, we couldn't practically expect to dynamically change the tracer: they were effectively hard-coded at compile time, despite having various traits that made it look like they could be changed. This PR ultimately (I think/hope!) makes dynamic switching possible, although it doesn't expose a knob to the user to allow them to actually dynamically switch a tracer.

The three commits each compile and pass tests, though you can see from one to another an evolution in what I think possible and desirable. I think they are still usefully kept apart.

In terms of simplification, this PR is not the end. It is not even the beginning of the end. But it is, perhaps, the end of the beginning.