### PR TITLE
Push trace decoding selection to the tracer.

### DIFF
--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -1,8 +1,8 @@
 //! Hardware tracing via ykrustc.
 
-use super::{IRTrace, ThreadTracer, UnmappedTrace};
+use super::{IRTrace, ThreadTracer, Tracer, UnmappedTrace};
 use crate::errors::InvalidTraceError;
-use hwtracer::decode::{TraceDecoderBuilder, TraceDecoderKind};
+use hwtracer::decode::TraceDecoderBuilder;
 use std::{error::Error, sync::Arc};
 
 pub mod mapper;
@@ -51,8 +51,8 @@ impl ThreadTracer for HWTThreadTracer {
 struct PTTrace(Box<dyn hwtracer::Trace>);
 
 impl UnmappedTrace for PTTrace {
-    fn map(self: Box<Self>, decoder: TraceDecoderKind) -> Result<IRTrace, InvalidTraceError> {
-        let tdec = TraceDecoderBuilder::new().kind(decoder).build().unwrap();
+    fn map(self: Box<Self>, _tracer: Arc<dyn Tracer>) -> Result<IRTrace, InvalidTraceError> {
+        let tdec = TraceDecoderBuilder::new().build().unwrap();
         let mut itr = tdec.iter_blocks(self.0.as_ref());
         let mut mt = HWTMapper::new();
 

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -7,7 +7,6 @@
 #![allow(clippy::missing_safety_doc)]
 
 mod errors;
-use hwtracer::decode::TraceDecoderKind;
 use libc::c_void;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
@@ -381,5 +380,5 @@ pub fn default_tracer_for_platform() -> Result<Arc<dyn Tracer>, Box<dyn Error>> 
 }
 
 pub trait UnmappedTrace: Send {
-    fn map(self: Box<Self>, decoder: TraceDecoderKind) -> Result<IRTrace, InvalidTraceError>;
+    fn map(self: Box<Self>, tracer: Arc<dyn Tracer>) -> Result<IRTrace, InvalidTraceError>;
 }


### PR DESCRIPTION
Since we may have different types of tracer (various types of hardware tracers; software tracers; and so on), `MT` can't sensibly offer the ability to pick different trace decoders -- different backends will have very different ideas of what decoders they wish to offer.

This commit thus removes the ability to specify a trace decoder within `MT`, but gives trace decoders a reference to a `Tracer`, so that users can configure a `Tracer` object and have that later control trace decoding (if they want to). At the moment, we don't make use of this facility, because we only have one decoder.