### PR TITLE
Simplify `Tracer` & `ThreadTracer` in hwtracer.

### DIFF
--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -107,10 +107,11 @@ mod test_helpers {
         collect::{test_helpers::trace_closure, Tracer},
         work_loop,
     };
+    use std::sync::Arc;
 
     /// Trace two loops, one 10x larger than the other, then check the proportions match the number
     /// of block the trace passes through.
-    pub fn ten_times_as_many_blocks(tc: Box<dyn Tracer>, decoder_kind: TraceDecoderKind) {
+    pub fn ten_times_as_many_blocks(tc: Arc<dyn Tracer>, decoder_kind: TraceDecoderKind) {
         let trace1 = trace_closure(&tc, || work_loop(10));
         let trace2 = trace_closure(&tc, || work_loop(100));
 

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -12,7 +12,7 @@
 //! langtester suite) and then they call into this file to have assertions checked in Rust code.
 
 use hwtracer::{
-    collect::{default_tracer_for_platform, ThreadTracer, Tracer},
+    collect::{default_tracer_for_platform, ThreadTracer},
     decode::{TraceDecoderBuilder, TraceDecoderKind},
     Trace,
 };
@@ -21,21 +21,19 @@ use std::ffi::c_void;
 #[no_mangle]
 /// The value returned by this function *must* be passed to [__hwykpt_stop_collector] or memory
 /// will leak.
-pub extern "C" fn __hwykpt_start_collector() -> *mut (Box<dyn Tracer>, Box<dyn ThreadTracer>) {
+pub extern "C" fn __hwykpt_start_collector() -> *mut Box<dyn ThreadTracer> {
     let t = default_tracer_for_platform().unwrap();
     let tt = t.start_collector().unwrap();
     // In order to pass the trait object over the FFI, we have to box it twice.
-    Box::into_raw(Box::new((t, tt)))
+    Box::into_raw(Box::new(tt))
 }
 
 #[no_mangle]
 /// The value passed to this function *must* have come from [ __hwykpt_start_collector]; doing
 /// otherwise leads to undefined behaviour.
-pub extern "C" fn __hwykpt_stop_collector(
-    tc: *mut (Box<dyn Tracer>, Box<dyn ThreadTracer>),
-) -> *mut c_void {
-    let (t, tt): (Box<dyn Tracer>, Box<dyn ThreadTracer>) = *unsafe { Box::from_raw(tc) };
-    let trace = t.stop_collector(tt).unwrap();
+pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn ThreadTracer>) -> *mut c_void {
+    let tt: Box<dyn ThreadTracer> = *unsafe { Box::from_raw(tc) };
+    let trace = tt.stop_collector().unwrap();
     // We have to return a double-boxed trait object, as the inner Box is a fat pointer that
     // can't be passed across the C ABI.
     Box::into_raw(Box::new(trace)) as *mut c_void


### PR DESCRIPTION
This more-or-less makes these two traits similar to their namesakes in `yktrace`. Previously a `ThreadTracer` was passed to a `Tracer`, but that forces complexity onto the user of the API. By judicious use of `Arc` (which can be seen as very similar to `Box` in this setting), we simplify the API. Notably this lets us get rid of the horrible use of `Any`.

[Since I accidentally created two similar but distinct APIs last week, I've now had the opportunity to compare the two over time. `yktrace`'s API is clearly less worse than `hwtracer`'s, so it makes sense to make the latter look more like the former.]