### PR TITLE
Restore a test.

### DIFF
--- a/tests/c/direct_recursion.c
+++ b/tests/c/direct_recursion.c
@@ -1,4 +1,3 @@
-// ignore: Requires function calls in stopgap interpreter.
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
@@ -18,7 +17,7 @@
 //     jit-state: exit-jit-code
 //     jit-state: enter-jit-code
 //     1:0
-//     jit-state: stopgap
+//     jit-state: deoptimise
 //     ...
 
 // Check that recursive function calls are not unrolled.


### PR DESCRIPTION
This test didn't work when we had stopgapping but it does work (correctly!) with deoptimisation. It's a useful test so restoring it makes sense.