### PR TITLE
Remove unnecessary features.

### DIFF
--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -1,5 +1,3 @@
-#![feature(fn_traits)]
-
 use rerun_except::rerun_except;
 use std::env;
 use std::path::PathBuf;

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -1,6 +1,3 @@
-#![feature(fn_traits)]
-#![feature(lazy_cell)]
-
 use lang_tester::LangTester;
 use regex::Regex;
 use std::{

--- a/tests/langtest_trace_compiler.rs
+++ b/tests/langtest_trace_compiler.rs
@@ -1,7 +1,5 @@
 //! Lang tester harness for trace compiler tests.
 
-#![feature(lazy_cell)]
-
 use lang_tester::LangTester;
 use regex::Regex;
 use std::{env, fs::read_to_string, path::PathBuf, process::Command};

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -7,9 +7,6 @@
 //! other crates are regular `rlibs`.
 
 #![allow(clippy::missing_safety_doc)]
-#![feature(c_variadic)]
-#![feature(naked_functions)]
-#![feature(lazy_cell)]
 
 use std::{
     ffi::{c_char, c_void, CString},

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -1,6 +1,5 @@
 //! Utilities for collecting and decoding traces.
 
-#![feature(lazy_cell)]
 #![feature(naked_functions)]
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::new_without_default)]

--- a/yktracec/build.rs
+++ b/yktracec/build.rs
@@ -1,5 +1,3 @@
-#![feature(fn_traits)]
-
 use rerun_except::rerun_except;
 use std::{env, process::Command};
 use ykbuild::{apply_llvm_ld_library_path, completion_wrapper::CompletionWrapper, ykllvm_bin};


### PR DESCRIPTION
As code has shuffled around different crates, we've expanded the number of `#![feature(lazy_cell)]` lines, but not pruned them. This commit is a spring clean of the features which are no longer necessary.