### PR TITLE
Fix clangd paths.

### DIFF
--- a/hwtracer/.clangd
+++ b/hwtracer/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-    CompilationDatabase: ../target/compile_commands/hwtracer/
+    CompilationDatabase: ../target/debug/clangd/hwtracer/

--- a/tests/c/.clangd
+++ b/tests/c/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-    CompilationDatabase: ../../target/compile_commands/c_tests/
+    CompilationDatabase: ../../target/debug/clangd/c_tests/

--- a/yktracec/.clangd
+++ b/yktracec/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-    CompilationDatabase: ../target/debug/clangd/ykllvmwrap/
+    CompilationDatabase: ../target/debug/clangd/yktracec/

--- a/yktracec/.clangd
+++ b/yktracec/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-    CompilationDatabase: ../target/compile_commands/ykllvmwrap/
+    CompilationDatabase: ../target/debug/clangd/ykllvmwrap/

--- a/yktracec/build.rs
+++ b/yktracec/build.rs
@@ -46,7 +46,7 @@ fn main() {
     }
 
     // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new(ykllvm_bin("clang++"), "ykllvmwrap");
+    let ccg = CompletionWrapper::new(ykllvm_bin("clang++"), "yktracec");
     for (k, v) in ccg.build_env() {
         env::set_var(k, v);
     }


### PR DESCRIPTION
Note that these are all hard-coded to debug builds: yk does generate different completion sets for debug/release.