### PR TITLE
Change `HotLocationKind::Compiled` from `const *` to `Arc`.

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -440,10 +440,10 @@ pub(crate) struct HotLocation {
 pub(crate) enum HotLocationKind {
     /// Points to executable machine code that can be executed instead of the interpreter for this
     /// HotLocation.
-    Compiled(*const CompiledTrace),
+    Compiled(Arc<CompiledTrace>),
     /// This HotLocation is being compiled in another thread: when compilation has completed the
     /// `Option` will change from `None` to `Some`.
-    Compiling(Arc<Mutex<Option<Box<CompiledTrace>>>>),
+    Compiling(Arc<Mutex<Option<Arc<CompiledTrace>>>>),
     /// This HotLocation has encountered problems (e.g. traces which are too long) and shouldn't be
     /// traced again.
     DontTrace,


### PR DESCRIPTION
I think the reason we stored this as a raw pointer is because, at one point, we literally pointed directly at executable machine code: now we point at a `CompiledTrace` struct which then (indirectly) points at executable machine code.

In general I'm leery of storing raw pointers when we don't need to do so because it's easy to get things with raw pointers wrong: in that sense, simply moving from `const *` to `Arc` is a correctness win. I also suspect that we'll find it easier to do things like trace expiry by having access to an `Arc` rather than a raw pointer.

Note that this commit does impose an atomic increment upon each trace execution: I think this is an inevitable cost (though perhaps in the future we might move that cost to a sub-struct), so we might as well bite the bullet now. In terms of our current performance, this cost is outweighed -- probably by several orders of magnitude! -- by slowness elsewhere.