### PR TITLE
Document `gdb_c_test` and make it give a better error if gdb is missing.

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Development](./dev/index.md)
   - [Configuring the build](./dev/build_config.md)
   - [Run-time configuration](./dev/runtime_config.md)
+  - [Debugging](./dev/debugging.md)
   - [Profiling](./dev/profiling.md)
   - [Understanding Traces](./dev/understanding_traces.md)
   - [Gotchas](./dev/gotchas.md)

--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -1,0 +1,41 @@
+# Debugging.
+
+## Debugging JITted code.
+
+Often you will find the need to inspect JITted code with a debugger. If the
+problem trace comes from a C test (i.e. one of the test cases under `tests/c`),
+then you can use the `gdb_c_test` tool.
+
+The tool automates the compilation and invocation of the resulting binary
+under GDB.
+
+The simplest invocation of `gdb_c_test` would look like:
+
+```
+cargo run --bin gdb_c_test -- simple.c
+```
+
+This will automatically compile and run the `tests/c/simple.c` test under GDB.
+This would be ideal if you have a crashing trace, as it will dump you into a
+GDB shell at the time of the crash.
+
+The tool has some other switches which are useful for other situations, e.g.:
+
+```
+cargo run --bin gdb_c_test -- -j -s -b10 simple.c
+```
+
+compiles and runs `tests/c/simple.c` test under GDB with [JIT state
+debugging](runtime_config.md#ykd_print_jitstate)
+enabled, with [compilation
+serialised](runtime_config.md#ykd_serialise_compilation), setting a
+breakpoint on the first 10 traces compiled.
+
+For a list of all switches available, run:
+
+```
+cargo run --bin gdb_c_test --help
+```
+
+For help on using GDB, see the [GDB
+documentation](https://sourceware.org/gdb/documentation/).

--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -96,5 +96,5 @@ fn main() {
     }
 
     // Run gdb!
-    gdb.spawn().unwrap().wait().unwrap();
+    gdb.spawn().expect("failed to spawn gdb").wait().unwrap();
 }


### PR DESCRIPTION
See commits.