### PR TITLE
Remove bogus compiler environment variable.

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -102,7 +102,6 @@ pub fn mk_compiler(
     patch_cp: bool,
 ) -> Command {
     let mut compiler = Command::new(compiler);
-    compiler.env("YKD_PRINT_IR", "1");
 
     let yk_config = [
         &env::var("CARGO_MANIFEST_DIR").unwrap(),


### PR DESCRIPTION
`YKD_PRINT_IR` is valid for run-time, but not compile-time. "1" would also be an invalid value for it.