### PR TITLE
Provide `LocationInner::from_hotlocation`.

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -348,6 +348,15 @@ impl LocationInner {
         }
     }
 
+    /// Create a new unlocked [LocationInner] with [HotLocation] `hl_ptr`.
+    pub(super) fn from_hotlocation(hl_ptr: *mut HotLocation) -> Self {
+        let hl_ptr = hl_ptr as usize;
+        debug_assert_eq!(hl_ptr & !STATE_TAG, hl_ptr);
+        LocationInner {
+            x: (STATE_TAG & !STATE_IS_COUNTING) | hl_ptr,
+        }
+    }
+
     fn from_usize(x: usize) -> Self {
         LocationInner { x }
     }
@@ -417,17 +426,6 @@ impl LocationInner {
         debug_assert_eq!(count << STATE_NUM_BITS >> STATE_NUM_BITS, count);
         LocationInner {
             x: (self.x & STATE_TAG) | (usize::try_from(count).unwrap() << STATE_NUM_BITS),
-        }
-    }
-
-    /// Set this `State`'s `HotLocation`. It is undefined behaviour for this `State` to already
-    /// have a `HotLocation`.
-    pub(super) fn with_hotlocation(&self, hl_ptr: *mut HotLocation) -> Self {
-        debug_assert!(self.is_counting());
-        let hl_ptr = hl_ptr as usize;
-        debug_assert_eq!(hl_ptr & !STATE_TAG, hl_ptr);
-        LocationInner {
-            x: (self.x & (STATE_TAG & !STATE_IS_COUNTING)) | hl_ptr,
         }
     }
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -250,7 +250,7 @@ impl MT {
                             kind: HotLocationKind::Tracing(Arc::clone(&mtt.tracing)),
                             trace_failure: 0,
                         }));
-                        let new_ls = LocationInner::new().with_hotlocation(hl_ptr).with_lock();
+                        let new_ls = LocationInner::from_hotlocation(hl_ptr).with_lock();
                         debug_assert!(!ls.is_locked());
                         match loc.compare_exchange(ls, new_ls, Ordering::Acquire, Ordering::Relaxed)
                         {


### PR DESCRIPTION
Previously we created a counting `LocationInner` then immediately converted it a non-counting state. This commit allows us to immediately create a non-locked non-counting state, avoiding that pointless intermediate stage.