### PR TITLE
Significantly simplify `Location`s and `Location` transitions.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -10,8 +10,6 @@ hwtracer = { path = "../hwtracer" }
 libc = "0.2.117"
 num_cpus = "1.13.1"
 parking_lot = "0.12.0"
-parking_lot_core = "0.9.1"
-strum = { version = "0.24.0", features = ["derive"] }
 tempfile = "3.3.0"
 ykfr = { path = "../ykfr" }
 yksmp = { path = "../yksmp" }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -273,7 +273,7 @@ impl CompiledTrace {
         }
     }
 
-    #[cfg(feature = "yk_testing")]
+    #[cfg(any(test, feature = "yk_testing"))]
     #[doc(hidden)]
     /// Create a `CompiledTrace` with null contents. This is unsafe and only intended for testing
     /// purposes where a `CompiledTrace` instance is required, but cannot sensibly be constructed


### PR DESCRIPTION
Previously we did a lot of very clever, and very `unsafe`, stuff with `Location`s. Most obviously we used atomics extensively: we also relied on pointer-related stuff. While wanting to extend this code I found a case where we compared two pointers in a way that in C could be undefined behaviour, due to differing provenances -- I suspect the same is true of Rust, but pointer provenance rules are less developed in Rust than C. This has made me realise two things: firstly, we were being too clever for our own good; secondly, we're relying on parts of Rust whose semantics are unclear.

This commit thus radically simplifies all this code. It preserves the property we care about the most: `Location`s don't allocate memory unless they become hot. After that, most of the low-level details change. A `Location` is now either a count (i.e. a "normal"(ish) integer) or a pointer to an `Arc<Mutex<HotLocation>>`. We use `Arc::into_raw` and `Arc::from_raw`, relying on the neat property that even when the `Location` is dropped, the `Arc` will only be dropped if/when its strong count goes to 0 (which, if a thread is using the `Location` elsewhere, might not happen until later, if at all). Ultimately, this allows to rely on 4 simple `unsafe`s in `location.rs`: relative to before, it's easier to examine these and have confidence as to their correctness. Note: I'm not promising I've got everything right. But a) I hope there's less obviously wrong b) if there is something wrong it should be easier to spot than before!

I have deliberately chosen to keep the structure of the code, and the nature of the `Location` state machine as close as possible to what we had before. In particular, I have been able to maintain (for better or worse) the same performance properties: our benchmarks run in virtually the same time as before (one even runs slightly faster, but I think that's a happy accident, rather than a virtue of this commit).