### PR TITLE
Spin for a bit while trying to gain a `HotLocation` lock.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -10,6 +10,7 @@ hwtracer = { path = "../hwtracer" }
 libc = "0.2.117"
 num_cpus = "1.13.1"
 parking_lot = "0.12.0"
+parking_lot_core = "0.9.1"
 tempfile = "3.3.0"
 ykfr = { path = "../ykfr" }
 yksmp = { path = "../yksmp" }


### PR DESCRIPTION
Before this commit, if two threads tried to access the same `HotLocation` at the same time, at least one of them would immediately give up (depending on the underlying architecture, if weak CAS was used, both might give up!). This commit changes things so that threads spin for a bit to try and grab the lock in the expectation that contention will be brief. We use parking_lot_core's `SpinWait` as it gives us a good guide to "spinning doesn't look like it's worth it anymore: give up".

This makes one of our tests (only_one_thread_starts_tracing) a lot slower (0.4s vs 0.03s) but that is the absolute worse possible performance case: lots of threads hammer away at a `Location` without doing any other execution in between locking/unlocking. That could never happen in a real program, which must do at least a little bit of *something* between accessing a `Location`. Our more realistic benchmarks are unimpacted by this change, and I expect real VMs will be happier to spin briefly on the (probably rare) occasions they contend for a lock rather than immediately falling back to the interpreter.