### PR TITLE
Provide a meaningful error when run on a non-PT processor.

### DIFF
--- a/hwtracer/src/collect/mod.rs
+++ b/hwtracer/src/collect/mod.rs
@@ -42,7 +42,9 @@ pub fn default_tracer_for_platform() -> Result<Arc<dyn Tracer>, HWTracerError> {
     if pt_supported() {
         Ok(PerfTracer::new(PerfCollectorConfig::default())?)
     } else {
-        todo!();
+        Err(HWTracerError::NoHWSupport(
+            "CPU doesn't support the Processor Trace (PT) feature".to_owned(),
+        ))
     }
 }
 


### PR DESCRIPTION
Running yk on e.g. valgrind caused a "todo" error, which wasn't very descriptive. This commit bubbles up an `Err` which tells the user "we currently only run if you have a CPU with PT":

```
thread '<unnamed>' panicked at 'CPU doesn't support the Processor Trace (PT) feature', ykcapi/src/lib.rs:24:17
```

It's not pretty, but it is at least informative.