### PR TITLE
Remove `YKD_FORCE_TRACE_DECODER`.

### DIFF
--- a/docs/src/dev/runtime_config.md
+++ b/docs/src/dev/runtime_config.md
@@ -10,15 +10,6 @@ program execution, sometimes significantly.
 
 ## Run-time Variables
 
-### `YKD_FORCE_TRACE_DECODER`
-
-Forces use of the specified trace decoder. The only valid value for now is
-`ykpt`.
-
-This variable is only available when `hwtracer` is compiled with the
-`yk_testing` Cargo feature enabled.
-
-
 ### `YKD_PRINT_IR`
 
 `YKD_PRINT_IR` accepts a comma-separated list of JIT pipeline stages at which

--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -1,8 +1,6 @@
 //! Trace decoders.
 
 use crate::{errors::HWTracerError, Block, Trace};
-#[cfg(feature = "yk_testing")]
-use std::env;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -33,14 +31,6 @@ impl TraceDecoderKind {
                 #[cfg(not(decoder_ykpt))]
                 return Err(HWTracerError::DecoderUnavailable(Self::YkPT));
             }
-        }
-    }
-
-    #[cfg(feature = "yk_testing")]
-    fn from_str(name: &str) -> Self {
-        match name {
-            "ykpt" => Self::YkPT,
-            _ => panic!(),
         }
     }
 }
@@ -80,13 +70,7 @@ impl TraceDecoderBuilder {
     ///
     /// An error is returned if the requested decoder is inappropriate for the platform or the
     /// requested decoder was not compiled in to hwtracer.
-    pub fn build(mut self) -> Result<Box<dyn TraceDecoder>, HWTracerError> {
-        #[cfg(feature = "yk_testing")]
-        {
-            if let Ok(val) = env::var("YKD_FORCE_TRACE_DECODER") {
-                self.kind = TraceDecoderKind::from_str(&val);
-            }
-        }
+    pub fn build(self) -> Result<Box<dyn TraceDecoder>, HWTracerError> {
         self.kind.match_platform()?;
         match self.kind {
             TraceDecoderKind::YkPT => {

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -12,11 +12,8 @@ use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
 
 const COMMENT: &str = "//";
 
-fn run_suite(opt: &'static str, force_decoder: &'static str) {
-    println!(
-        "Running C tests with opt level {} and forcing the {} decoder...",
-        opt, force_decoder
-    );
+fn run_suite(opt: &'static str) {
+    println!("Running C tests with opt level {}...", opt);
 
     // Tests with the filename prefix `debug_` are only run in debug builds.
     #[cfg(cargo_profile = "release")]
@@ -83,7 +80,6 @@ fn run_suite(opt: &'static str, force_decoder: &'static str) {
             let mut compiler = mk_compiler(wrapper_path.as_path(), &exe, p, opt, &extra_objs, true);
             compiler.env("YK_COMPILER_PATH", ykllvm_bin("clang"));
             let mut runtime = Command::new(exe.clone());
-            runtime.env("YKD_FORCE_TRACE_DECODER", force_decoder);
             vec![("Compiler", compiler), ("Run-time", runtime)]
         })
         .fm_options(|_, _, fmb| {
@@ -103,5 +99,5 @@ fn main() {
     // reconstruction. This isn't a huge problem as in the future we will keep two versions of the
     // interpreter around and only swap to -O0 when tracing and run on higher optimisation levels
     // otherwise.
-    run_suite("-O0", "ykpt");
+    run_suite("-O0");
 }


### PR DESCRIPTION
This is a PT specific option, so is really only relevant to (at most) the HW tracer backend or, maybe, the hwtracer crate. At the moment, since we only have one decoder in that backend anyway, the option can't do anything.