### PR TITLE
Simplify the `Compiling` state.

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -204,9 +204,9 @@ pub(crate) enum HotLocationKind {
     /// Points to executable machine code that can be executed instead of the interpreter for this
     /// HotLocation.
     Compiled(Arc<CompiledTrace>),
-    /// This HotLocation is being compiled in another thread: when compilation has completed the
-    /// `Option` will change from `None` to `Some`.
-    Compiling(Arc<Mutex<Option<Arc<CompiledTrace>>>>),
+    /// A trace for this HotLocation is being compiled in another trace. When compilation is
+    /// complete, the compiling thread will update the state of this HotLocation.
+    Compiling,
     /// This HotLocation has encountered problems (e.g. traces which are too long) and shouldn't be
     /// traced again.
     DontTrace,

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -211,5 +211,5 @@ pub(crate) enum HotLocationKind {
     /// traced again.
     DontTrace,
     /// This HotLocation started a trace which is ongoing.
-    Tracing(u32),
+    Tracing,
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -262,7 +262,7 @@ impl MT {
                                 }
                             }
                         }
-                        HotLocationKind::Tracing(_) => {
+                        HotLocationKind::Tracing => {
                             let hl = loc.hot_location_arc_clone().unwrap();
                             let mut thread_hl_out = mtt.tracing.borrow_mut();
                             if let Some(ref thread_hl_in) = *thread_hl_out {
@@ -286,7 +286,7 @@ impl MT {
                                     if lk.trace_failure < self.trace_failure_threshold() {
                                         // Let's try tracing the location again in this thread.
                                         lk.trace_failure += 1;
-                                        lk.kind = HotLocationKind::Tracing(0);
+                                        lk.kind = HotLocationKind::Tracing;
                                         *thread_hl_out = Some(Arc::clone(&hl));
                                         TransitionLocation::StartTracing
                                     } else {
@@ -316,7 +316,7 @@ impl MT {
                                 TransitionLocation::NoAction
                             } else {
                                 let hl = HotLocation {
-                                    kind: HotLocationKind::Tracing(0),
+                                    kind: HotLocationKind::Tracing,
                                     trace_failure: 0,
                                 };
                                 if let Some(hl) = loc.count_to_hot_location(x, hl) {
@@ -467,7 +467,7 @@ mod tests {
         );
         assert!(matches!(
             loc.hot_location().unwrap().lock().kind,
-            HotLocationKind::Tracing(_)
+            HotLocationKind::Tracing
         ));
         match mt.transition_location(&loc) {
             TransitionLocation::StopTracing(mtx) => {
@@ -575,14 +575,14 @@ mod tests {
             }
             assert!(matches!(
                 loc.hot_location().unwrap().lock().kind,
-                HotLocationKind::Tracing(_)
+                HotLocationKind::Tracing
             ));
             assert_eq!(loc.hot_location().unwrap().lock().trace_failure, i);
         }
 
         assert!(matches!(
             loc.hot_location().unwrap().lock().kind,
-            HotLocationKind::Tracing(_)
+            HotLocationKind::Tracing
         ));
         assert_eq!(mt.transition_location(&loc), TransitionLocation::NoAction);
         assert!(matches!(
@@ -622,14 +622,14 @@ mod tests {
             }
             assert!(matches!(
                 loc.hot_location().unwrap().lock().kind,
-                HotLocationKind::Tracing(_)
+                HotLocationKind::Tracing
             ));
             assert_eq!(loc.hot_location().unwrap().lock().trace_failure, i);
         }
 
         assert!(matches!(
             loc.hot_location().unwrap().lock().kind,
-            HotLocationKind::Tracing(_)
+            HotLocationKind::Tracing
         ));
         // Start tracing again...
         assert!(matches!(
@@ -638,7 +638,7 @@ mod tests {
         ));
         assert!(matches!(
             loc.hot_location().unwrap().lock().kind,
-            HotLocationKind::Tracing(_)
+            HotLocationKind::Tracing
         ));
         // ...and this time let tracing succeed.
         assert!(matches!(
@@ -675,7 +675,7 @@ mod tests {
         assert_eq!(mt.transition_location(&loc2), TransitionLocation::NoAction);
         assert!(matches!(
             loc1.hot_location().unwrap().lock().kind,
-            HotLocationKind::Tracing(_)
+            HotLocationKind::Tracing
         ));
         assert_eq!(loc2.count(), Some(THRESHOLD));
         assert!(matches!(
@@ -723,7 +723,7 @@ mod tests {
                             num_starts.fetch_add(1, Ordering::Relaxed);
                             assert!(matches!(
                                 loc.hot_location().unwrap().lock().kind,
-                                HotLocationKind::Tracing(_)
+                                HotLocationKind::Tracing
                             ));
 
                             match mt.transition_location(&loc) {


### PR DESCRIPTION
Now that `Location`s point to an `Arc<Mutex<HotLocation>>` the compilation thread can clone the `Arc` and update the `HotLocation` directly. This means that the `Compiling` state no longer needs to check whether compilation has completed: the `Compiling` state really just means "don't try tracing this `Location`".

Not only does this PR simplify the code, but by removing an extra lock we also make the `Compiling` state notably faster (which given how long we spend in the `Compiling` state at the moment might be useful!). This speeds the `bench_single_threaded_control_point` benchmark (which, admittedly, is grossly unrepresentative of what will happen in real programs) up by over 40%.

[This PR also (hopefully) opens the way for side traces!]
