### PR TITLE
error message for uninitialised submodules build

### DIFF
--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -18,6 +18,9 @@ fn main() {
         return;
     }
 
+    if !Path::new(YKLLVM_SUBMODULE_PATH).is_dir() {
+        panic!("YKLLVM Submodule ({}) was not found! To check submodules, run:\n $ git submodule update --init --recursive\n", YKLLVM_SUBMODULE_PATH);
+    }
     // To avoid running cmake config/build/install, we only do anything with cmake if either a) no
     // build of ykllvm exists b) the ykllvm submodule's hash has changed since we last built it.
     //


### PR DESCRIPTION
Error message for a build with uninitialised git modules:
```
error: failed to run custom build command for `ykbuild v0.1.0 (/yk-fork/ykbuild)`

Caused by:
  process didn't exit successfully: `/yk-fork/target/debug/build/ykbuild-69dfbc5c3b299358/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'YKLLVM Submodule (../ykllvm/llvm) was not found! To check submodules, run:
   $ git submodule update --init --recursive
  ', ykbuild/build.rs:22:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
related issue: https://github.com/ykjit/yk/issues/747