### PR TITLE
A second stab at variable promotion.

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1.5.4"
 tempfile = "3.3.0"
 ykbuild = { path = "../ykbuild" }
 ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }
+yktracec = { path = "../yktracec", features = ["yk_testing"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -41,4 +42,8 @@ ykbuild = { path = "../ykbuild" }
 
 [[bench]]
 name = "bench"
+harness = false
+
+[[bench]]
+name = "promote"
 harness = false

--- a/tests/benches/promote.c
+++ b/tests/benches/promote.c
@@ -1,0 +1,46 @@
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+uint64_t inner(uint64_t a, uint64_t b, uint64_t x, uint64_t y, uint64_t z) {
+#ifdef DO_PROMOTE
+  a = yk_promote(a);
+  b = yk_promote(b);
+  x = yk_promote(x);
+  z = yk_promote(z);
+#endif
+  y += x * 3 - z;  // +1
+  y += a - 10 * b; // no-op
+  return y;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: promote <reps>\n");
+    exit(EXIT_FAILURE);
+  }
+  int reps = atoi(argv[1]);
+
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  uint64_t a = 100, b = 10, x = 1, y = 0, z = 2;
+  NOOPT_VAL(a);
+  NOOPT_VAL(b);
+  NOOPT_VAL(x);
+  NOOPT_VAL(z);
+
+  for (int i = 0; i < reps; i++) {
+    yk_mt_control_point(mt, &loc);
+    y = inner(a, b, x, y, z);
+  }
+
+  assert(y == reps);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/benches/promote.rs
+++ b/tests/benches/promote.rs
@@ -1,0 +1,91 @@
+//! Critereon benchmarks for measuring the impact of promotion.
+
+use criterion::{
+    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
+    Criterion, SamplingMode,
+};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    time::Duration,
+};
+use tempfile::TempDir;
+use tests::mk_compiler;
+use ykbuild::ykllvm_bin;
+
+const SAMPLE_SIZE: usize = 30;
+const MEASUREMENT_TIME: Duration = Duration::from_secs(20);
+
+fn check_output(out: &Output) {
+    if !out.status.success() {
+        println!("{}", std::str::from_utf8(&out.stdout).unwrap());
+        eprintln!("{}", std::str::from_utf8(&out.stderr).unwrap());
+        panic!();
+    }
+}
+
+fn compile_bench(tempdir: &TempDir, promote: bool) -> PathBuf {
+    let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let src = [&md, "benches", "promote.c"].iter().collect::<PathBuf>();
+
+    let mut exe = PathBuf::new();
+    exe.push(tempdir);
+    exe.push(src.file_stem().unwrap());
+
+    let mut compiler = mk_compiler(&ykllvm_bin("clang"), &exe, &src, "-O0", &[], true);
+    compiler.arg("-ltests");
+    if promote {
+        compiler.arg("-DDO_PROMOTE");
+    }
+    let out = compiler.output().unwrap();
+    check_output(&out);
+
+    exe
+}
+
+fn setup<'c, M: Measurement>(
+    c: &'c mut Criterion<M>,
+    group_name: &str,
+) -> (TempDir, PathBuf, PathBuf, BenchmarkGroup<'c, M>) {
+    let tempdir = TempDir::new().unwrap();
+    let bin_np = compile_bench(&tempdir, false);
+    let bin_p = compile_bench(&tempdir, true);
+
+    let mut group = c.benchmark_group(group_name);
+    group.sample_size(SAMPLE_SIZE);
+    group.measurement_time(MEASUREMENT_TIME);
+    group.sampling_mode(SamplingMode::Flat);
+
+    (tempdir, bin_np, bin_p, group)
+}
+
+fn run_bench(bench_bin: &Path, param: usize) {
+    assert!(bench_bin.exists());
+    let out = Command::new(bench_bin)
+        .arg(format!("{}", param))
+        .env("YKD_SERIALISE_COMPILATION", "1")
+        .env("YKD_PRINT_JITSTATE", "1")
+        .output()
+        .unwrap();
+    check_output(&out);
+}
+
+fn bench_promote(c: &mut Criterion) {
+    let (_tempdir, bin_np, bin_p, mut group) = setup(c, "promote");
+
+    let reps = 100000;
+    // Benchmark a simple loop *without* promotion.
+    group.bench_function(
+        BenchmarkId::new("without promotes", format!("{}", reps)),
+        |b| b.iter(|| run_bench(&bin_np, reps)),
+    );
+    // Benchmark a simple loop *with* promotion.
+    group.bench_function(
+        BenchmarkId::new("with promotes", format!("{}", reps)),
+        |b| b.iter(|| run_bench(&bin_p, reps)),
+    );
+}
+
+criterion_group!(promote_benchmarks, bench_promote);
+criterion_main!(promote_benchmarks);

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -3,7 +3,7 @@ use std::env;
 
 pub fn main() {
     // Don't rebuild the whole crate when only test inputs change.
-    rerun_except(&["c", "extra_linkage", "trace_compiler"]).unwrap();
+    rerun_except(&["c", "extra_linkage", "trace_compiler", "benches/*.c"]).unwrap();
 
     // Expose the cargo profile to run.rs so that it can set the right link flags.
     if let Ok(profile) = env::var("PROFILE") {

--- a/tests/c/promote.c
+++ b/tests/c/promote.c
@@ -1,0 +1,72 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_PRINT_IR=jit-post-opt
+//   stderr:
+//     jit-state: start-tracing
+//     y=100
+//     jit-state: stop-tracing
+//     --- Begin jit-post-opt ---
+//     ...
+//     define ptr @__yk_compiled_trace_0(...
+//       ...
+//       %{{cond}} = icmp eq i64 {{x}}, 100
+//       br i1 %{{cond}}, label %{{succbb}}, label %{{failbb}}
+//
+//     {{failbb}}:...
+//       ...
+//       %{{deopt}} = call ptr (...) @llvm.experimental.deoptimize...
+//       ret ...
+//
+//     {{succbb}}:...
+//       ...
+//       %{{res}} = add {{size_t}} %{{arg1}}, 100...
+//       ...
+//       %{{cond2}} = icmp eq i64 {{x2}}, 100
+//       br i1 %{{cond2}}, label %{{succbb}}, label %{{failbb}}
+//     }
+//     ...
+//     --- End jit-post-opt ---
+//     y=200
+//     jit-state: enter-jit-code
+//     y=300
+//     y=400
+//     y=500
+//     jit-state: deoptimise
+//     jit-state: exit-jit-code
+
+// Check that promotion works in traces.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+size_t inner(size_t x, size_t y) {
+  size_t xp = yk_promote(x);
+  y += xp;
+  return y;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  size_t x = 100;
+  size_t y = 0;
+  NOOPT_VAL(x);
+
+  for (int i = 0; i < 5; i++) {
+    yk_mt_control_point(mt, &loc);
+    y = inner(x, y);
+    fprintf(stderr, "y=%" PRIu64 "\n", y);
+  }
+
+  NOOPT_VAL(y);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/promote_expr.c
+++ b/tests/c/promote_expr.c
@@ -1,0 +1,68 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_PRINT_IR=jit-post-opt
+//   stderr:
+//     jit-state: start-tracing
+//     y=50
+//     jit-state: stop-tracing
+//     --- Begin jit-post-opt ---
+//     ...
+//     define ptr @__yk_compiled_trace_0(...
+//       ...
+//       %{{cond}} = icmp eq i64 {{x}}, 50
+//       br i1 %{{cond}}, label %{{succbb}}, label %{{failbb}}
+//
+//     {{failbb}}:...
+//       ...
+//       %{{deopt}} = call ptr (...) @llvm.experimental.deoptimize...
+//       ret ...
+//
+//     {{succbb}}:...
+//       ...
+//       %{{res}} = add {{size_t}} %{{arg1}}, 50...
+//       ...
+//     }
+//     ...
+//     --- End jit-post-opt ---
+//     y=100
+//     jit-state: enter-jit-code
+//     y=150
+//     y=200
+//     y=250
+//     jit-state: deoptimise
+//     jit-state: exit-jit-code
+
+// Check that expression promotion works in traces.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+__attribute__((__noinline__)) size_t inner(size_t x) {
+  return yk_promote(x + 25);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  size_t x = 25;
+  size_t y = 0;
+  NOOPT_VAL(x);
+
+  for (int i = 0; i < 5; i++) {
+    yk_mt_control_point(mt, &loc);
+    y += inner(x);
+    fprintf(stderr, "y=%" PRIu64 "\n", y);
+  }
+
+  NOOPT_VAL(y);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/promote_guard.c
+++ b/tests/c/promote_guard.c
@@ -1,0 +1,87 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_PRINT_IR=jit-post-opt
+//   stderr:
+//     jit-state: start-tracing
+//     y=100
+//     jit-state: stop-tracing
+//     --- Begin jit-post-opt ---
+//     ...
+//     define ptr @__yk_compiled_trace_0(...
+//       ...
+//       %{{cond}} = icmp eq i64 {{x}}, 100
+//       br i1 %{{cond}}, label %{{succbb}}, label %{{failbb}}
+//
+//     {{failbb}}:...
+//       ...
+//       %{{deopt}} = call ptr (...) @llvm.experimental.deoptimize...
+//       ...
+//       ret ...
+//
+//     {{succbb}}:...
+//       ...
+//       %{{res}} = add {{size_t}} %{{arg1}}, 100...
+//       ...
+//       %{{cond2}} = icmp eq i64 %{{x2}}, 100
+//       br i1 %{{cond2}}, label %{{succbb}}, label %{{failbb}}
+//     }
+//     ...
+//     --- End jit-post-opt ---
+//     y=200
+//     jit-state: enter-jit-code
+//     y=300
+//     y=400
+//     y=500
+//     jit-state: deoptimise
+//     jit-state: exit-jit-code
+//     y=700
+//     jit-state: enter-jit-code
+//     y=800
+//     y=900
+//     y=1000
+//     jit-state: deoptimise
+//     jit-state: exit-jit-code
+//     y=1999
+
+// Check that promotions are guarded correctly.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define ELEMS 10
+
+size_t inner(size_t x, size_t y) {
+  size_t xp = yk_promote(x);
+  y += xp;
+  return y;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  // We will trace 100 baked into the trace, and every iteration where there's
+  // a 200 we should guard fail.
+  size_t xs[ELEMS] = {100, 100, 100, 100, 100, 200, 100, 100, 100, 999};
+  size_t y = 0;
+  NOOPT_VAL(xs);
+
+  // On the third iteration, a guard must fail to stop us blindly adding 100
+  // instead of 200.
+  for (int i = 0; i < ELEMS; i++) {
+    yk_mt_control_point(mt, &loc);
+    y = inner(xs[i], y);
+    fprintf(stderr, "y=%" PRIu64 "\n", y);
+  }
+
+  NOOPT_VAL(y);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/promote_not_great.c
+++ b/tests/c/promote_not_great.c
@@ -1,0 +1,66 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_PRINT_IR=jit-post-opt
+//   stderr:
+//     jit-state: start-tracing
+//     z=2
+//     jit-state: stop-tracing
+//     --- Begin jit-post-opt ---
+//     ...
+//     define ptr @__yk_compiled_trace_0(...
+//       ...
+//       %{{cond1}} = icmp eq i64 %{{x1}}, 200...
+//       ...
+//       %{{res}} = udiv {{size_t}} %{{notconst}}, 100...
+//       ...
+//       %{{cond2}} = icmp eq i64 %{{x2}}, 200...
+//       ...
+//     }
+//     ...
+//     --- End jit-post-opt ---
+//     z=4
+//     jit-state: enter-jit-code
+//     z=6
+//     z=8
+//     z=10
+//     jit-state: deoptimise
+//     jit-state: exit-jit-code
+
+// Demonstrate where yk_promote() needs improvement.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+size_t inner(size_t x, size_t y) {
+  x = yk_promote(x);
+  y = yk_promote(y);
+  size_t ret = x / y; // JIT doesn't manage to promote `x`.
+  x = yk_promote(x);  // JIT doesn't manage to kill repeated guard.
+  return ret;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  size_t x = 200, y = 100, z = 0;
+  NOOPT_VAL(x);
+  NOOPT_VAL(y);
+
+  for (int i = 0; i < 5; i++) {
+    yk_mt_control_point(mt, &loc);
+    z += inner(x, y);
+    fprintf(stderr, "z=%" PRIu64 "\n", z);
+  }
+
+  NOOPT_VAL(y);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/promote_only_returned_val.c
+++ b/tests/c/promote_only_returned_val.c
@@ -1,0 +1,59 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_PRINT_IR=jit-post-opt
+//   stderr:
+//     jit-state: start-tracing
+//     y=1
+//     jit-state: stop-tracing
+//     --- Begin jit-post-opt ---
+//     ...
+//     define ptr @__yk_compiled_trace_0(...
+//       ...
+//       %{{res}} = udiv {{size_t}} 100, %{{notconst}}...
+//       ...
+//     }
+//     ...
+//     --- End jit-post-opt ---
+//     y=2
+//     jit-state: enter-jit-code
+//     y=3
+//     y=4
+//     y=5
+//     jit-state: deoptimise
+//     jit-state: exit-jit-code
+
+// Check that the incoming argument to `yk_promote()` isn't what is promoted
+// (it's the returned value that is!)
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+size_t inner(size_t x) {
+  yk_promote(x);  // Didn't capture and use return value!
+  return 100 / x; // <- This use of `x` is therefore not promoted.
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  size_t x = 100, y = 0;
+  NOOPT_VAL(x);
+
+  for (int i = 0; i < 5; i++) {
+    yk_mt_control_point(mt, &loc);
+    y += inner(x);
+    fprintf(stderr, "y=%" PRIu64 "\n", y);
+  }
+
+  NOOPT_VAL(y);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -86,7 +86,7 @@ fn run_suite(opt: &'static str) {
             // Use `{{}}` to match non-literal strings in tests.
             // E.g. use `%{{var}}` to capture the name of a variable.
             let ptn_re = Regex::new(r"\{\{.+?\}\}").unwrap();
-            let text_re = Regex::new(r".+?\b").unwrap();
+            let text_re = Regex::new(r"[a-zA-Z0-9\._]+").unwrap();
             fmb.name_matcher(ptn_re, text_re)
         })
         .run();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -12,6 +12,8 @@ use std::{
 };
 use ykbuild::ykllvm_bin;
 
+pub use yktracec::promote::__yk_lookup_promote_usize;
+
 const TEMPDIR_SUBST: &str = "%%TEMPDIR%%";
 pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = LazyLock::new(|| {
     let mut map = HashMap::new();

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -2,6 +2,7 @@
 #define YK_H
 
 #include <stdint.h>
+#include <sys/types.h>
 
 // A `Location` stores state that the meta-tracer needs to identify hot loops
 // and run associated machine code. This is a C mirror of `ykrt::Location`.
@@ -62,5 +63,12 @@ YkLocation yk_location_new(void);
 // `Location` must not be further used after this call or undefined behaviour
 // will occur.
 void yk_location_drop(YkLocation);
+
+// Promote a value to a constant.
+//
+// This is an identity function whose return value will be promoted to a
+// constant when the call is traced.
+#define yk_promote(X) __ykllvm_recognised_promote(X)
+size_t __ykllvm_recognised_promote(size_t);
 
 #endif

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot = "0.12.0"
 parking_lot_core = "0.9.1"
 tempfile = "3.3.0"
 yksmp = { path = "../yksmp" }
+strum = { version = "0.24.0", features = ["derive"] }
 yktracec = { path = "../yktracec" }
 ykutil = { path = "../ykutil" }
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -27,6 +27,7 @@ use crate::{
     location::{HotLocation, HotLocationKind, Location},
     trace::{default_tracer_for_platform, CompiledTrace, ThreadTracer, Tracer, UnmappedTrace},
 };
+use yktracec::promote;
 
 // The HotThreshold must be less than a machine word wide for [`Location::Location`] to do its
 // pointer tagging thing. We therefore choose a type which makes this statically clear to
@@ -173,12 +174,14 @@ impl MT {
                 let tracer = Arc::clone(&self.tracer);
                 match Arc::clone(&tracer).start_collector() {
                     Ok(tt) => THREAD_MTTHREAD.with(|mtt| {
+                        promote::thread_record_enable(true);
                         *mtt.thread_tracer.borrow_mut() = Some((tracer, tt));
                     }),
                     Err(e) => todo!("{e:?}"),
                 }
             }
             TransitionLocation::StopTracing(hl_arc) => {
+                promote::thread_record_enable(false);
                 // Assuming no bugs elsewhere, the `unwrap` cannot fail, because `StartTracing`
                 // will have put a `Some` in the `Rc`.
                 let (trcr, thrdtrcr) =

--- a/yktracec/src/lib.rs
+++ b/yktracec/src/lib.rs
@@ -1,12 +1,16 @@
 // Exporting parts of the LLVM C++ API not present in the LLVM C API.
 
 #![allow(clippy::new_without_default)]
+#![feature(local_key_cell_methods)]
+#![feature(c_variadic)]
 
 // FIXME: C++ exceptions may unwind over the Rust FFI?
 // https://github.com/ykjit/yk/issues/426
 
 use libc::{c_void, size_t};
 use std::ffi::{c_char, c_int};
+
+pub mod promote;
 
 extern "C" {
     pub fn __yktracec_irtrace_compile(

--- a/yktracec/src/promote.rs
+++ b/yktracec/src/promote.rs
@@ -1,0 +1,77 @@
+//! Software constant recorder.
+//!
+//! This is used for promoting values to constants when compiling a trace.
+
+use std::{cell::RefCell, collections::VecDeque};
+
+// FIXME: Try to move this into ykrt in the existing thread local.
+thread_local! {
+    /// The thread's value recorder.
+    ///
+    /// This has to be specific to a thread to avoid cross-talk from other threads which may be
+    /// executing functions with promoted arguments at the same time.
+    pub static VAL_REC: RefCell<ValueRecorder> = RefCell::new(ValueRecorder::default());
+}
+
+/// A value recorder observes and records constant values during tracing. The trace compiler
+/// queries this when building a trace to replace promoted values with the observed constants.
+#[derive(Debug, Default)]
+pub struct ValueRecorder {
+    // `true` when recording promotions.
+    record_enable: bool,
+    // A vector of to-be-promoted values, in the order their `yk_promote()` calls were encountered
+    // in the trace through the AOT module.
+    //
+    // FIXME: currently you may only promote pointer-sized integers.
+    pbuf: VecDeque<usize>,
+}
+
+impl ValueRecorder {
+    /// Enable (`record=true`) or disable (`record=false`) observations.
+    pub fn record_enable(&mut self, record: bool) {
+        debug_assert_ne!(self.record_enable, record);
+        self.record_enable = record;
+    }
+
+    /// Record a constant for a value that will be promoted.
+    pub fn push(&mut self, val: usize) {
+        if self.record_enable {
+            self.pbuf.push_back(val);
+        }
+    }
+
+    /// Remove and return the oldest recorded constant.
+    pub fn pop(&mut self) -> usize {
+        debug_assert!(!self.record_enable);
+        self.pbuf
+            .pop_front()
+            .expect(&format!("promote buffer undeflow"))
+    }
+}
+
+/// For the current thread, enable or disable constant recording.
+pub fn thread_record_enable(record: bool) {
+    VAL_REC.with_borrow_mut(|r| {
+        r.record_enable(record);
+    })
+}
+
+/// For the current thread, remove and return the oldest recorded value.
+#[no_mangle]
+pub extern "C" fn __yk_lookup_promote_usize() -> usize {
+    VAL_REC.with_borrow_mut(|r| r.pop())
+}
+
+/// Promote a value.
+///
+/// When encountered during trace collection, the returned value will be considered constant in the
+/// resulting compiled trace.
+///
+/// The user sees this as `yk_promote` via a macro.
+#[no_mangle]
+pub unsafe extern "C" fn __ykllvm_recognised_promote(val: usize) -> usize {
+    VAL_REC.with_borrow_mut(|r| {
+        r.push(val);
+    });
+    val
+}


### PR DESCRIPTION
Compiler change: ~~coming soon~~ https://github.com/ykjit/ykllvm/pull/71

To hint to the JIT that a variable should be promoted, do:

  x = yk_promote(x);

During tracing, this function observes and records the concrete value of `x`. At trace compliation time, the value is fished out the value and replaces the variable with the observed constant.

As discussed with the team, some of the existing inefficiencies of our JITted code often prevent promotion from being effective. See the `promote_many_funcs.c` test for examples.