### PR TITLE
Assign index to guards.

### DIFF
--- a/yktracec/src/jitmodbuilder.h
+++ b/yktracec/src/jitmodbuilder.h
@@ -10,11 +10,13 @@
 
 using namespace llvm;
 
-std::tuple<Module *, std::string, std::map<GlobalValue *, void *>, void *>
+std::tuple<Module *, std::string, std::map<GlobalValue *, void *>, void *,
+           size_t>
 createModule(Module *AOTMod, char *FuncNames[], size_t BBs[], size_t TraceLen,
              char *FAddrKeys[], void *FAddrVals[], size_t FAddrLen);
 #ifdef YK_TESTING
-std::tuple<Module *, std::string, std::map<GlobalValue *, void *>, void *>
+std::tuple<Module *, std::string, std::map<GlobalValue *, void *>, void *,
+           size_t>
 createModuleForTraceCompilerTests(Module *AOTMod, char *FuncNames[],
                                   size_t BBs[], size_t TraceLen,
                                   char *FAddrKeys[], void *FAddrVals[],


### PR DESCRIPTION
Each guard now has an assigned index that can be used to retrieve a guard struct inside `CompileTrace`. We will soon use this struct to store hotness count and compiled side traces of guard failures.

@ltratt Does this vaguely look like what we discussed and sets us up for actually counting and start/stop tracing? We could possibly do just counting next and work towards side traces is small increments.