### PR TITLE
Add llvm namespace to bit_cast call

### DIFF
--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -372,7 +372,7 @@ public:
       // (a `size_t`) to encode the stack adjustment value (a `ssize_t`). The
       // cast below reverses that.
       return TraceLoc(variant<IRBlock, UnmappableRegion>{
-          UnmappableRegion{bit_cast<ssize_t, size_t>(BBs[Idx])}});
+          UnmappableRegion{llvm::bit_cast<ssize_t, size_t>(BBs[Idx])}});
     } else {
       return TraceLoc(
           variant<IRBlock, UnmappableRegion>{IRBlock{FuncName, BBs[Idx]}});


### PR DESCRIPTION
bit_cast call can be ambiguous since the 
+same function is defined and used in the standard library. Adding llvm namespace call removes this ambiguity.

This change fixes the following build-time error:
```
cargo:warning=src/jitmodbuilder.cc:375:28: error: call to 'bit_cast' is ambiguous
  cargo:warning=          UnmappableRegion{bit_cast<ssize_t, size_t>(BBs[Idx])}});
  cargo:warning=                           ^~~~~~~~~~~~~~~~~~~~~~~~~
```