### PR TITLE
Add _IO_fflush as an assertion option for dli_snam result 

### DIFF
--- a/ykutil/src/addr.rs
+++ b/ykutil/src/addr.rs
@@ -196,7 +196,10 @@ mod tests {
         use libc::fflush;
         let func_vaddr = fflush as *const fn();
         let sio = vaddr_to_sym_and_obj(func_vaddr as usize).unwrap();
-        assert_eq!(sio.dli_sname().unwrap().to_str().unwrap(), "fflush");
+        assert!(matches!(
+            sio.dli_sname().unwrap().to_str().unwrap(),
+            "fflush" | "_IO_fflush"
+        ));
         let obj_path = PathBuf::from(sio.dli_fname().unwrap().to_str().unwrap());
         assert!(obj_path
             .file_name()


### PR DESCRIPTION
Add _IO_fflush as an assertion option for the `dli_snam` result
On some machines `dli_sname` returns `_IO_fflush` and `fflush` on others for `libc::fflush`.