### PR TITLE
Add a wrapper around gdb_c_test to make it easier to use.

### DIFF
--- a/bin/gdb_c_test
+++ b/bin/gdb_c_test
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Wrapper around the `gdb_c_test` binary to make it easier to use.
+
+set -e
+cargo run --bin gdb_c_test -- $@

--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -9,10 +9,11 @@ then you can use the `gdb_c_test` tool.
 The tool automates the compilation and invocation of the resulting binary
 under GDB.
 
-The simplest invocation of `gdb_c_test` would look like:
+The simplest invocation of `gdb_c_test` (from the top-level of the `yk` repo)
+would look like:
 
 ```
-cargo run --bin gdb_c_test -- simple.c
+bin/gdb_c_test simple.c
 ```
 
 This will automatically compile and run the `tests/c/simple.c` test under GDB.
@@ -22,7 +23,7 @@ GDB shell at the time of the crash.
 The tool has some other switches which are useful for other situations, e.g.:
 
 ```
-cargo run --bin gdb_c_test -- -j -s -b10 simple.c
+bin/gdb_c_test -j -s -b10 simple.c
 ```
 
 compiles and runs `tests/c/simple.c` test under GDB with [JIT state
@@ -34,7 +35,7 @@ breakpoint on the first 10 traces compiled.
 For a list of all switches available, run:
 
 ```
-cargo run --bin gdb_c_test --help
+bin/gdb_c_test --help
 ```
 
 For help on using GDB, see the [GDB


### PR DESCRIPTION
Running the tool from cargo is a bit lengthy, and you have to remember where to put the `--` to start passing args to the underlying binary.

By using a shell wrapper:

```
cargo run --bin gdb_c_test -- -j -s -b10 simple.c
```

can become just:

```
bin/gdb_c_test -j -s -b10 simple.c
```