### PR TITLE
Explicitly use `resolver=2` in the workspace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ members = [
     "yksmp",
     "xtask",
 ]
+resolver = "2"


### PR DESCRIPTION
Without this we get this warning:

```
  warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
  note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
  note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Since we want to move to the 2021 edition, using the 2021 resolver at the workspace level seems the right thing to do.