### PR TITLE
Explicitly drop values.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -38,7 +38,7 @@ pub extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *mut MT {
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn yk_mt_drop(mt: *mut MT) {
-    unsafe { Box::from_raw(mt) };
+    drop(unsafe { Box::from_raw(mt) });
 }
 
 // The "dummy control point" that is replaced in an LLVM pass.

--- a/ykrt/src/testing.rs
+++ b/ykrt/src/testing.rs
@@ -10,7 +10,7 @@ pub extern "C" fn __yktrace_hwt_mapper_blockmap_new() -> *mut BlockMap {
 
 #[no_mangle]
 pub extern "C" fn __yktrace_hwt_mapper_blockmap_free(bm: *mut BlockMap) {
-    unsafe { Box::from_raw(bm) };
+    drop(unsafe { Box::from_raw(bm) });
 }
 
 #[no_mangle]


### PR DESCRIPTION
Newer rustc nightly warns that values like this are unused and should be explicitly dropped if that's what intended. That is what we intended, so this commit explicitly drops them.