### PR TITLE
Tidy up the control point a little bit

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -62,7 +62,7 @@ pub extern "C" fn __ykrt_control_point(
     if !loc.is_null() {
         let mt = unsafe { &*mt };
         let loc = unsafe { &*loc };
-        return mt.control_point(loc, ctrlp_vars, frameaddr);
+        mt.control_point(loc, ctrlp_vars, frameaddr);
     }
     std::ptr::null()
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -153,12 +153,7 @@ impl MT {
         }
     }
 
-    pub fn control_point(
-        &self,
-        loc: &Location,
-        ctrlp_vars: *mut c_void,
-        frameaddr: *mut c_void,
-    ) -> *const c_void {
+    pub fn control_point(&self, loc: &Location, ctrlp_vars: *mut c_void, frameaddr: *mut c_void) {
         match self.transition_location(loc) {
             TransitionLocation::NoAction => (),
             TransitionLocation::Execute(ctr) => {
@@ -203,7 +198,6 @@ impl MT {
                 }
             }
         }
-        std::ptr::null()
     }
 
     /// Perform the next step to `loc` in the `Location` state-machine. If `loc` moves to the

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -1255,6 +1255,7 @@ class JITModBuilder {
   GetControlPointInfo(Module *AOTMod) {
     Function *F = AOTMod->getFunction(YK_NEW_CONTROL_POINT);
     assert(F->arg_size() == YK_CONTROL_POINT_NUM_ARGS);
+    assert(F->getReturnType()->isVoidTy());
 
     User *CallSite = F->user_back();
     CallInst *CPCI = cast<CallInst>(CallSite);

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -1270,10 +1270,7 @@ class JITModBuilder {
     }
 
     Value *Inputs = CPCI->getArgOperand(YK_CONTROL_POINT_ARG_VARS_IDX);
-#ifndef NDEBUG
-    Type *InputsTy = Inputs->getType();
-    assert(InputsTy->isPointerTy());
-#endif
+    assert(Inputs->getType()->isPointerTy());
 
     return {CPCI, CPCIIdx, Inputs};
   }


### PR DESCRIPTION
The main (though it's hardly big!) commit here is https://github.com/ykjit/yk/commit/8ae512e8b1df0baccb54326fee56df3c0783c3bc which removes the `*const c_void` return type from `MT::control_point`.