### PR TITLE
Store `MT`s in `Arc`s

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -11,14 +11,15 @@
 use std::{
     ffi::{c_char, c_void, CString},
     ptr,
+    sync::Arc,
 };
 use ykrt::{HotThreshold, Location, MT};
 
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *mut MT {
+pub extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *const MT {
     match MT::new() {
-        Ok(mt) => Box::into_raw(Box::new(mt)),
+        Ok(mt) => Arc::into_raw(mt),
         Err(e) => {
             if err_msg.is_null() {
                 panic!("{}", e);
@@ -37,8 +38,8 @@ pub extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *mut MT {
 
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn yk_mt_drop(mt: *mut MT) {
-    drop(unsafe { Box::from_raw(mt) });
+pub extern "C" fn yk_mt_drop(mt: *const MT) {
+    drop(unsafe { Arc::from_raw(mt) });
 }
 
 // The "dummy control point" that is replaced in an LLVM pass.

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -10,6 +10,7 @@
 
 use std::{
     ffi::{c_char, c_void, CString},
+    mem::forget,
     ptr,
     sync::Arc,
 };
@@ -53,7 +54,7 @@ pub extern "C" fn yk_mt_control_point(_mt: *mut MT, _loc: *mut Location) {
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn __ykrt_control_point(
-    mt: *mut MT,
+    mt: *const MT,
     loc: *mut Location,
     ctrlp_vars: *mut c_void,
     // Frame address of caller.
@@ -63,14 +64,18 @@ pub extern "C" fn __ykrt_control_point(
     if !loc.is_null() {
         let mt = unsafe { &*mt };
         let loc = unsafe { &*loc };
-        mt.control_point(loc, ctrlp_vars, frameaddr);
+        let arc = unsafe { Arc::from_raw(mt) };
+        arc.control_point(loc, ctrlp_vars, frameaddr);
+        forget(arc);
     }
     std::ptr::null()
 }
 
 #[no_mangle]
-pub extern "C" fn yk_mt_hot_threshold_set(mt: &MT, hot_threshold: HotThreshold) {
-    mt.set_hot_threshold(hot_threshold);
+pub extern "C" fn yk_mt_hot_threshold_set(mt: *const MT, hot_threshold: HotThreshold) {
+    let arc = unsafe { Arc::from_raw(mt) };
+    arc.set_hot_threshold(hot_threshold);
+    forget(arc);
 }
 
 #[no_mangle]

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -70,8 +70,8 @@ pub struct MT {
 impl MT {
     // Create a new meta-tracer instance. Arbitrarily many of these can be created, though there
     // are no guarantees as to whether they will share resources effectively or fairly.
-    pub fn new() -> Result<Self, Box<dyn Error>> {
-        Ok(Self {
+    pub fn new() -> Result<Arc<Self>, Box<dyn Error>> {
+        Ok(Arc::new(Self {
             hot_threshold: AtomicHotThreshold::new(DEFAULT_HOT_THRESHOLD),
             trace_failure_threshold: AtomicTraceFailureThreshold::new(
                 DEFAULT_TRACE_FAILURE_THRESHOLD,
@@ -80,7 +80,7 @@ impl MT {
             max_worker_threads: AtomicUsize::new(cmp::max(1, num_cpus::get() - 1)),
             active_worker_threads: AtomicUsize::new(0),
             tracer: default_tracer_for_platform()?,
-        })
+        }))
     }
 
     /// Return this `MT` instance's current hot threshold. Notice that this value can be changed by


### PR DESCRIPTION
This turned out to be easier than I expected (famous last words).

Note that `self: Arc<Self>` would probably be more common than `self: Arc<&Self>`, but for `MT` we can avoid incing/decing the `Arc` in many instances through the C API by using `self: Arc<&Self>` and `forget`. This seems like a reasonable compromise: if it turns out to be a problem we can probably change to the other representation easily enough.