### PR TITLE
Remove the docs README and give people a pointer on how best to edit the book

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,0 @@
-# ykdocs
-
-Documentation for the Yk Metatracer.
-
-Use [mdbook](https://crates.io/crates/mdbook) to generate the docs.
-
-Current documentation is [hosted here](https://ykjit.github.io/yk/).

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,9 +1,11 @@
 # Introduction
 
-yk is a meta-tracing system built on LLVM.
+This book contains documentation for the yk metatracing system. A preformatted
+version of this book can be found at
+[https://ykjit.github.io/yk/](https://ykjit.github.io/yk/). 
 
-Note that the system is in early stages of development: don't expect it to work
-yet.
+This book is written in [mdbook](https://crates.io/crates/mdbook) format. If
+you want to edit this book, `mdbook serve --open` runs a local server, opens a
+formatted version of this book in your browser, and automatically refreshes the
+browser when you save a markdown file after editing.
 
-The source for this documentation is
-[available on GitHub](https://github.com/ykjit/yk/tree/master/docs).


### PR DESCRIPTION
The README is a hangover from when this was a separate repo: it had become an out-of-sync duplication of `intro.md`. This commit deletes it and expands `intro.md`, which more people are likely to actually see.