### PR TITLE
Always build ykllvm when dirty.

### DIFF
--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -15,4 +15,5 @@ tempfile = "3.3.0"
 [build-dependencies]
 fs4 = "0.6"
 num_cpus = "1.0"
+rerun_except = "1.0.0"
 which = "4.4.0"

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -1,15 +1,18 @@
 #![feature(exit_status_error)]
 
 use fs4::FileExt;
+use rerun_except::rerun_except;
 use std::{
     env,
-    fs::{canonicalize, create_dir_all, read_to_string, write, File},
+    fs::{canonicalize, create_dir_all, File},
     path::Path,
     process::Command,
 };
 use which::which;
 
-/// Where is ykllvm's source code relative to this crate?
+/// The path we use to determine which ykllvm files will cause this build.rs file to be rerun.
+const YKLLVM_SRC_DEPEND_PATH: &str = "../ykllvm";
+/// The path we use to determine that the ykllvm submodule has been cloned.
 const YKLLVM_SUBMODULE_PATH: &str = "../ykllvm/llvm";
 
 fn main() {
@@ -21,16 +24,9 @@ fn main() {
     if !Path::new(YKLLVM_SUBMODULE_PATH).is_dir() {
         panic!("YKLLVM Submodule ({}) was not found! To check submodules, run:\n $ git submodule update --init --recursive\n", YKLLVM_SUBMODULE_PATH);
     }
-    // To avoid running cmake config/build/install, we only do anything with cmake if either a) no
-    // build of ykllvm exists b) the ykllvm submodule's hash has changed since we last built it.
-    //
-    // First we get the ykllvms submodule's hash.
-    let out = Command::new("git")
-        .args(["rev-parse", ":ykllvm"])
-        .output()
-        .unwrap();
-    assert!(out.status.exit_ok().is_ok());
-    let ykllvm_hash = String::from_utf8(out.stdout).unwrap();
+
+    println!("cargo:rerun-if-changed={YKLLVM_SRC_DEPEND_PATH}");
+    rerun_except(&[]).unwrap();
 
     // Build ykllvm in "target/[debug|release]". Note that the directory used here *must*
     // be exactly the same as that produced by `ykbuild/src/lib.rs:llvm_bin_dir` and
@@ -49,18 +45,6 @@ fn main() {
     }
     ykllvm_dir.push("ykllvm");
     create_dir_all(&ykllvm_dir).unwrap();
-
-    let mut cached_hash_path = ykllvm_dir.clone();
-    cached_hash_path.push("hash");
-    if cached_hash_path.exists() {
-        let cached_hash = read_to_string(&cached_hash_path).unwrap();
-        // We use trim() here because git's output -- and possibly anyone manually edits the `hash`
-        // file -- is likely to leave a trailing newline.
-        if ykllvm_hash.trim() == cached_hash.trim() {
-            // The submodule hash hasn't changed since the last build, so there's nothing to do.
-            return;
-        }
-    }
 
     // We now know we want to build ykllvm. However, cargo can -- and in release mode does! -- run
     // more than 1 copy of this build script in parallel. We thus need to make sure that we don't
@@ -82,20 +66,15 @@ fn main() {
     lock_file.lock_exclusive().unwrap();
 
     // We execute three commands, roughly:
-    //   cmake <configure>
+    //   cmake <configure> # Only needed for a fresh build
     //   cmake --build .
     //   cmake --install .
     // We have to build up the precise command in steps.
 
     let mut build_dir = ykllvm_dir.clone();
     build_dir.push("build");
-    create_dir_all(&build_dir).unwrap();
+    let fresh_build = !build_dir.is_dir();
 
-    // If ninja is available use that, otherwise use standard "make".
-    let mut generator = which("ninja")
-        .map(|_| "Ninja")
-        .unwrap_or("Unix Makefiles")
-        .to_owned();
     let mut cfg_cmd = Command::new("cmake");
     cfg_cmd
         .args([
@@ -126,6 +105,11 @@ fn main() {
         .args(["--install", "."])
         .current_dir(build_dir.as_os_str().to_str().unwrap());
 
+    // If ninja is available use that, otherwise use standard "make".
+    let mut generator = which("ninja")
+        .map(|_| "Ninja")
+        .unwrap_or("Unix Makefiles")
+        .to_owned();
     if let Ok(args) = env::var("YKB_YKLLVM_BUILD_ARGS") {
         // Caveat: this assumes no cmake argument contains a ',' or a ':'.
         for arg in args.split(',') {
@@ -145,26 +129,27 @@ fn main() {
         }
     }
 
-    cfg_cmd.arg(&format!("-G{generator}"));
-    cfg_cmd.arg(
-        canonicalize(YKLLVM_SUBMODULE_PATH)
-            .unwrap()
-            .as_os_str()
-            .to_str()
-            .unwrap(),
-    );
+    if fresh_build {
+        create_dir_all(&build_dir).unwrap();
 
-    if generator == "Unix Makefiles" {
-        build_cmd.args(["-j", num_cpus::get().to_string().as_str()]);
+        cfg_cmd.arg(&format!("-G{generator}"));
+        cfg_cmd.arg(
+            canonicalize(YKLLVM_SUBMODULE_PATH)
+                .unwrap()
+                .as_os_str()
+                .to_str()
+                .unwrap(),
+        );
+
+        if generator == "Unix Makefiles" {
+            build_cmd.args(["-j", num_cpus::get().to_string().as_str()]);
+        }
+
+        cfg_cmd.status().unwrap().exit_ok().unwrap();
     }
 
-    cfg_cmd.status().unwrap().exit_ok().unwrap();
     build_cmd.status().unwrap().exit_ok().unwrap();
     inst_cmd.status().unwrap().exit_ok().unwrap();
-
-    // We only update the hash if we're successful: if we're not successful, we expect that the
-    // user will change something in the wider environment and expect us to rerun things.
-    write(cached_hash_path, ykllvm_hash).unwrap();
 
     // We don't particularly need to unlock manually, but this might help the OS clean the lock up
     // sooner (Windows suggests that if a process leaves it to the OS to do the unlocking


### PR DESCRIPTION
If ykbuild detects changed/untracked files in the bundled ykllvm, it automatically triggers a rebuild. This makes quickly fiddling with the bundled ykllvm easier because you don't have to remember to manually force a ykllvm rebuild.

This commit does not affect those using "external" ykllvm's specified with `YKB_YKLLVM_BIN_DIR`.