### PR TITLE
Rerun the build script, and possibly even configure, if env vars changes

### DIFF
--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -3,19 +3,38 @@
 use fs4::FileExt;
 use rerun_except::rerun_except;
 use std::{
+    collections::HashMap,
     env,
-    fs::{canonicalize, create_dir_all, File},
+    fs::{canonicalize, create_dir_all, read_to_string, write, File},
     path::Path,
     process::Command,
 };
 use which::which;
 
+/// The path where we store "KEY=VALUE" pairs for environment variables relevant to ykbuild.
+const ENV_VARS_LEAF: &str = "yk_env_vars";
+/// Which environment variables need to be cached, as changes in their value require us to
+/// rerun the full cmake configure process?
+const ENV_VARS_RERUN: &[&str] = &[
+    "CC",
+    "CFLAGS",
+    "CXX",
+    "CPPFLAGS",
+    "LD",
+    "LDFLAGS",
+    "YKB_YKLLVM_BIN_DIR",
+    "YKB_YKLLVM_BUILD_ARGS",
+];
 /// The path we use to determine which ykllvm files will cause this build.rs file to be rerun.
 const YKLLVM_SRC_DEPEND_PATH: &str = "../ykllvm";
 /// The path we use to determine that the ykllvm submodule has been cloned.
 const YKLLVM_SUBMODULE_PATH: &str = "../ykllvm/llvm";
 
 fn main() {
+    for k in ENV_VARS_RERUN {
+        println!("cargo:rerun-if-env-changed={}", k);
+    }
+
     // If the user defines YKB_YKLLVM_BIN_DIR then we don't try to build ykllvm ourselves.
     if env::var("YKB_YKLLVM_BIN_DIR").is_ok() {
         return;
@@ -66,14 +85,35 @@ fn main() {
     lock_file.lock_exclusive().unwrap();
 
     // We execute three commands, roughly:
-    //   cmake <configure> # Only needed for a fresh build
+    //   cmake <configure> # Can be skipped in some cases
     //   cmake --build .
     //   cmake --install .
     // We have to build up the precise command in steps.
 
     let mut build_dir = ykllvm_dir.clone();
     build_dir.push("build");
-    let fresh_build = !build_dir.is_dir();
+
+    let mut cached_env_vars = ykllvm_dir.clone();
+    cached_env_vars.push(ENV_VARS_LEAF);
+    let run_cfg_cmd = if cached_env_vars.exists() {
+        let mut new_vars = HashMap::new();
+        for k in ENV_VARS_RERUN {
+            new_vars.insert((*k).to_owned(), env::var(k).unwrap_or("".to_owned()));
+        }
+        let mut cached_vars = HashMap::new();
+        for l in read_to_string(&cached_env_vars).unwrap().lines() {
+            let l = l.trim();
+            if l.is_empty() {
+                continue;
+            }
+            let v = l.splitn(2, '=').collect::<Vec<_>>();
+            assert_eq!(v.len(), 2);
+            cached_vars.insert(v[0].to_owned(), v[1].to_owned());
+        }
+        new_vars != cached_vars
+    } else {
+        true
+    };
 
     let mut cfg_cmd = Command::new("cmake");
     cfg_cmd
@@ -129,7 +169,7 @@ fn main() {
         }
     }
 
-    if fresh_build {
+    if run_cfg_cmd {
         create_dir_all(&build_dir).unwrap();
 
         cfg_cmd.arg(&format!("-G{generator}"));
@@ -150,6 +190,14 @@ fn main() {
 
     build_cmd.status().unwrap().exit_ok().unwrap();
     inst_cmd.status().unwrap().exit_ok().unwrap();
+
+    // We only update the env_vars if we're successful: if we're not successful, we expect that the
+    // user will change something in the wider environment and expect us to rerun things.
+    let env_vars = ENV_VARS_RERUN
+        .iter()
+        .map(|k| format!("{k}={}", env::var(k).unwrap_or_else(|_| "".to_owned())))
+        .collect::<Vec<String>>();
+    write(cached_env_vars, env_vars.join("\n")).unwrap();
 
     // We don't particularly need to unlock manually, but this might help the OS clean the lock up
     // sooner (Windows suggests that if a process leaves it to the OS to do the unlocking


### PR DESCRIPTION
`cargo` automatically rebuilds Rust projects if relevant environment variables change.

This PR brings that same idea to ykbuild: if you change `CC`/`CFLAGS`/`YKB_YKLLVM_BUILD_ARGS` (etc etc), ykbuild automatically reruns `cmake <configure>` as well as `cmake`. The aim is to make editing the inbuilt ykllvm easy to do without making mistakes. In order to do this, we have to cache "key=value" pairs in
`target/<debug|release>/yk_env_vars`.

AFAICS, this largely removes the need for `YKB_YKLLVM_BIN_DIR` while developing, though using that is still supported as before.