### PR TITLE
Use mold in CI

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -3,11 +3,13 @@ ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci
 RUN apt-get update && \
 apt-get -y install clang-15 make curl procps file git cmake python3 \
-    libtinfo-dev libzip-dev ninja-build
+    libtinfo-dev libzip-dev mold ninja-build
 RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 999
 RUN update-alternatives --set cc /usr/bin/clang-15
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 999
 RUN update-alternatives --set c++ /usr/bin/clang++-15
+RUN update-alternatives --install /usr/bin/ld ld /usr/bin/mold 999
+RUN update-alternatives --set ld /usr/bin/mold
 RUN ln -sf /usr/bin/clang-15 /usr/bin/clang
 RUN ln -sf /usr/bin/clang++-15 /usr/bin/clang++
 WORKDIR /ci


### PR DESCRIPTION
For docker, we can force the use of mold, but normal users might try running `.buildbot.sh` on machines which have neither it or lld, so search for the best, and accept the system ld as a backup option.