### PR TITLE
Basic support for outputting JIT stats.

### DIFF
--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -1,5 +1,16 @@
 # Debugging.
 
+## JIT statistics
+
+At the end of an interpreter run, yk can print out some simple statistics about
+what happened during execution. If the `YKD_JITSTATS=<path>` environment
+variable is defined, then JSON statistics will be written to the file at
+`<path>` once the interpreter "drops" the `YkMt` instance. `-` (i.e. a single
+dash) can be used in place of path, in which case the statistics will be
+written to `stderr`. Note that if the interpreter starts multiple yk instances,
+then statistics will be written (and, probably, overwritten) to `<file>`.
+
+
 ## Debugging JITted code.
 
 Often you will find the need to inspect JITted code with a debugger. If the

--- a/tests/c/jitstats1.c
+++ b/tests/c/jitstats1.c
@@ -1,0 +1,35 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_JITSTATS=/dev/stderr
+//   stderr:
+//     {
+//       "traces_collected_ok": 1,
+//       "traces_collected_err": 0,
+//       "traces_compiled_ok": 1,
+//       "traces_compiled_err": 0
+//     }
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+    YkMT *mt = yk_mt_new(NULL);
+    yk_mt_hot_threshold_set(mt, 0);
+    YkLocation loc = yk_location_new();
+
+    int i = 4;
+    NOOPT_VAL(loc);
+    NOOPT_VAL(i);
+    while (i > 0) {
+        yk_mt_control_point(mt, &loc);
+        fprintf(stdout, "i=%d\n", i);
+        i--;
+    }
+    yk_location_drop(loc);
+    yk_mt_drop(mt);
+    return (EXIT_SUCCESS);
+}

--- a/tests/c/jitstats2.c
+++ b/tests/c/jitstats2.c
@@ -1,0 +1,69 @@
+// ignore: Shadow stack not supported on non-main threads.
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_JITSTATS=/dev/stderr
+//   stderr:
+//     {
+//       "traces_collected_ok": 1,
+//       "traces_collected_err": 1,
+//       "traces_compiled_ok": 1,
+//       "traces_compiled_err": 0
+//     }
+
+// Notice that this test is not itself tested, because of the "ignore" at the
+// top!
+
+#include <assert.h>
+#include <err.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+struct S {
+    YkLocation *loc;
+    YkMT *mt;
+    uint8_t i;
+};
+
+void *main_loop(void *arg) {
+    struct S *s = (struct S*) arg;
+    while (true) {
+      yk_mt_control_point(s->mt, s->loc);
+      if (s->i == 0)
+        return NULL;
+      fprintf(stdout, "i=%d\n", s->i);
+      s->i--;
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    YkMT *mt = yk_mt_new(NULL);
+    yk_mt_hot_threshold_set(mt, 0);
+    YkLocation loc = yk_location_new();
+
+    // Thread t1 will try tracing the loop and return before a full loop has
+    // occurred...
+    pthread_t t1;
+    struct S t1_data = { &loc, mt, 0 };
+    if (pthread_create(&t1, NULL, main_loop, (void *) &t1_data) != 0)
+        err(EXIT_FAILURE, "pthread_create");
+    pthread_join(t1, NULL);
+
+    // ...so when t2 tries tracing the loop it will realise there was a
+    // recording error.
+    pthread_t t2;
+    struct S t2_data = { &loc, mt, 1 };
+    if (pthread_create(&t2, NULL, main_loop, (void *) &t2_data) != 0)
+        err(EXIT_FAILURE, "pthread_create");
+
+    pthread_join(t2, NULL);
+
+    yk_location_drop(loc);
+    yk_mt_drop(mt);
+    return (EXIT_SUCCESS);
+}

--- a/tests/c/jitstats3.c
+++ b/tests/c/jitstats3.c
@@ -1,0 +1,34 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_JITSTATS=/dev/stderr
+//   stderr:
+//     {
+//       "traces_collected_ok": 1,
+//       "traces_collected_err": 0,
+//       "traces_compiled_ok": 0,
+//       "traces_compiled_err": 1
+//     }
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+    YkMT *mt = yk_mt_new(NULL);
+    yk_mt_hot_threshold_set(mt, 0);
+    YkLocation loc = yk_location_new();
+
+    for (int i = 0; i < 2; i += 1) {
+        yk_mt_control_point(mt, &loc);
+        jmp_buf env;
+        setjmp(env);
+    }
+
+    yk_location_drop(loc);
+    yk_mt_drop(mt);
+    return (EXIT_SUCCESS);
+}

--- a/ykrt/src/jitstats.rs
+++ b/ykrt/src/jitstats.rs
@@ -1,0 +1,103 @@
+#[cfg(not(test))]
+use std::env;
+use std::{fs, ops::DerefMut, sync::Mutex};
+
+pub(crate) struct JitStats {
+    inner: Option<Mutex<JitStatsInner>>,
+}
+
+struct JitStatsInner {
+    /// The path to write output. If exactly equal to `-`, output will be written to stderr.
+    output_path: String,
+    /// How many traces were collected successfully?
+    traces_collected_ok: u64,
+    /// How many traces were collected unsuccessfully?
+    traces_collected_err: u64,
+    /// How many traces were compiled successfully?
+    traces_compiled_ok: u64,
+    /// How many traces were compiled unsuccessfully?
+    traces_compiled_err: u64,
+}
+
+impl JitStats {
+    #[cfg(not(test))]
+    pub fn new() -> Self {
+        if let Ok(p) = env::var("YKD_JITSTATS") {
+            Self {
+                inner: Some(Mutex::new(JitStatsInner::new(p))),
+            }
+        } else {
+            Self { inner: None }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new() -> Self {
+        Self {
+            inner: Some(Mutex::new(JitStatsInner::new("-".to_string()))),
+        }
+    }
+
+    fn lock<F, T>(&self, f: F) -> Option<T>
+    where
+        F: FnOnce(&mut JitStatsInner) -> T,
+    {
+        self.inner
+            .as_ref()
+            .map(|x| f(x.lock().unwrap().deref_mut()))
+    }
+
+    pub fn trace_collected_ok(&self) {
+        self.lock(|inner| inner.traces_collected_ok += 1);
+    }
+
+    pub fn trace_collected_err(&self) {
+        self.lock(|inner| inner.traces_collected_err += 1);
+    }
+
+    pub fn trace_compiled_ok(&self) {
+        self.lock(|inner| inner.traces_compiled_ok += 1);
+    }
+
+    pub fn trace_compiled_err(&self) {
+        self.lock(|inner| inner.traces_compiled_err += 1);
+    }
+}
+
+impl JitStatsInner {
+    fn new(output_path: String) -> Self {
+        Self {
+            output_path,
+            traces_collected_ok: 0,
+            traces_collected_err: 0,
+            traces_compiled_ok: 0,
+            traces_compiled_err: 0,
+        }
+    }
+
+    fn to_json(&self) -> String {
+        let traces_collected_ok = self.traces_collected_ok;
+        let traces_collected_err = self.traces_collected_err;
+        let traces_compiled_ok = self.traces_compiled_ok;
+        let traces_compiled_err = self.traces_compiled_err;
+        format!(
+            r#"{{
+    "traces_collected_ok": {traces_collected_ok},
+    "traces_collected_err": {traces_collected_err},
+    "traces_compiled_ok": {traces_compiled_ok},
+    "traces_compiled_err": {traces_compiled_err}
+}}"#
+        )
+    }
+}
+
+impl Drop for JitStatsInner {
+    fn drop(&mut self) {
+        let json = self.to_json();
+        if self.output_path == "-" {
+            eprintln!("{json}");
+        } else {
+            fs::write(&self.output_path, json).ok();
+        }
+    }
+}

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod deopt;
 mod frame;
+mod jitstats;
 mod location;
 pub(crate) mod mt;
 pub mod trace;


### PR DESCRIPTION
Setting the environment variable `YKD_JITSTATS` to a file path or `-` (which outputs to stderr) outputs JSON with stats about the yk compilation process. For example:

```
$ YKD_SERIALISE_COMPILATION=1 YKD_JITSTATS=- src/lua tests/db.lua
testing debug library and debug information
+
testing inspection of parameters/returned values
+
+
testing traceback sizes
testing debug functions on chunk without debug info
OK
{
    "traces_recorded_ok": 11,
    "traces_recorded_err": 0,
    "traces_compiled_ok": 10,
    "traces_compiled_err": 1
}
```

This commit is very much a "first stab to see if this looks like the sort of thing we want" rather than "here is a complete thing". That doesn't mean it's not useful already, but it clearly only captures a tiny amount of the information we might like to see captured.