### PR TITLE
Record basic timing information in `JITStats`.

### DIFF
--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -1,17 +1,6 @@
-# Debugging.
+# Debugging
 
-## JIT statistics
-
-At the end of an interpreter run, yk can print out some simple statistics about
-what happened during execution. If the `YKD_JITSTATS=<path>` environment
-variable is defined, then JSON statistics will be written to the file at
-`<path>` once the interpreter "drops" the `YkMt` instance. `-` (i.e. a single
-dash) can be used in place of path, in which case the statistics will be
-written to `stderr`. Note that if the interpreter starts multiple yk instances,
-then statistics will be written (and, probably, overwritten) to `<file>`.
-
-
-## Debugging JITted code.
+## Debugging JITted code
 
 Often you will find the need to inspect JITted code with a debugger. If the
 problem trace comes from a C test (i.e. one of the test cases under `tests/c`),

--- a/docs/src/dev/profiling.md
+++ b/docs/src/dev/profiling.md
@@ -1,13 +1,67 @@
 # Profiling
 
-This section describes how best to profile yk (and its consumers).
+This section describes how best to profile yk and interpreters.
+
+
+## JIT statistics
+
+At the end of an interpreter run, yk can print out some simple statistics about
+what happened during execution. If the `YKD_JITSTATS=<path>` environment
+variable is defined, then JSON statistics will be written to the file at
+`<path>` once the interpreter "drops" the `YkMt` instance. `-` (i.e. a single
+dash) can be used in place of path, in which case the statistics will be
+written to `stderr`. Note that if the interpreter starts multiple yk instances,
+then the contents of `<file>` are undefined (at best the file will be
+nondeterministically overwritten as instances are "dropped", but output may
+be interleaved, or otherwise bizarre).
+
+Output from `YKD_JITATS` looks as follows:
+
+```
+{                                       
+    "duration_compiling": 5.5219,                                               
+    "duration_deopting": 2.2638,
+    "duration_jit_executing": 0.2,
+    "duration_outside_yk": 0.142,
+    "duration_trace_mapping": 3.3797,                                           
+    "traces_collected_err": 0,                                                  
+    "traces_collected_ok": 11,                                                  
+    "traces_compiled_err": 1,
+    "traces_compiled_ok": 10                                                    
+}
+```
+
+Fields and their meaning are as follows:
+
+ * `duration_compiling`. Float, seconds. How long was spent compiling traces?
+ * `duration_deopting`. Float, seconds. How long was spent deoptimising from
+   failed guards?
+ * `duration_jit_executing`. Float, seconds. How long was spent executing JIT
+   compiled code?
+ * `duration_outside_yk`. Float, seconds. How long was spent outside yk? This
+   is a proxy for "how much time was spent in the interpreter", but is inherently
+   an over-approximation because we can't truly know exactly what the system
+   outside Yk counts as "interpreting" or not. For example, if an interpreter
+   thread puts itself to sleep, we will still count it as time spent
+   "outside yk".
+ * `duration_trace_mapping`. Float, seconds. How long was spent mapping a "raw"
+   trace to compiler-ready IR?
+ * `traces_collected_err`. Unsigned integer. How many traces were collected
+   unsuccessfully?
+ * `traces_collected_ok`. Unsigned integer. How many traces were collected
+   successfully?
+ * `traces_compiled_err`. Unsigned integer. How many traces were compiled
+   unsuccessfully?
+ * `traces_compiled_ok`. Unsigned integer. How many traces were compiled
+   successfully?
+
+
+## Perf
 
 Note that `yk-config --cflags` includes `-Wl,--no-rosegment`, which [gives
 better profiling
 information](https://github.com/flamegraph-rs/flamegraph#cargo-flamegraph) for
 binaries linked with `lld` (as all yk C interpreters are). 
-
-## Perf
 
 One way to view profile data is with perf.
 
@@ -26,7 +80,7 @@ versions of `perf` [may fix
 this](https://eighty-twenty.org/2021/09/09/perf-addr2line-speed-improvement),
 but at the time of writing, the `perf` included in Debian is slow).
 
-## Flame graphs
+### Flame graphs
 
 The most convenient way to make a flame graph is to use the Rust
 [`flamegraph`](https://github.com/flamegraph-rs/flamegraph) tool.

--- a/tests/c/jitstats1.c
+++ b/tests/c/jitstats1.c
@@ -3,10 +3,12 @@
 //   env-var: YKD_JITSTATS=/dev/stderr
 //   stderr:
 //     {
-//       "traces_collected_ok": 1,
+//       ...
 //       "traces_collected_err": 0,
-//       "traces_compiled_ok": 1,
-//       "traces_compiled_err": 0
+//       "traces_collected_ok": 1,
+//       "traces_compiled_err": 0,
+//       "traces_compiled_ok": 1
+//       ...
 //     }
 
 #include <assert.h>

--- a/tests/c/jitstats1.c
+++ b/tests/c/jitstats1.c
@@ -19,19 +19,19 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-    YkMT *mt = yk_mt_new(NULL);
-    yk_mt_hot_threshold_set(mt, 0);
-    YkLocation loc = yk_location_new();
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
 
-    int i = 4;
-    NOOPT_VAL(loc);
-    NOOPT_VAL(i);
-    while (i > 0) {
-        yk_mt_control_point(mt, &loc);
-        fprintf(stdout, "i=%d\n", i);
-        i--;
-    }
-    yk_location_drop(loc);
-    yk_mt_drop(mt);
-    return (EXIT_SUCCESS);
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stdout, "i=%d\n", i);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
 }

--- a/tests/c/jitstats2.c
+++ b/tests/c/jitstats2.c
@@ -26,46 +26,46 @@
 #include <yk_testing.h>
 
 struct S {
-    YkLocation *loc;
-    YkMT *mt;
-    uint8_t i;
+  YkLocation *loc;
+  YkMT *mt;
+  uint8_t i;
 };
 
 void *main_loop(void *arg) {
-    struct S *s = (struct S*) arg;
-    while (true) {
-      yk_mt_control_point(s->mt, s->loc);
-      if (s->i == 0)
-        return NULL;
-      fprintf(stdout, "i=%d\n", s->i);
-      s->i--;
-    }
-    return NULL;
+  struct S *s = (struct S *)arg;
+  while (true) {
+    yk_mt_control_point(s->mt, s->loc);
+    if (s->i == 0)
+      return NULL;
+    fprintf(stdout, "i=%d\n", s->i);
+    s->i--;
+  }
+  return NULL;
 }
 
 int main(int argc, char **argv) {
-    YkMT *mt = yk_mt_new(NULL);
-    yk_mt_hot_threshold_set(mt, 0);
-    YkLocation loc = yk_location_new();
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
 
-    // Thread t1 will try tracing the loop and return before a full loop has
-    // occurred...
-    pthread_t t1;
-    struct S t1_data = { &loc, mt, 0 };
-    if (pthread_create(&t1, NULL, main_loop, (void *) &t1_data) != 0)
-        err(EXIT_FAILURE, "pthread_create");
-    pthread_join(t1, NULL);
+  // Thread t1 will try tracing the loop and return before a full loop has
+  // occurred...
+  pthread_t t1;
+  struct S t1_data = {&loc, mt, 0};
+  if (pthread_create(&t1, NULL, main_loop, (void *)&t1_data) != 0)
+    err(EXIT_FAILURE, "pthread_create");
+  pthread_join(t1, NULL);
 
-    // ...so when t2 tries tracing the loop it will realise there was a
-    // recording error.
-    pthread_t t2;
-    struct S t2_data = { &loc, mt, 1 };
-    if (pthread_create(&t2, NULL, main_loop, (void *) &t2_data) != 0)
-        err(EXIT_FAILURE, "pthread_create");
+  // ...so when t2 tries tracing the loop it will realise there was a
+  // recording error.
+  pthread_t t2;
+  struct S t2_data = {&loc, mt, 1};
+  if (pthread_create(&t2, NULL, main_loop, (void *)&t2_data) != 0)
+    err(EXIT_FAILURE, "pthread_create");
 
-    pthread_join(t2, NULL);
+  pthread_join(t2, NULL);
 
-    yk_location_drop(loc);
-    yk_mt_drop(mt);
-    return (EXIT_SUCCESS);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
 }

--- a/tests/c/jitstats2.c
+++ b/tests/c/jitstats2.c
@@ -4,10 +4,12 @@
 //   env-var: YKD_JITSTATS=/dev/stderr
 //   stderr:
 //     {
-//       "traces_collected_ok": 1,
+//       ...
 //       "traces_collected_err": 1,
-//       "traces_compiled_ok": 1,
-//       "traces_compiled_err": 0
+//       "traces_collected_ok": 1,
+//       "traces_compiled_err": 0,
+//       "traces_compiled_ok": 1
+//       ...
 //     }
 
 // Notice that this test is not itself tested, because of the "ignore" at the

--- a/tests/c/jitstats3.c
+++ b/tests/c/jitstats3.c
@@ -3,10 +3,12 @@
 //   env-var: YKD_JITSTATS=/dev/stderr
 //   stderr:
 //     {
-//       "traces_collected_ok": 1,
+//       ...
 //       "traces_collected_err": 0,
-//       "traces_compiled_ok": 0,
-//       "traces_compiled_err": 1
+//       "traces_collected_ok": 1,
+//       "traces_compiled_err": 1,
+//       "traces_compiled_ok": 0
+//       ...
 //     }
 
 #include <assert.h>

--- a/tests/c/jitstats3.c
+++ b/tests/c/jitstats3.c
@@ -20,17 +20,17 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-    YkMT *mt = yk_mt_new(NULL);
-    yk_mt_hot_threshold_set(mt, 0);
-    YkLocation loc = yk_location_new();
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
 
-    for (int i = 0; i < 2; i += 1) {
-        yk_mt_control_point(mt, &loc);
-        jmp_buf env;
-        setjmp(env);
-    }
+  for (int i = 0; i < 2; i += 1) {
+    yk_mt_control_point(mt, &loc);
+    jmp_buf env;
+    setjmp(env);
+  }
 
-    yk_location_drop(loc);
-    yk_mt_drop(mt);
-    return (EXIT_SUCCESS);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
 }

--- a/ykrt/src/jitstats.rs
+++ b/ykrt/src/jitstats.rs
@@ -1,6 +1,21 @@
+/// This module records statistics about Yk and the VM it is part of. The accuracy of the
+/// statistics varies: in general, the statistics about yk's internals are accurate, but
+/// interactions with the wider interpreter are likely to be approximations, because we can only
+/// guess at what the interpreter is doing. For example, when an interpreter spins up a thread,
+/// does that count as "time spent interpreting"? What happens if it's a job queue that immediately
+/// goes to sleep? In such cases, we are very much in "best effort" territory -- but it's better
+/// than nothing!
+
 #[cfg(not(test))]
 use std::env;
-use std::{fs, ops::DerefMut, sync::Mutex};
+use std::{
+    cell::Cell,
+    fs,
+    ops::DerefMut,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+use strum::{Display, EnumCount, EnumIter, IntoEnumIterator};
 
 pub(crate) struct JitStats {
     inner: Option<Mutex<JitStatsInner>>,
@@ -17,6 +32,7 @@ struct JitStatsInner {
     traces_compiled_ok: u64,
     /// How many traces were compiled unsuccessfully?
     traces_compiled_err: u64,
+    durations: [Duration; TimingState::COUNT],
 }
 
 impl JitStats {
@@ -62,6 +78,17 @@ impl JitStats {
     pub fn trace_compiled_err(&self) {
         self.lock(|inner| inner.traces_compiled_err += 1);
     }
+
+    /// Change the [TimingState] the current thread is in.
+    pub fn timing_state(&self, new_state: TimingState) {
+        self.lock(|inner| {
+            let now = Instant::now();
+            let (prev_state, then) = VM_STATE.replace((new_state, now));
+            let d = now.saturating_duration_since(then);
+            inner.durations[prev_state as usize] =
+                inner.durations[prev_state as usize].saturating_add(d);
+        });
+    }
 }
 
 impl JitStatsInner {
@@ -72,21 +99,49 @@ impl JitStatsInner {
             traces_collected_err: 0,
             traces_compiled_ok: 0,
             traces_compiled_err: 0,
+            durations: [Duration::new(0, 0); TimingState::COUNT],
         }
     }
 
     fn to_json(&self) -> String {
-        let traces_collected_ok = self.traces_collected_ok;
-        let traces_collected_err = self.traces_collected_err;
-        let traces_compiled_ok = self.traces_compiled_ok;
-        let traces_compiled_err = self.traces_compiled_err;
+        fn fmt_duration(d: Duration) -> String {
+            format!("{}.{}", d.as_secs(), d.as_millis())
+        }
+
+        let mut fields = vec![
+            (
+                "traces_collected_ok".to_owned(),
+                self.traces_collected_ok.to_string(),
+            ),
+            (
+                "traces_collected_err".to_owned(),
+                self.traces_collected_err.to_string(),
+            ),
+            (
+                "traces_compiled_ok".to_owned(),
+                self.traces_compiled_ok.to_string(),
+            ),
+            (
+                "traces_compiled_err".to_owned(),
+                self.traces_compiled_err.to_string(),
+            ),
+        ];
+        for v in TimingState::iter() {
+            let s = v.to_string();
+            if !s.is_empty() {
+                fields.push((s, fmt_duration(self.durations[v as usize])));
+            }
+        }
+        fields.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
         format!(
             r#"{{
-    "traces_collected_ok": {traces_collected_ok},
-    "traces_collected_err": {traces_collected_err},
-    "traces_compiled_ok": {traces_compiled_ok},
-    "traces_compiled_err": {traces_compiled_err}
-}}"#
+    {}
+}}"#,
+            fields
+                .iter()
+                .map(|(x, y)| format!(r#""{x}": {y}"#))
+                .collect::<Vec<_>>()
+                .join(",\n    ")
         )
     }
 }
@@ -100,4 +155,41 @@ impl Drop for JitStatsInner {
             fs::write(&self.output_path, json).ok();
         }
     }
+}
+
+/// The different timing states a VM can go through.
+#[repr(u8)]
+#[derive(Copy, Clone, Display, EnumCount, EnumIter)]
+// You can add new states to this with the following notes:
+//   1. `TimingState` must be `repr(T)` where `T` is an integer that can be convert with `as usize`
+//      without loss of information.
+//   2. The variants range from `0..TimingState::COUNT`. In other words, don't assign numbers to
+//      any of the variants with `= <int>`!
+//   2. Any new state has a `strum` `to_string` that produces the name of the key that will appear
+//      in the JSON stats. If `to_string` produces the empty string, that value will not appear in
+//      the JSON stats.
+pub(crate) enum TimingState {
+    /// The "we don't know what this thread is doing" state. Time spent in this state is not
+    /// counted towards anything and is not displayed to the user.
+    #[strum(to_string = "")]
+    None,
+    /// This thread is compiling a mapped trace.
+    #[strum(to_string = "duration_compiling")]
+    Compiling,
+    /// This thread is deoptimising from a guard failure.
+    #[strum(to_string = "duration_deopting")]
+    Deopting,
+    /// This thread is executing machine code compiled by yk.
+    #[strum(to_string = "duration_jit_executing")]
+    JitExecuting,
+    /// This thread is executing code outside yk (roughly "in the interpreter").
+    #[strum(to_string = "duration_outside_yk")]
+    OutsideYk,
+    /// This thread is mapping a trace into IR.
+    #[strum(to_string = "duration_trace_mapping")]
+    TraceMapping,
+}
+
+thread_local! {
+    static VM_STATE: Cell<(TimingState, Instant)> = Cell::new((TimingState::OutsideYk, Instant::now()));
 }

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(test, feature(test))]
 #![feature(lazy_cell)]
+#![feature(local_key_cell_methods)]
 #![feature(naked_functions)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]


### PR DESCRIPTION
This records the time spent in various VM states (compiling, deopting, interpreting, JIT executing) and shows it in `JITStats` output (in seconds). The "interpreting" state is an over-approximation, because we don't know what the interpreter is doing: if a thread puts itself to sleep, we will count that as execution time. These times are thus "best efforts" rather than "guaranteed to be perfect". They do, however, already tell a very interesting story:

```
$ YKD_SERIALISE_COMPILATION=1 YKD_JITSTATS=- src/lua tests/db.lua
testing debug library and debug information
+
testing inspection of parameters/returned values
+
+
testing traceback sizes
testing debug functions on chunk without debug info
OK
{
    "traces_collected_ok": 11,
    "traces_collected_err": 0,
    "traces_compiled_ok": 10,
    "traces_compiled_err": 1,
    "duration_compiling": 9.9087,
    "duration_deopting": 2.2660,
    "duration_interpreting": 0.144,
    "duration_jit_executing": 0.2
}
```