### PR TITLE
Cache the stackmap of a compiled trace.

### DIFF
--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -192,12 +192,8 @@ extern "C" fn ts_reconstruct(ctx: *mut c_void, module: LLVMModuleRef) -> LLVMErr
 
     let mut framerec = unsafe { FrameReconstructor::new(activeframes, module) };
 
-    // Parse the stackmap of the JIT module.
-    // OPT: Parsing the stackmap and initialising `framerec` is slow and could be heavily reduced
-    // by caching the result.
-    let slice = unsafe { slice::from_raw_parts(ctr.smptr as *mut u8, ctr.smsize) };
-    let map = StackMapParser::parse(slice).unwrap();
-    let live_vars = map.get(&retaddr.try_into().unwrap()).unwrap();
+    // Retrieve the live variables for this guard from this trace's stackmap.
+    let live_vars = ctr.smap.get(&retaddr.try_into().unwrap()).unwrap();
 
     // Extract live values from the stackmap.
     // Skip first live variable that contains 3 unrelated locations (CC, Flags, Num Deopts).


### PR DESCRIPTION
Reading out the entire trace's stackmap each time a guard fails is slow, especially, since we only need a small part of that stackmap. We could either modify the stackmap parser to only read the part that is relevant for the current guard failure, or we read the entire stackmap immediately after compiling the trace and store it alongside it inside `CompiledTrace`. The latter has the advantage of moving the stackmap parsing from deopt to inside the compilation thread.

Storing the result of the parsed stackmap also means we no longer need to keep the original stackmap data around which can now be freed, squashing another memory leak that was on our todo list for a while.