### PR TITLE
Count how often traces are executed.

### DIFF
--- a/docs/src/dev/profiling.md
+++ b/docs/src/dev/profiling.md
@@ -46,6 +46,8 @@ Fields and their meaning are as follows:
    "outside yk".
  * `duration_trace_mapping`. Float, seconds. How long was spent mapping a "raw"
    trace to compiler-ready IR?
+ * `trace_executions`. Unsigned integer. How many times have traces been
+   executed? Note that the same trace can count arbitrarily many times to this.
  * `traces_collected_err`. Unsigned integer. How many traces were collected
    unsuccessfully?
  * `traces_collected_ok`. Unsigned integer. How many traces were collected

--- a/tests/c/jitstats1.c
+++ b/tests/c/jitstats1.c
@@ -4,6 +4,7 @@
 //   stderr:
 //     {
 //       ...
+//       "trace_executions": 1,
 //       "traces_collected_err": 0,
 //       "traces_collected_ok": 1,
 //       "traces_compiled_err": 0,

--- a/tests/c/jitstats2.c
+++ b/tests/c/jitstats2.c
@@ -5,6 +5,7 @@
 //   stderr:
 //     {
 //       ...
+//       "trace_executions": 1,
 //       "traces_collected_err": 1,
 //       "traces_collected_ok": 1,
 //       "traces_compiled_err": 0,

--- a/tests/c/jitstats3.c
+++ b/tests/c/jitstats3.c
@@ -4,6 +4,7 @@
 //   stderr:
 //     {
 //       ...
+//       "trace_executions": 0,
 //       "traces_collected_err": 0,
 //       "traces_collected_ok": 1,
 //       "traces_compiled_err": 1,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -173,6 +173,7 @@ impl MT {
             TransitionLocation::Execute(ctr) => {
                 #[cfg(feature = "yk_jitstate_debug")]
                 print_jit_state("enter-jit-code");
+                self.jitstats.trace_executed();
                 self.jitstats.timing_state(TimingState::JitExecuting);
 
                 unsafe {


### PR DESCRIPTION
This gives some sense of the average time each trace spends in execution.