### PR TITLE
Format `Duration`s properly.

### DIFF
--- a/ykrt/src/jitstats.rs
+++ b/ykrt/src/jitstats.rs
@@ -105,7 +105,7 @@ impl JitStatsInner {
 
     fn to_json(&self) -> String {
         fn fmt_duration(d: Duration) -> String {
-            format!("{}.{}", d.as_secs(), d.as_millis())
+            format!("{}.{:03}", d.as_secs(), d.subsec_millis())
         }
 
         let mut fields = vec![


### PR DESCRIPTION
This little line contained two amusing mistakes:

  1. It showed the number after the separator in seconds, not milliseconds. So "3.45"s was formatted as "3.345".

  2. Sub-100ms times were shown without padding. So "0.002" was shown as "0.2".

This commit fixes both, and I will hang my head in shame for not spotting either earlier!