### PR TITLE
Rename `JITStats`.

### DIFF
--- a/docs/src/dev/profiling.md
+++ b/docs/src/dev/profiling.md
@@ -6,7 +6,7 @@ This section describes how best to profile yk and interpreters.
 ## JIT statistics
 
 At the end of an interpreter run, yk can print out some simple statistics about
-what happened during execution. If the `YKD_JITSTATS=<path>` environment
+what happened during execution. If the `YKD_STATS=<path>` environment
 variable is defined, then JSON statistics will be written to the file at
 `<path>` once the interpreter "drops" the `YkMt` instance. `-` (i.e. a single
 dash) can be used in place of path, in which case the statistics will be
@@ -15,7 +15,7 @@ then the contents of `<file>` are undefined (at best the file will be
 nondeterministically overwritten as instances are "dropped", but output may
 be interleaved, or otherwise bizarre).
 
-Output from `YKD_JITATS` looks as follows:
+Output from `YKD_STATS` looks as follows:
 
 ```
 {                                       

--- a/tests/c/stats1.c
+++ b/tests/c/stats1.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_JITSTATS=/dev/stderr
+//   env-var: YKD_STATS=-
 //   stderr:
 //     {
 //       ...

--- a/tests/c/stats2.c
+++ b/tests/c/stats2.c
@@ -1,7 +1,7 @@
 // ignore: Shadow stack not supported on non-main threads.
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_JITSTATS=/dev/stderr
+//   env-var: YKD_STATS=-
 //   stderr:
 //     {
 //       ...

--- a/tests/c/stats3.c
+++ b/tests/c/stats3.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_JITSTATS=/dev/stderr
+//   env-var: YKD_STATS=-
 //   stderr:
 //     {
 //       ...

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -4,7 +4,7 @@
 use crate::frame::{BitcodeSection, FrameReconstructor, LLVMGetThreadSafeModule};
 #[cfg(feature = "yk_jitstate_debug")]
 use crate::print_jit_state;
-use crate::{jitstats::TimingState, trace::CompiledTrace};
+use crate::{trace::CompiledTrace, ykstats::TimingState};
 use llvm_sys::orc2::LLVMOrcThreadSafeModuleWithModuleDo;
 use llvm_sys::{
     error::{LLVMCreateStringError, LLVMErrorRef},
@@ -276,7 +276,7 @@ unsafe extern "C" fn __ykrt_deopt(
 
     #[cfg(feature = "yk_jitstate_debug")]
     print_jit_state("deoptimise");
-    ctr.mt.jitstats.timing_state(TimingState::Deopting);
+    ctr.mt.stats.timing_state(TimingState::Deopting);
 
     // FIXME: Check here if we have a side trace and execute it. Otherwise just increment the guard
     // failure counter.
@@ -302,7 +302,7 @@ unsafe extern "C" fn __ykrt_deopt(
     // pass in variables from this scope via a struct which is passed into the function.
     LLVMOrcThreadSafeModuleWithModuleDo(moduleref, ts_reconstruct, infoptr as *mut c_void);
 
-    ctr.mt.jitstats.timing_state(TimingState::OutsideYk);
+    ctr.mt.stats.timing_state(TimingState::OutsideYk);
     info.nfi.unwrap()
 }
 

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -9,10 +9,10 @@
 
 mod deopt;
 mod frame;
-mod jitstats;
 mod location;
 pub(crate) mod mt;
 pub mod trace;
+mod ykstats;
 
 pub use self::location::Location;
 pub use self::mt::{HotThreshold, MT};


### PR DESCRIPTION
In retrospect this is too narrow a name. Internally the struct is now `YkStats` and the external environment names is `YKD_STATS`.