### PR TITLE
Mark locations that cause "too long" traces as `DontTrace`.

### DIFF
--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -31,6 +31,8 @@ pub enum HWTracerError {
     NoMorePackets,
     /// The trace was interrupted by an asynchronous event.
     TraceInterrupted,
+    /// The trace was too long
+    TraceTooLong,
     /// Any other error.
     Custom(Box<dyn Error>),
 }
@@ -56,6 +58,7 @@ impl Display for HWTracerError {
             HWTracerError::NoMorePackets => write!(f, "End of packet stream"),
             HWTracerError::DisasmFail(ref s) => write!(f, "failed to disassemble: {}", s),
             HWTracerError::TraceInterrupted => write!(f, "trace interrupted"),
+            HWTracerError::TraceTooLong => write!(f, "trace too long"),
             HWTracerError::Unknown => write!(f, "Unknown error"),
         }
     }
@@ -81,6 +84,7 @@ impl Error for HWTracerError {
             HWTracerError::NoMorePackets => None,
             HWTracerError::DisasmFail(_) => None,
             HWTracerError::TraceInterrupted => None,
+            HWTracerError::TraceTooLong => None,
         }
     }
 }

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -147,7 +147,10 @@ impl<'a> HWTMapper {
     ) -> Result<Vec<IRBlock>, HWTracerError> {
         let mut ret: Vec<IRBlock> = Vec::new();
 
-        for block in &mut trace_iter {
+        for (i, block) in &mut trace_iter.enumerate() {
+            if i > crate::mt::DEFAULT_TRACE_TOO_LONG {
+                return Err(HWTracerError::TraceTooLong);
+            }
             let block = block?;
             let irblocks = self.map_block(&block);
             if irblocks.is_empty() {


### PR DESCRIPTION
Once traces get beyond a certain size, the time for mapping and compilation becomes ever more punishing. For example, with yklua and db.lua, one trace in particular takes 6 seconds to map and compile because the PT trace generates 250,000 blocks!

This commit very crudely implements "abort compilation when a trace is too long". After a very quick experiment, 5000 blocks seemed a reasonable threshold, in the sense that a threshold of 10,000 blocks can end up with LLVM compilation becoming very slower. I don't know if compilation slows down linearly or not as the number of blocks increases, but the small numbers I have suggest it is superlinear. It looks like the mapping phase but that's misleading because "mapping" includes "mapping" and "IR generation" -- the latter seems to be the main slowdown.

Not only does this commit stop compiling a trace if it's too long, but it marks the `HotLocation` as `DontTrace` so there won't be an attempt to make a second trace. We should probably do something more RPython-esque such as "wait for a location to fail 5 times before marking it as DontTrace", but given how slow mapping and compilation are, we'll probably end up having to have a lower threshold.

The effect on db.lua and tpack.lua is noticable. Before this commit, db.lua:

```
"duration_compiling": 4.978,
"duration_deopting": 0.314,
"duration_jit_executing": 0.002,
"duration_outside_yk": 0.137,
"duration_trace_mapping": 3.709,
"trace_executions": 771,
"traces_collected_err": 0,
"traces_collected_ok": 11,
"traces_compiled_err": 1,
"traces_compiled_ok": 10
YKD_SERIALISE_COMPILATION=1 YKD_STATS=- src/lua tests/db.lua  9.24s user 0.14s system 98% cpu 9.475 total
```

After:

```
"duration_compiling": 4.955,
"duration_deopting": 0.313,
"duration_jit_executing": 0.001,
"duration_outside_yk": 0.145,
"duration_trace_mapping": 0.766,
"trace_executions": 771,
"traces_collected_err": 0,
"traces_collected_ok": 11,
"traces_compiled_err": 1,
"traces_compiled_ok": 10
YKD_SERIALISE_COMPILATION=1 YKD_STATS=- src/lua tests/db.lua  6.29s user 0.13s system 98% cpu 6.534 total
```

And tpack.lua before:

```
"duration_compiling": 13.403,
"duration_deopting": 0.055,
"duration_jit_executing": 0.000,
"duration_outside_yk": 0.087,
"duration_trace_mapping": 2.841,
"trace_executions": 5,
"traces_collected_err": 0,
"traces_collected_ok": 8,
"traces_compiled_err": 2,
"traces_compiled_ok": 6
YKD_SERIALISE_COMPILATION=1 YKD_STATS=- src/lua tests/tpack.lua  16.32s user 0.18s system 99% cpu 16.615 total
```

And tpack.lua after:

```
"duration_compiling": 13.345,
"duration_deopting": 0.055,
"duration_jit_executing": 0.000,
"duration_outside_yk": 0.080,
"duration_trace_mapping": 1.258,
"trace_executions": 5,
"traces_collected_err": 0,
"traces_collected_ok": 8,
"traces_compiled_err": 2,
"traces_compiled_ok": 6
YKD_SERIALISE_COMPILATION=1 YKD_STATS=- src/lua tests/tpack.lua  14.68s user 0.17s system 99% cpu 14.933 total
```