### PR TITLE
Remove `unsafe impl`s

### DIFF
--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -172,7 +172,7 @@ extern "C" fn ts_reconstruct(ctx: *mut c_void, module: LLVMModuleRef) -> LLVMErr
 
     // Find the relevant AOT variables for this deopt in the AOT variables section.
     let aotvalsptr =
-        unsafe { (ctr.aotvals as *const u8).offset(isize::try_from(aotvals.offset).unwrap()) };
+        unsafe { (ctr.aotvals() as *const u8).offset(isize::try_from(aotvals.offset).unwrap()) };
 
     // Parse the live AOT values.
     let aotvals = unsafe { slice::from_raw_parts(aotvalsptr as *const AOTVar, aotvals.length) };

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -178,11 +178,11 @@ impl MT {
 
                 unsafe {
                     #[cfg(feature = "yk_testing")]
-                    assert_ne!(ctr.entry as *const (), std::ptr::null());
+                    assert_ne!(ctr.entry() as *const (), std::ptr::null());
                     let f = mem::transmute::<
                         _,
                         unsafe extern "C" fn(*mut c_void, *const CompiledTrace, *const c_void) -> !,
-                    >(ctr.entry);
+                    >(ctr.entry());
                     // FIXME: Calling this function overwrites the current (Rust) function frame,
                     // rather than unwinding it. https://github.com/ykjit/yk/issues/778
                     f(ctrlp_vars, Arc::into_raw(ctr), frameaddr);

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -105,9 +105,6 @@ pub struct IRTrace {
     faddrs: HashMap<CString, *const c_void>,
 }
 
-unsafe impl Send for IRTrace {}
-unsafe impl Sync for IRTrace {}
-
 impl IRTrace {
     pub fn new(blocks: Vec<IRBlock>, faddrs: HashMap<CString, *const c_void>) -> Self {
         debug_assert!(blocks.len() < usize::MAX);


### PR DESCRIPTION
This PR removes two dodgy `unsafe impl Sync/Send`s. The first (https://github.com/ykjit/yk/commit/9d7bff4faf1a2c8e158c8ccbfd2e8bd998b004e4) is no longer needed. The second (https://github.com/ykjit/yk/commit/1e70fc9fa6c246cf3ce50fe5291d83e4115c2de9) is a bit more work, but arguably more important.