### PR TITLE
Add a `Compiler` trait to allow us to have multiple JIT compilers.

### DIFF
--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -1,3 +1,5 @@
 pub fn main() {
     ykbuild::apply_llvm_ld_library_path();
+
+    println!("cargo:rustc-cfg=jitc_llvm");
 }

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -1,0 +1,24 @@
+//! An LLVM JIT backend. Currently a minimal wrapper around the fact that [IRTrace]s are hardcoded
+//! to be compiled with LLVM.
+
+use crate::{compile::Compiler, trace::IRTrace};
+use libc::c_void;
+use std::{error::Error, sync::Arc};
+use tempfile::NamedTempFile;
+
+pub(crate) struct JITCLLVM;
+
+impl JITCLLVM {
+    pub(crate) fn new() -> Result<Arc<Self>, Box<dyn Error>> {
+        Ok(Arc::new(JITCLLVM))
+    }
+}
+
+impl Compiler for JITCLLVM {
+    fn compile(
+        &self,
+        irtrace: IRTrace,
+    ) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>> {
+        irtrace.compile()
+    }
+}

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -1,0 +1,26 @@
+use crate::trace::IRTrace;
+use libc::c_void;
+use std::{error::Error, sync::Arc};
+use tempfile::NamedTempFile;
+
+#[cfg(jitc_llvm)]
+mod jitc_llvm;
+
+/// The trait that every JIT compiler backend must implement.
+pub(crate) trait Compiler: Send + Sync {
+    /// Compile an [IRTrace] into machine code.
+    fn compile(
+        &self,
+        irtrace: IRTrace,
+    ) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>>;
+}
+
+pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, Box<dyn Error>> {
+    #[cfg(jitc_llvm)]
+    {
+        return Ok(jitc_llvm::JITCLLVM::new()?);
+    }
+
+    #[allow(unreachable_code)]
+    Err("No JIT compiler supported on this platform/configuration.".into())
+}

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]
 
+mod compile;
 mod deopt;
 mod frame;
 mod location;

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -19,6 +19,7 @@ use std::{
 pub mod hwt;
 use tempfile::NamedTempFile;
 use yksmp::{LiveVar, StackMapParser};
+#[cfg(not(test))]
 use ykutil::obj::llvmbc_section;
 
 use crate::mt::MT;
@@ -161,6 +162,15 @@ impl IRTrace {
         (di_tmp, di_fd, di_tmpname_c)
     }
 
+    #[cfg(test)]
+    pub fn compile(&self) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>> {
+        // llvmbc_section is only defined when ykllvm is used to compile code: rustc doesn't use
+        // ykllvm, so in testing mode we end up getting a linking error with the "main" `compile`
+        // method just below this one. Simply stubbing out `compile` is a horrible hack.
+        panic!("This code cannot be compiled in test mode because it uses llvmbc_section");
+    }
+
+    #[cfg(not(test))]
     pub fn compile(&self) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>> {
         let (func_names, bbs, trace_len) = self.encode_trace();
 


### PR DESCRIPTION
This commit minimally adds a `Compiler` trait which will in the future allow us to swap between different JIT compilers. At the moment this is slightly farcical because `IRTrace` `compile`s itself, and that `compile` method assumes an LLVM backend. This commit isn't aiming to fix that -- though hopefully we'll do so soon! -- but having a trait seems the right first step towards separating out the different concerns.