### PR TITLE
Move more of the LLVM JIT compiler code into `jitc_llvm.rs`.

### DIFF
--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -2,23 +2,162 @@
 //! to be compiled with LLVM.
 
 use crate::{compile::Compiler, trace::IRTrace};
-use libc::c_void;
-use std::{error::Error, sync::Arc};
+use libc::{c_void, dlsym};
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+use std::{
+    env,
+    error::Error,
+    ffi::{c_char, c_int, CString},
+    ptr,
+    sync::Arc,
+};
 use tempfile::NamedTempFile;
 
 pub(crate) struct JITCLLVM;
-
-impl JITCLLVM {
-    pub(crate) fn new() -> Result<Arc<Self>, Box<dyn Error>> {
-        Ok(Arc::new(JITCLLVM))
-    }
-}
 
 impl Compiler for JITCLLVM {
     fn compile(
         &self,
         irtrace: IRTrace,
     ) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>> {
-        irtrace.compile()
+        let (func_names, bbs, trace_len) = self.encode_trace(&irtrace);
+
+        let mut faddr_keys = Vec::new();
+        let mut faddr_vals = Vec::new();
+        for k in irtrace.faddrs.iter() {
+            faddr_keys.push(k.0.as_ptr());
+            faddr_vals.push(*k.1);
+        }
+
+        let (llvmbc_data, llvmbc_len) = llvmbc_section();
+        let (di_tmp, di_fd, di_tmpname_c) = Self::create_debuginfo_temp_file();
+
+        let ret = unsafe {
+            yktracec::__yktracec_irtrace_compile(
+                func_names.as_ptr(),
+                bbs.as_ptr(),
+                trace_len,
+                faddr_keys.as_ptr(),
+                faddr_vals.as_ptr(),
+                faddr_keys.len(),
+                llvmbc_data,
+                llvmbc_len,
+                di_fd,
+                di_tmpname_c,
+            )
+        };
+        if ret.is_null() {
+            Err("Could not compile trace.".into())
+        } else {
+            Ok((ret, di_tmp))
+        }
     }
+
+    #[cfg(feature = "yk_testing")]
+    unsafe fn compile_for_tc_tests(
+        &self,
+        irtrace: IRTrace,
+        llvmbc_data: *const u8,
+        llvmbc_len: u64,
+    ) {
+        let (func_names, bbs, trace_len) = self.encode_trace(&irtrace);
+        let (_di_tmp, di_fd, di_tmpname_c) = Self::create_debuginfo_temp_file();
+
+        // These would only need to be populated if we were to load the resulting compiled code
+        // into the address space, which for trace compiler tests, we don't.
+        let faddr_keys = Vec::new();
+        let faddr_vals = Vec::new();
+
+        let ret = yktracec::__yktracec_irtrace_compile_for_tc_tests(
+            func_names.as_ptr(),
+            bbs.as_ptr(),
+            trace_len,
+            faddr_keys.as_ptr(),
+            faddr_vals.as_ptr(),
+            faddr_keys.len(),
+            llvmbc_data,
+            llvmbc_len,
+            di_fd,
+            di_tmpname_c,
+        );
+        assert_ne!(ret, ptr::null());
+    }
+}
+
+impl JITCLLVM {
+    pub(crate) fn new() -> Result<Arc<Self>, Box<dyn Error>> {
+        Ok(Arc::new(JITCLLVM))
+    }
+
+    fn encode_trace(&self, irtrace: &IRTrace) -> (Vec<*const i8>, Vec<usize>, usize) {
+        let trace_len = irtrace.len();
+        let mut func_names = Vec::with_capacity(trace_len);
+        let mut bbs = Vec::with_capacity(trace_len);
+        for blk in &irtrace.blocks {
+            if blk.is_unmappable() {
+                // The block was unmappable. Indicate this with a null function name and the block
+                // index encodes the stack adjustment value.
+                func_names.push(ptr::null());
+                // Subtle cast from `isize` to `usize`. `as` is used deliberately here to preserve
+                // the exact bit pattern. The consumer on the other side of the FFI knows to
+                // reverse this.
+                bbs.push(blk.stack_adjust() as usize);
+            } else {
+                func_names.push(blk.func_name().as_ptr());
+                bbs.push(blk.bb());
+            }
+        }
+        (func_names, bbs, trace_len)
+    }
+
+    // If necessary, create a temporary file for us to write the trace's debugging "source code"
+    // into. Elsewhere, the JIT module will have `DebugLoc`s inserted into it which will point to
+    // lines in this temporary file.
+    //
+    // If the `YKD_TRACE_DEBUGINFO` environment variable is set to "1", then this function returns
+    // a `NamedTempFile`, a non-negative file descriptor, and a path to the file.
+    //
+    // If the `YKD_TRACE_DEBUGINFO` environment variable is *not* set to "1", then no file is
+    // created and this function returns `(None, -1, ptr::null())`.
+    #[cfg(unix)]
+    fn create_debuginfo_temp_file() -> (Option<NamedTempFile>, c_int, *const c_char) {
+        let mut di_tmp = None;
+        let mut di_fd = -1;
+        let mut di_tmpname_c = ptr::null() as *const c_char;
+        if let Ok(di_val) = env::var("YKD_TRACE_DEBUGINFO") {
+            if di_val == "1" {
+                let tmp = NamedTempFile::new().unwrap();
+                di_tmpname_c = tmp.path().to_str().unwrap().as_ptr() as *const c_char;
+                di_fd = tmp.as_raw_fd();
+                di_tmp = Some(tmp);
+            }
+        }
+        (di_tmp, di_fd, di_tmpname_c)
+    }
+}
+
+/// The `llvm.embedded.module` symbol in the `.llvmbc` section.
+#[repr(C)]
+struct EmbeddedModule {
+    /// The length of the bitcode.
+    len: u64,
+    /// The start of the bitcode itself.
+    first_byte_of_bitcode: u8,
+}
+
+/// Returns a pointer to (and the size of) the raw LLVM bitcode in the current address space.
+pub(crate) fn llvmbc_section() -> (*const u8, u64) {
+    // ykllvm adds the `SHF_ALLOC` flag to the `.llvmbc` section so that the loader puts it into
+    // our address space at load time.
+    let bc = unsafe {
+        &*(dlsym(
+            std::ptr::null_mut(),
+            CString::new("llvm.embedded.module")
+                .unwrap()
+                .as_c_str()
+                .as_ptr(),
+        ) as *const EmbeddedModule)
+    };
+    (&bc.first_byte_of_bitcode as *const u8, bc.len)
 }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -1,21 +1,30 @@
-use crate::trace::IRTrace;
+use crate::{mt::MT, trace::IRTrace};
 use libc::c_void;
-use std::{error::Error, sync::Arc};
+use std::{collections::HashMap, error::Error, fmt, slice, sync::Arc};
 use tempfile::NamedTempFile;
+use yksmp::{LiveVar, StackMapParser};
 
 #[cfg(jitc_llvm)]
-mod jitc_llvm;
+pub(crate) mod jitc_llvm;
 
 /// The trait that every JIT compiler backend must implement.
-pub(crate) trait Compiler: Send + Sync {
+pub trait Compiler: Send + Sync {
     /// Compile an [IRTrace] into machine code.
     fn compile(
         &self,
         irtrace: IRTrace,
     ) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>>;
+
+    #[cfg(feature = "yk_testing")]
+    unsafe fn compile_for_tc_tests(
+        &self,
+        irtrace: IRTrace,
+        llvmbc_data: *const u8,
+        llvmbc_len: u64,
+    );
 }
 
-pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, Box<dyn Error>> {
+pub fn default_compiler() -> Result<Arc<dyn Compiler>, Box<dyn Error>> {
     #[cfg(jitc_llvm)]
     {
         return Ok(jitc_llvm::JITCLLVM::new()?);
@@ -23,4 +32,110 @@ pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, Box<dyn Error>> {
 
     #[allow(unreachable_code)]
     Err("No JIT compiler supported on this platform/configuration.".into())
+}
+
+struct SendSyncConstPtr<T>(*const T);
+unsafe impl<T> Send for SendSyncConstPtr<T> {}
+unsafe impl<T> Sync for SendSyncConstPtr<T> {}
+
+struct Guard {
+    failed: u32,
+    code: Option<SendSyncConstPtr<c_void>>,
+}
+
+/// A trace compiled into machine code. Note that these are passed around as raw pointers and
+/// potentially referenced by multiple threads so, once created, instances of this struct can only
+/// be updated if a lock is held or a field is atomic.
+pub struct CompiledTrace {
+    pub mt: Arc<MT>,
+    /// A function which when called, executes the compiled trace.
+    ///
+    /// The argument to the function is a pointer to a struct containing the live variables at the
+    /// control point. The exact definition of this struct is not known to Rust: the struct is
+    /// generated at interpreter compile-time by ykllvm.
+    entry: SendSyncConstPtr<c_void>,
+    /// Parsed stackmap of this trace. We only need to read this once, and can then use it to
+    /// lookup stackmap information for each guard failure as needed.
+    pub smap: HashMap<u64, Vec<LiveVar>>,
+    /// Pointer to heap allocated live AOT values.
+    aotvals: SendSyncConstPtr<c_void>,
+    /// List of guards containing hotness counts or compiled side traces.
+    guards: Vec<Option<Guard>>,
+    /// If requested, a temporary file containing the "source code" for the trace, to be shown in
+    /// debuggers when stepping over the JITted code.
+    ///
+    /// (rustc incorrectly identifies this field as dead code. Although it isn't being "used", the
+    /// act of storing it is preventing the deletion of the file via its `Drop`)
+    #[allow(dead_code)]
+    di_tmpfile: Option<NamedTempFile>,
+}
+
+impl CompiledTrace {
+    /// Create a `CompiledTrace` from a pointer to an array containing: the pointer to the compiled
+    /// trace, the pointer to the stackmap and the size of the stackmap, and the pointer to the
+    /// live AOT values.
+    pub fn new(mt: Arc<MT>, data: *const c_void, di_tmpfile: Option<NamedTempFile>) -> Self {
+        let slice = unsafe { slice::from_raw_parts(data as *const usize, 5) };
+        let funcptr = slice[0] as *const c_void;
+        let smptr = slice[1] as *const c_void;
+        let smsize = slice[2];
+        let aotvals = slice[3] as *mut c_void;
+        let guardcount = slice[4] as usize;
+
+        // Parse the stackmap of this trace and cache it. The original data allocated by memman.cc
+        // is now no longer needed and can be freed.
+        let smslice = unsafe { slice::from_raw_parts(smptr as *mut u8, smsize) };
+        let smap = StackMapParser::parse(smslice).unwrap();
+        unsafe { libc::munmap(smptr as *mut c_void, smsize) };
+
+        // We heap allocated this array in yktracec to pass the data here. Now that we've
+        // extracted it we no longer need to keep the array around.
+        unsafe { libc::free(data as *mut c_void) };
+        Self {
+            mt,
+            entry: SendSyncConstPtr(funcptr),
+            smap,
+            aotvals: SendSyncConstPtr(aotvals),
+            di_tmpfile,
+            guards: Vec::with_capacity(guardcount),
+        }
+    }
+
+    #[cfg(any(test, feature = "yk_testing"))]
+    #[doc(hidden)]
+    /// Create a `CompiledTrace` with null contents. This is unsafe and only intended for testing
+    /// purposes where a `CompiledTrace` instance is required, but cannot sensibly be constructed
+    /// without overwhelming the test. The resulting instance must not be inspected or executed.
+    pub unsafe fn new_null(mt: Arc<MT>) -> Self {
+        Self {
+            mt,
+            entry: SendSyncConstPtr(std::ptr::null()),
+            smap: HashMap::new(),
+            aotvals: SendSyncConstPtr(std::ptr::null()),
+            di_tmpfile: None,
+            guards: Vec::new(),
+        }
+    }
+
+    pub fn aotvals(&self) -> *const c_void {
+        self.aotvals.0
+    }
+
+    pub fn entry(&self) -> *const c_void {
+        self.entry.0
+    }
+}
+
+impl Drop for CompiledTrace {
+    fn drop(&mut self) {
+        // The memory holding the AOT live values needs to live as long as the trace. Now that we
+        // no longer need the trace, this can be freed too.
+        unsafe { libc::free(self.aotvals.0 as *mut c_void) };
+    }
+}
+
+impl fmt::Debug for CompiledTrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CompiledTrace {{ ... }}")
+    }
 }

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -4,7 +4,7 @@
 use crate::frame::{BitcodeSection, FrameReconstructor, __yktracec_get_aot_module};
 #[cfg(feature = "yk_jitstate_debug")]
 use crate::print_jit_state;
-use crate::{trace::CompiledTrace, ykstats::TimingState};
+use crate::{compile::CompiledTrace, ykstats::TimingState};
 use llvm_sys::orc2::LLVMOrcThreadSafeModuleWithModuleDo;
 use llvm_sys::{
     error::{LLVMCreateStringError, LLVMErrorRef},
@@ -294,7 +294,7 @@ unsafe extern "C" fn __ykrt_deopt(
 
     let infoptr = Box::into_raw(Box::new(&mut info));
 
-    let (data, len) = ykutil::obj::llvmbc_section();
+    let (data, len) = crate::compile::jitc_llvm::llvmbc_section();
     let moduleref = __yktracec_get_aot_module(&BitcodeSection { data, len });
 
     // The LLVM CAPI doesn't allow us to manually lock/unlock a ThreadSafeModule, and uses a

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -2,12 +2,13 @@
 
 #![cfg_attr(test, feature(test))]
 #![feature(lazy_cell)]
+#![feature(link_llvm_intrinsics)]
 #![feature(local_key_cell_methods)]
 #![feature(naked_functions)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]
 
-mod compile;
+pub mod compile;
 mod deopt;
 mod frame;
 mod location;

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use crate::{
+    compile::CompiledTrace,
     mt::{HotThreshold, TraceFailureThreshold, MT},
-    trace::CompiledTrace,
 };
 use parking_lot::Mutex;
 

--- a/yktracec/src/lib.rs
+++ b/yktracec/src/lib.rs
@@ -1,7 +1,6 @@
 // Exporting parts of the LLVM C++ API not present in the LLVM C API.
 
 #![allow(clippy::new_without_default)]
-#![feature(local_key_cell_methods)]
 #![feature(c_variadic)]
 
 // FIXME: C++ exceptions may unwind over the Rust FFI?

--- a/ykutil/src/obj.rs
+++ b/ykutil/src/obj.rs
@@ -131,25 +131,3 @@ pub static SELF_BIN_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let info = dladdr(addr as usize).unwrap(); // ptr to usize cast always safe.
     PathBuf::from(info.dli_fname().unwrap().to_str().unwrap())
 });
-
-/// The `llvm.embedded.module` symbol in the `.llvmbc` section.
-#[repr(C)]
-struct EmbeddedModule {
-    /// The length of the bitcode.
-    len: u64,
-    /// The start of the bitcode itself.
-    first_byte_of_bitcode: u8,
-}
-
-// ykllvm adds the `SHF_ALLOC` flag to the `.llvmbc` section so that the loader puts it into our
-// address space at load time.
-extern "C" {
-    #[link_name = "llvm.embedded.module"]
-    static LLVMBC: EmbeddedModule;
-}
-
-/// Returns a pointer to (and the size of) the raw LLVM bitcode in the current address space.
-pub fn llvmbc_section() -> (*const u8, u64) {
-    let bc = unsafe { &LLVMBC };
-    (&bc.first_byte_of_bitcode as *const u8, bc.len)
-}


### PR DESCRIPTION
At a high-level, this commit inlines the call to `irtrace.compile` in:

```rust
impl Compiler for JITCLLVM {
    fn compile(
        &self,
        irtrace: IRTrace,
    ) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>> {
      irtrace.compile()
    }
}
```

That has various knock-on effects which somewhat drown this out. Mostly these are rather minor, but note that `llvmbc_section`:

  1. Moves from ykutil to ykrt.
  2. Moves from using linker hacks to `dlsym` (I couldn't get the linker hacks to work with the rest of this commit).

Interestingly, this commit indirectly makes clearer the depth of the assumption that "LLVM is our only JIT", for example in deopting. That should help us continue to refactor things.