### PR TITLE
There's no need to store a `Tracer` object.

### DIFF
--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -45,7 +45,7 @@ impl ThreadTracer for HWTThreadTracer {
 struct PTTrace(Box<dyn hwtracer::Trace>);
 
 impl UnmappedTrace for PTTrace {
-    fn map(self: Box<Self>, _tracer: Arc<dyn Tracer>) -> Result<MappedTrace, InvalidTraceError> {
+    fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError> {
         let tdec = TraceDecoderBuilder::new().build().unwrap();
         let mut itr = tdec.iter_blocks(self.0.as_ref());
         let mut mt = HWTMapper::new();

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -139,5 +139,5 @@ pub trait ThreadTracer {
 }
 
 pub trait UnmappedTrace: Send {
-    fn map(self: Box<Self>, tracer: Arc<dyn Tracer>) -> Result<MappedTrace, InvalidTraceError>;
+    fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError>;
 }


### PR DESCRIPTION
When we start tracing, all we need to remember is the `ThreadTracer`. If a `ThreadTracer` (or a mapper) wants access to the `Tracer` (e.g. for shared caching), it can store that instance itself because the `Tracer` is `self: Arc<Self>` and can thus store/pass references to itself.

[*Why* this was in the code I no longer remember. I suspect it was needed at some point in the past and no longer is. But, perhaps, it was never needed!]