### PR TITLE
Rename "unmapped" to "raw"

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -27,7 +27,7 @@ use crate::print_jit_state;
 use crate::{
     compile::{default_compiler, CompiledTrace, Compiler},
     location::{HotLocation, HotLocationKind, Location, TraceFailed},
-    trace::{default_tracer, ThreadTracer, Tracer, UnmappedTrace},
+    trace::{default_tracer, RawTrace, ThreadTracer, Tracer},
     ykstats::{TimingState, YkStats},
 };
 use yktracec::promote;
@@ -379,7 +379,7 @@ impl MT {
     /// Add a compilation job for `utrace` to the global work queue.
     fn queue_compile_job(
         self: &Arc<Self>,
-        utrace: Box<dyn UnmappedTrace>,
+        utrace: Box<dyn RawTrace>,
         hl_arc: Arc<Mutex<HotLocation>>,
     ) {
         self.stats.trace_collected_ok();

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,6 +1,6 @@
 //! Hardware tracing via ykrustc.
 
-use super::{errors::InvalidTraceError, MappedTrace, ThreadTracer, Tracer, UnmappedTrace};
+use super::{errors::InvalidTraceError, MappedTrace, RawTrace, ThreadTracer, Tracer};
 use hwtracer::decode::TraceDecoderBuilder;
 use std::{error::Error, sync::Arc};
 
@@ -34,7 +34,7 @@ struct HWTThreadTracer {
 }
 
 impl ThreadTracer for HWTThreadTracer {
-    fn stop_collector(self: Box<Self>) -> Result<Box<dyn UnmappedTrace>, InvalidTraceError> {
+    fn stop_collector(self: Box<Self>) -> Result<Box<dyn RawTrace>, InvalidTraceError> {
         match self.thread_tracer.stop_collector() {
             Ok(t) => Ok(Box::new(PTTrace(t))),
             Err(e) => todo!("{e:?}"),
@@ -44,7 +44,7 @@ impl ThreadTracer for HWTThreadTracer {
 
 struct PTTrace(Box<dyn hwtracer::Trace>);
 
-impl UnmappedTrace for PTTrace {
+impl RawTrace for PTTrace {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError> {
         let tdec = TraceDecoderBuilder::new().build().unwrap();
         let mut itr = tdec.iter_blocks(self.0.as_ref());

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -46,6 +46,10 @@ pub trait ThreadTracer {
     fn stop_collector(self: Box<Self>) -> Result<Box<dyn RawTrace>, InvalidTraceError>;
 }
 
+/// A raw trace resulting from a tracer.
+///
+/// Depending on the backend: the raw trace may need considerable processing to convert into basic
+/// block addresses; or it may contain those basic block addresses in an easily digestible fashion.
 pub trait RawTrace: Send {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError>;
 }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -43,10 +43,10 @@ pub fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 /// Represents a thread which is currently tracing.
 pub trait ThreadTracer {
     /// Stop collecting a trace of the current thread.
-    fn stop_collector(self: Box<Self>) -> Result<Box<dyn UnmappedTrace>, InvalidTraceError>;
+    fn stop_collector(self: Box<Self>) -> Result<Box<dyn RawTrace>, InvalidTraceError>;
 }
 
-pub trait UnmappedTrace: Send {
+pub trait RawTrace: Send {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError>;
 }
 


### PR DESCRIPTION
This PR (mostly) moves us from "unmapped" (which as https://github.com/ykjit/yk/commit/86e38dadc875e38d9aaf61db1279b617e95280fe explains is ambiguous) to "raw" as terminology for "the direct output of a tracer (e.g. Intel PT)".