### PR TITLE
Remove `TraceDecoderBuilder`.

### DIFF
--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -877,15 +877,12 @@ fn is_ret_near(inst: &iced_x86::Instruction) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        collect::default_tracer_for_platform,
-        decode::{test_helpers, TraceDecoderKind},
-    };
+    use crate::{collect::default_tracer_for_platform, decode::test_helpers};
 
     #[ignore] // FIXME
     #[test]
     fn ten_times_as_many_blocks() {
         let tc = default_tracer_for_platform().unwrap();
-        test_helpers::ten_times_as_many_blocks(tc, TraceDecoderKind::YkPT);
+        test_helpers::ten_times_as_many_blocks(tc);
     }
 }

--- a/tests/benches/collect_and_decode.c
+++ b/tests/benches/collect_and_decode.c
@@ -43,7 +43,7 @@ __attribute__((noinline)) uint64_t disasm(uint64_t iters) {
   return res;
 }
 
-void collect_and_decode(int benchmark, size_t param, int decoder_kind) {
+void collect_and_decode(int benchmark, size_t param) {
   uint64_t res;
 
   void *tc = __hwykpt_start_collector();
@@ -57,17 +57,17 @@ void collect_and_decode(int benchmark, size_t param, int decoder_kind) {
   void *trace = __hwykpt_stop_collector(tc);
   NOOPT_VAL(res);
 
-  __hwykpt_decode_trace(trace, decoder_kind);
+  __hwykpt_decode_trace(trace);
 }
 
 void usage(void) {
-  printf("args: <benchmark> <param> <decoder-kind>\n");
+  printf("args: <benchmark> <param>\n");
   exit(EXIT_FAILURE);
 }
 
 int main(int argc, char **argv) {
-  if (argc != 4)
+  if (argc != 3)
     usage();
 
-  collect_and_decode(atoi(argv[1]), atoi(argv[2]), atoi(argv[3]));
+  collect_and_decode(atoi(argv[1]), atoi(argv[2]));
 }

--- a/tests/benches/collect_and_decode.rs
+++ b/tests/benches/collect_and_decode.rs
@@ -4,7 +4,6 @@ use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
     Criterion, SamplingMode,
 };
-use hwtracer::decode::TraceDecoderKind;
 use std::{
     env,
     path::{Path, PathBuf},
@@ -36,16 +35,10 @@ fn compile_runner(tempdir: &TempDir) -> PathBuf {
     exe
 }
 
-fn collect_and_decode_trace(
-    runner: &Path,
-    benchmark: usize,
-    param: usize,
-    decoder_kind: TraceDecoderKind,
-) {
+fn collect_and_decode_trace(runner: &Path, benchmark: usize, param: usize) {
     let out = Command::new(runner)
         .arg(format!("{}", benchmark))
         .arg(format!("{}", param))
-        .arg(format!("{}", decoder_kind as u8))
         .output()
         .unwrap();
     check_output(&out);
@@ -73,7 +66,7 @@ fn bench_native(c: &mut Criterion) {
 
     for param in [1000, 10000, 100000] {
         group.bench_function(BenchmarkId::new("YkPT", format!("{}", param)), |b| {
-            b.iter(|| collect_and_decode_trace(&runner, 0, param, TraceDecoderKind::YkPT))
+            b.iter(|| collect_and_decode_trace(&runner, 0, param))
         });
     }
 }
@@ -85,7 +78,7 @@ fn bench_disasm(c: &mut Criterion) {
 
     for param in [10, 30, 50] {
         group.bench_function(BenchmarkId::new("YkPT", format!("{}", param)), |b| {
-            b.iter(|| collect_and_decode_trace(&runner, 1, param, TraceDecoderKind::YkPT))
+            b.iter(|| collect_and_decode_trace(&runner, 1, param))
         });
     }
 }

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -13,7 +13,7 @@
 
 use hwtracer::{
     collect::{default_tracer_for_platform, ThreadTracer},
-    decode::{TraceDecoderBuilder, TraceDecoderKind},
+    decode::default_decoder,
     Trace,
 };
 use std::ffi::c_void;
@@ -43,17 +43,10 @@ pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn ThreadTracer>) -> *mu
 ///
 /// Used for benchmarks.
 #[no_mangle]
-pub extern "C" fn __hwykpt_decode_trace(
-    trace: *mut Box<dyn Trace>,
-    decoder_kind: TraceDecoderKind,
-) {
+pub extern "C" fn __hwykpt_decode_trace(trace: *mut Box<dyn Trace>) {
     let trace: Box<Box<dyn Trace>> = unsafe { Box::from_raw(trace) };
 
-    let ipt_tdec = TraceDecoderBuilder::new()
-        .kind(decoder_kind)
-        .build()
-        .unwrap();
-
+    let ipt_tdec = default_decoder().unwrap();
     for b in ipt_tdec.iter_blocks(&**trace) {
         b.unwrap();
     }

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -39,4 +39,4 @@ void __yktrace_hwt_mapper_blockmap_free(void *mapper);
 void *__hwykpt_start_collector(void);
 void *__hwykpt_stop_collector(void *tc);
 void __hwykpt_libipt_vs_ykpt(void *trace);
-void __hwykpt_decode_trace(void *trace, int decoder_kind);
+void __hwykpt_decode_trace(void *trace);

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,7 +1,7 @@
 //! Hardware tracing via ykrustc.
 
 use super::{errors::InvalidTraceError, MappedTrace, RawTrace, ThreadTracer, Tracer};
-use hwtracer::decode::TraceDecoderBuilder;
+use hwtracer::decode::default_decoder;
 use std::{error::Error, sync::Arc};
 
 pub mod mapper;
@@ -46,7 +46,7 @@ struct PTTrace(Box<dyn hwtracer::Trace>);
 
 impl RawTrace for PTTrace {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError> {
-        let tdec = TraceDecoderBuilder::new().build().unwrap();
+        let tdec = default_decoder().map_err(|_| InvalidTraceError::InternalError)?;
         let mut itr = tdec.iter_blocks(self.0.as_ref());
         let mut mt = HWTMapper::new();
 


### PR DESCRIPTION
This is a lot of complexity that we currently, and probably indefinitely, have no use for. The important thing is that there is a `TraceDecoder` trait which means that it is possible to swap different decoders in/out whether or not there's a `Builder` or not.