### PR TITLE
Simpler trace decoder API

### DIFF
--- a/hwtracer/src/collect/perf/mod.rs
+++ b/hwtracer/src/collect/perf/mod.rs
@@ -4,8 +4,9 @@ use super::PerfCollectorConfig;
 use crate::{
     c_errors::PerfPTCError,
     collect::{ThreadTracer, Tracer},
+    decode::ykpt::YkPTBlockIterator,
     errors::HWTracerError,
-    Trace,
+    Block, Trace,
 };
 use libc::{c_void, free, geteuid, malloc, size_t};
 use std::{convert::TryFrom, fs::File, io::Read, slice, sync::Arc};
@@ -192,6 +193,11 @@ impl Trace for PerfTrace {
     #[cfg(test)]
     fn capacity(&self) -> usize {
         self.capacity as usize
+    }
+
+    #[cfg(decoder_ykpt)]
+    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a> {
+        Box::new(YkPTBlockIterator::new(self))
     }
 }
 

--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -1,34 +1,11 @@
 //! Trace decoders.
 
-use crate::{errors::HWTracerError, Block, Trace};
-
 #[cfg(decoder_ykpt)]
-mod ykpt;
-#[cfg(decoder_ykpt)]
-use ykpt::YkPTTraceDecoder;
-
-pub trait TraceDecoder {
-    /// Create the trace decoder.
-    fn new(trace: Box<dyn Trace>) -> Self
-    where
-        Self: Sized;
-
-    /// Iterate over the blocks of the trace.
-    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
-}
-
-/// Returns the default trace decoder for this configuration.
-pub fn default_decoder(trace: Box<dyn Trace>) -> Result<Box<dyn TraceDecoder>, HWTracerError> {
-    #[cfg(decoder_ykpt)]
-    return Ok(Box::new(YkPTTraceDecoder::new(trace)));
-    #[cfg(not(decoder_ykpt))]
-    return Err(HWTracerError::DecoderUnavailable(self.kind));
-}
+pub(crate) mod ykpt;
 
 /// Decoder agnostic tests  and helper routines live here.
 #[cfg(test)]
 mod test_helpers {
-    use super::default_decoder;
     use crate::{
         collect::{test_helpers::trace_closure, Tracer},
         work_loop,
@@ -41,8 +18,8 @@ mod test_helpers {
         let trace1 = trace_closure(&tc, || work_loop(10));
         let trace2 = trace_closure(&tc, || work_loop(100));
 
-        let ct1 = default_decoder(trace1).unwrap().iter_blocks().count();
-        let ct2 = default_decoder(trace2).unwrap().iter_blocks().count();
+        let ct1 = trace1.iter_blocks().count();
+        let ct2 = trace2.iter_blocks().count();
 
         // Should be roughly 10x more blocks in trace2. It won't be exactly 10x, due to the stuff
         // we trace either side of the loop itself. On a smallish trace, that will be significant.

--- a/hwtracer/src/decode/mod.rs
+++ b/hwtracer/src/decode/mod.rs
@@ -1,8 +1,6 @@
 //! Trace decoders.
 
 use crate::{errors::HWTracerError, Block, Trace};
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 
 #[cfg(decoder_ykpt)]
 mod ykpt;
@@ -11,21 +9,18 @@ use ykpt::YkPTTraceDecoder;
 
 pub trait TraceDecoder {
     /// Create the trace decoder.
-    fn new() -> Self
+    fn new(trace: Box<dyn Trace>) -> Self
     where
         Self: Sized;
 
     /// Iterate over the blocks of the trace.
-    fn iter_blocks<'t>(
-        &'t self,
-        trace: &'t dyn Trace,
-    ) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + '_>;
+    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
 }
 
 /// Returns the default trace decoder for this configuration.
-pub fn default_decoder() -> Result<Box<dyn TraceDecoder>, HWTracerError> {
+pub fn default_decoder(trace: Box<dyn Trace>) -> Result<Box<dyn TraceDecoder>, HWTracerError> {
     #[cfg(decoder_ykpt)]
-    return Ok(Box::new(YkPTTraceDecoder::new()));
+    return Ok(Box::new(YkPTTraceDecoder::new(trace)));
     #[cfg(not(decoder_ykpt))]
     return Err(HWTracerError::DecoderUnavailable(self.kind));
 }
@@ -33,7 +28,7 @@ pub fn default_decoder() -> Result<Box<dyn TraceDecoder>, HWTracerError> {
 /// Decoder agnostic tests  and helper routines live here.
 #[cfg(test)]
 mod test_helpers {
-    use super::{default_decoder, TraceDecoder};
+    use super::default_decoder;
     use crate::{
         collect::{test_helpers::trace_closure, Tracer},
         work_loop,
@@ -46,10 +41,8 @@ mod test_helpers {
         let trace1 = trace_closure(&tc, || work_loop(10));
         let trace2 = trace_closure(&tc, || work_loop(100));
 
-        let dec: Box<dyn TraceDecoder> = default_decoder().unwrap();
-
-        let ct1 = dec.iter_blocks(&*trace1).count();
-        let ct2 = dec.iter_blocks(&*trace2).count();
+        let ct1 = default_decoder(trace1).unwrap().iter_blocks().count();
+        let ct2 = default_decoder(trace2).unwrap().iter_blocks().count();
 
         // Should be roughly 10x more blocks in trace2. It won't be exactly 10x, due to the stuff
         // we trace either side of the loop itself. On a smallish trace, that will be significant.

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -68,18 +68,17 @@ use packet_parser::{
     PacketParser,
 };
 
-pub(crate) struct YkPTTraceDecoder {}
+pub(crate) struct YkPTTraceDecoder {
+    trace: Box<dyn Trace>,
+}
 
 impl TraceDecoder for YkPTTraceDecoder {
-    fn new() -> Self {
-        Self {}
+    fn new(trace: Box<dyn Trace>) -> Self {
+        Self { trace }
     }
 
-    fn iter_blocks<'t>(
-        &'t self,
-        trace: &'t dyn Trace,
-    ) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + '_> {
-        Box::new(YkPTBlockIterator::new(trace))
+    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a> {
+        Box::new(YkPTBlockIterator::new(&*self.trace))
     }
 }
 

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -30,6 +30,9 @@ pub trait Trace: Debug + Send {
 
     /// Get the size of the trace in bytes.
     fn len(&self) -> usize;
+
+    /// Iterate over the blocks of the trace.
+    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
 }
 
 /// A loop that does some work that we can use to build a trace.

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -46,8 +46,8 @@ pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn ThreadTracer>) -> *mu
 pub extern "C" fn __hwykpt_decode_trace(trace: *mut Box<dyn Trace>) {
     let trace: Box<Box<dyn Trace>> = unsafe { Box::from_raw(trace) };
 
-    let ipt_tdec = default_decoder().unwrap();
-    for b in ipt_tdec.iter_blocks(&**trace) {
+    let ipt_tdec = default_decoder(*trace).unwrap();
+    for b in ipt_tdec.iter_blocks() {
         b.unwrap();
     }
 }

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -13,7 +13,6 @@
 
 use hwtracer::{
     collect::{default_tracer_for_platform, ThreadTracer},
-    decode::default_decoder,
     Trace,
 };
 use std::ffi::c_void;
@@ -45,9 +44,7 @@ pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn ThreadTracer>) -> *mu
 #[no_mangle]
 pub extern "C" fn __hwykpt_decode_trace(trace: *mut Box<dyn Trace>) {
     let trace: Box<Box<dyn Trace>> = unsafe { Box::from_raw(trace) };
-
-    let ipt_tdec = default_decoder(*trace).unwrap();
-    for b in ipt_tdec.iter_blocks() {
+    for b in trace.iter_blocks() {
         b.unwrap();
     }
 }

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -2,7 +2,7 @@
 
 use crate::trace::TracedAOTBlock;
 use hwtracer::llvm_blockmap::LLVM_BLOCK_MAP;
-use hwtracer::{decode::TraceDecoder, Block, HWTracerError};
+use hwtracer::{HWTracerError, Trace};
 use libc::c_void;
 use std::{collections::HashMap, convert::TryFrom, ffi::CString};
 use ykaddr::{
@@ -143,11 +143,11 @@ impl<'a> HWTMapper {
     /// foreign "turn on tracing" routine is omitted).
     pub fn map_trace(
         &mut self,
-        tdec: Box<dyn TraceDecoder>,
+        trace: Box<dyn Trace>,
     ) -> Result<Vec<TracedAOTBlock>, HWTracerError> {
         let mut ret: Vec<TracedAOTBlock> = Vec::new();
 
-        for (i, block) in tdec.iter_blocks().enumerate() {
+        for (i, block) in trace.iter_blocks().enumerate() {
             if i > crate::mt::DEFAULT_TRACE_TOO_LONG {
                 return Err(HWTracerError::TraceTooLong);
             }

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -2,7 +2,7 @@
 
 use crate::trace::TracedAOTBlock;
 use hwtracer::llvm_blockmap::LLVM_BLOCK_MAP;
-use hwtracer::{Block, HWTracerError};
+use hwtracer::{decode::TraceDecoder, Block, HWTracerError};
 use libc::c_void;
 use std::{collections::HashMap, convert::TryFrom, ffi::CString};
 use ykaddr::{
@@ -143,11 +143,11 @@ impl<'a> HWTMapper {
     /// foreign "turn on tracing" routine is omitted).
     pub fn map_trace(
         &mut self,
-        mut trace_iter: &'a mut dyn Iterator<Item = Result<Block, HWTracerError>>,
+        tdec: Box<dyn TraceDecoder>,
     ) -> Result<Vec<TracedAOTBlock>, HWTracerError> {
         let mut ret: Vec<TracedAOTBlock> = Vec::new();
 
-        for (i, block) in &mut trace_iter.enumerate() {
+        for (i, block) in tdec.iter_blocks().enumerate() {
             if i > crate::mt::DEFAULT_TRACE_TOO_LONG {
                 return Err(HWTracerError::TraceTooLong);
             }

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -46,12 +46,11 @@ struct PTTrace(Box<dyn hwtracer::Trace>);
 
 impl RawTrace for PTTrace {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError> {
-        let tdec = default_decoder().map_err(|_| InvalidTraceError::InternalError)?;
-        let mut itr = tdec.iter_blocks(self.0.as_ref());
+        let tdec = default_decoder(self.0).map_err(|_| InvalidTraceError::InternalError)?;
         let mut mt = HWTMapper::new();
 
         let mapped = mt
-            .map_trace(&mut *itr)
+            .map_trace(tdec)
             .map_err(|_| InvalidTraceError::InternalError)?;
         if mapped.is_empty() {
             return Err(InvalidTraceError::EmptyTrace);

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,7 +1,6 @@
 //! Hardware tracing via ykrustc.
 
-use super::{errors::InvalidTraceError, MappedTrace, RawTrace, ThreadTracer, Tracer};
-use hwtracer::decode::default_decoder;
+use super::{errors::InvalidTraceError, MappedTrace, RawTrace, ThreadTracer};
 use std::{error::Error, sync::Arc};
 
 pub mod mapper;
@@ -46,11 +45,10 @@ struct PTTrace(Box<dyn hwtracer::Trace>);
 
 impl RawTrace for PTTrace {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError> {
-        let tdec = default_decoder(self.0).map_err(|_| InvalidTraceError::InternalError)?;
         let mut mt = HWTMapper::new();
 
         let mapped = mt
-            .map_trace(tdec)
+            .map_trace(self.0)
             .map_err(|_| InvalidTraceError::InternalError)?;
         if mapped.is_empty() {
             return Err(InvalidTraceError::EmptyTrace);

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -6,8 +6,6 @@
 
 mod errors;
 use libc::c_void;
-#[cfg(unix)]
-use std::os::unix::io::AsRawFd;
 use std::{
     collections::HashMap,
     error::Error,


### PR DESCRIPTION
This PR simplifies the trace decoding API. Previously, hwtracer had separate notions of a "trace" and a "trace decoder".

Although it wasn't obvious (because we only have one type of tracer and one type of decoder at the moment) this API was suboptimal because it allowed you to express at compile-time impossible combinations. For example, (let's pretend there are in fact multiple decoders!), I could have created a "PT trace" and a "CoreSight" decoder, and that would have compiled, and then done lord alone knows what at run-time. We partly solved this by forcing the client of hwtracer to know what type of trace it had created and to use the correct decoder, accidentally hardcoding details that we would have preferred to be internal to hwtracer into the client.

After a seemingly minor simplification (https://github.com/ykjit/yk/commit/4def543d4c159855251d566fc80936d41078b0bb) this PR thus moves `iter_blocks` to `Trace` itself (https://github.com/ykjit/yk/commit/1beeb8267028e2e18c4d202328b1fe1ad91f426d). There are various further simplifications / alterations we could make by going further in this direction (e.g. this PR does not give users a way of specifying which decoder they want), but I'm not yet sure which looks the most promising. This thus seems like a useful checkpoint for a PR.