### PR TITLE
Tweak trace methods

### DIFF
--- a/hwtracer/src/collect/perf/mod.rs
+++ b/hwtracer/src/collect/perf/mod.rs
@@ -180,11 +180,6 @@ impl PerfTrace {
 }
 
 impl Trace for PerfTrace {
-    /// Return the length of the trace, in bytes.
-    fn len(&self) -> usize {
-        usize::try_from(self.len).unwrap()
-    }
-
     #[cfg(decoder_ykpt)]
     fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a> {
         let bytes =
@@ -200,6 +195,11 @@ impl Trace for PerfTrace {
     #[cfg(test)]
     fn capacity(&self) -> usize {
         self.capacity as usize
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        usize::try_from(self.len).unwrap()
     }
 }
 

--- a/hwtracer/src/collect/perf/mod.rs
+++ b/hwtracer/src/collect/perf/mod.rs
@@ -192,6 +192,7 @@ impl Trace for PerfTrace {
         Box::new(YkPTBlockIterator::new(bytes))
     }
 
+    #[cfg(test)]
     fn bytes(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.buf.0, usize::try_from(self.len).unwrap()) }
     }

--- a/hwtracer/src/collect/perf/mod.rs
+++ b/hwtracer/src/collect/perf/mod.rs
@@ -180,24 +180,25 @@ impl PerfTrace {
 }
 
 impl Trace for PerfTrace {
-    /// Return the raw bytes of the trace.
-    fn bytes(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.buf.0, usize::try_from(self.len).unwrap()) }
-    }
-
     /// Return the length of the trace, in bytes.
     fn len(&self) -> usize {
         usize::try_from(self.len).unwrap()
     }
 
+    #[cfg(decoder_ykpt)]
+    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a> {
+        let bytes =
+            unsafe { slice::from_raw_parts(self.buf.0, usize::try_from(self.len).unwrap()) };
+        Box::new(YkPTBlockIterator::new(bytes))
+    }
+
+    fn bytes(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.buf.0, usize::try_from(self.len).unwrap()) }
+    }
+
     #[cfg(test)]
     fn capacity(&self) -> usize {
         self.capacity as usize
-    }
-
-    #[cfg(decoder_ykpt)]
-    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a> {
-        Box::new(YkPTBlockIterator::new(self))
     }
 }
 

--- a/hwtracer/src/decode/ykpt/mod.rs
+++ b/hwtracer/src/decode/ykpt/mod.rs
@@ -228,10 +228,10 @@ pub(crate) struct YkPTBlockIterator<'t> {
 }
 
 impl<'t> YkPTBlockIterator<'t> {
-    pub(crate) fn new(trace: &'t dyn Trace) -> Self {
+    pub(crate) fn new(trace: &'t [u8]) -> Self {
         let mut this = YkPTBlockIterator {
             next: Cell::new(Ok(Block::new_unknown())),
-            parser: PacketParser::new(trace.bytes()),
+            parser: PacketParser::new(trace),
             cur_loc: ObjLoc::OtherObjOrUnknown(None),
             tnts: VecDeque::new(),
             comprets: CompressedReturns::new(),

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -28,6 +28,7 @@ pub trait Trace: Debug + Send {
     /// Iterate over the blocks of the trace.
     fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
 
+    #[cfg(test)]
     fn bytes(&self) -> &[u8];
 
     /// Get the capacity of the trace in bytes.

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -22,17 +22,17 @@ use std::time::SystemTime;
 ///
 /// Each trace decoder has its own concrete implementation.
 pub trait Trace: Debug + Send {
-    fn bytes(&self) -> &[u8];
-
-    /// Get the capacity of the trace in bytes.
-    #[cfg(test)]
-    fn capacity(&self) -> usize;
-
     /// Get the size of the trace in bytes.
     fn len(&self) -> usize;
 
     /// Iterate over the blocks of the trace.
     fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
+
+    fn bytes(&self) -> &[u8];
+
+    /// Get the capacity of the trace in bytes.
+    #[cfg(test)]
+    fn capacity(&self) -> usize;
 }
 
 /// A loop that does some work that we can use to build a trace.

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -22,9 +22,6 @@ use std::time::SystemTime;
 ///
 /// Each trace decoder has its own concrete implementation.
 pub trait Trace: Debug + Send {
-    /// Get the size of the trace in bytes.
-    fn len(&self) -> usize;
-
     /// Iterate over the blocks of the trace.
     fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
 
@@ -34,6 +31,10 @@ pub trait Trace: Debug + Send {
     /// Get the capacity of the trace in bytes.
     #[cfg(test)]
     fn capacity(&self) -> usize;
+
+    /// Get the size of the trace in bytes.
+    #[cfg(test)]
+    fn len(&self) -> usize;
 }
 
 /// A loop that does some work that we can use to build a trace.


### PR DESCRIPTION
This PR reduces the size of the non-testing API that `hwtracer::Trace` exposes.