### PR TITLE
De PT-ify ykrt.

### DIFF
--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -35,15 +35,15 @@ struct HWTThreadTracer {
 impl ThreadTracer for HWTThreadTracer {
     fn stop_collector(self: Box<Self>) -> Result<Box<dyn RawTrace>, InvalidTraceError> {
         match self.thread_tracer.stop_collector() {
-            Ok(t) => Ok(Box::new(PTTrace(t))),
+            Ok(t) => Ok(Box::new(HWTTrace(t))),
             Err(e) => todo!("{e:?}"),
         }
     }
 }
 
-struct PTTrace(Box<dyn hwtracer::Trace>);
+struct HWTTrace(Box<dyn hwtracer::Trace>);
 
-impl RawTrace for PTTrace {
+impl RawTrace for HWTTrace {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError> {
         let mut mt = HWTMapper::new();
 


### PR DESCRIPTION
ykrt's interface to PT is hwtracer: but hwtracer can also (potentially, at least!) interface to other tracers (e.g. CoreSight). Mentions of "PT" in ykrt are thus misleading. This commit thus (more-or-less) renames "PT" to "hwtracer" inside ykrt. There is no functional change.