### PR TITLE
Floating point instructions error

### DIFF
--- a/tests/c/floats.c
+++ b/tests/c/floats.c
@@ -1,7 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   status: error
-//   stderr: Floating point instructions are not supported yet...
+//   status: success
 
 #include <stdio.h>
 #include <yk.h>

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -273,6 +273,13 @@ impl FrameReconstructor {
                 // will deal with them as they appear.
                 match l {
                     SMLocation::Register(reg, _size, off, extra) => {
+                        if *reg > 16 {
+                            // FIXME: Implement deoptimisation into floating point registers.
+                            //        LLVM stackmaps use DWARF register number mapping.
+                            //        See page 57 in https://refspecs.linuxbase.org /elf/x86_64-abi-0.99.pdf
+                            //        Anything above 16 (most notably floating registers) we currently do not support.
+                            todo!()
+                        }
                         registers[usize::from(*reg)] = val;
                         if *extra != 0 {
                             // The stackmap has recorded an additional register we need to write

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -1471,10 +1471,6 @@ public:
         auto I = BB->begin();
         std::advance(I, CurInstrIdx);
         assert(I != BB->end());
-        if (I->getType()->isFloatingPointTy()) {
-          dumpValueAndExit("Floating point instructions are not supported yet",
-                           &*I);
-        }
 #ifdef YK_TESTING
         // In trace compiler tests, blocks may be terminated with an
         // `unreachable` terminator.


### PR DESCRIPTION
Related to https://github.com/ykjit/yk/issues/774

- Remove general floating point error messsage
- Added`todo` for floating point registers deoptimisation implementation

Note:
We couldn't find a program example that would trigger floating point register deoptimisation since floating points are stored on the stack.

