### PR TITLE
Make the `Compiler::compile` trait method return a `CompiledTrace`.

### DIFF
--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -10,10 +10,7 @@ pub(crate) mod jitc_llvm;
 /// The trait that every JIT compiler backend must implement.
 pub trait Compiler: Send + Sync {
     /// Compile an [MappedTrace] into machine code.
-    fn compile(
-        &self,
-        irtrace: MappedTrace,
-    ) -> Result<(*const c_void, Option<NamedTempFile>), Box<dyn Error>>;
+    fn compile(&self, mt: Arc<MT>, irtrace: MappedTrace) -> Result<CompiledTrace, Box<dyn Error>>;
 
     #[cfg(feature = "yk_testing")]
     unsafe fn compile_for_tc_tests(

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -394,11 +394,9 @@ impl MT {
                         Arc::clone(&*lk)
                     };
                     mt.stats.timing_state(TimingState::Compiling);
-                    match compiler.compile(irtrace) {
-                        Ok((codeptr, di_tmpfile)) => {
-                            hl_arc.lock().kind = HotLocationKind::Compiled(Arc::new(
-                                CompiledTrace::new(Arc::clone(&mt), codeptr, di_tmpfile),
-                            ));
+                    match compiler.compile(Arc::clone(&mt), irtrace) {
+                        Ok(ct) => {
+                            hl_arc.lock().kind = HotLocationKind::Compiled(Arc::new(ct));
                             mt.stats.trace_compiled_ok();
                         }
                         Err(_) => {


### PR DESCRIPTION
Previously we made the caller of `Compiler::compile` construct a `CompiledTrace` which meant we leaked minor internal details such as `Option<NamedTempFile>`.

This commit makes the `compile` method have the simpler signature:

```rust
pub trait Compiler: Send + Sync {
    /// Compile an [MappedTrace] into machine code.
    fn compile(&self, mt: Arc<MT>, irtrace: MappedTrace) -> Result<CompiledTrace, Box<dyn Error>>;
    ...
}
```