### PR TITLE
Remove `Custom` error enum variant

### DIFF
--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -30,8 +30,6 @@ pub enum HWTracerError {
     NoMorePackets,
     /// The trace was interrupted by an asynchronous event.
     TraceInterrupted,
-    /// Any other error.
-    Custom(Box<dyn Error>),
 }
 
 impl Display for HWTracerError {
@@ -50,7 +48,6 @@ impl Display for HWTracerError {
             }
             HWTracerError::AlreadyStopped => write!(f, "Can't stop an inactice collector"),
             HWTracerError::BadConfig(ref s) => write!(f, "{}", s),
-            HWTracerError::Custom(ref bx) => write!(f, "{}", bx),
             HWTracerError::TraceParseError(ref s) => write!(f, "failed to parse trace: {}", s),
             HWTracerError::NoMorePackets => write!(f, "End of packet stream"),
             HWTracerError::DisasmFail(ref s) => write!(f, "failed to disassemble: {}", s),
@@ -74,7 +71,6 @@ impl Error for HWTracerError {
             HWTracerError::AlreadyStopped => None,
             HWTracerError::BadConfig(_) => None,
             HWTracerError::Errno(_) => None,
-            HWTracerError::Custom(ref bx) => Some(bx.as_ref()),
             HWTracerError::TraceParseError(_) => None,
             HWTracerError::Unknown => None,
             HWTracerError::NoMorePackets => None,

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -1,6 +1,6 @@
 use libc::{c_int, strerror};
 use std::error::Error;
-use std::ffi::{self, CStr};
+use std::ffi::CStr;
 use std::fmt::{self, Display, Formatter};
 use std::io;
 
@@ -81,17 +81,5 @@ impl Error for HWTracerError {
             HWTracerError::DisasmFail(_) => None,
             HWTracerError::TraceInterrupted => None,
         }
-    }
-}
-
-impl From<io::Error> for HWTracerError {
-    fn from(err: io::Error) -> Self {
-        HWTracerError::Custom(Box::new(err))
-    }
-}
-
-impl From<ffi::NulError> for HWTracerError {
-    fn from(err: ffi::NulError) -> Self {
-        HWTracerError::Custom(Box::new(err))
     }
 }

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -1,8 +1,9 @@
 use libc::{c_int, strerror};
-use std::error::Error;
-use std::ffi::CStr;
-use std::fmt::{self, Display, Formatter};
-use std::io;
+use std::{
+    error::Error,
+    ffi::CStr,
+    fmt::{self, Display, Formatter},
+};
 
 #[derive(Debug)]
 pub enum HWTracerError {

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::ffi::{self, CStr};
 use std::fmt::{self, Display, Formatter};
 use std::io;
-use std::num::ParseIntError;
 
 #[derive(Debug)]
 pub enum HWTracerError {
@@ -93,12 +92,6 @@ impl From<io::Error> for HWTracerError {
 
 impl From<ffi::NulError> for HWTracerError {
     fn from(err: ffi::NulError) -> Self {
-        HWTracerError::Custom(Box::new(err))
-    }
-}
-
-impl From<ParseIntError> for HWTracerError {
-    fn from(err: ParseIntError) -> Self {
         HWTracerError::Custom(Box::new(err))
     }
 }


### PR DESCRIPTION
This PR removes the `Custom` variant from hwtracer's `Error` enum. As the PR implicitly shows, it wasn't serving any useful purpose.