### PR TITLE
Rework hwtracer's error interface.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -14,6 +14,7 @@ ykaddr = { path = "../ykaddr" }
 intervaltree = "0.2.7"
 byteorder = "1.4.3"
 leb128 = "0.2.5"
+thiserror = "1"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 iced-x86 = { version = "1.18.0", features = ["decoder"]}

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -1,82 +1,40 @@
-use libc::{c_int, strerror};
-use std::{
-    error::Error,
-    ffi::CStr,
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum HWTracerError {
+    /// hwtracer does not support the requested configuration. Adjust the configuration and retry.
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    /// hwtracer has failed in such a way that there is no point retrying the operation.
+    #[error("Unrecoverable error: {0}")]
+    Unrecoverable(String),
+    /// hwtracer has encountered a temporary error: it is possible (though not guaranteed!) that
+    /// retrying the same operation again will succeed.
+    #[error("Temporary error: {0}")]
+    Temporary(TemporaryErrorKind),
+    /// Temporary hack.
+    #[error("Temporary hack")]
+    NoMorePackets,
+}
 
 #[derive(Debug)]
-pub enum HWTracerError {
-    /// The trace buffer being used by the hardware overflowed.
-    HWBufferOverflow,
-    /// The hardware doesn't support a required feature.
-    NoHWSupport(String),
-    /// Permission denied.
-    Permissions(String),
-    /// Something went wrong in C code.
-    Errno(c_int),
-    /// The collector is already collecting.
-    AlreadyCollecting,
-    /// Trying to stop a not-currently-active collector.
-    AlreadyStopped,
-    /// Invalid configuration.
-    BadConfig(String),
-    /// An unknown error. Used sparingly for C code which doesn't set errno.
-    Unknown,
-    /// Failed to decode trace.
-    TraceParseError(String),
-    /// A disassembly-related error.
-    DisasmFail(String),
-    /// End of hardware decoder packet stream.
-    NoMorePackets,
-    /// The trace was interrupted by an asynchronous event.
+pub enum TemporaryErrorKind {
+    /// Memory allocation failed.
+    CantAllocate,
+    /// The trace buffer has overflowed. Either record a smaller trace or increase the size of the
+    /// trace buffer.
+    TraceBufferOverflow,
+    /// The trace was interrupted.
     TraceInterrupted,
 }
 
-impl Display for HWTracerError {
+impl Display for TemporaryErrorKind {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            HWTracerError::HWBufferOverflow => write!(f, "Hardware trace buffer overflow"),
-            HWTracerError::NoHWSupport(ref s) => write!(f, "{}", s),
-            HWTracerError::Permissions(ref s) => write!(f, "{}", s),
-            HWTracerError::Errno(n) => {
-                // Ask libc for a string representation of the error code.
-                let err_str = unsafe { CStr::from_ptr(strerror(n)) };
-                write!(f, "{}", err_str.to_str().unwrap())
-            }
-            HWTracerError::AlreadyCollecting => {
-                write!(f, "Can't start a collector that's already collecting")
-            }
-            HWTracerError::AlreadyStopped => write!(f, "Can't stop an inactice collector"),
-            HWTracerError::BadConfig(ref s) => write!(f, "{}", s),
-            HWTracerError::TraceParseError(ref s) => write!(f, "failed to parse trace: {}", s),
-            HWTracerError::NoMorePackets => write!(f, "End of packet stream"),
-            HWTracerError::DisasmFail(ref s) => write!(f, "failed to disassemble: {}", s),
-            HWTracerError::TraceInterrupted => write!(f, "trace interrupted"),
-            HWTracerError::Unknown => write!(f, "Unknown error"),
-        }
-    }
-}
-
-impl Error for HWTracerError {
-    fn description(&self) -> &str {
-        "hwtracer error"
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        match *self {
-            HWTracerError::HWBufferOverflow => None,
-            HWTracerError::NoHWSupport(_) => None,
-            HWTracerError::Permissions(_) => None,
-            HWTracerError::AlreadyCollecting => None,
-            HWTracerError::AlreadyStopped => None,
-            HWTracerError::BadConfig(_) => None,
-            HWTracerError::Errno(_) => None,
-            HWTracerError::TraceParseError(_) => None,
-            HWTracerError::Unknown => None,
-            HWTracerError::NoMorePackets => None,
-            HWTracerError::DisasmFail(_) => None,
-            HWTracerError::TraceInterrupted => None,
+            TemporaryErrorKind::CantAllocate => write!(f, "Unable to allocate memory"),
+            TemporaryErrorKind::TraceBufferOverflow => write!(f, "Trace buffer overflow"),
+            TemporaryErrorKind::TraceInterrupted => write!(f, "Trace interrupted"),
         }
     }
 }

--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -13,9 +13,6 @@ pub enum HWTracerError {
     /// retrying the same operation again will succeed.
     #[error("Temporary error: {0}")]
     Temporary(TemporaryErrorKind),
-    /// Temporary hack.
-    #[error("Temporary hack")]
-    NoMorePackets,
 }
 
 #[derive(Debug)]

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -58,6 +58,7 @@ use std::{
     ptr, slice,
     sync::LazyLock,
 };
+use thiserror::Error;
 use ykaddr::{
     self,
     obj::{PHDR_MAIN_OBJ, PHDR_OBJECT_CACHE, SELF_BIN_PATH},
@@ -209,7 +210,7 @@ impl CompressedReturns {
 pub(crate) struct YkPTBlockIterator<'t> {
     /// The next block that the iterator will hand out. We lookahead like this so that we can
     /// retrospectively add the stack adjustment value of the block (if neccessary).
-    next: Cell<Result<Block, HWTracerError>>,
+    next: Cell<Result<Block, IteratorError>>,
     /// The packet iterator used to drive the decoding process.
     parser: PacketParser<'t>,
     /// Keeps track of where we are in the traced binary.
@@ -245,12 +246,12 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     /// Convert a file offset to a virtual address.
-    fn off_to_vaddr(&self, obj: &Path, off: u64) -> Result<usize, HWTracerError> {
+    fn off_to_vaddr(&self, obj: &Path, off: u64) -> Result<usize, IteratorError> {
         Ok(ykaddr::addr::off_to_vaddr(obj, off).unwrap())
     }
 
     /// Convert a virtual address to a file offset.
-    fn vaddr_to_off(&self, vaddr: usize) -> Result<(PathBuf, u64), HWTracerError> {
+    fn vaddr_to_off(&self, vaddr: usize) -> Result<(PathBuf, u64), IteratorError> {
         Ok(ykaddr::addr::vaddr_to_obj_and_off(vaddr).unwrap())
     }
 
@@ -270,7 +271,7 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     // Lookup a block from an offset in the "main binary" (i.e. not from a shared object).
-    fn lookup_block_from_main_bin_offset(&mut self, off: u64) -> Result<Block, HWTracerError> {
+    fn lookup_block_from_main_bin_offset(&mut self, off: u64) -> Result<Block, IteratorError> {
         if let Some(ent) = self.lookup_blockmap_entry(off) {
             Ok(Block::from_vaddr_range(
                 u64::try_from(self.off_to_vaddr(&PHDR_MAIN_OBJ, ent.range.start)?).unwrap(),
@@ -291,7 +292,7 @@ impl<'t> YkPTBlockIterator<'t> {
         &mut self,
         b_off: u64,
         ent: &BlockMapEntry,
-    ) -> Result<Option<Block>, HWTracerError> {
+    ) -> Result<Option<Block>, IteratorError> {
         if let Some(call_info) = ent.call_offs().iter().find(|c| c.callsite_off() >= b_off) {
             self.comprets
                 .push(CompRetAddr::AfterCall(call_info.callsite_off()));
@@ -314,7 +315,7 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     /// Follow the successor of the block described by the blockmap entry `ent`.
-    fn follow_blockmap_successor(&mut self, ent: &BlockMapEntry) -> Result<Block, HWTracerError> {
+    fn follow_blockmap_successor(&mut self, ent: &BlockMapEntry) -> Result<Block, IteratorError> {
         match ent.successor() {
             SuccessorKind::Unconditional { target } => {
                 if let Some(target_off) = target {
@@ -391,7 +392,7 @@ impl<'t> YkPTBlockIterator<'t> {
         }
     }
 
-    fn do_next(&mut self) -> Result<Block, HWTracerError> {
+    fn do_next(&mut self) -> Result<Block, IteratorError> {
         // Read as far ahead as we can using static successor info encoded into the blockmap.
         match self.cur_loc {
             ObjLoc::MainObj(b_off) => {
@@ -432,7 +433,7 @@ impl<'t> YkPTBlockIterator<'t> {
     // Determines if a return from a function was compressed in the packet stream.
     //
     // In the event that the return is compressed, the taken decision is popped from `self.tnts`.
-    fn is_return_compressed(&mut self) -> Result<bool, HWTracerError> {
+    fn is_return_compressed(&mut self) -> Result<bool, IteratorError> {
         let compressed = if !self.tnts.is_empty() {
             // As the Intel manual explains, when a return is *not* compressed, the CPU's TNT
             // buffers are flushed, so if we have any buffered TNT decisions, then this must be a
@@ -464,7 +465,7 @@ impl<'t> YkPTBlockIterator<'t> {
         *slot = new;
     }
 
-    fn disassemble(&mut self, start_vaddr: usize) -> Result<Block, HWTracerError> {
+    fn disassemble(&mut self, start_vaddr: usize) -> Result<Block, IteratorError> {
         let mut seg = CODE_SEGS.seg(start_vaddr);
         let mut dis =
             iced_x86::Decoder::with_ip(64, seg.slice, u64::try_from(seg.vaddrs.start).unwrap(), 0);
@@ -618,7 +619,7 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     /// Skip over "foreign code" for which we have no blockmap info for.
-    fn skip_foreign(&mut self, start_vaddr: Option<usize>) -> Result<Block, HWTracerError> {
+    fn skip_foreign(&mut self, start_vaddr: Option<usize>) -> Result<Block, IteratorError> {
         let start_vaddr = match start_vaddr {
             Some(v) => v,
             None => {
@@ -638,7 +639,7 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     /// Keep decoding packets until we encounter a TNT packet.
-    fn seek_tnt(&mut self) -> Result<(), HWTracerError> {
+    fn seek_tnt(&mut self) -> Result<(), IteratorError> {
         loop {
             let pkt = self.packet()?; // Potentially populates `self.tnts`.
             if pkt.tnts().is_some() {
@@ -648,7 +649,7 @@ impl<'t> YkPTBlockIterator<'t> {
     }
 
     /// Keep decoding packets until we encounter one with a TIP update.
-    fn seek_tip(&mut self) -> Result<(), HWTracerError> {
+    fn seek_tip(&mut self) -> Result<(), IteratorError> {
         loop {
             if self.packet()?.kind().encodes_target_ip() {
                 // Note that self.packet() will have update `self.cur_loc`.
@@ -661,7 +662,7 @@ impl<'t> YkPTBlockIterator<'t> {
     ///
     /// The packet is returned so that the consumer can determine which kind of packet was
     /// encountered.
-    fn seek_tnt_or_tip(&mut self) -> Result<Packet, HWTracerError> {
+    fn seek_tnt_or_tip(&mut self) -> Result<Packet, IteratorError> {
         loop {
             let pkt = self.packet()?;
             if pkt.kind().encodes_target_ip() || pkt.tnts().is_some() {
@@ -672,33 +673,33 @@ impl<'t> YkPTBlockIterator<'t> {
 
     /// Skip packets up until and including the next `PSBEND` packet. The first packet after the
     /// `PSBEND` is returned.
-    fn skip_psb_plus(&mut self) -> Result<Packet, HWTracerError> {
+    fn skip_psb_plus(&mut self) -> Result<Packet, IteratorError> {
         loop {
             if let Some(pkt_or_err) = self.parser.next() {
                 if pkt_or_err?.kind() == PacketKind::PSBEND {
                     break;
                 }
             } else {
-                return Err(HWTracerError::NoMorePackets);
+                panic!("No more packets");
             }
         }
 
         if let Some(pkt_or_err) = self.parser.next() {
-            pkt_or_err
+            Ok(pkt_or_err?)
         } else {
-            return Err(HWTracerError::NoMorePackets);
+            Err(IteratorError::NoMorePackets)
         }
     }
 
     /// Fetch the next packet and update iterator state.
-    fn packet(&mut self) -> Result<Packet, HWTracerError> {
+    fn packet(&mut self) -> Result<Packet, IteratorError> {
         if let Some(pkt_or_err) = self.parser.next() {
             let mut pkt = pkt_or_err?;
 
             if pkt.kind() == PacketKind::OVF {
-                return Err(HWTracerError::Temporary(
+                return Err(IteratorError::HWTracerError(HWTracerError::Temporary(
                     TemporaryErrorKind::TraceBufferOverflow,
-                ));
+                )));
             }
 
             if pkt.kind() == PacketKind::FUP && self.pge && !self.unbound_modes {
@@ -714,20 +715,20 @@ impl<'t> YkPTBlockIterator<'t> {
                 // FUPs more generally.
                 pkt = self.seek_tnt_or_tip()?;
                 if pkt.kind() != PacketKind::TIPPGD {
-                    return Err(HWTracerError::Temporary(
+                    return Err(IteratorError::HWTracerError(HWTracerError::Temporary(
                         TemporaryErrorKind::TraceInterrupted,
-                    ));
+                    )));
                 }
                 pkt = self.seek_tnt_or_tip()?;
                 if pkt.kind() != PacketKind::TIPPGE {
-                    return Err(HWTracerError::Temporary(
+                    return Err(IteratorError::HWTracerError(HWTracerError::Temporary(
                         TemporaryErrorKind::TraceInterrupted,
-                    ));
+                    )));
                 }
                 if let Some(pkt_or_err) = self.parser.next() {
                     pkt = pkt_or_err?;
                 } else {
-                    return Err(HWTracerError::NoMorePackets);
+                    return Err(IteratorError::NoMorePackets);
                 }
             }
 
@@ -800,7 +801,7 @@ impl<'t> YkPTBlockIterator<'t> {
 
             Ok(pkt)
         } else {
-            return Err(HWTracerError::NoMorePackets);
+            Err(IteratorError::NoMorePackets)
         }
     }
 }
@@ -817,9 +818,9 @@ impl<'t> Iterator for YkPTBlockIterator<'t> {
         // updated).
         let new_next = match self.next.get_mut() {
             Ok(_) => self.do_next(),
-            Err(HWTracerError::NoMorePackets) => {
+            Err(IteratorError::NoMorePackets) => {
                 // If the iterator is exhausted, it remains exhausted.
-                Err(HWTracerError::NoMorePackets)
+                return None;
             }
             Err(_) => {
                 // In the case where the iterator yields an error for the first time, subsequent
@@ -827,14 +828,30 @@ impl<'t> Iterator for YkPTBlockIterator<'t> {
                 // initial error, giving that out for each subsequent call to `next()`, but that
                 // would require us to clone the error. That is hard for `HWTracerError`, because
                 // one variant contains a `dyn Error` which isn't `Clone`.
-                Err(HWTracerError::NoMorePackets)
+                return None;
             }
         };
         match self.next.replace(new_next) {
             Ok(b) => Some(Ok(b)),
-            Err(HWTracerError::NoMorePackets) => None,
-            Err(e) => Some(Err(e)),
+            Err(IteratorError::NoMorePackets) => None,
+            Err(IteratorError::HWTracerError(e)) => Some(Err(e)),
         }
+    }
+}
+
+/// An internal-to-this-module struct which allows the block iterator to distinguish "we reached
+/// the end of the packet stream in an expected manner" from more serious errors.
+#[derive(Debug, Error)]
+enum IteratorError {
+    #[error("No more packets")]
+    NoMorePackets,
+    #[error("HWTracerError: {0}")]
+    HWTracerError(HWTracerError),
+}
+
+impl From<HWTracerError> for IteratorError {
+    fn from(e: HWTracerError) -> Self {
+        IteratorError::HWTracerError(e)
     }
 }
 

--- a/hwtracer/src/pt/ykpt/parser.rs
+++ b/hwtracer/src/pt/ykpt/parser.rs
@@ -163,11 +163,11 @@ impl<'t> PacketParser<'t> {
                 return Ok(pkt);
             }
         }
-        Err(HWTracerError::TraceParseError(format!(
+        panic!(
             "In state {:?}, failed to parse packet from bytes: {}",
             self.state,
             self.byte_stream_str(8, ", ")
-        )))
+        );
     }
 
     /// Returns a string showing a binary formatted peek at the next `nbytes` bytes of

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -6,7 +6,7 @@ use crate::{
     mt::MT,
     trace::MappedTrace,
 };
-use libc::{c_void, dlsym};
+use libc::dlsym;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 use std::{


### PR DESCRIPTION
Previously hwtracer exposed an `HWTracerError` with a large number of variants. https://github.com/ykjit/yk/pull/832 slightly reduced that number, but still there was no way that a user of hwtracer could be expected to work out what to do with most of the variants.

This PR therefore makes a radical change to `HWTracerError`:

```rust
#[derive(Debug, Error)]
pub enum HWTracerError {
    /// hwtracer does not support the requested configuration. Adjust the configuration and retry.
    #[error("Configuration error: {0}")]
    ConfigError(String),
    /// hwtracer has failed in such a way that there is no point retrying the operation.
    #[error("Unrecoverable error: {0}")]
    Unrecoverable(String),
    /// hwtracer has encountered a temporary error: it is possible (though not guaranteed!) that
    /// retrying the same operation again will succeed.
    #[error("Temporary error: {0}")]
    Temporary(TemporaryErrorKind),
}
```

In essence, `HWTracerError` now bundles all the errors it can encounter into four categories: configuration errors; unrecoverable errors; and temporary errors. In general, you probably can't do much about the first two categories other than show an error to the user and then exit. However, the last category allows you to make intelligent decisions about whether "let's try that again" makes sense. `TemporaryErrorKind` is:

```rust
#[derive(Debug)]
pub enum TemporaryErrorKind {
    /// Memory allocation failed.
    CantAllocate,
    /// The trace buffer has overflowed. Either record a smaller trace or increase the size of the
    /// trace buffer.
    TraceBufferOverflow,
    /// The trace was interrupted.
    TraceInterrupted,
}
```

The first commit (https://github.com/ykjit/yk/commit/505829a4151b011e31bc2726368f092c9f0ed75f) does most of the hard work and exposed two things. First, we sometimes returned errors for things that are either unfinished code or the breaking of internal invariants: I've made those `panic`s because the only thing anyone can do if they encounter one of those is tell us, and then we can fix it. Second, the `NoMorePackets` variant was used solely for control flow within ykpt: in other words, we had the somewhat bizarre situation that we exposed an error variant to make code within hwtracer easier to structure! So I left a temporary hack in and then https://github.com/ykjit/yk/commit/d381f242c084069d8664f8818750f8eb9bc085ae (somewhat brutally) removes the temporary hack. I'm sure a nicer design is possible, but since this is now kept internal to ykpt, I'm not too worried about making it nicer quite yet.