### PR TITLE
Tidy up side tracing a bit

### DIFF
--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -27,7 +27,7 @@ impl Compiler for JITCLLVM {
         &self,
         mt: Arc<MT>,
         irtrace: MappedTrace,
-        sti: &SideTraceInfo,
+        sti: SideTraceInfo,
         hl: Weak<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>> {
         let (func_names, bbs, trace_len) = self.encode_trace(&irtrace);

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -16,7 +16,7 @@ use std::{
     error::Error,
     ffi::{c_char, c_int, CString},
     ptr,
-    sync::{Arc, Weak},
+    sync::Arc,
 };
 use tempfile::NamedTempFile;
 
@@ -28,7 +28,7 @@ impl Compiler for JITCLLVM {
         mt: Arc<MT>,
         irtrace: MappedTrace,
         sti: Option<SideTraceInfo>,
-        hl: Weak<Mutex<HotLocation>>,
+        hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>> {
         let (func_names, bbs, trace_len) = self.encode_trace(&irtrace);
 
@@ -67,7 +67,7 @@ impl Compiler for JITCLLVM {
         if ret.is_null() {
             Err("Could not compile trace.".into())
         } else {
-            Ok(CompiledTrace::new(mt, ret, di_tmp, hl))
+            Ok(CompiledTrace::new(mt, ret, di_tmp, Arc::downgrade(&hl)))
         }
     }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -27,7 +27,7 @@ pub trait Compiler: Send + Sync {
         &self,
         mt: Arc<MT>,
         irtrace: MappedTrace,
-        sti: SideTraceInfo,
+        sti: Option<SideTraceInfo>,
         hl: Weak<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>>;
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -28,7 +28,7 @@ pub trait Compiler: Send + Sync {
         mt: Arc<MT>,
         irtrace: MappedTrace,
         sti: Option<SideTraceInfo>,
-        hl: Weak<Mutex<HotLocation>>,
+        hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>>;
 
     #[cfg(feature = "yk_testing")]

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -27,7 +27,7 @@ pub trait Compiler: Send + Sync {
         &self,
         mt: Arc<MT>,
         irtrace: MappedTrace,
-        sti: &SideTraceInfo,
+        sti: SideTraceInfo,
         hl: Weak<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>>;
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -474,13 +474,14 @@ impl MT {
                         Arc::clone(&*lk)
                     };
                     mt.stats.timing_state(TimingState::Compiling);
-                    match compiler.compile(Arc::clone(&mt), irtrace, &sti, hlclone) {
+                    let guardid = sti.guardid;
+                    match compiler.compile(Arc::clone(&mt), irtrace, sti, hlclone) {
                         Ok(ct) => {
                             let mut hl = hl_arc.lock();
                             match &hl.kind {
                                 HotLocationKind::Compiled(_ctr) => {
                                     let ctr = parent.unwrap();
-                                    let guard = &ctr.guards[sti.guardid];
+                                    let guard = &ctr.guards[guardid];
                                     guard.setct(Arc::new(ct));
                                 }
                                 _ => {

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -442,7 +442,13 @@ impl MT {
         })
     }
 
-    /// Add a compilation job for `utrace` to the global work queue.
+    /// Add a compilation job for to the global work queue:
+    ///   * `utrace` is the trace to be compiled.
+    ///   * `hl_arc` is the [HotLocation] this compilation job is related to.
+    ///   * `sidetrace`, if not `None`, specifies that this is a side-trace compilation job.
+    ///     The `Arc<CompiledTrace>` is the parent [CompiledTrace] for the side-trace. Because
+    ///     side-traces can nest, this may or may not be the same [CompiledTrace] as contained
+    ///     in the `hl_arc`.
     fn queue_compile_job(
         self: &Arc<Self>,
         utrace: Box<dyn RawTrace>,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -455,6 +455,10 @@ impl MT {
             mt.stats.timing_state(TimingState::TraceMapping);
             match utrace.map() {
                 Ok(irtrace) => {
+                    debug_assert!(
+                        sidetrace.is_none()
+                            || matches!(hl_arc.lock().kind, HotLocationKind::Compiled(_))
+                    );
                     mt.stats.timing_state(TimingState::None);
                     let compiler = {
                         let lk = mt.compiler.lock();
@@ -472,6 +476,9 @@ impl MT {
                             let mut hl = hl_arc.lock();
                             match &hl.kind {
                                 HotLocationKind::Compiled(_) => {
+                                    // The `unwrap`s cannot fail because of the condition contained
+                                    // in the `debug_assert` above: if `sidetrace` is not-`None`
+                                    // then `hl_arc.kind` is `Compiled`.
                                     let ctr = sidetrace.map(|x| x.1).unwrap();
                                     let guard = &ctr.guards[guardid.unwrap()];
                                     guard.setct(Arc::new(ct));

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -452,7 +452,6 @@ impl MT {
     ) {
         self.stats.trace_collected_ok();
         let mt = Arc::clone(self);
-        let hlclone = Arc::downgrade(&hl_arc);
         let do_compile = move || {
             mt.stats.timing_state(TimingState::TraceMapping);
             match utrace.map() {
@@ -464,7 +463,7 @@ impl MT {
                     };
                     mt.stats.timing_state(TimingState::Compiling);
                     let guardid = sti.map(|x| x.guardid);
-                    match compiler.compile(Arc::clone(&mt), irtrace, sti, hlclone) {
+                    match compiler.compile(Arc::clone(&mt), irtrace, sti, Arc::clone(&hl_arc)) {
                         Ok(ct) => {
                             let mut hl = hl_arc.lock();
                             match &hl.kind {


### PR DESCRIPTION
This PR starts to tidy up some of the side-tracing code a bit, mostly by making the interfaces use more common Rust idioms. There isn't much, if any, functional change here. There's also more that we can do, but this feels like a useful unit of work already.