### PR TITLE
Change many traits/structs from `pub` to `pub(crate)`.

### DIFF
--- a/tests/src/bin/run_trace_compiler_test.rs
+++ b/tests/src/bin/run_trace_compiler_test.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, convert::TryInto, env, error::Error, ffi::CString, fs::File};
 use ykrt::{
-    compile::default_compiler,
+    compile::compile_for_tc_tests,
     trace::{MappedTrace, TracedAOTBlock},
 };
 
@@ -47,10 +47,7 @@ fn main() -> Result<(), String> {
     let ll_file = File::open(ll_path).unwrap();
     let mmap = unsafe { memmap2::Mmap::map(&ll_file).unwrap() };
 
-    let compiler = default_compiler().unwrap();
-    unsafe {
-        compiler.compile_for_tc_tests(irtrace, mmap.as_ptr(), mmap.len().try_into().unwrap())
-    };
+    unsafe { compile_for_tc_tests(irtrace, mmap.as_ptr(), mmap.len().try_into().unwrap()) };
 
     Ok(())
 }

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -90,7 +90,7 @@ struct LiveAOTVals {
 /// Struct containing pointers needed for frame reconstruction.
 #[derive(Debug)]
 #[repr(C)]
-pub struct NewFramesInfo {
+pub(crate) struct NewFramesInfo {
     // Address of the new stackframes in memory.
     src: *const c_void,
     // Address into the current stack we want to write `src` to.

--- a/ykrt/src/frame/llvmbridge.rs
+++ b/ykrt/src/frame/llvmbridge.rs
@@ -6,7 +6,7 @@ use std::{ffi::CStr, fmt};
 
 // Replicates struct of same name in `ykllvmwrap.cc`.
 #[repr(C)]
-pub struct BitcodeSection {
+pub(crate) struct BitcodeSection {
     pub data: *const u8,
     pub len: u64,
 }
@@ -16,7 +16,7 @@ extern "C" {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Type(LLVMTypeRef);
+pub(crate) struct Type(LLVMTypeRef);
 impl Type {
     pub fn kind(&self) -> LLVMTypeKind {
         unsafe { LLVMGetTypeKind(self.0) }
@@ -33,7 +33,7 @@ impl Type {
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Value(LLVMValueRef);
+pub(crate) struct Value(LLVMValueRef);
 impl Value {
     pub unsafe fn new(vref: LLVMValueRef) -> Self {
         Value(vref)

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -14,7 +14,7 @@ use std::{
 use yksmp::{Location as SMLocation, SMEntry, StackMapParser};
 
 mod llvmbridge;
-pub use llvmbridge::{BitcodeSection, __yktracec_get_aot_module};
+pub(crate) use llvmbridge::{BitcodeSection, __yktracec_get_aot_module};
 use llvmbridge::{Type, Value};
 
 pub static AOT_STACKMAPS: LazyLock<Vec<SMEntry>> = LazyLock::new(|| {
@@ -42,7 +42,7 @@ static RBP_DWARF_NUM: u16 = 6;
 
 /// Live value.
 #[derive(Clone, Copy, PartialEq)]
-pub struct SGValue {
+pub(crate) struct SGValue {
     pub val: u64,
     pub ty: Type,
 }
@@ -101,7 +101,7 @@ fn get_stackmap_call(pc: Value) -> Value {
 }
 
 /// The struct responsible for reconstructing the new frames after a guard failure.
-pub struct FrameReconstructor {
+pub(crate) struct FrameReconstructor {
     /// Current frames.
     frames: Vec<Frame>,
 }

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -199,7 +199,7 @@ impl Drop for Location {
 }
 
 #[derive(Debug)]
-pub struct HotLocation {
+pub(crate) struct HotLocation {
     pub(crate) kind: HotLocationKind,
     pub(crate) trace_failure: TraceFailureThreshold,
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -63,7 +63,7 @@ static SERIALISE_COMPILATION: LazyLock<bool> = LazyLock::new(|| {
 /// Stores information required for compiling a side-trace. Passed down from a (parent) trace
 /// during deoptimisation.
 #[derive(Debug, Copy, Clone)]
-pub struct SideTraceInfo {
+pub(crate) struct SideTraceInfo {
     pub callstack: *const c_void,
     pub aotvalsptr: *const c_void,
     pub aotvalslen: usize,
@@ -562,7 +562,7 @@ impl Drop for MT {
 
 /// Meta-tracer per-thread state. Note that this struct is neither `Send` nor `Sync`: it can only
 /// be accessed from within a single thread.
-pub struct MTThread {
+pub(crate) struct MTThread {
     /// Is this thread currently tracing something? If so, this will be a `Some<...>`. This allows
     /// another thread to tell whether the thread that started tracing a [Location] is still alive
     /// or not by inspecting its strong count (if the strong count is equal to 1 then the thread

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -11,7 +11,7 @@ use ykaddr::{
 };
 
 /// Maps each entry of a hardware trace back to the IR block from which it was compiled.
-pub struct HWTMapper {
+pub(crate) struct HWTMapper {
     faddrs: HashMap<CString, *const c_void>,
 }
 

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -3,11 +3,11 @@
 use super::{errors::InvalidTraceError, MappedTrace, RawTrace, ThreadTracer};
 use std::{error::Error, sync::Arc};
 
-pub mod mapper;
-pub use mapper::HWTMapper;
+pub(crate) mod mapper;
+pub(crate) use mapper::HWTMapper;
 mod testing;
 
-pub struct HWTracer {
+pub(crate) struct HWTracer {
     backend: Arc<dyn hwtracer::Tracer>,
 }
 

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -14,13 +14,13 @@ use std::{
 };
 
 #[cfg(tracer_hwt)]
-pub mod hwt;
+pub(crate) mod hwt;
 
-pub use errors::InvalidTraceError;
+pub(crate) use errors::InvalidTraceError;
 
 /// A tracer is an object which can start / stop collecting traces. It may have its own
 /// configuration, but that is dependent on the concrete tracer itself.
-pub trait Tracer: Send + Sync {
+pub(crate) trait Tracer: Send + Sync {
     /// Start collecting a trace of the current thread.
     fn start_collector(self: Arc<Self>) -> Result<Box<dyn ThreadTracer>, Box<dyn Error>>;
 }
@@ -28,7 +28,7 @@ pub trait Tracer: Send + Sync {
 /// Return a [Tracer] instance or `Err` if none can be found. The [Tracer] returned will be
 /// selected on a combination of what the platform can support and other (possibly run-time) user
 /// configuration.
-pub fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
+pub(crate) fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
     #[cfg(tracer_hwt)]
     {
         return Ok(Arc::new(hwt::HWTracer::new()?));
@@ -39,7 +39,7 @@ pub fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 }
 
 /// Represents a thread which is currently tracing.
-pub trait ThreadTracer {
+pub(crate) trait ThreadTracer {
     /// Stop collecting a trace of the current thread.
     fn stop_collector(self: Box<Self>) -> Result<Box<dyn RawTrace>, InvalidTraceError>;
 }
@@ -48,7 +48,7 @@ pub trait ThreadTracer {
 ///
 /// Depending on the backend: the raw trace may need considerable processing to convert into basic
 /// block addresses; or it may contain those basic block addresses in an easily digestible fashion.
-pub trait RawTrace: Send {
+pub(crate) trait RawTrace: Send {
     fn map(self: Box<Self>) -> Result<MappedTrace, InvalidTraceError>;
 }
 


### PR DESCRIPTION
Doing so makes clearer what's part of the public API and what isn't. Most of these are mechanical with the exception of introducing a `compile_for_tc_tests` test-only function (which is necessary for us to make the `Compiler` trait be `pub(crate)`).