### PR TITLE
Make non_null non-dangerous

### DIFF
--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -100,7 +100,8 @@ impl Guard {
 /// be updated if a lock is held or a field is atomic.
 pub(crate) struct CompiledTrace {
     // Reference to the meta-tracer required for side tracing.
-    pub(crate) mt: Arc<MT>,
+    #[cfg(not(test))]
+    mt: Arc<MT>,
     /// A function which when called, executes the compiled trace.
     ///
     /// The argument to the function is a pointer to a struct containing the live variables at the
@@ -171,6 +172,10 @@ impl CompiledTrace {
         }
     }
 
+    pub(crate) fn mt(&self) -> &Arc<MT> {
+        &self.mt
+    }
+
     pub(crate) fn aotvals(&self) -> *const c_void {
         self.aotvals.0
     }
@@ -194,15 +199,18 @@ impl CompiledTrace {
     /// Create a `CompiledTrace` with null contents. This is unsafe and only intended for testing
     /// purposes where a `CompiledTrace` instance is required, but cannot sensibly be constructed
     /// without overwhelming the test. The resulting instance must not be inspected or executed.
-    pub(crate) unsafe fn new_null(mt: Arc<MT>) -> Self {
+    pub(crate) unsafe fn new_null(_mt: Arc<MT>) -> Self {
         Self {
-            mt,
             smap: HashMap::new(),
             aotvals: SendSyncConstPtr(std::ptr::null()),
             di_tmpfile: None,
             guards: Vec::new(),
             hl: Weak::new(),
         }
+    }
+
+    pub(crate) fn mt(&self) -> &Arc<MT> {
+        todo!();
     }
 
     pub(crate) fn aotvals(&self) -> *const c_void {

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -126,7 +126,8 @@ pub(crate) struct CompiledTrace {
     #[allow(dead_code)]
     di_tmpfile: Option<NamedTempFile>,
     /// Reference to the HotLocation, required for side tracing.
-    pub(crate) hl: Weak<Mutex<HotLocation>>,
+    #[cfg(not(test))]
+    hl: Weak<Mutex<HotLocation>>,
 }
 
 #[cfg(not(test))]
@@ -193,6 +194,10 @@ impl CompiledTrace {
     pub(crate) fn entry(&self) -> *const c_void {
         self.entry.0
     }
+
+    pub(crate) fn hl(&self) -> &Weak<Mutex<HotLocation>> {
+        &self.hl
+    }
 }
 
 #[cfg(test)]
@@ -213,7 +218,6 @@ impl CompiledTrace {
         Self {
             aotvals: SendSyncConstPtr(std::ptr::null()),
             di_tmpfile: None,
-            hl: Weak::new(),
         }
     }
 
@@ -234,6 +238,10 @@ impl CompiledTrace {
     }
 
     pub(crate) fn entry(&self) -> *const c_void {
+        todo!();
+    }
+
+    pub(crate) fn hl(&self) -> &Weak<Mutex<HotLocation>> {
         todo!();
     }
 }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -111,7 +111,8 @@ pub(crate) struct CompiledTrace {
     entry: SendSyncConstPtr<c_void>,
     /// Parsed stackmap of this trace. We only need to read this once, and can then use it to
     /// lookup stackmap information for each guard failure as needed.
-    pub(crate) smap: HashMap<u64, Vec<LiveVar>>,
+    #[cfg(not(test))]
+    smap: HashMap<u64, Vec<LiveVar>>,
     /// Pointer to heap allocated live AOT values.
     aotvals: SendSyncConstPtr<c_void>,
     /// List of guards containing hotness counts and compiled side traces.
@@ -176,6 +177,10 @@ impl CompiledTrace {
         &self.mt
     }
 
+    pub(crate) fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
+        &self.smap
+    }
+
     pub(crate) fn aotvals(&self) -> *const c_void {
         self.aotvals.0
     }
@@ -201,7 +206,6 @@ impl CompiledTrace {
     /// without overwhelming the test. The resulting instance must not be inspected or executed.
     pub(crate) unsafe fn new_null() -> Self {
         Self {
-            smap: HashMap::new(),
             aotvals: SendSyncConstPtr(std::ptr::null()),
             di_tmpfile: None,
             guards: Vec::new(),
@@ -210,6 +214,10 @@ impl CompiledTrace {
     }
 
     pub(crate) fn mt(&self) -> &Arc<MT> {
+        todo!();
+    }
+
+    pub(crate) fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
         todo!();
     }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -116,7 +116,8 @@ pub(crate) struct CompiledTrace {
     /// Pointer to heap allocated live AOT values.
     aotvals: SendSyncConstPtr<c_void>,
     /// List of guards containing hotness counts and compiled side traces.
-    pub(crate) guards: Vec<Guard>,
+    #[cfg(not(test))]
+    guards: Vec<Guard>,
     /// If requested, a temporary file containing the "source code" for the trace, to be shown in
     /// debuggers when stepping over the JITted code.
     ///
@@ -181,6 +182,10 @@ impl CompiledTrace {
         &self.smap
     }
 
+    pub(crate) fn guards(&self) -> &Vec<Guard> {
+        &self.guards
+    }
+
     pub(crate) fn aotvals(&self) -> *const c_void {
         self.aotvals.0
     }
@@ -208,7 +213,6 @@ impl CompiledTrace {
         Self {
             aotvals: SendSyncConstPtr(std::ptr::null()),
             di_tmpfile: None,
-            guards: Vec::new(),
             hl: Weak::new(),
         }
     }
@@ -218,6 +222,10 @@ impl CompiledTrace {
     }
 
     pub(crate) fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
+        todo!();
+    }
+
+    pub(crate) fn guards(&self) -> &Vec<Guard> {
         todo!();
     }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -199,7 +199,7 @@ impl CompiledTrace {
     /// Create a `CompiledTrace` with null contents. This is unsafe and only intended for testing
     /// purposes where a `CompiledTrace` instance is required, but cannot sensibly be constructed
     /// without overwhelming the test. The resulting instance must not be inspected or executed.
-    pub(crate) unsafe fn new_null(_mt: Arc<MT>) -> Self {
+    pub(crate) unsafe fn new_null() -> Self {
         Self {
             smap: HashMap::new(),
             aotvals: SendSyncConstPtr(std::ptr::null()),

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -380,7 +380,7 @@ unsafe extern "C" fn __ykrt_deopt(
         guard.inc();
         if guard.failcount() >= ctr.mt().sidetrace_threshold() {
             // This guard is hot, so compile a new side-trace.
-            if let Some(hl) = ctr.hl.upgrade() {
+            if let Some(hl) = ctr.hl().upgrade() {
                 let aotvalsptr = unsafe {
                     (ctr.aotvals() as *const u8).offset(isize::try_from(aotvals.offset).unwrap())
                 } as *const c_void;

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -198,7 +198,7 @@ extern "C" fn ts_reconstruct(ctx: *mut c_void, _module: LLVMModuleRef) -> LLVMEr
     let mut framerec = unsafe { FrameReconstructor::new(activeframes) };
 
     // Retrieve the live variables for this guard from this trace's stackmap.
-    let live_vars = ctr.smap.get(&retaddr.try_into().unwrap()).unwrap();
+    let live_vars = ctr.smap().get(&retaddr.try_into().unwrap()).unwrap();
 
     // Extract live values from the stackmap.
     // Skip first live variable that contains 3 unrelated locations (CC, Flags, Num Deopts).
@@ -289,7 +289,7 @@ unsafe extern "C" fn __ykrt_deopt(
         let guard = &ctr.guards[guardid];
         if let Some(st) = guard.getct() {
             let registers = Registers::from_ptr(rsp);
-            let live_vars = ctr.smap.get(&retaddr.try_into().unwrap()).unwrap();
+            let live_vars = ctr.smap().get(&retaddr.try_into().unwrap()).unwrap();
             let mut ykctrlpvars = Vec::new();
             for (_i, locs) in live_vars.iter().skip(1).enumerate() {
                 assert!(locs.len() == 1);

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -286,7 +286,7 @@ unsafe extern "C" fn __ykrt_deopt(
 
     // Check if we have a side trace and execute it.
     if guardid != SIDETRACE_LAST_GUARD_ID {
-        let guard = &ctr.guards[guardid];
+        let guard = &ctr.guards()[guardid];
         if let Some(st) = guard.getct() {
             let registers = Registers::from_ptr(rsp);
             let live_vars = ctr.smap().get(&retaddr.try_into().unwrap()).unwrap();
@@ -376,7 +376,7 @@ unsafe extern "C" fn __ykrt_deopt(
     // We want to start side tracing only after we deoptimised. Otherwise we'd trace the whole
     // deopt routine which will later be costly to disassemble.
     if guardid != SIDETRACE_LAST_GUARD_ID {
-        let guard = &ctr.guards[guardid];
+        let guard = &ctr.guards()[guardid];
         guard.inc();
         if guard.failcount() >= ctr.mt().sidetrace_threshold() {
             // This guard is hot, so compile a new side-trace.

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -350,7 +350,7 @@ unsafe extern "C" fn __ykrt_deopt(
 
     #[cfg(feature = "yk_jitstate_debug")]
     print_jit_state("deoptimise");
-    (*ctr).mt.stats.timing_state(TimingState::Deopting);
+    (*ctr).mt().stats.timing_state(TimingState::Deopting);
 
     // Copy arguments into a struct we can pass into the ThreadSafeModuleWithModuleDo function.
     let mut info = ReconstructInfo {
@@ -378,7 +378,7 @@ unsafe extern "C" fn __ykrt_deopt(
     if guardid != SIDETRACE_LAST_GUARD_ID {
         let guard = &ctr.guards[guardid];
         guard.inc();
-        if guard.failcount() >= ctr.mt.sidetrace_threshold() {
+        if guard.failcount() >= ctr.mt().sidetrace_threshold() {
             // This guard is hot, so compile a new side-trace.
             if let Some(hl) = ctr.hl.upgrade() {
                 let aotvalsptr = unsafe {
@@ -390,12 +390,12 @@ unsafe extern "C" fn __ykrt_deopt(
                     aotvalslen: aotvals.length,
                     guardid,
                 };
-                ctr.mt.side_trace(hl, sti, Arc::clone(&ctr));
+                ctr.mt().side_trace(hl, sti, Arc::clone(&ctr));
             }
         }
     }
 
-    ctr.mt.stats.timing_state(TimingState::OutsideYk);
+    ctr.mt().stats.timing_state(TimingState::OutsideYk);
 
     info.nfi.unwrap()
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -486,7 +486,7 @@ impl MT {
                                     // in the `debug_assert` above: if `sidetrace` is not-`None`
                                     // then `hl_arc.kind` is `Compiled`.
                                     let ctr = sidetrace.map(|x| x.1).unwrap();
-                                    let guard = &ctr.guards[guardid.unwrap()];
+                                    let guard = &ctr.guards()[guardid.unwrap()];
                                     guard.setct(Arc::new(ct));
                                 }
                                 _ => {

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -659,9 +659,7 @@ mod tests {
                     HotLocationKind::Compiling
                 ));
                 loc.hot_location().unwrap().lock().kind =
-                    HotLocationKind::Compiled(Arc::new(unsafe {
-                        CompiledTrace::new_null(Arc::clone(&mt))
-                    }));
+                    HotLocationKind::Compiled(Arc::new(unsafe { CompiledTrace::new_null() }));
             }
             _ => unreachable!(),
         }
@@ -679,7 +677,7 @@ mod tests {
             mt.transition_guard_failure(
                 loc.hot_location_arc_clone().unwrap(),
                 sti,
-                Arc::new(unsafe { CompiledTrace::new_null(Arc::clone(&mt)) }),
+                Arc::new(unsafe { CompiledTrace::new_null() }),
             ),
             TransitionGuardFailure::StartSideTracing
         ));
@@ -985,7 +983,7 @@ mod tests {
                                     ));
                                     loc.hot_location().unwrap().lock().kind =
                                         HotLocationKind::Compiled(Arc::new(unsafe {
-                                            CompiledTrace::new_null(Arc::clone(&mt))
+                                            CompiledTrace::new_null()
                                         }));
                                 }
                                 x => unreachable!("Reached incorrect state {:?}", x),
@@ -1098,9 +1096,7 @@ mod tests {
                         HotLocationKind::Compiling
                     ));
                     loc.hot_location().unwrap().lock().kind =
-                        HotLocationKind::Compiled(Arc::new(unsafe {
-                            CompiledTrace::new_null(Arc::clone(&mt))
-                        }));
+                        HotLocationKind::Compiled(Arc::new(unsafe { CompiledTrace::new_null() }));
                 }
                 _ => unreachable!(),
             }
@@ -1123,7 +1119,7 @@ mod tests {
                     mt.transition_guard_failure(
                         loc1.hot_location_arc_clone().unwrap(),
                         sti,
-                        Arc::new(unsafe { CompiledTrace::new_null(Arc::clone(&mt)) }),
+                        Arc::new(unsafe { CompiledTrace::new_null() }),
                     ),
                     TransitionGuardFailure::StartSideTracing
                 ));
@@ -1142,7 +1138,7 @@ mod tests {
             mt.transition_guard_failure(
                 loc2.hot_location_arc_clone().unwrap(),
                 sti,
-                Arc::new(unsafe { CompiledTrace::new_null(Arc::clone(&mt)) }),
+                Arc::new(unsafe { CompiledTrace::new_null() }),
             ),
             TransitionGuardFailure::StartSideTracing
         ));
@@ -1202,9 +1198,7 @@ mod tests {
         ));
         if let TransitionControlPoint::StopTracing(_) = mt.transition_control_point(&loc1) {
             loc1.hot_location().unwrap().lock().kind =
-                HotLocationKind::Compiled(Arc::new(unsafe {
-                    CompiledTrace::new_null(Arc::clone(&mt))
-                }));
+                HotLocationKind::Compiled(Arc::new(unsafe { CompiledTrace::new_null() }));
         } else {
             panic!();
         }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -659,7 +659,7 @@ mod tests {
                     HotLocationKind::Compiling
                 ));
                 loc.hot_location().unwrap().lock().kind =
-                    HotLocationKind::Compiled(Arc::new(unsafe { CompiledTrace::new_null() }));
+                    HotLocationKind::Compiled(Arc::new(CompiledTrace::new_testing()));
             }
             _ => unreachable!(),
         }
@@ -677,7 +677,7 @@ mod tests {
             mt.transition_guard_failure(
                 loc.hot_location_arc_clone().unwrap(),
                 sti,
-                Arc::new(unsafe { CompiledTrace::new_null() }),
+                Arc::new(CompiledTrace::new_testing()),
             ),
             TransitionGuardFailure::StartSideTracing
         ));
@@ -982,9 +982,9 @@ mod tests {
                                         HotLocationKind::Compiling
                                     ));
                                     loc.hot_location().unwrap().lock().kind =
-                                        HotLocationKind::Compiled(Arc::new(unsafe {
-                                            CompiledTrace::new_null()
-                                        }));
+                                        HotLocationKind::Compiled(Arc::new(
+                                            CompiledTrace::new_testing(),
+                                        ));
                                 }
                                 x => unreachable!("Reached incorrect state {:?}", x),
                             }
@@ -1096,7 +1096,7 @@ mod tests {
                         HotLocationKind::Compiling
                     ));
                     loc.hot_location().unwrap().lock().kind =
-                        HotLocationKind::Compiled(Arc::new(unsafe { CompiledTrace::new_null() }));
+                        HotLocationKind::Compiled(Arc::new(CompiledTrace::new_testing()));
                 }
                 _ => unreachable!(),
             }
@@ -1119,7 +1119,7 @@ mod tests {
                     mt.transition_guard_failure(
                         loc1.hot_location_arc_clone().unwrap(),
                         sti,
-                        Arc::new(unsafe { CompiledTrace::new_null() }),
+                        Arc::new(CompiledTrace::new_testing()),
                     ),
                     TransitionGuardFailure::StartSideTracing
                 ));
@@ -1138,7 +1138,7 @@ mod tests {
             mt.transition_guard_failure(
                 loc2.hot_location_arc_clone().unwrap(),
                 sti,
-                Arc::new(unsafe { CompiledTrace::new_null() }),
+                Arc::new(CompiledTrace::new_testing()),
             ),
             TransitionGuardFailure::StartSideTracing
         ));
@@ -1198,7 +1198,7 @@ mod tests {
         ));
         if let TransitionControlPoint::StopTracing(_) = mt.transition_control_point(&loc1) {
             loc1.hot_location().unwrap().lock().kind =
-                HotLocationKind::Compiled(Arc::new(unsafe { CompiledTrace::new_null() }));
+                HotLocationKind::Compiled(Arc::new(CompiledTrace::new_testing()));
         } else {
             panic!();
         }


### PR DESCRIPTION
This PR bit-by-bit makes `CompiledTrace::non_null` impossible to use incorrectly, because it removes all of `CompiledTrace`'s contents in test mode. In essence, we have different `struct CompiledTrace` and `impl CompiledTrace` for test/non-test. It's a slightly crude way of doing things, but it does mean that we can no longer have UB in testing mode because of the raw pointers floating around.