### PR TITLE
Flesh out (very roughly) instruction encoding for Yk IR.

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -65,7 +65,9 @@ handle_arg() {
             # Embed LLVM bitcode as late as possible.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--embed-bitcode-final"
             # Embed Yk's IR.
-            OUTPUT="${OUTPUT} -Wl,-mllvm=--yk-embed-ir"
+            if [ "${YKD_NEW_CODEGEN}" = "1" ]; then
+                OUTPUT="${OUTPUT} -Wl,-mllvm=--yk-embed-ir"
+            fi
 
             # Disable machine passes that would interfere with block mapping.
             #

--- a/docs/src/internals/ir.md
+++ b/docs/src/internals/ir.md
@@ -5,14 +5,22 @@ using LLVM IR to our own IR. This document describes the new IR**
 
 ## On-disk serialisation format.
 
+### Module encoding.
+
 ```
 Module {
     // header
-    magic: u32      // hard-coded `0xedd5f00d`
+    magic: u32 = 0xedd5f00d
     version: u32    // format version (currently 0)
     // functions
     num_funcs: usize
     funcs: Function[num_funcs]
+    // types
+    num_types: usize
+    types: Type[num_types]
+    // constants
+    num_constants: usize
+    constants: Constant[num_constants]
 }
 
 Function {
@@ -28,5 +36,45 @@ Block {
 
 Instruction {
     opcode: u8
+    num_operands: u32
+    operands: Operand[num_operands]
+}
+
+Constant {
+    type_index: usize,
+    num_bytes: usize,
+    bytes: u8[num_bytes]
+}
+```
+
+
+### Type encoding.
+
+`Type` is encoded as one of the following:
+
+IntegerType {
+    type_kind: u8 = 0
+    num_bits: u32
+}
+
+### Operand encoding.
+
+`Operand` is encoded as one of the following:
+
+```
+ConstantOperand {
+    operand_kind: u8 = 0
+    constant_index: usize
+}
+
+LocalVariableOperand {
+    operand_kind: u8 = 1
+    bb_idx: usize       // This field and the following one identify which
+    inst_idx: usize     // instruction defines the referenced local variable.
+}
+
+StringOperand { // Used as a catch-all for unimplemented operands.
+    operand_kind: u8 = 2
+    str: null_term_str
 }
 ```


### PR DESCRIPTION
**Compiler change: ~~coming soon~~ https://github.com/ykjit/ykllvm/pull/82**

This adds to Yk IR: a few opcodes, an instruction encoding, basic type encoding, basic constant encoding.

Types and constants are not stored inline inside the instruction (because types and constants are arbitrarily large, and we don't want multiple copies of large things hanging around). Instructions instead store indices to type and constant tables.

Following LLVM's precedent, where a value is identified by the instruction that generates it, our local variables are a pair: the basic block index and instruction index of the instruction that creates the value.

This unit of work has highlighted some problems with using `Display` as a human-readbale IR formatter:

 - Because constants are not stored inline, to print the actual constant we need access to the constant table.

 - Similarly for types.

 - When we print an instruction, if the instruction generates a value, we don't have context (from the parent function and block) to print the variable's name.

This should be fixable by using a "printer" struct (with state) to do the printing instead of `Display`.

Another solution would be to have references to the things we need in `self`, but it's not clear that would be easy.

Sample snippet of human-readable IR at this stage:

```
func main {
  bb0:
    $_ = alloca const[0]
    $_ = call const[1], const[2]
    $_ = call const[3], const[4], $0_0, const[5]
    store $0_1, const[6]
    $_ = alloca const[0]
    $_ = alloca const[0]
    $_ = getelementptr $0_1, const[4]
    $_ = getelementptr $0_1, const[7]
    $_ = getelementptr $0_1, const[8]
    store $0_8, const[6]
    ...
```

As you can see, constants and generated values cannot be printed properly yet.

I didn't extend our tests just yet, as I want to fix the formatting first. This will be my next PR.