### PR TITLE
Check for and fix dead code warnings.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -64,18 +64,19 @@ PATH=${YKB_YKLLVM_BIN_DIR}:${PATH} cargo xtask cfmt
 # FIXME: Add build/ to .gitignore in ykllvm
 git diff --exit-code --ignore-submodules
 
-# Check for unused variables in each package
+# Check for annoying compiler warnings in each package.
+WARNING_DEFINES="-D unused-variables -D dead-code"
 for p in $(sed -n -e '/^members =/,/^\]$/{/^members =/d;/^\]$/d;p;}' \
   Cargo.toml \
   | \
   tr -d ' \t\",'); do
     cd $p
     if [ $p = "tests" ]; then
-        cargo rustc --profile check --lib -- -D unused-variables
+        cargo rustc --profile check --lib -- ${WARNING_DEFINES}
     else
-        cargo rustc --profile check -- -D unused-variables
-        cargo rustc --profile check --tests -- -D unused-variables
-        cargo rustc --profile check --benches -- -D unused-variables
+        cargo rustc --profile check -- ${WARNING_DEFINES}
+        cargo rustc --profile check --tests -- ${WARNING_DEFINES}
+        cargo rustc --profile check --benches -- ${WARNING_DEFINES}
     fi
     cd ..
 done

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -210,6 +210,7 @@ impl Display for Function {
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
 pub(crate) struct IntegerType {
+    #[deku(temp)] // FIXME: untemp when needed.
     num_bits: u32,
 }
 
@@ -226,10 +227,11 @@ pub(crate) enum Type {
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
 pub(crate) struct Constant {
+    #[deku(temp)] // FIXME: untemp when needed.
     type_index: usize,
     #[deku(temp)]
     num_bytes: usize,
-    #[deku(count = "num_bytes")]
+    #[deku(count = "num_bytes", temp)] // FIXME: untemp when needed.
     bytes: Vec<u8>,
 }
 
@@ -249,11 +251,11 @@ pub(crate) struct AOTModule {
     funcs: Vec<Function>,
     #[deku(temp)]
     num_types: usize,
-    #[deku(count = "num_types")]
+    #[deku(count = "num_types", temp)] // FIXME: untemp when needed.
     types: Vec<Type>,
     #[deku(temp)]
     num_consts: usize,
-    #[deku(count = "num_consts")]
+    #[deku(count = "num_consts", temp)] // FIXME: untemp when needed.
     consts: Vec<Constant>,
 }
 


### PR DESCRIPTION
First, we should be checking for dead code warnings. Add defines to CI instructions for that.

Second, fix the warnings in the tree.

Rust doesn't realise that, although we don't read some of the IR fields, deku is in fact using them for decoding.

What we can do for now is mark them as `#[deku(temp)]`, which means deku still consumes them, but excludes them from the struct afterwards. This means the fields don't exist after decoding, and there are no dead code warnings.

When we come to actually read these fields, we will be forced to remove the annotations too, so that's good.