### PR TITLE
Plumb in a more capable way of printing IR.

### DIFF
--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -26,8 +26,8 @@ impl Compiler for JITCYk {
             todo!();
         }
         let ir_slice = yk_ir_section();
-        let _aot_mod = aot_ir::deserialise_module(ir_slice);
-        todo!();
+        let aot_mod = aot_ir::deserialise_module(ir_slice).unwrap();
+        todo!("{}", aot_mod.to_str());
     }
 
     #[cfg(feature = "yk_testing")]


### PR DESCRIPTION
The problem with using `Display` for this was that it made it hard to pass around the necessary state required to print the various elements of the IR. For example:

 - stringifying constants and types requires table lookups into the parent module.

 - stringifying generated values requires us to know about where the instruction that generates the value lives in the block and instruction structure of the IR.

This is the result of trying several different designs, none of which are perfect, but this seems to be the least offensive.

This change introduces a `YkDispaly` trait for converting in-memory IR to human-readable form. It works similarly to `Display`, but the parent module is always passed in, thus solving the issues outlined above.

To print the local variable generated by an instruction, we need to know the block and instruction index of the instruction. Rather than compute it on-demand, we compute *all* variable names the first time an instruction is stringifed and cache the names inside each instruction. Because the IR is conceptually immutable, we get away with this.

The other approaches I dismissed:

 - Having an explicit printer struct: annoying for the user.

 - Having Deku put references to the parent structures in each IR element so that we can always walk upwards toward the `AOTModule`: wastes a lot of memory, even if you never print the IR.

Note that I still haven't implemented printing for everything. For example, printing constants and types still prints placeholder strings.

Follow up PRs will fix these. I just want to have the interface reviewed first.