### PR TITLE
Pass-finder scripts supports argument, moved yklua test suite to same folder as pass-finder script.

### DIFF
--- a/ykrt/pass_finder/try_passes.py
+++ b/ykrt/pass_finder/try_passes.py
@@ -30,9 +30,6 @@ STAGES = "pre_link", "link_time"
 @dataclass
 class Pass:
     name: str
-    # FIXME: implement support for pass parameters?
-    #args: list
-
     def __str__(self):
         return self.name
 
@@ -82,10 +79,10 @@ def get_all_passes(is_prelink):
     seen = set()
      
     for descr in pass_descrs:
-        parts = descr.split("<")
-        if parts[0] not in seen:
-            seen.add(parts[0])
-            passes.append(Pass(parts[0]))
+        if descr not in seen:
+            seen.add(descr)
+            passes.append(Pass(descr))
+    
 
     print(f"Found {len(passes)} passes")    
     return passes

--- a/ykrt/pass_finder/yklua_tests.sh
+++ b/ykrt/pass_finder/yklua_tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+MODE=release
+
+if [ ! -z $PRELINK_PASSES ]; then
+  echo "yk-here"
+  yk-config ${MODE} --prelink-pipeline "${PRELINK_PASSES}" --cflags 
+else
+  yk-config ${MODE} --cflags
+fi
+
+if [ ! -z $LINKTIME_PASSES ]; then
+  yk-config ${MODE} --postlink-pipeline "${LINKTIME_PASSES}" --ldflags
+else
+  yk-config ${MODE} --ldflags
+fi
+
+make clean && make YK_BUILD_TYPE=release
+
+cd tests
+
+LUA=../src/lua
+
+for serialise in 0 1; do
+    for test in api bwcoercion closure code coroutine events \
+        gengc pm tpack tracegc utf8 vararg; do
+        echo "### YKD_SERIALISE_COMPILATION=$serialise $test.lua ###"
+        YKD_SERIALISE_COMPILATION=$serialise ${LUA} ${test}.lua
+    done
+done


### PR DESCRIPTION
This PR addresses two changes:
1) Earlier pass-finder script stripped off arguments from passes, with changes from this commit we will now be able to use passes with arguments.
2) Moved yklua test suite to same folder as pass-finder script.