### PR TITLE
Add testing infrastructure for new codegen development.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -91,6 +91,7 @@ cargo -Z unstable-options build --build-plan -p ykrt | \
 
 for i in $(seq 10); do
     RUST_TEST_SHUFFLE=1 cargo test
+    YKD_NEW_CODEGEN=1 RUST_TEST_SHUFFLE=1 cargo test
 done
 
 # We now want to test building with `--release`, which we also take as an
@@ -107,6 +108,7 @@ cargo build --release -p ykcapi
 
 for i in $(seq 10); do
     RUST_TEST_SHUFFLE=1 cargo test --release
+    YKD_NEW_CODEGEN=1 RUST_TEST_SHUFFLE=1 cargo test --release
 done
 
 # We want to check that the benchmarks build and run correctly, but want to

--- a/tests/c/simple.newcg.c
+++ b/tests/c/simple.newcg.c
@@ -1,0 +1,55 @@
+// Run-time:
+//   env-var: YKD_PRINT_IR=aot
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   status: error
+//   stderr:
+//     jit-state: start-tracing
+//     i=4
+//     jit-state: stop-tracing
+//     --- Begin aot ---
+//     ...
+//     func main {
+//     ...
+//     --- End aot ---
+//     ...
+//     not yet implemented: new codegen doesn't work yet
+//     ...
+
+// Check that basic trace compilation works.
+
+// FIXME: Get this test all the way through the new codegen pipeline!
+//
+// Currently it succeeds even though it crashes out on a todo!(). This is so
+// that we can incrementally implement the new codegen and have CI merge our
+// incomplete work.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "i=%d\n", i);
+    res += 2;
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/langtest_trace_compiler.rs
+++ b/tests/langtest_trace_compiler.rs
@@ -9,6 +9,13 @@ const COMMENT: &str = ";";
 fn main() {
     println!("Running trace compiler tests...");
 
+    if let Ok(val) = env::var("YKD_NEW_CODEGEN") {
+        if val == "1" {
+            eprintln!("This suite is for the LLVM JIT backend only. skipping.");
+            return;
+        }
+    }
+
     // Find the `run_trace_compiler_test` binary in the target dir.
     let md = env::var("CARGO_MANIFEST_DIR").unwrap();
     let mut run_tc_test = PathBuf::from(md);


### PR DESCRIPTION
This allows us to add C tests prefixed "newcg_" which are only tested using the new codegen: i.e. when YKD_NEW_CODEGEN=1.

This allows us to have some partial testing for the new codegen without compromising testing on the old codegen.

Thoughts? comments?