### PR TITLE
Update dependencies.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -7,9 +7,9 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = "0.2.148"
-strum = { version = "0.25", features = ["derive", "strum_macros"] }
+strum = { version = "0.25", features = ["derive"] }
 strum_macros = "0.25"
-deku = { version = "0.16.0", features = ["std"] }
+deku = "0.16.0"
 ykaddr = { path = "../ykaddr" }
 intervaltree = "0.2.7"
 byteorder = "1.4.3"

--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-libc = "0.2.80"
-strum = { version = "0.24.1", features = ["derive", "strum_macros"] }
-strum_macros = "0.24.3"
+libc = "0.2.148"
+strum = { version = "0.25", features = ["derive", "strum_macros"] }
+strum_macros = "0.25"
 deku = { version = "0.16.0", features = ["std"] }
 ykaddr = { path = "../ykaddr" }
 intervaltree = "0.2.7"
@@ -20,6 +20,6 @@ thiserror = "1"
 iced-x86 = { version = "1.18.0", features = ["decoder"]}
 
 [build-dependencies]
-cc = "1.0.62"
+cc = "1.0.83"
 rerun_except = "1"
 ykbuild = { path = "../ykbuild" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,18 +20,18 @@ path = "langtest_trace_compiler.rs"
 harness = false
 
 [dependencies]
-clap = { features = ["derive"], version = "4.0.11" }
+clap = { features = ["derive"], version = "4.4" }
 hwtracer = { path = "../hwtracer" }
-memmap2 = "0.6"
-regex = "1.5.4"
-tempfile = "3.3.0"
+memmap2 = "0.7"
+regex = "1.9"
+tempfile = "3.8"
 ykbuild = { path = "../ykbuild" }
 ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }
 yktracec = { path = "../yktracec", features = ["yk_testing"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
-lang_tester = "0.7.1"
+lang_tester = "0.7.4"
 ykcapi = { path = "../ykcapi", features = ["yk_testing"] }
 yktracec = { path = "../yktracec", features = ["yk_testing"] }
 ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-walkdir = "2.3.2"
+walkdir = "2.4"
 ykbuild = { path = "../ykbuild" }

--- a/ykaddr/Cargo.toml
+++ b/ykaddr/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-cached = { version = "0.43", features = ["proc_macro"] }
-libc = "0.2.117"
+cached = { version = "0.45", features = ["proc_macro"] }
+libc = "0.2"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 
 [build-dependencies]
-cc = "1.0.72"
+cc = "1.0.83"

--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -10,10 +10,10 @@ links = "ykbuild"
 
 [dependencies]
 glob = "0.3.1"
-tempfile = "3.3.0"
+tempfile = "3.8"
 
 [build-dependencies]
 fs4 = "0.6"
 num_cpus = "1.0"
 rerun_except = "1.0.0"
-which = "4.4.0"
+which = "4.4"

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-libc = "0.2.117"
+libc = "0.2.148"
 ykrt = { path = "../ykrt" }
 
 [build-dependencies]

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -8,15 +8,15 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 deku = { version = "0.16.0", features = ["std"] }
 hwtracer = { path = "../hwtracer" }
-libc = "0.2.117"
-memmap2 = "0.6"
+libc = "0.2.148"
+memmap2 = "0.7"
 num_cpus = "1.13.1"
 parking_lot = "0.12.0"
 parking_lot_core = "0.9.1"
-tempfile = "3.3.0"
+tempfile = "3.8"
 ykaddr = { path = "../ykaddr" }
 yksmp = { path = "../yksmp" }
-strum = { version = "0.24.0", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 yktracec = { path = "../yktracec" }
 
 [dependencies.llvm-sys]
@@ -28,12 +28,12 @@ rev = "678b3da2b2239ae12766c964e6e613c0d82b5f37"
 features = ["no-llvm-linking"]
 
 [dependencies.object]
-version = "0.31"
+version = "0.32"
 default-features = false
 features = ["read_core", "elf"]
 
 [build-dependencies]
-regex = "1.5.4"
+regex = "1.9"
 ykbuild = { path = "../ykbuild" }
 
 [dev-dependencies]

--- a/yktracec/Cargo.toml
+++ b/yktracec/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-libc = "0.2.117"
+libc = "0.2.148"
 ykbuild = { path = "../ykbuild" }
 
 [build-dependencies]
-cc = "1.0.72"
+cc = "1.0.83"
 rerun_except = "1.0.0"
 ykbuild = { path = "../ykbuild" }
 


### PR DESCRIPTION
Some of these are quite old, and are rather more specific than seems useful: `x.y.z` only really makes sense when we know for sure that we need a specific `.z` or `.y.z` version, when generally we don't really know. So if `.y` (or, when appropriate, `.x`) has increased, I've dropped the suffix(es), for simplicity's sake.