### PR TITLE
Fix memory leak due to `CompiledTrace` not dropping.

### DIFF
--- a/tests/c/side-trace.c
+++ b/tests/c/side-trace.c
@@ -2,6 +2,7 @@
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_STATS=-
 //   stderr:
 //     jit-state: start-tracing
 //     1
@@ -49,6 +50,11 @@
 //     28
 //     jit-state: deoptimise
 //     30
+//     {
+//         ...
+//         "trace_executions": 7,
+//         ...
+//     }
 //   stdout:
 //     exit
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -229,7 +229,9 @@ impl MT {
                         unsafe extern "C" fn(*mut c_void, *const CompiledTrace, *const c_void) -> !,
                     >(ctr.entry());
                     // FIXME: Calling this function overwrites the current (Rust) function frame,
-                    // rather than unwinding it. https://github.com/ykjit/yk/issues/778
+                    // rather than unwinding it. https://github.com/ykjit/yk/issues/778.
+                    // The `Arc<CompiledTrace>` passed into the trace here will be safely dropped
+                    // upon deoptimisation, which is the only way to exit a trace.
                     f(ctrlp_vars, Arc::into_raw(ctr), frameaddr);
                 }
             }


### PR DESCRIPTION
We can test for leaks by enabled yk stats which are only printed when `MT` drops, which doesn't happen if we are leaking `CompiledTrace`s.

Also, while we are here make it very clear that we can never return from executing a side-trace.