### PR TITLE
Weaken test as symbols are not guaranteed to be in a particular object.

### DIFF
--- a/ykaddr/src/addr.rs
+++ b/ykaddr/src/addr.rs
@@ -144,7 +144,7 @@ mod tests {
     use super::{off_to_vaddr, vaddr_to_obj_and_off, vaddr_to_sym_and_obj, MaybeUninit};
     use crate::obj::PHDR_MAIN_OBJ;
     use libc::{self, dlsym, Dl_info};
-    use std::{ffi::CString, path::PathBuf, ptr};
+    use std::{ffi::CString, ptr};
 
     #[test]
     fn map_libc() {

--- a/ykaddr/src/addr.rs
+++ b/ykaddr/src/addr.rs
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn vaddr_to_sym_and_obj_found() {
+    fn vaddr_to_sym() {
         // To test this we need an exported symbol with a predictable (i.e. unmangled) name.
         use libc::fflush;
         let func_vaddr = fflush as *const fn();
@@ -200,13 +200,6 @@ mod tests {
             sio.dli_sname().unwrap().to_str().unwrap(),
             "fflush" | "_IO_fflush"
         ));
-        let obj_path = PathBuf::from(sio.dli_fname().unwrap().to_str().unwrap());
-        assert!(obj_path
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .starts_with("libc.so."));
     }
 
     #[test]


### PR DESCRIPTION
There is no guarantee that fflush, or indeed any symbol, comes from a particular object file, so this test is fragile. The particular way I've encountered this possibility is with LLVM sanitisers where fflush ends up in
`target/x86_64-unknown-linux-gnu/debug/deps/ykaddr-7516308ead64a32b`. But even without sanitisers, one can imagine `LD_PRELOAD` or similar causing this part of the test not to work. See https://github.com/ykjit/yk/issues/495#issuecomment-1744797808 for some more details.