### PR TITLE
Optimise deoptimisation.

### DIFF
--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -306,8 +306,9 @@ unsafe extern "C" fn __ykrt_deopt(
         if let Some(st) = guard.getct() {
             let registers = Registers::from_ptr(rsp);
             let live_vars = ctr.smap().get(&retaddr.try_into().unwrap()).unwrap();
-            let mut ykctrlpvars = Vec::new();
-            for (_i, locs) in live_vars.iter().skip(1).enumerate() {
+            debug_assert!(live_vars.len() > 0);
+            let mut ykctrlpvars = vec![0; live_vars.len() - 1];
+            for (i, locs) in live_vars.iter().skip(1).enumerate() {
                 assert!(locs.len() == 1);
                 let l = locs.get(0).unwrap();
                 match l {
@@ -321,7 +322,7 @@ unsafe extern "C" fn __ykrt_deopt(
                         assert_eq!(*reg, 6);
                         let addr = unsafe { registers.get(*reg) as *mut u8 };
                         let addr = unsafe { addr.offset(isize::try_from(*off).unwrap()) };
-                        ykctrlpvars.push(addr as u64);
+                        ykctrlpvars[i] = addr as u64;
                     }
                     SMLocation::Indirect(reg, off, size) => {
                         let addr = unsafe { registers.get(*reg) as *mut u8 };
@@ -333,10 +334,10 @@ unsafe extern "C" fn __ykrt_deopt(
                             8 => unsafe { ptr::read::<u64>(addr as *mut u64) },
                             _ => unreachable!(),
                         };
-                        ykctrlpvars.push(v);
+                        ykctrlpvars[i] = v;
                     }
                     SMLocation::Constant(v) => {
-                        ykctrlpvars.push(*v as u64);
+                        ykctrlpvars[i] = *v as u64;
                     }
                     SMLocation::LargeConstant(_v) => {
                         todo!();

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -296,6 +296,7 @@ unsafe extern "C" fn __ykrt_deopt(
     // an `Arc` so it will be dropped at the end of this function. Unless, we are going to execute
     // a side-trace. In that case this function will not return and we need to drop `ctr` manually.
     let ctr = Arc::from_raw(ctr);
+    (*ctr).mt().stats.timing_state(TimingState::Deopting);
 
     let guardid = GuardId(guardid);
 
@@ -347,6 +348,7 @@ unsafe extern "C" fn __ykrt_deopt(
                 _,
                 unsafe extern "C" fn(*mut c_void, *const CompiledTrace, *const c_void) -> !,
             >(st.entry());
+            (*ctr).mt().stats.timing_state(TimingState::JitExecuting);
 
             // This `Arc<CompiledTrace>` was cloned before executing this trace. Since the
             // side-trace will not return, we need to drop `ctr` manually here to avoid leaks.
@@ -366,7 +368,6 @@ unsafe extern "C" fn __ykrt_deopt(
 
     #[cfg(feature = "yk_jitstate_debug")]
     print_jit_state("deoptimise");
-    (*ctr).mt().stats.timing_state(TimingState::Deopting);
 
     // Copy arguments into a struct we can pass into the ThreadSafeModuleWithModuleDo function.
     let mut info = ReconstructInfo {

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -9,6 +9,7 @@ use std::{
     ffi::{c_void, CStr},
     fs, ptr, slice,
     sync::LazyLock,
+    thread,
 };
 use yksmp::{Location as SMLocation, SMEntry, StackMapParser};
 
@@ -34,6 +35,10 @@ pub static AOT_STACKMAPS: LazyLock<Vec<SMEntry>> = LazyLock::new(|| {
     };
     StackMapParser::get_entries(slice)
 });
+
+pub(crate) fn load_aot_stackmaps() {
+    thread::spawn(|| LazyLock::force(&AOT_STACKMAPS));
+}
 
 static USIZEOF_POINTER: usize = std::mem::size_of::<*const ()>();
 static ISIZEOF_POINTER: isize = std::mem::size_of::<*const ()>() as isize;

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -4,7 +4,6 @@
 use llvm_sys::{core::*, prelude::LLVMValueRef};
 use object::{Object, ObjectSection};
 use std::{
-    collections::HashMap,
     convert::TryFrom,
     env,
     ffi::{c_void, CStr},
@@ -55,26 +54,26 @@ impl SGValue {
 
 /// A frame holding live variables.
 struct Frame {
-    vars: HashMap<Value, SGValue>,
+    vars: Vec<SGValue>,
     pc: Value,
 }
 
 impl Frame {
     fn new(pc: Value) -> Frame {
         Frame {
-            vars: HashMap::new(),
+            vars: Vec::new(),
             pc,
         }
     }
 
     /// Get the value of the variable `key` in this frame.
-    fn get(&self, key: &Value) -> Option<&SGValue> {
-        self.vars.get(key)
+    fn get(&self, i: usize) -> Option<&SGValue> {
+        self.vars.get(i)
     }
 
     /// Add new variable `key` with value `val`.
-    fn add(&mut self, key: Value, val: SGValue) {
-        self.vars.insert(key, val);
+    fn add(&mut self, val: SGValue) {
+        self.vars.push(val);
     }
 }
 
@@ -248,11 +247,11 @@ impl FrameReconstructor {
             // WRITE STACKMAP LOCATIONS.
             // Now write all live variables to the new stack in the order they are listed in the
             // AOT stackmap call.
-            let smcall = get_stackmap_call(frame.pc);
             for (j, lv) in rec.live_vars.iter().enumerate() {
                 // Adjust the operand index by 2 to skip stackmap ID and shadow bytes.
-                let op = smcall.get_operand(u32::try_from(j + 2).unwrap());
-                if op.is_frameaddr_call() {
+                let val = if let Some(sg) = frame.get(j) {
+                    sg.val
+                } else {
                     // Sidetraces require an unconditional guard at the end which deopts back to
                     // the control point. The stackmap at this location contains the value returned
                     // by the call to `frameaddr`. We are not interested in its value and tracking
@@ -260,9 +259,11 @@ impl FrameReconstructor {
                     // to). So the easiest approach for now is to simply omit this live variable
                     // during deoptimisation. In the future we will patch side traces into the
                     // parent trace, so this hack will no longer be needed then.
+                    debug_assert!(get_stackmap_call(frame.pc)
+                        .get_operand(u32::try_from(j + 2).unwrap())
+                        .is_frameaddr_call());
                     continue;
-                }
-                let val = frame.get(&op).unwrap().val;
+                };
                 let l = if lv.len() == 1 {
                     lv.get(0).unwrap()
                 } else {
@@ -406,6 +407,6 @@ impl FrameReconstructor {
         }
 
         let liveval = SGValue::new(val, ty);
-        self.frames.get_mut(sfidx).unwrap().add(aotval, liveval);
+        self.frames.get_mut(sfidx).unwrap().add(liveval);
     }
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -100,10 +100,13 @@ impl std::fmt::Debug for MT {
     }
 }
 
+use crate::frame::load_aot_stackmaps;
+
 impl MT {
     // Create a new meta-tracer instance. Arbitrarily many of these can be created, though there
     // are no guarantees as to whether they will share resources effectively or fairly.
     pub fn new() -> Result<Arc<Self>, Box<dyn Error>> {
+        load_aot_stackmaps();
         Ok(Arc::new(Self {
             hot_threshold: AtomicHotThreshold::new(DEFAULT_HOT_THRESHOLD),
             sidetrace_threshold: AtomicHotThreshold::new(DEFAULT_SIDETRACE_THRESHOLD),


### PR DESCRIPTION
This PR attempts to improve the performance of deoptimisation. Since deoptimisation can happen frequently we want it to be as cheap as possible so it doesn't negate the performance gain from running traces.

These changes manage to improve deoptimisation in debug mode yk by about 2x. While a good improvement it is still way to high: according to `YK_STATS` we are spending 34x more time in deopt than running traces (from `db.lua`: 0.007s JIT exec; 0.24 deopt). Unfortunately, in relase-mode yk the speedup gained by this PR is even lower, down to 5%. The reason for this appear to be side-traces which trigger a lot of deoptimisations for little gain as they don't run very long (this might change once we use patching to make side-traces loop back to the beginning of the trace). We can also see that side-traces can be nested deeply putting even more pressure on deoptimisation: executing a side-trace always requires a some (though not all of) deoptimisation to run first. The following screenshot shows some nested side-traces for illustration:

![image](https://github.com/ykjit/yk/assets/375552/bf073305-8586-4f1b-be7c-2eacfcfb12a3)

I will have a quick look if I can optimise the side-trace part of deoptimisation a little and then either add it as a commit here or push it in a separate PR. In the meantime this is open for discussion.