### PR TITLE
Add an "IR lowering" test suite.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -69,17 +69,17 @@ WARNING_DEFINES="-D unused-variables -D dead-code"
 for p in $(sed -n -e '/^members =/,/^\]$/{/^members =/d;/^\]$/d;p;}' \
   Cargo.toml \
   | \
-  tr -d ' \t\",'); do
-    cd $p
-    if [ $p = "tests" ]; then
-        cargo rustc --profile check --lib -- ${WARNING_DEFINES}
-    else
-        cargo rustc --profile check -- ${WARNING_DEFINES}
-        cargo rustc --profile check --tests -- ${WARNING_DEFINES}
-        cargo rustc --profile check --benches -- ${WARNING_DEFINES}
+  tr -d ' \t\",' | grep -v xtask); do
+    cargo rustc -p $p --profile check --lib -- ${WARNING_DEFINES}
+    # For some reason, we can't do these checks on crates with binary targets.
+    if [ "$p" != "ykrt" ] && [ "$p" != "tests" ]; then
+        cargo rustc -p $p --profile check --tests -- ${WARNING_DEFINES}
+        cargo rustc -p $p --profile check --benches -- ${WARNING_DEFINES}
     fi
-    cd ..
 done
+cargo rustc -p tests --profile check --bin dump_ir -- ${WARNING_DEFINES}
+cargo rustc -p tests --profile check --bin gdb_c_test -- ${WARNING_DEFINES}
+cargo rustc -p xtask --profile check --bin xtask -- ${WARNING_DEFINES}
 
 # There are some feature-gated testing/debugging switches which slow the JIT
 # down a bit. Check that if we build the system without tests, those features

--- a/bin/dump_ir
+++ b/bin/dump_ir
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Wrapper around the `dump_ir` binary to make it easier to use.
+
+set -e
+cargo run --bin dump_ir -- $@

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,6 +19,11 @@ name = "trace_compiler_tests"
 path = "langtest_trace_compiler.rs"
 harness = false
 
+[[test]]
+name = "ir_lowering_tests"
+path = "langtest_ir_lowering.rs"
+harness = false
+
 [dependencies]
 clap = { features = ["derive"], version = "4.4" }
 hwtracer = { path = "../hwtracer" }

--- a/tests/ir_lowering/call_operands.ll
+++ b/tests/ir_lowering/call_operands.ll
@@ -1,0 +1,23 @@
+; Dump:
+;   stdout:
+;     ...
+;     func main {
+;       bb0:
+;         call f(1i32, 2i32, 3i32)
+;         ret 0i32
+;     }
+
+; Check a call instruction lowers and prints correctly.
+;
+; The reason for this is that in LLVM's IR data structures the call target is
+; the last operand, but in Yk's IR it's the first. A generic lowering would do
+; the wrong thing.
+
+
+define void @f(i32 %0, i32 %1, i32 %2) { ret void }
+
+define i32 @main() {
+entry:
+  call void @f(i32 1, i32 2, i32 3);
+  ret i32 0
+}

--- a/tests/ir_lowering/empty.ll
+++ b/tests/ir_lowering/empty.ll
@@ -1,0 +1,18 @@
+; Dump:
+;   stdout:
+;     # IR format version: 0
+;     # Num funcs: 1
+;     # Num consts: 1
+;     # Num types: 2
+;
+;     func main {
+;       bb0:
+;         ret 0i32
+;     }
+
+; The simplest test you could write. Checks an empty module lowers correctly.
+
+define i32 @main() {
+entry:
+  ret i32 0
+}

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -39,30 +39,24 @@ fn correct_codegen_for_test(p: &Path) -> bool {
 fn run_suite(opt: &'static str) {
     println!("Running C tests with opt level {}...", opt);
 
+    fn is_c(p: &Path) -> bool {
+        p.extension().as_ref().and_then(|p| p.to_str()) == Some("c")
+    }
+
     // Tests with the filename prefix `debug_` are only run in debug builds.
     #[cfg(cargo_profile = "release")]
-    let filter: fn(&Path) -> bool = |p| {
-        if let Some(ext) = p.extension() {
-            ext == "c"
-                && correct_codegen_for_test(p)
-                && !p
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .starts_with("debug_")
-        } else {
-            false
-        }
+    let filter = |p: &Path| {
+        is_c(p)
+            && correct_codegen_for_test(p)
+            && !p
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("debug_")
     };
     #[cfg(cargo_profile = "debug")]
-    let filter: fn(&Path) -> bool = |p| {
-        if let Some(ext) = p.extension() {
-            ext == "c" && correct_codegen_for_test(p)
-        } else {
-            false
-        }
-    };
+    let filter = |p: &Path| is_c(p) && correct_codegen_for_test(p);
 
     let tempdir = TempDir::new().unwrap();
 

--- a/tests/langtest_ir_lowering.rs
+++ b/tests/langtest_ir_lowering.rs
@@ -1,0 +1,67 @@
+//! A suite for testing lowerings of LLVM IR to Yk IR.
+
+use lang_tester::LangTester;
+use regex::Regex;
+use std::{env, fs::read_to_string, path::PathBuf, process::Command};
+use tempfile::TempDir;
+use ykbuild::ykllvm_bin;
+
+const COMMENT: &str = ";";
+
+fn main() {
+    println!("Running IR lowering tests...");
+
+    let tempdir = TempDir::new().unwrap();
+    LangTester::new()
+        .test_dir("ir_lowering")
+        .test_file_filter(|p| p.extension().as_ref().and_then(|p| p.to_str()) == Some("ll"))
+        .test_extract(move |p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
+                .skip_while(|l| !l.starts_with(COMMENT))
+                .take_while(|l| l.starts_with(COMMENT))
+                .map(|l| &l[COMMENT.len()..])
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .test_cmds(move |p| {
+            let mut exe = PathBuf::new();
+            exe.push(&tempdir);
+            exe.push(p.file_stem().unwrap());
+
+            // We don't use yk-config here, as we are testing one very specific functionality that
+            // requires only one special flag.
+            let mut compiler = Command::new(ykllvm_bin("clang"));
+            compiler.args(&[
+                "-flto",
+                "-fuse-ld=lld",
+                "-O0",
+                "-o",
+                exe.to_str().unwrap(),
+                "-Wl,-mllvm=--yk-embed-ir",
+                p.to_str().unwrap(),
+            ]);
+
+            let md = env::var("CARGO_MANIFEST_DIR").unwrap();
+            #[cfg(cargo_profile = "debug")]
+            let build_kind = "debug";
+            #[cfg(cargo_profile = "release")]
+            let build_kind = "release";
+            let dumper_path = [&md, "..", "target", build_kind, "dump_ir"]
+                .iter()
+                .collect::<PathBuf>();
+            let mut dumper = Command::new(dumper_path);
+            dumper.arg(exe);
+
+            vec![("Compiler", compiler), ("Dump", dumper)]
+        })
+        .fm_options(|_, _, fmb| {
+            // Use `{{}}` to match non-literal strings in tests.
+            // E.g. use `%{{var}}` to capture the name of a variable.
+            let ptn_re = Regex::new(r"\{\{.+?\}\}").unwrap();
+            let text_re = Regex::new(r"[a-zA-Z0-9\._]+").unwrap();
+            fmb.name_matcher(ptn_re, text_re)
+        })
+        .run();
+}

--- a/tests/langtest_trace_compiler.rs
+++ b/tests/langtest_trace_compiler.rs
@@ -29,13 +29,7 @@ fn main() {
 
     LangTester::new()
         .test_dir("trace_compiler")
-        .test_file_filter(|p| {
-            if let Some(ext) = p.extension() {
-                ext == "ll"
-            } else {
-                false
-            }
-        })
+        .test_file_filter(|p| p.extension().as_ref().and_then(|p| p.to_str()) == Some("ll"))
         .test_extract(move |p| {
             read_to_string(p)
                 .unwrap()

--- a/tests/src/bin/dump_ir.rs
+++ b/tests/src/bin/dump_ir.rs
@@ -1,0 +1,48 @@
+use std::{
+    env,
+    error::Error,
+    path::PathBuf,
+    process::{exit, Command},
+};
+use tempfile::TempDir;
+use ykrt::compile::jitc_yk::aot_ir;
+
+const OUTFILE: &str = "ykir";
+
+#[cfg(target_family = "unix")]
+fn extract_bytecode(tempdir: &TempDir, fname: &str) -> Result<PathBuf, Box<dyn Error>> {
+    let mut out_file = tempdir.path().to_owned();
+    out_file.push(OUTFILE);
+    let output = Command::new("objcopy")
+        .args(&[
+            "--dump-section",
+            &format!(".yk_ir={}", out_file.to_str().unwrap()),
+            fname,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(String::from_utf8(output.stderr)?.into());
+    }
+
+    Ok(out_file)
+}
+
+fn inner() -> Result<(), Box<dyn Error>> {
+    if let Some(exe) = env::args().skip(1).next() {
+        let tempdir = TempDir::new()?;
+        let bcfile = extract_bytecode(&tempdir, &exe)?;
+        aot_ir::print_from_file(&bcfile)?;
+        drop(tempdir); // hold it live until here so we can read from it.
+        Ok(())
+    } else {
+        Err(String::from("Dumps Yk IR from an executable binary.\n\nusage: dump_ir <exe>").into())
+    }
+}
+
+fn main() {
+    if let Err(e) = inner() {
+        eprintln!("{e}");
+        exit(1);
+    }
+}

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -5,7 +5,7 @@
 
 use byteorder::{NativeEndian, ReadBytesExt};
 use deku::prelude::*;
-use std::{cell::RefCell, error::Error, ffi::CStr, io::Cursor};
+use std::{cell::RefCell, error::Error, ffi::CStr, fs, io::Cursor, path::PathBuf};
 
 /// A magic number that all bytecode payloads begin with.
 const MAGIC: u32 = 0xedd5f00d;
@@ -496,6 +496,16 @@ pub(crate) fn deserialise_module(data: &[u8]) -> Result<AOTModule, Box<dyn Error
         }
         Err(e) => Err(e.to_string().into()),
     }
+}
+
+/// Deserialise and print IR from an on-disk file.
+///
+/// Used for support tooling (in turn used by tests too).
+pub fn print_from_file(path: &PathBuf) -> Result<(), Box<dyn Error>> {
+    let data = fs::read(path)?;
+    let ir = deserialise_module(&data)?;
+    println!("{}", ir.to_str());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -48,7 +48,7 @@ static PHASES_TO_PRINT: LazyLock<HashSet<IRPhase>> = LazyLock::new(|| {
     }
 });
 
-mod aot_ir;
+pub mod aot_ir;
 
 pub(crate) struct JITCYk;
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -26,7 +26,7 @@ use yksmp::StackMapParser;
 pub(crate) mod jitc_llvm;
 
 #[cfg(jitc_yk)]
-pub(crate) mod jitc_yk;
+pub mod jitc_yk;
 
 /// The trait that every JIT compiler backend must implement.
 pub(crate) trait Compiler: Send + Sync {


### PR DESCRIPTION
For each test you feed in textual LLVM IR and it gets compiled with ykllvm's clang. We then extract and deserialise the Yk IR, and use lang_tester to match against it.

We do have to be a bit careful when writing tests. Even at -O0, clang optimises away some LLVM instructions if it deems them redundant. If in doubt, make instructions depend on dynamic properties (e.g. argc or argv).

Nonetheless, this is much less painful that manually throwing bytes into a vector, as we've been doing in unit tests.