### PR TITLE
Add pthread_create interception call in ykrt

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -88,6 +88,8 @@ handle_arg() {
             OUTPUT="${OUTPUT} -fuse-ld=lld"
             # Embed LLVM bitcode as late as possible.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--embed-bitcode-final"
+            # Add pthread_create wrapper function (__wrap_pthread_create)
+            OUTPUT="${OUTPUT} -Wl,--wrap=pthread_create"
             # Embed Yk's IR.
             if [ "${YKD_NEW_CODEGEN}" = "1" ]; then
                 OUTPUT="${OUTPUT} -Wl,-mllvm=--yk-embed-ir"

--- a/tests/c/pthread_create.c
+++ b/tests/c/pthread_create.c
@@ -1,0 +1,31 @@
+// Compiler:
+// Run-time:
+//   status: error
+//   stderr: ...
+//    not yet implemented: Allocate and set thread-local ShadowStack instance. No support for threads yet!
+//    ...
+
+#include <pthread.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+void *thread_function(void *arg) { return NULL; }
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 3;
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    pthread_t thread;
+    pthread_create(&thread, NULL, thread_function, NULL);
+    pthread_join(thread, NULL);
+    i--;
+  }
+
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return 0;
+}

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -13,6 +13,7 @@ mod deopt;
 mod frame;
 mod location;
 pub(crate) mod mt;
+pub(crate) mod thread_intercept;
 pub mod trace;
 mod ykstats;
 

--- a/ykrt/src/thread_intercept.rs
+++ b/ykrt/src/thread_intercept.rs
@@ -1,0 +1,11 @@
+use std::os::raw::{c_int, c_void};
+
+#[no_mangle]
+pub extern "C" fn __wrap_pthread_create(
+    _: *mut c_void,
+    _: *const c_void,
+    _: extern "C" fn(*mut c_void) -> *mut c_void,
+    _: *mut c_void,
+) -> c_int {
+    todo!("Allocate and set thread-local ShadowStack instance. No support for threads yet!");
+}


### PR DESCRIPTION
Related Issue: https://github.com/ykjit/yk/issues/794
Dependant on https://github.com/ykjit/ykllvm/pull/92

Moving pthread_create calls detection from compiletime to runtime using `ld --wrap` functionality.

This approach will work with staticly linked objects but won't work with dynamic loading. 

Next step will be to set ThreadLocal shadowstack for newly created threads in the wrapper function `__wrap_pthread_create`.
