### PR TITLE
Add tests to exercise recently fixed ykllvm indices bugs.

### DIFF
--- a/tests/ir_lowering/after_alloca.ll
+++ b/tests/ir_lowering/after_alloca.ll
@@ -1,0 +1,31 @@
+; Dump:
+;   stdout:
+;     ...
+;     func main {
+;       bb0:
+;         $0_0: ptr = alloca i32, 1i32
+;         store 1i32, $0_0: ptr
+;         $0_2: i1 = icmp ?op<i32 %0>, 1i32
+;         condbr $0_2: i1, bb2, bb1
+;     ...
+
+
+; Check that a instructions following a call are correctly lowered.
+
+define i32 @f(i32 %0) noinline {
+  ret i32 %0
+}
+
+define i32 @main(i32 %argc, ptr %argv) {
+entry:
+  %0 = alloca i32
+  store i32 1, ptr %0
+  %1 = icmp eq i32 %argc, 1
+  br i1 %1, label %bb1, label %bb2
+
+bb1:
+    ret i32 0
+
+bb2:
+    ret i32 1
+}

--- a/tests/ir_lowering/after_call.ll
+++ b/tests/ir_lowering/after_call.ll
@@ -1,0 +1,29 @@
+; Dump:
+;   stdout:
+;     ...
+;     func main {
+;       bb0:
+;         $0_0: i32 = call f(?op<i32 %0>)
+;         $0_1: i1 = icmp ?op<i32 %0>, 1i32
+;         condbr $0_1: i1, bb2, bb1
+;     ...
+
+
+; Check that a instructions following a call are correctly lowered.
+
+define i32 @f(i32 %0) noinline {
+  ret i32 %0
+}
+
+define i32 @main(i32 %argc, ptr %argv) {
+entry:
+  %0 = call i32 @f(i32 %argc)
+  %1 = icmp eq i32 %argc, 1
+  br i1 %1, label %bb1, label %bb2
+
+bb1:
+    ret i32 0
+
+bb2:
+    ret i32 1
+}


### PR DESCRIPTION
When lowering allocas, calls and branches, the indices were passed by value, meaning that their index mutations weren't observed.

This is a companion to https://github.com/ykjit/ykllvm/pull/93