### PR TITLE
Resizing the aux buffer causes problems, so don't.

### DIFF
--- a/hwtracer/src/perf/collect.c
+++ b/hwtracer/src/perf/collect.c
@@ -270,24 +270,13 @@ bool read_aux(void *aux_buf, struct perf_event_mmap_page *hdr,
     new_data_size = (size - tail) + head;
   }
 
-  // Reallocate the trace storage buffer if more space is required.
   __u64 required_capacity = trace->len + new_data_size;
   if (required_capacity > trace->capacity) {
-    // Over-allocate to 2x what we need, checking that the result fits in
-    // the size_t argument of realloc(3).
-    if (required_capacity >= SIZE_MAX / 2) {
-      // We would overflow the size_t argument of realloc(3).
-      hwt_set_cerr(err, hwt_cerror_errno, ENOMEM);
-      return false;
-    }
-    size_t new_capacity = required_capacity * 2;
-    void *new_buf = realloc(trace->buf.p, new_capacity);
-    if (new_buf == NULL) {
-      hwt_set_cerr(err, hwt_cerror_errno, errno);
-      return false;
-    }
-    trace->capacity = new_capacity;
-    trace->buf.p = new_buf;
+    // FIXME: Reallocate the trace storage buffer if more space is required.
+    // Note that this requires careful synchronisation between the collection
+    // thread, the main thread, and Rust code.
+    hwt_set_cerr(err, hwt_cerror_errno, ENOMEM);
+    return false;
   }
 
   // Finally append the new AUX data to the end of the trace storage buffer.

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -217,6 +217,8 @@ mod tests {
 
     /// Check that a long trace causes the trace buffer to reallocate.
     #[test]
+    // FIXME: Reallocating the trace buffer causes synchronisation problems.
+    #[ignore]
     fn relloc_trace_buf() {
         let start_bufsize = 512;
         let config = PerfCollectorConfig {


### PR DESCRIPTION
If the collector thread determines that the trace needed more room, it resizes the buffer and updates the capacity. However, something goes wrong that causes (at least) the pointer value to become corrupted in some way. There are several possible candidates: the updates are done non-atomically in a "collector" thread so may not synchronise with the being-collected thread; and updates are also not atomically synchronised with Rust code. My surface-level attempts to fix this haven't succeeded, so either there's more synchronisation needed than I currently realise, or there are other problems as well.

This commit thus simply disables trace buffer reallocation. For yk this isn't likely to be a big problem: we throw away big traces anyway. [Arguably the current buffer size is much bigger than we need and want, but that's something we can worry about separately.]

With this commit I can successfully run "yklua db.lua" in a loop without an error: without this commit, it nearly always dies (normally with a SEGFAULT in realloc/malloc).

Fixes https://github.com/ykjit/yklua/issues/38.