### PR TITLE
IR: Only print local variable types at def sites.

### DIFF
--- a/tests/ir_lowering/after_alloca.ll
+++ b/tests/ir_lowering/after_alloca.ll
@@ -4,9 +4,9 @@
 ;     func main($arg0: i32, $arg1: ptr) -> i32 {
 ;       bb0:
 ;         $0_0: ptr = alloca i32, 1i32
-;         store 1i32, $0_0: ptr
+;         store 1i32, $0_0
 ;         $0_2: i1 = icmp $arg0, 1i32
-;         condbr $0_2: i1, bb2, bb1
+;         condbr $0_2, bb2, bb1
 ;     ...
 
 

--- a/tests/ir_lowering/after_call.ll
+++ b/tests/ir_lowering/after_call.ll
@@ -5,7 +5,7 @@
 ;       bb0:
 ;         $0_0: i32 = call f($arg0)
 ;         $0_1: i1 = icmp $arg0, 1i32
-;         condbr $0_1: i1, bb2, bb1
+;         condbr $0_1, bb2, bb1
 ;     ...
 
 

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -90,13 +90,8 @@ pub(crate) struct LocalVariableOperand {
 }
 
 impl IRDisplay for LocalVariableOperand {
-    fn to_str(&self, m: &AOTModule) -> String {
-        format!(
-            "${}_{}: {}",
-            self.bb_idx,
-            self.inst_idx,
-            m.local_var_operand_type(self).to_str(m)
-        )
+    fn to_str(&self, _m: &AOTModule) -> String {
+        format!("${}_{}", self.bb_idx, self.inst_idx,)
     }
 }
 
@@ -528,15 +523,6 @@ impl AOTModule {
         &self.types[instr.type_index]
     }
 
-    /// Get the type of the local variable operand.
-    ///
-    /// It is UB to pass an operand that is not from an instruction in the `AOTModule` referenced
-    /// by `self`.
-    fn local_var_operand_type(&self, o: &LocalVariableOperand) -> &Type {
-        let instr = &self.funcs[o.func_idx].blocks[o.bb_idx].instrs[o.inst_idx];
-        self.instr_type(instr)
-    }
-
     fn instr_generates_value(&self, i: &Instruction) -> bool {
         self.instr_type(i) != &Type::Void
     }
@@ -852,7 +838,7 @@ func foo($arg0: ptr, $arg1: i32) -> i32 {
   bb0:
     $0_0: ptr = alloca ?cst<a_type>
     nop
-    condbr $0_0: ptr, bb0, bb1
+    condbr $0_0, bb0, bb1
   bb1:
     ?inst<%3 = some_llvm_instruction ...>
     $1_1: ptr = getelementptr -1i32


### PR DESCRIPTION
Before we were printing the types of all uses of local variables. This made the IR too noisy IMHO.

This change makes it so that they are only printed at definition sites.