### PR TITLE
Handle uncovered control flow events in disassembly-based PT decoding.

### DIFF
--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -608,7 +608,25 @@ impl<'t> YkPTBlockIterator<'t> {
                         self.update_stack_adjust(1);
                     }
                 }
-                _ => todo!(),
+                iced_x86::FlowControl::Interrupt => {
+                    // It's my understanding that `INT` instructions aren't really used any more.
+                    // Interrupt 0x80 used to be used to do system calls, but now there is the
+                    // `SYSCALL` instruction which is generally preferred.
+                    unreachable!("interrupt");
+                }
+                iced_x86::FlowControl::XbeginXabortXend => {
+                    // Transactions. These are a bit like time machines for the CPU. They can cause
+                    // memory and registers to be rewound to a (dynamically decided) past state.
+                    //
+                    // FIXME: We might be able to handle these by peeking ahead in the trace, but
+                    // let's cross that bridge when we come to it.
+                    todo!("transaction instruction: {}", inst);
+                }
+                iced_x86::FlowControl::Exception => {
+                    // We were unable to disassemble the instruction stream to a valid x86_64
+                    // instruction. This shouldn't happen, and if it does, I want to know about it!
+                    unreachable!("invalid instruction encoding");
+                }
             }
         }
     }


### PR DESCRIPTION
There are outstanding 3 cases to handle. Thanks to issue #883, We know one of them has arisen in the past, but we don't know which.

This change splits out the 3 cases and makes a different crash for each so that we know which case we are hitting.

I've run this code on try_repeat for 2 hours during which time it completed 1000 runs of the test suite in release mode, so the crash must be either no longer present or exceptionally rare.

Let's merge this now, then if it comes up again we can at least know which case to think about. Depending on which, we may decide to flag a temporary failure, thus aborting trace compilation and allowing the interpreter to continue. Cross that bridge if/when we come to it.