### PR TITLE
Respect `CARGO_JOBS` when building ykllvm

### DIFF
--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -14,6 +14,5 @@ tempfile = "3.8"
 
 [build-dependencies]
 fs4 = "0.6"
-num_cpus = "1.0"
 rerun_except = "1.0.0"
 which = "4.4"

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -136,8 +136,13 @@ fn main() {
         .current_dir(build_dir.as_os_str().to_str().unwrap());
 
     let mut build_cmd = Command::new("cmake");
+    let mut build_args = vec!["--build".into(), ".".into()];
+    if let Ok(jobs) = env::var("NUM_JOBS") {
+        build_args.push("-j".into());
+        build_args.push(jobs);
+    }
     build_cmd
-        .args(["--build", "."])
+        .args(build_args)
         .current_dir(build_dir.as_os_str().to_str().unwrap());
 
     let mut inst_cmd = Command::new("cmake");
@@ -180,10 +185,6 @@ fn main() {
                 .to_str()
                 .unwrap(),
         );
-
-        if generator == "Unix Makefiles" {
-            build_cmd.args(["-j", num_cpus::get().to_string().as_str()]);
-        }
 
         cfg_cmd.status().unwrap().exit_ok().unwrap();
     }


### PR DESCRIPTION
This PR makes ykbuild pass down the value of `CARGO_JOBS` to ykllvm, so that you can easily restrict the number of jobs that building yk spawns without knowing that ykllvm is lots and lots of non-cargo-controlled code. Most of the hard work is in https://github.com/ykjit/yk/commit/4362533660e89098da6dd6d5e8f7187248b129e7, but when I looked at the code a bit more, I realised there's a long-standing weirdness that I ended up fixing in https://github.com/ykjit/yk/commit/6a6761bc2d5e866f7b927f02ee6b663509dc276d.

Note that this PR has one mild surprise that probably won't lead to actual surprise: if you're really unlucky `cargo` can be building `CARGO_JOBS` number of jobs at just the point that ykbuild kicks off `CARGO_JOBS` number of jobs in ykllvm. In practise this is unlikely to be an issue, because a) ykbuild is an unintentional synchronisation point in the build that almost immediately else blocks anything else from compiling until it's done b) the first ykbuild does is run ykllvm's config stuff, which takes about 10 secs to run, virtually guaranteeing that cargo's other jobs are in fact complete.