### PR TITLE
Zero length call fixes for our PT decoder.

### DIFF
--- a/hwtracer/src/llvm_blockmap.rs
+++ b/hwtracer/src/llvm_blockmap.rs
@@ -39,6 +39,8 @@ pub enum SuccessorKind {
 pub struct CallInfo {
     /// Offset of the call instruction
     callsite_off: u64,
+    /// Offset of the return address (should the call return conventionally).
+    return_off: u64,
     /// Offset of the target of the call (if known statically).
     target_off: Option<u64>,
 }
@@ -46,6 +48,10 @@ pub struct CallInfo {
 impl CallInfo {
     pub fn callsite_off(&self) -> u64 {
         self.callsite_off
+    }
+
+    pub fn return_off(&self) -> u64 {
+        self.return_off
     }
 
     pub fn target_off(&self) -> Option<u64> {
@@ -151,10 +157,13 @@ impl BlockMap {
                 let mut call_offs = Vec::new();
                 for _ in 0..num_calls {
                     let callsite_off = crsr.read_u64::<NativeEndian>().unwrap();
+                    let return_off = crsr.read_u64::<NativeEndian>().unwrap();
+                    debug_assert!(callsite_off < return_off);
                     let target = crsr.read_u64::<NativeEndian>().unwrap();
                     let target_off = if target != 0 { Some(target) } else { None };
                     call_offs.push(CallInfo {
                         callsite_off,
+                        return_off,
                         target_off,
                     })
                 }

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -550,10 +550,13 @@ impl<'t> YkPTBlockIterator<'t> {
                     };
 
                     if inst.flow_control() == iced_x86::FlowControl::IndirectCall {
-                        if usize::try_from(inst.next_ip()).unwrap() == vaddr {
-                            todo!("zero length call");
-                        }
                         debug_assert!(!inst.is_call_far());
+                        // Indirect calls, even zero-length ones, are always compressed. See
+                        // Section 33.4.2.2 of the Intel Manual:
+                        //
+                        // "push the next IP onto the stack...note that this excludes zero-length
+                        // CALLs, which are *direct* near CALLs with displacement zero (to the next
+                        // IP)
                         self.comprets
                             .push(CompRetAddr::VAddr(usize::try_from(inst.next_ip()).unwrap()));
                         self.update_stack_adjust(1);

--- a/tests/c/x86_64_zero_len_call.c
+++ b/tests/c/x86_64_zero_len_call.c
@@ -1,0 +1,43 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     jit-state: enter-jit-code
+//     ...
+//  stdout:
+//     exit
+
+// Check that disassembly-based PT decoding does the right thing with
+// zero-length calls.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+extern uintptr_t zero_len_call(void);
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int sum = 0;
+  int i = 20;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(sum);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    sum += zero_len_call();
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(sum);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/extra_linkage/x86_64_zero_len_call.s
+++ b/tests/extra_linkage/x86_64_zero_len_call.s
@@ -1,0 +1,24 @@
+.global zero_len_call
+.intel_syntax
+
+# A little function that returns the value of RIP via (what Intel calls) a
+# "zero-length call".
+zero_len_call:
+    mov rax, 0
+    call y # zero-length return.
+y:
+    # FIXME: There have to be an equal number of calls and returns or the
+    # outliner's frame counter will get confused. We've already done a `call`
+    # with no matching `ret`, so now we have to do a `ret` with no matching
+    # `call`.
+    #
+    # Once https://github.com/ykjit/yk/issues/818 is fixed, we can hopefully
+    # remove this hack.
+    #
+    # Note that `push z` doesn't do what you think it would!
+    lea rdi, [z]
+    push rdi
+    ret
+z:
+    pop rax
+    ret

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -45,6 +45,19 @@ pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = Lazy
             )],
         );
     }
+    map.insert(
+        "x86_64_zero_len_call.c",
+        vec![ExtraLinkage::new(
+            "%%TEMPDIR%%/x86_64_zero_len_call.o",
+            ykllvm_bin("clang").to_owned(),
+            &[
+                "-c",
+                "extra_linkage/x86_64_zero_len_call.s",
+                "-o",
+                "%%TEMPDIR%%/x86_64_zero_len_call.o",
+            ],
+        )],
+    );
     map
 });
 


### PR DESCRIPTION
This is a handful of "zero-length calls" fixes and clarifications for compressed returns in our PT decoder.

To be clear: we have not (as far as I know) been bitten by any of the issues that these fixes solve. But that's not to say that we couldn't be in the future.

This sadly does **not** fix #874, but we may as well be as correct as we can.

Requires a compiler change. ~Coming soon~ https://github.com/ykjit/ykllvm/pull/100