### PR TITLE
Disable compressed returns for now.

### DIFF
--- a/hwtracer/src/perf/collect.c
+++ b/hwtracer/src/perf/collect.c
@@ -37,6 +37,9 @@
 #define INFTIM -1
 #endif
 
+// The bit in the IA32_RTIT_CTL MSR that disables compressed returns.
+#define IA32_RTIT_CTL_DISRETC 1 << 11
+
 /*
  * The thread's perf file descriptor and its associated underlying `mmap(2)`
  * regions. The file descriptor is re-used for subsequent trace collections for
@@ -384,6 +387,11 @@ static int open_perf(size_t aux_bufsize, struct hwt_cerror *err) {
   memset(&attr, 0, sizeof(attr));
   attr.size = sizeof(attr);
   attr.size = sizeof(struct perf_event_attr);
+
+  // Disable compressed returns for now.
+  //
+  // FIXME: https://github.com/ykjit/yk/issues/874
+  attr.config |= IA32_RTIT_CTL_DISRETC;
 
   int ret = -1;
 

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -453,7 +453,7 @@ impl<'t> YkPTBlockIterator<'t> {
 
         if compressed {
             // If the return was compressed, we must we consume one "taken=true" decision from the
-            // TNT buffer. The unwrap cannot fail becuase the above code ensures that `self.tnts`
+            // TNT buffer. The unwrap cannot fail because the above code ensures that `self.tnts`
             // is not empty.
             let taken = self.tnts.pop_front().unwrap();
             // FIXME: If you re-enable compressed returns (in `collect.c`), once in a blue moon

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -456,6 +456,10 @@ impl<'t> YkPTBlockIterator<'t> {
             // TNT buffer. The unwrap cannot fail becuase the above code ensures that `self.tnts`
             // is not empty.
             let taken = self.tnts.pop_front().unwrap();
+            // FIXME: If you re-enable compressed returns (in `collect.c`), once in a blue moon
+            // this assertion will fail.
+            //
+            // More info: https://github.com/ykjit/yk/issues/874
             debug_assert!(taken);
         }
 


### PR DESCRIPTION
See commits.

This ran all night on `try_repeat`. Usually I can get the assertion crash after 2 or 3 hours.