### PR TITLE
Make sure threads don't exit until all LLVM compilation threads complete.

### DIFF
--- a/ykcapi/build.rs
+++ b/ykcapi/build.rs
@@ -1,3 +1,7 @@
 pub fn main() {
     ykbuild::apply_llvm_ld_library_path();
+
+    // FIXME: This is a temporary hack because LLVM has problems if the main thread exits before
+    // compilation threads have finished.
+    println!("cargo:rustc-cfg=yk_llvm_sync_hack");
 }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -39,7 +39,9 @@ pub unsafe extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *const MT {
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn yk_mt_drop(mt: *const MT) {
-    drop(unsafe { Arc::from_raw(mt) });
+    let mt = unsafe { Arc::from_raw(mt) };
+    #[cfg(yk_llvm_sync_hack)]
+    mt.llvm_sync_hack();
 }
 
 // The "dummy control point" that is replaced in an LLVM pass.

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -7,4 +7,7 @@ pub fn main() {
     println!("cargo:rustc-cfg=jitc_yk");
     // Always compile in the HWT tracer.
     println!("cargo:rustc-cfg=tracer_hwt");
+    // FIXME: This is a temporary hack because LLVM has problems if the main thread exits before
+    // compilation threads have finished.
+    println!("cargo:rustc-cfg=yk_llvm_sync_hack");
 }


### PR DESCRIPTION
This is a horrible hack: we track in an atomic integer how many worker threads are doing something (which we use as a proxy for "are doing something with LLVM) and, when someone calls `yk_mt_drop` in C, we wait for those worker threads to finish doing whatever they're doing.

The obvious horror with this hack is that we stop the application exiting even if the interpreter has finished. A less obvious horror is that `Mt::drop` isn't called while compilation threads are running, which is why we have to put this hack into `yk_mt_drop` in the C API. That bakes in an assumption about the C-ness of interpreters, which is fine for now, but clearly not going forwards.

To emphasise how hacky this is, all the code is under a flag `yk_llvm_sync_hack`. This will also make it easy to find all the places to rip out when we no longer need this hack.