### PR TITLE
Temporarily disable the completion wrapper code.

### DIFF
--- a/ykbuild/src/completion_wrapper.rs
+++ b/ykbuild/src/completion_wrapper.rs
@@ -83,29 +83,30 @@ impl CompletionWrapper {
 
     /// Call when the build is done to generate the `compile_commands.json` file.
     pub fn generate(self) {
-        let mut entries = Vec::new();
+        let entries = Vec::<String>::new();
 
         for path in glob(&format!("{}/*", self.tmpdir.path().to_str().unwrap())).unwrap() {
             let mut infile = File::open(path.unwrap()).unwrap();
             let mut buf = String::new();
             infile.read_to_string(&mut buf).unwrap();
-            let buf = buf.trim();
+            let _buf = buf.trim();
 
-            // We assume (and assert) that the source file is the last argument.
-            let ccfile = buf.split(' ').last().unwrap();
-            assert!(["c", "cpp", "cxx", "cc"]
-                .iter()
-                .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
-            let mut entry = String::new();
-            entry.push_str("  {\n");
-            entry.push_str(&format!(
-                "    \"directory\": \"{}\",\n",
-                env::var("CARGO_MANIFEST_DIR").unwrap()
-            ));
-            entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
-            entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
-            entry.push_str("  }");
-            entries.push(entry);
+            // FIXME: This assert sometimes fails.
+            // // We assume (and assert) that the source file is the last argument.
+            // let ccfile = buf.split(' ').last().unwrap();
+            // assert!(["c", "cpp", "cxx", "cc"]
+            //     .iter()
+            //     .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
+            // let mut entry = String::new();
+            // entry.push_str("  {\n");
+            // entry.push_str(&format!(
+            //     "    \"directory\": \"{}\",\n",
+            //     env::var("CARGO_MANIFEST_DIR").unwrap()
+            // ));
+            // entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
+            // entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
+            // entry.push_str("  }");
+            // entries.push(entry);
         }
 
         // Write JSON to compile_commands.json.


### PR DESCRIPTION
This has started failing in some situations (the `assert` fails), including CI, but we don't understand what is really causing that. Since this is a developer convenience, and not important for the system per se, this commit temporarily disables the failing code. Someone who understands this better than I can hopefully reenable it later, but we don't want to block development in the meantime.