### PR TITLE
Reenable completion

### DIFF
--- a/ykbuild/src/completion_wrapper.rs
+++ b/ykbuild/src/completion_wrapper.rs
@@ -93,9 +93,17 @@ impl CompletionWrapper {
 
             // We assume (and assert) that the source file is the last argument.
             let ccfile = buf.split(' ').last().unwrap();
-            assert!(["c", "cpp", "cxx", "cc"]
-                .iter()
-                .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
+            let ext = Path::new(ccfile).extension();
+            match ext {
+                None => panic!("source file has no extension: {}", ccfile),
+                Some(ext) => {
+                    let ext = ext.to_str().unwrap();
+                    if !["c", "cpp", "cxx", "cc"].iter().any(|e| e == &ext) {
+                        panic!("unkonwn source file extension: {}", ext);
+                    }
+                }
+            }
+
             let mut entry = String::new();
             entry.push_str("  {\n");
             entry.push_str(&format!(

--- a/ykbuild/src/completion_wrapper.rs
+++ b/ykbuild/src/completion_wrapper.rs
@@ -83,30 +83,29 @@ impl CompletionWrapper {
 
     /// Call when the build is done to generate the `compile_commands.json` file.
     pub fn generate(self) {
-        let entries = Vec::<String>::new();
+        let mut entries = Vec::new();
 
         for path in glob(&format!("{}/*", self.tmpdir.path().to_str().unwrap())).unwrap() {
             let mut infile = File::open(path.unwrap()).unwrap();
             let mut buf = String::new();
             infile.read_to_string(&mut buf).unwrap();
-            let _buf = buf.trim();
+            let buf = buf.trim();
 
-            // FIXME: This assert sometimes fails.
-            // // We assume (and assert) that the source file is the last argument.
-            // let ccfile = buf.split(' ').last().unwrap();
-            // assert!(["c", "cpp", "cxx", "cc"]
-            //     .iter()
-            //     .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
-            // let mut entry = String::new();
-            // entry.push_str("  {\n");
-            // entry.push_str(&format!(
-            //     "    \"directory\": \"{}\",\n",
-            //     env::var("CARGO_MANIFEST_DIR").unwrap()
-            // ));
-            // entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
-            // entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
-            // entry.push_str("  }");
-            // entries.push(entry);
+            // We assume (and assert) that the source file is the last argument.
+            let ccfile = buf.split(' ').last().unwrap();
+            assert!(["c", "cpp", "cxx", "cc"]
+                .iter()
+                .any(|e| e == &Path::new(ccfile).extension().unwrap().to_str().unwrap()));
+            let mut entry = String::new();
+            entry.push_str("  {\n");
+            entry.push_str(&format!(
+                "    \"directory\": \"{}\",\n",
+                env::var("CARGO_MANIFEST_DIR").unwrap()
+            ));
+            entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
+            entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
+            entry.push_str("  }");
+            entries.push(entry);
         }
 
         // Write JSON to compile_commands.json.


### PR DESCRIPTION
I can't reproduce #903 locally or via repeated forced CI jobs. This makes it hard for me to debug.

Based on the bug report I have, it would appear that we see a compiler invocation with a source file that has no extension. I don't see how that could happen.

This change re-enables the completion stuff and adds better error messages, so that if it crops up again we get some information that might indicate what's going on.