### PR TITLE
Replace unsound StackAdjust code.

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -129,6 +129,9 @@ handle_arg() {
             # Ensure we can unambiguously map back to LLVM IR blocks.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-block-disambiguate"
 
+            # Ensure calls never appear in the entry block of a function.
+            OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-no-calls-in-entryblocks"
+
             # Use the yk extensions to the blockmap section.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-extended-llvmbbaddrmap-section"
             # Enable fix for spill reloads before stackmaps.

--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -1,3 +1,4 @@
+// ignore: currently broken
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -1,3 +1,4 @@
+// ignore: currently broken
 // Run-time:
 //   status: error
 //   env-var: YKD_SERIALISE_COMPILATION=1


### PR DESCRIPTION
With the recent change to ykllvm, which ensures no calls can appear in the entry block of a function, we no longer need to rely on the StackAdjust solution in order to detect callbacks from external functions (i.e. unmappable code). Instead, we now only need to check if an unmappable block is followed by an entry block. If it is, then the external function called back into mappable code; if not then we have returned from the external function.