### PR TITLE
Remove all remnants of the stackadjust code.

### DIFF
--- a/hwtracer/src/block.rs
+++ b/hwtracer/src/block.rs
@@ -20,10 +20,7 @@ pub enum Block {
     ///
     /// This is required because decoders don't have perfect knowledge about every block
     /// in the virtual address space.
-    Unknown {
-        /// The stack adjustment required as a consequence of executing this unknown code.
-        stack_adjust: isize,
-    },
+    Unknown,
 }
 
 impl fmt::Debug for Block {
@@ -36,8 +33,8 @@ impl fmt::Debug for Block {
             } => {
                 write!(f, "Block({:x}..={:x})", first_instr, last_instr)
             }
-            Self::Unknown { stack_adjust } => {
-                write!(f, "UnknownBlock(stack_adjust={stack_adjust})")
+            Self::Unknown => {
+                write!(f, "UnknownBlock")
             }
         }
     }
@@ -54,11 +51,6 @@ impl Block {
         }
     }
 
-    /// Create an unknown block.
-    pub fn from_stack_adjust(stack_adjust: isize) -> Self {
-        Self::Unknown { stack_adjust }
-    }
-
     /// Returns `true` if `self` represents an unknown virtual address range.
     pub fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
@@ -72,15 +64,6 @@ impl Block {
         } = self
         {
             Some((*first_instr, *last_instr))
-        } else {
-            None
-        }
-    }
-
-    /// Return the stack adjustment value, if applicable.
-    pub fn stack_adjust(&self) -> Option<isize> {
-        if let Self::Unknown { stack_adjust } = self {
-            Some(*stack_adjust)
         } else {
             None
         }

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -113,13 +113,10 @@ impl JITCLLVM {
         let mut bbs = Vec::with_capacity(trace_len);
         for blk in irtrace.blocks() {
             if blk.is_unmappable() {
-                // The block was unmappable. Indicate this with a null function name and the block
-                // index encodes the stack adjustment value.
+                // The block was unmappable. Indicate this with a null function name.
                 func_names.push(ptr::null());
-                // Subtle cast from `isize` to `usize`. `as` is used deliberately here to preserve
-                // the exact bit pattern. The consumer on the other side of the FFI knows to
-                // reverse this.
-                bbs.push(blk.stack_adjust() as usize);
+                // Block indices for unmappable blocks are irrelevant so we may pass anything here.
+                bbs.push(0);
             } else {
                 func_names.push(blk.func_name().as_ptr());
                 bbs.push(blk.bb());

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -159,14 +159,7 @@ impl HWTMapper {
                 // also take care to collapse consecutive unmappable blocks into one.
                 if let Some(last) = ret.last_mut() {
                     if !last.is_unmappable() {
-                        ret.push(TracedAOTBlock::new_unmappable(
-                            block.stack_adjust().unwrap(),
-                        ));
-                    } else {
-                        // The previous entry in the trace is already and unmappable region. Don't
-                        // push, thus collapsing repeated unmappable blocks into one. We do have to
-                        // sum together the stack adjust values though!
-                        *last.stack_adjust_mut() += block.stack_adjust().unwrap();
+                        ret.push(TracedAOTBlock::new_unmappable());
                     }
                 }
             } else {

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -97,10 +97,7 @@ pub enum TracedAOTBlock {
     /// One or more machine blocks that could not be mapped.
     ///
     /// This usually means that the blocks were compiled outside of ykllvm.
-    Unmappable {
-        /// The change to the stack depth as a result of executing the unmappable region.
-        stack_adjust: isize,
-    },
+    Unmappable,
 }
 
 impl TracedAOTBlock {
@@ -108,8 +105,8 @@ impl TracedAOTBlock {
         Self::Mapped { func_name, bb }
     }
 
-    pub fn new_unmappable(stack_adjust: isize) -> Self {
-        Self::Unmappable { stack_adjust }
+    pub fn new_unmappable() -> Self {
+        Self::Unmappable
     }
 
     /// If `self` is a mapped block, return the function name, otherwise panic.
@@ -132,23 +129,6 @@ impl TracedAOTBlock {
 
     /// Determines whether `self` represents unmappable code.
     pub fn is_unmappable(&self) -> bool {
-        matches!(self, Self::Unmappable { .. })
-    }
-
-    /// If `self` is an unmappable region, return the stack adjustment value, otherwise panic.
-    pub fn stack_adjust(&self) -> isize {
-        if let Self::Unmappable { stack_adjust } = self {
-            *stack_adjust
-        } else {
-            panic!();
-        }
-    }
-
-    pub fn stack_adjust_mut(&mut self) -> &mut isize {
-        if let Self::Unmappable { stack_adjust } = self {
-            stack_adjust
-        } else {
-            panic!();
-        }
+        matches!(self, Self::Unmappable)
     }
 }


### PR DESCRIPTION
We've recently removed the reliance on the stackadjust code to detect callbacks from unmappable code. This removes all remnants of code related to that.

@vext01 Did I miss anything?