### PR TITLE
Don't conflate a call with an unknown target with an indirect call.

### DIFF
--- a/hwtracer/src/llvm_blockmap.rs
+++ b/hwtracer/src/llvm_blockmap.rs
@@ -43,6 +43,8 @@ pub struct CallInfo {
     return_off: u64,
     /// Offset of the target of the call (if known statically).
     target_off: Option<u64>,
+    /// Indicates if the call is direct (true) or indirect (false).
+    direct: bool,
 }
 
 impl CallInfo {
@@ -56,6 +58,10 @@ impl CallInfo {
 
     pub fn target_off(&self) -> Option<u64> {
         self.target_off
+    }
+
+    pub fn is_direct(&self) -> bool {
+        self.direct
     }
 }
 
@@ -161,10 +167,12 @@ impl BlockMap {
                     debug_assert!(callsite_off < return_off);
                     let target = crsr.read_u64::<NativeEndian>().unwrap();
                     let target_off = if target != 0 { Some(target) } else { None };
+                    let direct = crsr.read_u8().unwrap() == 1;
                     call_offs.push(CallInfo {
                         callsite_off,
                         return_off,
                         target_off,
+                        direct,
                     })
                 }
 

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -282,20 +282,20 @@ impl<'t> YkPTBlockIterator<'t> {
             let target = call_info.target_off();
 
             if let Some(target_off) = target {
-                // This is a direct call.
+                // The address of the callee is known.
                 //
                 // PT won't compress returns from direct calls if the call target is the
                 // instruction address immediately after the call.
                 //
                 // See the Intel Manual, Section 33.4.2.2 for details.
-                if target_off != call_info.return_off() {
+                if !call_info.is_direct() || target_off != call_info.return_off() {
                     self.comprets
                         .push(CompRetAddr::AfterCall(call_info.callsite_off()));
                 }
                 self.cur_loc = ObjLoc::MainObj(target_off);
                 return Ok(Some(self.lookup_block_from_main_bin_offset(target_off)?));
             } else {
-                // This is an indirect call.
+                // The address of the callee isn't known.
                 self.comprets
                     .push(CompRetAddr::AfterCall(call_info.callsite_off()));
                 self.seek_tip()?;


### PR DESCRIPTION
You can call an external symbol (with an address statically unknown) directly.

Requires a compiler change, ~coming soon~: https://github.com/ykjit/ykllvm/pull/106

I had hoped this might fix #874, but alas no. Nonetheless, this is more correct and worth including.