### PR TITLE
Fix Clippy warnings.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -65,7 +65,7 @@ PATH=${YKB_YKLLVM_BIN_DIR}:${PATH} cargo xtask cfmt
 git diff --exit-code --ignore-submodules
 
 # Check for annoying compiler warnings in each package.
-WARNING_DEFINES="-D unused-variables -D dead-code"
+WARNING_DEFINES="-D unused-variables -D dead-code -D unused-imports"
 for p in $(sed -n -e '/^members =/,/^\]$/{/^members =/d;/^\]$/d;p;}' \
   Cargo.toml \
   | \

--- a/hwtracer/src/pt/ykpt/packets.rs
+++ b/hwtracer/src/pt/ykpt/packets.rs
@@ -68,7 +68,7 @@ impl TargetIP {
             0b001 => {
                 // The result is bytes 63..=16 from `prev_tip` and bytes 15..=0 from `ip`.
                 if let Self::Ip16(v) = self {
-                    prev_tip.unwrap() & 0xffffffffffff0000 | usize::try_from(*v).unwrap()
+                    prev_tip.unwrap() & 0xffffffffffff0000 | usize::from(*v)
                 } else {
                     unreachable!();
                 }

--- a/tests/src/bin/run_trace_compiler_test.rs
+++ b/tests/src/bin/run_trace_compiler_test.rs
@@ -3,7 +3,7 @@
 //! Each invocation of this program runs one of the trace compiler tests found in the
 //! `trace_compiler` directory of this crate.
 
-use std::{collections::HashMap, convert::TryInto, env, error::Error, ffi::CString, fs::File};
+use std::{convert::TryInto, env, error::Error, ffi::CString, fs::File};
 use ykrt::{
     compile::compile_for_tc_tests,
     trace::{MappedTrace, TracedAOTBlock},

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -303,7 +303,7 @@ impl FrameReconstructor {
                         if *extra != 0 {
                             // The stackmap has recorded an additional register we need to write
                             // this value to.
-                            registers[usize::try_from(*extra - 1).unwrap()] = val;
+                            registers[usize::from(*extra - 1)] = val;
                         }
                         if i == 0 {
                             // skip first frame

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -3,8 +3,7 @@
 use crate::trace::TracedAOTBlock;
 use hwtracer::llvm_blockmap::LLVM_BLOCK_MAP;
 use hwtracer::Trace;
-use libc::c_void;
-use std::{collections::HashMap, convert::TryFrom, error::Error, ffi::CString};
+use std::{convert::TryFrom, error::Error};
 use ykaddr::{
     addr::{vaddr_to_obj_and_off, vaddr_to_sym_and_obj},
     obj::SELF_BIN_PATH,

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -5,9 +5,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 mod errors;
-use libc::c_void;
 use std::{
-    collections::HashMap,
     error::Error,
     ffi::{CStr, CString},
     sync::Arc,


### PR DESCRIPTION
Most of these, to my surprise, turned out to be unused imports. I've therefore added a check in CI so that we won't re-add these, or others, in the future.