### PR TITLE
Start nudging us towards "trace decoding as an iterator".

### DIFF
--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -4,8 +4,7 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
-//     jit-state: stop-tracing
-//     jit-state: trace-compilation-aborted
+//     jit-state: stop-tracing-aborted
 //     ...
 
 // Tests that we can deal with setjmp/longjmp.

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -5,8 +5,7 @@
 //     jit-state: start-tracing
 //     set jump point
 //     jumped!
-//     jit-state: stop-tracing
-//     jit-state: trace-compilation-aborted
+//     jit-state: stop-tracing-aborted
 //     ...
 
 // Check that we bork on a call to setjmp in unmapped code.

--- a/tests/src/bin/run_trace_compiler_test.rs
+++ b/tests/src/bin/run_trace_compiler_test.rs
@@ -4,10 +4,7 @@
 //! `trace_compiler` directory of this crate.
 
 use std::{convert::TryInto, env, error::Error, ffi::CString, fs::File};
-use ykrt::{
-    compile::compile_for_tc_tests,
-    trace::{MappedTrace, TracedAOTBlock},
-};
+use ykrt::{compile::compile_for_tc_tests, trace::TracedAOTBlock};
 
 const BBS_ENV: &str = "YKT_TRACE_BBS";
 
@@ -38,7 +35,6 @@ fn main() -> Result<(), String> {
             BBS_ENV
         ));
     }
-    let irtrace = MappedTrace::new(bbs);
 
     // Map the `.ll` file into the address space so that we can give a pointer to it to the trace
     // compiler. Normally (i.e. outside of testing), the trace compiler wouldn't deal with textual
@@ -47,7 +43,7 @@ fn main() -> Result<(), String> {
     let ll_file = File::open(ll_path).unwrap();
     let mmap = unsafe { memmap2::Mmap::map(&ll_file).unwrap() };
 
-    unsafe { compile_for_tc_tests(irtrace, mmap.as_ptr(), mmap.len().try_into().unwrap()) };
+    unsafe { compile_for_tc_tests(bbs, mmap.as_ptr(), mmap.len().try_into().unwrap()) };
 
     Ok(())
 }

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -5,7 +5,7 @@ use crate::{
     compile::{CompiledTrace, Compiler},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
-    trace::MappedTrace,
+    trace::TracedAOTBlock,
 };
 use libc::dlsym;
 use parking_lot::Mutex;
@@ -26,7 +26,7 @@ impl Compiler for JITCLLVM {
     fn compile(
         &self,
         mt: Arc<MT>,
-        irtrace: MappedTrace,
+        irtrace: Vec<TracedAOTBlock>,
         sti: Option<SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>> {
@@ -64,7 +64,7 @@ impl Compiler for JITCLLVM {
     #[cfg(feature = "yk_testing")]
     unsafe fn compile_for_tc_tests(
         &self,
-        irtrace: MappedTrace,
+        irtrace: Vec<TracedAOTBlock>,
         llvmbc_data: *const u8,
         llvmbc_len: u64,
     ) {
@@ -90,11 +90,11 @@ impl JITCLLVM {
         Ok(Arc::new(JITCLLVM))
     }
 
-    fn encode_trace(&self, irtrace: &MappedTrace) -> (Vec<*const i8>, Vec<usize>, usize) {
+    fn encode_trace(&self, irtrace: &Vec<TracedAOTBlock>) -> (Vec<*const i8>, Vec<usize>, usize) {
         let trace_len = irtrace.len();
         let mut func_names = Vec::with_capacity(trace_len);
         let mut bbs = Vec::with_capacity(trace_len);
-        for blk in irtrace.blocks() {
+        for blk in irtrace {
             if blk.is_unmappable() {
                 // The block was unmappable. Indicate this with a null function name.
                 func_names.push(ptr::null());

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     compile::{CompiledTrace, Compiler},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
-    trace::MappedTrace,
+    trace::TracedAOTBlock,
 };
 use parking_lot::Mutex;
 use std::{
@@ -57,7 +57,7 @@ impl Compiler for JITCYk {
     fn compile(
         &self,
         _mt: Arc<MT>,
-        mtrace: MappedTrace,
+        mtrace: Vec<TracedAOTBlock>,
         sti: Option<SideTraceInfo>,
         _hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>> {
@@ -88,7 +88,7 @@ impl Compiler for JITCYk {
     #[cfg(feature = "yk_testing")]
     unsafe fn compile_for_tc_tests(
         &self,
-        _irtrace: MappedTrace,
+        _irtrace: Vec<TracedAOTBlock>,
         _llvmbc_data: *const u8,
         _llvmbc_len: u64,
     ) {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -4,17 +4,17 @@
 //! from the AOT IR. The output of this process will be the input to the code generator.
 
 use super::aot_ir::{self, Module};
-use crate::trace::{MappedTrace, TracedAOTBlock};
+use crate::trace::TracedAOTBlock;
 use std::error::Error;
 
 struct TraceBuilder<'a> {
     aot_mod: &'a Module,
     jit_mod: Module,
-    mtrace: &'a MappedTrace,
+    mtrace: &'a Vec<TracedAOTBlock>,
 }
 
 impl<'a> TraceBuilder<'a> {
-    fn new(aot_mod: &'a Module, mtrace: &'a MappedTrace) -> Self {
+    fn new(aot_mod: &'a Module, mtrace: &'a Vec<TracedAOTBlock>) -> Self {
         Self {
             aot_mod,
             mtrace,
@@ -34,7 +34,7 @@ impl<'a> TraceBuilder<'a> {
     }
 
     fn build(self) -> Result<Module, Box<dyn Error>> {
-        for tblk in self.mtrace.blocks() {
+        for tblk in self.mtrace {
             match self.lookup_aot_block(tblk) {
                 Some(_blk) => {
                     // Mapped block
@@ -51,6 +51,9 @@ impl<'a> TraceBuilder<'a> {
 }
 
 /// Given a mapped trace (through `aot_mod`), assemble and return a Yk IR trace.
-pub(super) fn build(aot_mod: &Module, mtrace: &MappedTrace) -> Result<Module, Box<dyn Error>> {
+pub(super) fn build(
+    aot_mod: &Module,
+    mtrace: &Vec<TracedAOTBlock>,
+) -> Result<Module, Box<dyn Error>> {
     TraceBuilder::new(aot_mod, mtrace).build()
 }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     location::HotLocation,
     mt::{SideTraceInfo, MT},
-    trace::MappedTrace,
+    trace::TracedAOTBlock,
 };
 use libc::c_void;
 use parking_lot::Mutex;
@@ -30,11 +30,11 @@ pub mod jitc_yk;
 
 /// The trait that every JIT compiler backend must implement.
 pub(crate) trait Compiler: Send + Sync {
-    /// Compile an [MappedTrace] into machine code.
+    /// Compile a mapped trace into machine code.
     fn compile(
         &self,
         mt: Arc<MT>,
-        irtrace: MappedTrace,
+        irtrace: Vec<TracedAOTBlock>,
         sti: Option<SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, Box<dyn Error>>;
@@ -42,7 +42,7 @@ pub(crate) trait Compiler: Send + Sync {
     #[cfg(feature = "yk_testing")]
     unsafe fn compile_for_tc_tests(
         &self,
-        irtrace: MappedTrace,
+        irtrace: Vec<TracedAOTBlock>,
         llvmbc_data: *const u8,
         llvmbc_len: u64,
     );
@@ -68,7 +68,11 @@ pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, Box<dyn Error>> {
 }
 
 #[cfg(feature = "yk_testing")]
-pub unsafe fn compile_for_tc_tests(irtrace: MappedTrace, llvmbc_data: *const u8, llvmbc_len: u64) {
+pub unsafe fn compile_for_tc_tests(
+    irtrace: Vec<TracedAOTBlock>,
+    llvmbc_data: *const u8,
+    llvmbc_len: u64,
+) {
     default_compiler()
         .unwrap()
         .compile_for_tc_tests(irtrace, llvmbc_data, llvmbc_len);


### PR DESCRIPTION
This PR is partly a sanity check before I go further. In essence, it introduces a `TraceIterator` which in essence replaces `RawTrace`. Currently the `hwt` backend still does its mapping in a single step, but it at least exposes an iterator (even if it doesn't make much use of it).

This commit is clearly a half-way house to what we might eventually want. In particular it doesn't yet support "trace mapping went wrong half-way through" because `hwt` can't go wrong in that way -- yet. But, hopefully, it is a nudge in the right direction. It also slightly simplifies the existing code as well as making the API more flexible.