### PR TITLE
Rewrite jitmodbuilder inlining/outlining logic.

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -126,6 +126,9 @@ handle_arg() {
             # Emit stackmaps used for JIT deoptimisation.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-insert-stackmaps"
 
+            # Split blocks after function calls.
+            OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-split-blocks-after-calls"
+
             # Ensure we can unambiguously map back to LLVM IR blocks.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-block-disambiguate"
 

--- a/tests/trace_compiler/call_ext.ll
+++ b/tests/trace_compiler/call_ext.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -21,6 +21,9 @@ declare dso_local i32 @getuid()
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = call i32 @getuid()
     unreachable
 }

--- a/tests/trace_compiler/direct_recursion.ll
+++ b/tests/trace_compiler/direct_recursion.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,f:0,f:1,f:0,f:1,f:0,f:2,f:1,f:2,f:1,f:2,main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1,f:0,f:1,f:2,f:0,f:1,f:2,f:0,f:1,f:3,f:2,f:3,f:2,f:3,main:1
 ;   stderr:
 ;     --- Begin jit-pre-opt ---
 ;
@@ -29,6 +29,8 @@
 ;     --- End jit-pre-opt ---
 
 define void @f(i32 %0) {
+    br label %bb1
+bb1:
     %2 = icmp eq i32 %0, 0
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i1 %2)
     br i1 %2, label %done, label %recurse
@@ -43,6 +45,8 @@ done:
 
 define void @main() {
 entry:
+    br label %bb1
+bb1:
     call void @f(i32 2)
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0)
     ret void

--- a/tests/trace_compiler/global_immut.ll
+++ b/tests/trace_compiler/global_immut.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -20,6 +20,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = load i32, ptr @g
     %1 = add i32 %0, 1
     unreachable

--- a/tests/trace_compiler/global_mut.ll
+++ b/tests/trace_compiler/global_mut.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -19,6 +19,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     store i32 1, ptr @g
     unreachable
 }

--- a/tests/trace_compiler/guard_eq.ll
+++ b/tests/trace_compiler/guard_eq.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,main:1
+;   env-var: YKT_TRACE_BBS=main:0,main:1,main:2
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -27,6 +27,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = alloca i32
     %1 = icmp eq i32 1, 1
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, ptr %0, i1 %1)

--- a/tests/trace_compiler/guard_switch_default.ll
+++ b/tests/trace_compiler/guard_switch_default.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,main:1
+;   env-var: YKT_TRACE_BBS=main:0,main:1,main:2
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -28,6 +28,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 0, 999
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
     switch i32 %0, label %bb_default [i32 0, label %bb_zero

--- a/tests/trace_compiler/guard_switch_non_default.ll
+++ b/tests/trace_compiler/guard_switch_non_default.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,main:4
+;   env-var: YKT_TRACE_BBS=main:0,main:1,main:5
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -26,6 +26,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 0, 2
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
     switch i32 %0, label %bb_default [i32 0, label %bb_zero

--- a/tests/trace_compiler/guards_collapse.ll
+++ b/tests/trace_compiler/guards_collapse.ll
@@ -1,6 +1,6 @@
 ; Run-time-filtered:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt,jit-post-opt
-;   env-var: YKT_TRACE_BBS=main:0,main:1,main:2
+;   env-var: YKT_TRACE_BBS=main:0,main:1,main:2,main:3
 ;   stdout:
 ;     --- Begin icmps ---
 ;     --- Begin jit-pre-opt ---
@@ -26,6 +26,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %v = load volatile i32 , ptr @g
     %cond1 = icmp slt i32 %v, 999
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %v)

--- a/tests/trace_compiler/inline_ret.ll
+++ b/tests/trace_compiler/inline_ret.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,f:0,main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1,f:0,main:1,main:2
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -22,9 +22,15 @@ define i32 @f() {
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 1, 1
     %1 = call i32 @f()
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
+    br label %bb2
+
+bb2:
     %2 = add i32 %0, %1
     unreachable
 }

--- a/tests/trace_compiler/inline_ret_args.ll
+++ b/tests/trace_compiler/inline_ret_args.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,f:0,main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1,f:0,main:1,main:2
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -24,9 +24,15 @@ define i32 @f(i32 %0, i32 %1) {
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 1, 1
     %1 = call i32 @f(i32 %0, i32 2)
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
+    br label %bb2
+
+bb2:
     %2 = add i32 %1, 3
     unreachable
 }

--- a/tests/trace_compiler/inline_simplest.ll
+++ b/tests/trace_compiler/inline_simplest.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,f:0,main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1,f:0,main:1,main:2
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -22,9 +22,15 @@ define void @f() {
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 1, 1
     call void @f()
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0)
+    br label %bb2
+
+bb2:
     %1 = add i32 %0, 2
     unreachable
 }

--- a/tests/trace_compiler/mutual_recursion.ll
+++ b/tests/trace_compiler/mutual_recursion.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,f:0,f:1,g:0,f:0,f:2,g:0,f:1,f:2,main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1,f:0,f:1,f:2,g:0,g:1,f:0,f:1,f:3,g:1,g:2,f:2,f:3,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;
@@ -28,6 +28,8 @@
 ;      --- End jit-pre-opt ---
 
 define void @f(i32 %0) {
+    br label %bb1
+bb1:
     %2 = icmp eq i32 %0, 0
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i1 %2)
     br i1 %2, label %done, label %recurse
@@ -40,13 +42,20 @@ done:
 }
 
 define void @g() {
+    br label %bb1
+bb1:
     call void @f(i32 0)
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
+    br label %done
+done:
     ret void
 }
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     call void @f(i32 1)
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     ret void

--- a/tests/trace_compiler/no_trace_annotation.ll
+++ b/tests/trace_compiler/no_trace_annotation.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt,jit-post-opt
-;   env-var: YKT_TRACE_BBS=main:0,call_me:0,main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1,call_me:0,main:1
 ;   stderr:
 ;     ...
 ;     --- Begin jit-pre-opt ---
@@ -25,6 +25,9 @@ attributes #0 = { "yk_outline" "noinline"}
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     call void @call_me()
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0)
     unreachable

--- a/tests/trace_compiler/phi.ll
+++ b/tests/trace_compiler/phi.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,main:1,main:3
+;   env-var: YKT_TRACE_BBS=main:0,main:1,main:2,main:4
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -21,6 +21,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 0, 0
     %1 = icmp eq i32 %0, 0
     call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %0, i1 %1)

--- a/tests/trace_compiler/small.ll
+++ b/tests/trace_compiler/small.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0
+;   env-var: YKT_TRACE_BBS=main:0,main:1
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -15,6 +15,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 100, 100
     unreachable
 }

--- a/tests/trace_compiler/two_blocks.ll
+++ b/tests/trace_compiler/two_blocks.ll
@@ -1,6 +1,6 @@
 ; Run-time:
 ;   env-var: YKD_PRINT_IR=jit-pre-opt
-;   env-var: YKT_TRACE_BBS=main:0,main:1
+;   env-var: YKT_TRACE_BBS=main:0,main:1,main:2
 ;   stderr:
 ;      --- Begin jit-pre-opt ---
 ;      ...
@@ -16,6 +16,9 @@
 
 define void @main() {
 entry:
+    br label %bb1
+
+bb1:
     %0 = add i32 1, 1
     br label %bb2
 

--- a/ykrt/src/frame/llvmbridge.rs
+++ b/ykrt/src/frame/llvmbridge.rs
@@ -43,10 +43,6 @@ impl Value {
         self.0
     }
 
-    pub fn is_instruction(&self) -> bool {
-        unsafe { !LLVMIsAInstruction(self.0).is_null() }
-    }
-
     pub fn is_call(&self) -> bool {
         unsafe { !LLVMIsACallInst(self.0).is_null() }
     }


### PR DESCRIPTION
With https://github.com/ykjit/ykllvm/pull/108 it is now easier to detect recursion and foreign callbacks:

In order to detect when to inline or outline a function call in a trace, we previously relied on a complicated call stack that tracked at which instruction we started outlining (or inlining) and whether we've processed an unmappable block or not. Returning from a call was also difficult due to the fact functions calls aren't terminators and we had to continue tracing within a duplicate block but had to make sure we continue after the instruction that started outlining. If this sounds complicated it's because it was. To make matters worse, this logic was spread through out `jitmodbuilder.cc`.

Luckily, we are now enforcing that 1) no call may appear inside an entry block and 2) calls are effectively terminators, meaning that there can only be at most one call per block. This makes it a lot easier to detect whether we called into or returned from unmappable code. This commit also moves the entire logic into a single place, making it easier to reason about and maintain.