### PR TITLE
Load blockmap and LLVM bitcode sections from the ELF binary.

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -151,11 +151,6 @@ handle_arg() {
 
             OUTPUT="${OUTPUT} -Xlinker --lto-newpm-passes=${POSTLINK_PASSES_STR}"
 
-            # Have the `.llvmbc` and `.llvm_bb_addr_map` sections loaded into
-            # memory by the loader.
-            OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-alloc-llvmbc-section"
-            OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-alloc-llvmbbaddrmap-section"
-
             # Emit a basic block map section. Used for block mapping.
             OUTPUT="${OUTPUT} -Wl,--lto-basic-block-sections=labels"
 

--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -15,6 +15,12 @@ intervaltree = "0.2.7"
 byteorder = "1.4.3"
 leb128 = "0.2.5"
 thiserror = "1"
+memmap2 = "0.7"
+
+[dependencies.object]
+version = "0.32"
+default-features = false
+features = ["read_core", "elf"]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 iced-x86 = { version = "1.18.0", features = ["decoder"]}

--- a/tests/c/blockmap.c
+++ b/tests/c/blockmap.c
@@ -10,9 +10,7 @@
 #include <yk_testing.h>
 
 int main(int argc, char **argv) {
-  void *bm = __yktrace_hwt_mapper_blockmap_new();
-  assert(__yktrace_hwt_mapper_blockmap_len(bm) > 0);
-  __yktrace_hwt_mapper_blockmap_free(bm);
+  assert(__yktrace_hwt_mapper_blockmap_len() > 0);
   return (EXIT_SUCCESS);
 }
 

--- a/ykaddr/Cargo.toml
+++ b/ykaddr/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 cached = { version = "0.45", features = ["proc_macro"] }
 libc = "0.2"
+memmap2 = "0.7"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 
 [build-dependencies]

--- a/ykaddr/src/obj.rs
+++ b/ykaddr/src/obj.rs
@@ -6,9 +6,11 @@ use libc::c_void;
 use libc::{
     Elf64_Addr as Elf_Addr, Elf64_Off as Elf_Off, Elf64_Word as Elf_Word, Elf64_Xword as Elf_Xword,
 };
+use memmap2;
 use phdrs;
 use std::{
     ffi::{CStr, CString},
+    fs,
     path::PathBuf,
     sync::LazyLock,
 };
@@ -130,4 +132,10 @@ pub static SELF_BIN_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     // If this fails, there's little we can do but crash.
     let info = dladdr(addr as usize).unwrap(); // ptr to usize cast always safe.
     PathBuf::from(info.dli_fname().unwrap().to_str().unwrap())
+});
+
+// The main binary's ELF executable mapped into the address space.
+pub static SELF_BIN_MMAP: LazyLock<memmap2::Mmap> = LazyLock::new(|| {
+    let file = fs::File::open(&SELF_BIN_PATH.as_path()).unwrap();
+    unsafe { memmap2::Mmap::map(&file).unwrap() }
 });

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -7,9 +7,7 @@
 #define SW_TRACING 0
 #define HW_TRACING 1
 
-void *__yktrace_hwt_mapper_blockmap_new(void);
-size_t __yktrace_hwt_mapper_blockmap_len(void *mapper);
-void __yktrace_hwt_mapper_blockmap_free(void *mapper);
+size_t __yktrace_hwt_mapper_blockmap_len();
 
 // Blocks the compiler from optimising the specified value or expression.
 //

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -387,8 +387,11 @@ unsafe extern "C" fn __ykrt_deopt(
 
     let infoptr = Box::into_raw(Box::new(&mut info));
 
-    let (data, len) = crate::compile::jitc_llvm::llvmbc_section();
-    let moduleref = __yktracec_get_aot_module(&BitcodeSection { data, len });
+    let bc = crate::compile::jitc_llvm::llvmbc_section();
+    let moduleref = __yktracec_get_aot_module(&BitcodeSection {
+        data: bc.as_ptr(),
+        len: u64::try_from(bc.len()).unwrap(),
+    });
 
     // The LLVM CAPI doesn't allow us to manually lock/unlock a ThreadSafeModule, and uses a
     // call-back function instead which it runs after locking the module. This means we need to

--- a/ykrt/src/trace/hwt/testing.rs
+++ b/ykrt/src/trace/hwt/testing.rs
@@ -1,19 +1,9 @@
 //! This module is only enabled when the `yk_testing` feature is enabled. It contains functions
 //! that are only needed when testing internal yk code.
 
-use hwtracer::llvm_blockmap::BlockMap;
+use hwtracer::llvm_blockmap::LLVM_BLOCK_MAP;
 
 #[no_mangle]
-pub extern "C" fn __yktrace_hwt_mapper_blockmap_new() -> *mut BlockMap {
-    Box::into_raw(Box::new(BlockMap::new()))
-}
-
-#[no_mangle]
-pub extern "C" fn __yktrace_hwt_mapper_blockmap_free(bm: *mut BlockMap) {
-    drop(unsafe { Box::from_raw(bm) });
-}
-
-#[no_mangle]
-pub extern "C" fn __yktrace_hwt_mapper_blockmap_len(bm: *mut BlockMap) -> usize {
-    unsafe { &*bm }.len()
+pub extern "C" fn __yktrace_hwt_mapper_blockmap_len() -> usize {
+    LLVM_BLOCK_MAP.len()
 }


### PR DESCRIPTION
This is to reflect a change in ykllvm. In short, it's not obviously correct for us to add SHF_ALLOC to those sections.

For more details see:
https://github.com/ykjit/yk/issues/923

Compiler change ~coming soon~: https://github.com/ykjit/yk/pull/927