### PR TITLE
Fix side-trace bug triggered by phi nodes.

### DIFF
--- a/tests/c/sidetrace_phinode.c
+++ b/tests/c/sidetrace_phinode.c
@@ -1,0 +1,59 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stdout:
+//     exit
+
+// Test case extracted from lua.
+// Testing sidetraces where the first traced block contains a PHI node. We need
+// to make sure to set LastBB when initialising the CallStack. There's nothing
+// specific we want to check here, except that this doesn't crash.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+struct CallInfo {
+  void *savedpc;
+};
+
+struct lua_State {
+  struct CallInfo *ci;
+  int hookmask;
+};
+
+int luaG_traceexec(struct lua_State *L, void *pc, int hookcount) {
+  struct CallInfo *ci = L->ci;
+  int mask = L->hookmask;
+  int counthook;
+  ci->savedpc = pc; /* save 'pc' */
+  counthook = (hookcount > 10 && mask);
+  if (counthook)
+    return 2; /* reset count */
+  return 1;   /* keep 'trap' on */
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  yk_mt_sidetrace_threshold_set(mt, 5);
+  YkLocation loc = yk_location_new();
+
+  int i = 20;
+  struct CallInfo ci = {NULL};
+  struct lua_State L = {&ci, 0};
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    luaG_traceexec(&L, NULL, i);
+    i--;
+  }
+  printf("exit");
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -988,6 +988,7 @@ class JITModBuilder {
       // building a side trace, that frame is equal to the frame we start
       // collection in, and is thus not needed on the stack, and can be
       // removed.
+      LastBB = CallStack.back()->getParent();
       CallStack.pop_back();
     }
 


### PR DESCRIPTION
PHI nodes require the `LastBB` value to be set, so we can determine which value we need to pick when creating a trace. When creating a side-trace we forgot to reset the `LastBB` value, which resulted in a crash when the first block in a side-trace contained phi nodes.