### PR TITLE
Fix outlining bug.

### DIFF
--- a/tests/c/outlinebase_bug.c
+++ b/tests/c/outlinebase_bug.c
@@ -1,0 +1,78 @@
+// Run-time:
+//   env-var: YKD_PRINT_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     --- Begin jit-pre-opt ---
+//     ...
+//     {{1}} = call i32 @fputc(...
+//     ...
+//     {{2}} = call i32 @fputc(...
+//     ...
+//     {{3}} = call i32 @fputc(...
+//     ...
+//     {{4}} = call i32 @fputc(...
+//     ...
+//     --- End jit-pre-opt ---
+//     ...
+//   stdout:
+//     exit
+
+// Test that outlining works as expected. Each trace in this test does two
+// rounds of the main interpreter loop, resulting in four `fprintf`s being
+// copied into the JIT module. However, if we forgot to reset the `OutlineBase`
+// in `jitmodbuilder.cc` after resetting `Outlining` to `false`, we will
+// continue outlining after seeing the first `yk_mt_control_point`, and miss
+// the second round of the loop.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int foo(int argc) {
+  int sum = 0;
+  // the loop ensures this function is outlined.
+  while (argc > 0) {
+    argc--;
+    sum = sum + argc;
+  }
+  return sum;
+}
+
+int bar(int argc) { return foo(argc); }
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 6;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    int r = bar(argc + 2);
+    NOOPT_VAL(r);
+    YkLocation *tmp;
+    if (i % 2 == 0) {
+      tmp = &loc;
+    } else {
+      tmp = NULL;
+    }
+    yk_mt_control_point(mt, tmp);
+    fprintf(stderr, "a");
+    fprintf(stderr, "a");
+    res += 2;
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -1149,6 +1149,7 @@ public:
           LastBB = BB;
           if (CallStack.size() == OutlineBase) {
             Outlining = false;
+            OutlineBase = 0;
           }
           continue;
         } else if (LastInst && isa<ReturnInst>(LastInst)) {
@@ -1158,6 +1159,7 @@ public:
           CallStack.pop_back();
           if (CallStack.size() == OutlineBase) {
             Outlining = false;
+            OutlineBase = 0;
           }
           continue;
         }
@@ -1378,13 +1380,14 @@ public:
               I++;
               CurInstrIdx++;
               assert(isa<CallInst>(I)); // stackmap call
+              LastInst = &*I;
               I++;
               CurInstrIdx++;
 
               // We've seen the control point so the next block will be
-              // unmappable. Set a resume point so we can continue collecting
-              // instructions afterwards.
+              // unmappable.
               if (!Outlining) {
+                assert(OutlineBase == 0);
                 Outlining = true;
               }
               break;


### PR DESCRIPTION
This change fixes a bug where we forgot to reset the `OutlineBase` in `jitmodbuilder.cc` after resetting `Outlining` to `false`. This meant we continued outlining after seeing `yk_mt_control_point`, when we should be copying into the trace instead. This bug only occured when a call immediately preceeded the control point and we were tracing at least 2 rounds of the main interpreter loop. This scenario wasn't previously covered by our test suite.