### PR TITLE
Bit twiddle tweaks

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -29,6 +29,7 @@ const SHORT_OPERAND_SIZE: u64 = 18;
 const SHORT_OPERAND_KIND_SIZE: u64 = 3;
 const SHORT_OPERAND_KIND_MASK: u64 = 7;
 const SHORT_OPERAND_VALUE_SIZE: u64 = 15;
+const SHORT_OPERAND_MAX_VALUE: u64 = !(u64::MAX << SHORT_OPERAND_VALUE_SIZE);
 const SHORT_OPERAND_MASK: u64 = 0x3ffff;
 /// Bit fiddling for instructions.
 const INSTR_ISSHORT_SIZE: u64 = 1;
@@ -95,7 +96,7 @@ pub enum Operand {
 impl Operand {
     pub(crate) fn new(kind: OpKind, val: u64) -> Self {
         // check if the operand's value can fit in a short operand.
-        if val & (u64::MAX << SHORT_OPERAND_VALUE_SIZE) == 0 {
+        if val <= SHORT_OPERAND_MAX_VALUE {
             Self::Short(ShortOperand::new(kind, val))
         } else {
             todo!()

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -220,11 +220,18 @@ impl Instruction {
         OpCode::from((self.0 & SHORT_INSTR_OPCODE_MASK) >> SHORT_INSTR_OPCODE_SHIFT)
     }
 
+    /// For short instrucitons, return the bit offset of the specified short operand.
+    fn short_operand_bit_off(&self, index: u64) -> u64 {
+        debug_assert!(self.is_short());
+        debug_assert!(index < SHORT_INSTR_MAX_OPERANDS);
+        SHORT_INSTR_FIRST_OPERAND_SHIFT + SHORT_OPERAND_SIZE * index
+    }
+
     /// Returns the specified operand.
     fn operand(&self, index: u64) -> Operand {
         if self.is_short() {
             // Shift operand down the the LSB.
-            let op = self.0 >> (SHORT_INSTR_FIRST_OPERAND_SHIFT + SHORT_OPERAND_SIZE * index);
+            let op = self.0 >> self.short_operand_bit_off(index);
             // Then mask it out.
             Operand::Short(ShortOperand(op & SHORT_OPERAND_MASK))
         } else {
@@ -268,7 +275,7 @@ impl Instruction {
     fn set_short_operand(&mut self, op: Operand, idx: u64) {
         debug_assert!(self.is_short());
         debug_assert!(idx < SHORT_INSTR_MAX_OPERANDS);
-        self.0 |= op.raw() << (SHORT_INSTR_FIRST_OPERAND_SHIFT + SHORT_OPERAND_SIZE * idx);
+        self.0 |= op.raw() << self.short_operand_bit_off(idx);
     }
 
     /// Returns `true` if the instruction defines a local variable.

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -428,13 +428,16 @@ mod tests {
     #[test]
     fn does_fit_short_operand() {
         for i in 0..SHORT_OPERAND_VALUE_SIZE {
-            Operand::new(OpKind::Local, 1 << i);
+            matches!(Operand::new(OpKind::Local, 1 << i), Operand::Short(_));
         }
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic] // Once long operands are implemented, remove.
     fn doesnt_fit_short_operand() {
-        Operand::new(OpKind::Local, 1 << SHORT_OPERAND_VALUE_SIZE);
+        matches!(
+            Operand::new(OpKind::Local, 1 << SHORT_OPERAND_VALUE_SIZE),
+            Operand::Long(_)
+        );
     }
 }

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -37,8 +37,8 @@ const SHORT_OPERAND_MASK: u64 = 0x3ffff;
 /// Bit fiddling for instructions.
 const INSTR_ISSHORT_SIZE: u64 = 1;
 const INSTR_ISSHORT_MASK: u64 = 1;
-const INSTR_OPCODE_MASK: u64 = 0xe;
 /// Bit fiddling for short instructions.
+const SHORT_INSTR_OPCODE_MASK: u64 = 0xe;
 const SHORT_INSTR_OPCODE_SHIFT: u64 = INSTR_ISSHORT_SIZE;
 const SHORT_INSTR_FIRST_OPERAND_SHIFT: u64 = INSTR_ISSHORT_SIZE + OPCODE_SIZE;
 
@@ -217,7 +217,7 @@ impl Instruction {
     /// Returns the opcode.
     fn opcode(&self) -> OpCode {
         debug_assert!(self.is_short());
-        OpCode::from((self.0 & INSTR_OPCODE_MASK) >> SHORT_INSTR_OPCODE_SHIFT)
+        OpCode::from((self.0 & SHORT_INSTR_OPCODE_MASK) >> SHORT_INSTR_OPCODE_SHIFT)
     }
 
     /// Returns the specified operand.


### PR DESCRIPTION
This hopefully addresses something we [discussed at the end of last year](https://github.com/ykjit/yk/pull/930#discussion_r1432625961): that all bit-twiddling computations for the JIT IR should (where possible) be defined as constants at the top of the file with as little duplication in the main body of code as possible.

While here, I've also tweaked some related bits.

All commits stand alone.

No functional change. Let me know what you think.