### PR TITLE
A new, statically typed, JIT IR.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -20,6 +20,7 @@ yksmp = { path = "../yksmp" }
 strum = { version = "0.25", features = ["derive"] }
 yktracec = { path = "../yktracec" }
 strum_macros = "0.25.3"
+static_assertions = "1.1.0"
 
 [dependencies.llvm-sys]
 # note: using a git version to get llvm linkage features in llvm-sys (not in a

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -1,22 +1,13 @@
 //! The Yk JIT IR
 //!
 //! This is the in-memory trace IR constructed by the trace builder and mutated by optimisations.
-//!
-//! Design notes:
-//!
-//!  - This module uses `u64` extensively for bit-fields. This is not a consequence of any
-//!    particular hardware platform, we just chose a 64-bit field.
-//!
-//!  - We avoid heap allocations at all costs.
 
-use std::fmt;
-use strum_macros::FromRepr;
+// For now, don't swap others working in other areas of the system.
+// FIXME: eventually delete.
+#![allow(dead_code)]
 
-/// Number of bits used to encode an opcode.
-const OPCODE_SIZE: u64 = 8;
-
-/// Max number of operands in a short instruction.
-const SHORT_INSTR_MAX_OPERANDS: u64 = 3;
+use super::aot_ir;
+use std::{fmt, mem, ptr};
 
 /// Bit fiddling.
 ///
@@ -26,288 +17,383 @@ const SHORT_INSTR_MAX_OPERANDS: u64 = 3;
 ///  - `*_SHIFT`: the number of bits required to left shift a field's value into position (from the
 ///  LSB).
 ///
-/// Bit fiddling for a short operands:
-const SHORT_OPERAND_SIZE: u64 = 18;
-const SHORT_OPERAND_KIND_SIZE: u64 = 3;
-const SHORT_OPERAND_KIND_MASK: u64 = 7;
-const SHORT_OPERAND_VALUE_SIZE: u64 = 15;
-const SHORT_OPERAND_VALUE_SHIFT: u64 = SHORT_OPERAND_KIND_SIZE;
-const SHORT_OPERAND_MAX_VALUE: u64 = !(u64::MAX << SHORT_OPERAND_VALUE_SIZE);
-const SHORT_OPERAND_MASK: u64 = 0x3ffff;
-/// Bit fiddling for instructions.
-const INSTR_ISSHORT_SIZE: u64 = 1;
-const INSTR_ISSHORT_MASK: u64 = 1;
-/// Bit fiddling for short instructions.
-const SHORT_INSTR_OPCODE_MASK: u64 = 0xe;
-const SHORT_INSTR_OPCODE_SHIFT: u64 = INSTR_ISSHORT_SIZE;
-const SHORT_INSTR_FIRST_OPERAND_SHIFT: u64 = INSTR_ISSHORT_SIZE + OPCODE_SIZE;
+const OPERAND_INDEX_MASK: u16 = 0x7fff;
 
-/// An instruction is identified by its index in the instruction vector.
-#[derive(Copy, Clone)]
-pub(crate) struct InstructionID(usize);
+// The largest operand index we can express in 15 bits.
+const MAX_OPERAND_IDX: u16 = (1 << 15) - 1;
 
-impl InstructionID {
-    pub(crate) fn new(v: usize) -> Self {
-        Self(v)
-    }
+/// A packed 24-bit unsigned integer.
+#[repr(packed)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct U24([u8; 3]);
 
-    pub(crate) fn get(&self) -> usize {
-        self.0
-    }
-}
-
-/// An operand kind.
-#[repr(u64)]
-#[derive(Debug, FromRepr, PartialEq)]
-pub enum OpKind {
-    /// The operand is not present.
+impl U24 {
+    /// Create a [U24] from a `usize`. Returns `None` if it won't fit.
     ///
-    /// This is used in short instructions where 3 operands are inlined. If the instruction
-    /// requires fewer then 3 operands, then it can use this variant to express that.
-    ///
-    /// By using the zero discriminant, this means that a freshly created short instruction has
-    /// with zero operands until they are explicitly filled in.
-    NotPresent = 0,
-    /// The operand references a previously defined local variable.
-    Local,
-}
-
-impl From<u64> for OpKind {
-    fn from(v: u64) -> Self {
-        // unwrap safe assuming only valid discriminant numbers are used.
-        Self::from_repr(v).unwrap()
-    }
-}
-
-#[derive(Debug, FromRepr, PartialEq)]
-#[repr(u64)]
-pub enum OpCode {
-    Load,
-    LoadArg,
-}
-
-impl From<u64> for OpCode {
-    fn from(v: u64) -> Self {
-        // unwrap safe assuming only valid discriminant numbers are used.
-        Self::from_repr(v).unwrap()
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum Operand {
-    Long(LongOperand),
-    Short(ShortOperand),
-}
-
-impl Operand {
-    pub(crate) fn new(kind: OpKind, val: u64) -> Self {
-        // check if the operand's value can fit in a short operand.
-        if val <= SHORT_OPERAND_MAX_VALUE {
-            Self::Short(ShortOperand::new(kind, val))
+    /// Returns none if the value won't fit.
+    fn from_usize(val: usize) -> Option<Self> {
+        if val >= 1 << 24 {
+            None
         } else {
-            todo!()
+            let b0 = val & 0xff;
+            let b1 = (val & 0xff00) >> 8;
+            let b2 = (val & 0xff0000) >> 16;
+            Some(Self([b2 as u8, b1 as u8, b0 as u8]))
         }
     }
 
-    fn raw(&self) -> u64 {
-        match self {
-            Self::Long(_) => todo!(),
-            Self::Short(op) => op.0,
+    /// Converts 3-bytes conceptually representing a `u24` to a usize.
+    fn to_usize(&self) -> usize {
+        static_assertions::const_assert!(mem::size_of::<usize>() >= 3);
+        let b0 = self.0[0] as usize; // most-significant byte.
+        let b1 = self.0[1] as usize;
+        let b2 = self.0[2] as usize;
+        (b0 << 16) | (b1 << 8) | b2
+    }
+}
+
+// Generate common methods for 24-bit index types.
+macro_rules! index_24bit {
+    ($struct:ident) => {
+        impl $struct {
+            /// Convert an AOT index to a reduced-size JIT index (if possible).
+            pub(crate) fn from_aot(aot_idx: aot_ir::$struct) -> $struct {
+                Self(U24::from_usize(aot_idx.to_usize()).unwrap()) // FIXME: propagate error
+            }
+
+            /// Convert a JIT index to an AOT index.
+            pub(crate) fn into_aot(&self) -> aot_ir::$struct {
+                aot_ir::$struct::new(self.0.to_usize())
+            }
+        }
+    };
+}
+
+// Generate common methods for 16-bit index types.
+macro_rules! index_16bit {
+    ($struct:ident) => {
+        impl $struct {
+            pub(crate) fn new(v: usize) -> Self {
+                Self(u16::try_from(v).unwrap()) // FIXME: propagate error
+            }
+
+            pub(crate) fn to_u16(&self) -> u16 {
+                self.0.into()
+            }
+        }
+    };
+}
+
+/// A function index that refers to a function in the AOT module's function table.
+///
+/// The JIT module shares its functions with the AOT module, but note that we use only a 24-bit
+/// index in order to pack instructions down into 64-bits. The ramifications of are that the JIT IR
+/// can only address a subset of the functions that the AOT module could possibly store. Arguably,
+/// if a trace refers to that many functions, then it is likely to be a long trace that we probably
+/// don't want to compile anyway.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct FuncIndex(U24);
+index_24bit!(FuncIndex);
+
+/// A type index that refers to a type in the AOT module's type table.
+///
+/// This works similarly to [FuncIndex], i.e. a reduced-size index type is used for compactness at
+/// the cost of not being able to index every possible AOT type index.
+///
+/// See the [FuncIndex] docs for a full justification of this design.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct TypeIndex(U24);
+index_24bit!(TypeIndex);
+
+/// An extra argument index.
+///
+/// One of these is an index into the [Module::extra_args].
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct ExtraArgsIndex(u16);
+index_16bit!(ExtraArgsIndex);
+
+/// A constant index.
+///
+/// One of these is an index into the [Module::consts].
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub(crate) struct ConstIndex(u16);
+index_16bit!(ConstIndex);
+
+/// An instruction index.
+///
+/// One of these is an index into the [Module::instrs].
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub(crate) struct InstrIndex(u16);
+index_16bit!(InstrIndex);
+
+/// The packed representation of an instruction operand.
+///
+/// # Encoding
+///
+/// ```ignore
+///  1             15
+/// +---+--------------------------+
+/// | k |         index            |
+/// +---+--------------------------+
+/// ```
+///
+///  - `k=0`: `index` is a local variable index
+///  - `k=1`: `index` is a constant index
+///
+///  The IR can represent 2^{15} = 32768 locals, and as many constants.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct PackedOperand(u16);
+
+impl PackedOperand {
+    pub fn new(op: &Operand) -> Self {
+        match op {
+            Operand::Local(lidx) => {
+                debug_assert!(lidx.to_u16() <= MAX_OPERAND_IDX);
+                PackedOperand(lidx.to_u16())
+            }
+            Operand::Const(constidx) => {
+                debug_assert!(constidx.to_u16() <= MAX_OPERAND_IDX);
+                PackedOperand(constidx.to_u16() | !OPERAND_INDEX_MASK)
+            }
         }
     }
 
-    fn kind(&self) -> OpKind {
-        match self {
-            Self::Long(_) => todo!(),
-            Self::Short(op) => op.kind(),
+    /// Unpacks a [PackedOperand] into a [Operand].
+    pub fn get(&self) -> Operand {
+        if (self.0 & !OPERAND_INDEX_MASK) == 0 {
+            Operand::Local(InstrIndex(self.0))
+        } else {
+            Operand::Const(ConstIndex(self.0 & OPERAND_INDEX_MASK))
         }
     }
+}
 
-    fn val(&self) -> u64 {
-        match self {
-            Self::Long(_) => todo!(),
-            Self::Short(op) => op.val(),
-        }
-    }
-
-    fn is_short(&self) -> bool {
-        matches!(self, Self::Short(_))
-    }
+/// An unpacked representation of a operand.
+///
+/// This exists both as a convenience (as working with packed operands is laborious) and as a means
+/// to add type safety when using operands.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Operand {
+    Local(InstrIndex),
+    Const(ConstIndex),
 }
 
 impl fmt::Display for Operand {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.kind() {
-            OpKind::Local => write!(f, " %{}", self.val())?,
-            OpKind::NotPresent => (),
+        match self {
+            Self::Local(idx) => write!(f, "%{}", idx.to_u16()),
+            Self::Const(idx) => write!(f, "Const({})", idx.to_u16()), // FIXME print constant properly.
         }
-        Ok(())
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct LongOperand(u64);
-
-#[derive(Debug, PartialEq)]
-pub struct ShortOperand(u64);
-
-impl ShortOperand {
-    fn new(kind: OpKind, val: u64) -> ShortOperand {
-        ShortOperand((kind as u64) | (val << SHORT_OPERAND_VALUE_SHIFT))
-    }
-
-    fn kind(&self) -> OpKind {
-        OpKind::from(self.0 & SHORT_OPERAND_KIND_MASK)
-    }
-
-    fn val(&self) -> u64 {
-        self.0 >> SHORT_OPERAND_VALUE_SHIFT
-    }
+// FIXME: this isn't the correct representation of a constant.
+// It should be a bag of bytes and a type.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Constant {
+    Usize(usize),
 }
 
-/// An instruction.
-///
-/// An instruction is either a short instruction or a long instruction.
-///
-/// ## Short instruction
-///
-/// - A 64-bit bit-field that encodes the entire instruction inline.
-/// - Can encode up to three short operands.
-/// - Is designed to encode the most commonly encountered instructions.
-///
-/// Encoding (LSB first):
-/// ```ignore
-/// field           bit-size
-/// ------------------------
-/// is_short=1      1
-/// opcode          8
-/// short_operand0  18
-/// short_operand1  18
-/// short_operand2  18
-/// reserved        1
-/// ```
-///
-/// Where a short operand is encoded like this (LSB first):
-/// ```ignore
-/// field       bit-size
-/// --------------------
-/// kind        3
-/// payload    15
-/// ```
-///
-/// ## Long instruction
-///
-/// - A pointer to an instruction description.
-/// - Can encode an arbitrary number of long operands.
-///
-/// The pointer is assumed to be at least 2-byte aligned, thus guaranteeing the LSB to be 0.
+/// An IR instruction.
+#[repr(u8)]
 #[derive(Debug)]
-pub(crate) struct Instruction(u64);
+pub enum Instruction {
+    Load(LoadInstruction),
+    LoadArg(LoadArgInstruction),
+    Call(CallInstruction),
+}
 
 impl Instruction {
-    fn new_short(opcode: OpCode) -> Self {
-        Self(((opcode as u64) << SHORT_INSTR_OPCODE_SHIFT) | INSTR_ISSHORT_MASK)
-    }
-
-    /// Returns true if the instruction is short.
-    fn is_short(&self) -> bool {
-        self.0 & INSTR_ISSHORT_MASK != 0
-    }
-
-    /// Returns the opcode.
-    fn opcode(&self) -> OpCode {
-        debug_assert!(self.is_short());
-        OpCode::from((self.0 & SHORT_INSTR_OPCODE_MASK) >> SHORT_INSTR_OPCODE_SHIFT)
-    }
-
-    /// For short instrucitons, return the bit offset of the specified short operand.
-    fn short_operand_bit_off(&self, index: u64) -> u64 {
-        debug_assert!(self.is_short());
-        debug_assert!(index < SHORT_INSTR_MAX_OPERANDS);
-        SHORT_INSTR_FIRST_OPERAND_SHIFT + SHORT_OPERAND_SIZE * index
-    }
-
-    /// Returns the specified operand.
-    fn operand(&self, index: u64) -> Operand {
-        if self.is_short() {
-            // Shift operand down the the LSB.
-            let op = self.0 >> self.short_operand_bit_off(index);
-            // Then mask it out.
-            Operand::Short(ShortOperand(op & SHORT_OPERAND_MASK))
-        } else {
-            todo!()
-        }
-    }
-
-    /// Create a new `Load` instruction.
-    ///
-    /// ## Operands
-    ///
-    /// - `<ptr>`:  The pointer to load from.
-    ///
-    /// ## Semantics
-    ///
-    /// Return the value obtained by dereferencing the operand (which must be pointer-typed).
-    pub(crate) fn create_load(op: Operand) -> Self {
-        if op.is_short() {
-            let mut instr = Instruction::new_short(OpCode::Load);
-            instr.set_short_operand(op, 0);
-            instr
-        } else {
-            todo!();
-        }
-    }
-
-    /// Create a new `LoadArg` instruction.
-    ///
-    /// ## Operands
-    ///
-    /// FIXME
-    ///
-    /// ## Semantics
-    ///
-    /// FIXME
-    pub(crate) fn create_loadarg() -> Self {
-        Instruction::new_short(OpCode::LoadArg)
-    }
-
-    /// Set the short operand at the specified index.
-    fn set_short_operand(&mut self, op: Operand, idx: u64) {
-        debug_assert!(self.is_short());
-        debug_assert!(idx < SHORT_INSTR_MAX_OPERANDS);
-        self.0 |= op.raw() << self.short_operand_bit_off(idx);
-    }
-
     /// Returns `true` if the instruction defines a local variable.
     pub(crate) fn is_def(&self) -> bool {
-        match self.opcode() {
-            OpCode::Load => true,
-            OpCode::LoadArg => true,
+        match self {
+            Self::Load(..) => true,
+            Self::LoadArg(..) => true,
+            Self::Call(..) => true, // FIXME: May or may not define. Ask func sig.
         }
     }
 }
 
 impl fmt::Display for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let opc = self.opcode();
-        write!(f, "{:?}", opc)?;
-        if self.is_short() {
-            for i in 0..=2 {
-                let op = self.operand(i);
-                write!(f, "{}", op)?;
+        match self {
+            Self::Load(i) => write!(f, "{}", i),
+            Self::LoadArg(i) => write!(f, "{}", i),
+            Self::Call(i) => write!(f, "{}", i),
+        }
+    }
+}
+
+macro_rules! instr {
+    ($discrim:ident, $instr_type:ident) => {
+        impl From<$instr_type> for Instruction {
+            fn from(instr: $instr_type) -> Instruction {
+                Instruction::$discrim(instr)
             }
         }
-        Ok(())
+    };
+}
+
+instr!(Load, LoadInstruction);
+instr!(LoadArg, LoadArgInstruction);
+instr!(Call, CallInstruction);
+
+/// The operands for a [Instruction::Load]
+///
+/// # Semantics
+///
+/// Loads a value from a given pointer operand.
+///
+#[derive(Debug)]
+pub struct LoadInstruction {
+    /// The pointer to load from.
+    op: PackedOperand,
+    /// The type of the pointee.
+    ty_idx: TypeIndex,
+}
+
+impl LoadInstruction {
+    pub(crate) fn new(op: Operand, ty_idx: TypeIndex) -> LoadInstruction {
+        LoadInstruction {
+            op: PackedOperand::new(&op),
+            ty_idx,
+        }
+    }
+
+    /// Return the pointer operand.
+    pub(crate) fn operand(&self) -> Operand {
+        self.op.get()
+    }
+}
+
+impl fmt::Display for LoadInstruction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Load {}", self.operand())
+    }
+}
+
+/// The `LoadArg` instruction.
+///
+/// ## Semantics
+///
+/// Loads a live variable from the trace input struct.
+///
+/// ## Operands
+///
+/// FIXME: unimplemented as yet.
+#[derive(Debug)]
+pub struct LoadArgInstruction {
+    // FIXME: todo
+}
+
+impl fmt::Display for LoadArgInstruction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LoadArg")
+    }
+}
+
+impl LoadArgInstruction {
+    pub(crate) fn new() -> LoadArgInstruction {
+        Self {}
+    }
+}
+
+/// The operands for a [Instruction::Call]
+///
+/// # Semantics
+///
+/// Perform a call to an external or AOT function.
+#[derive(Debug)]
+#[repr(packed)]
+pub struct CallInstruction {
+    /// The callee.
+    target: FuncIndex,
+    /// The first argument to the call, if present. Undefined if not present.
+    arg1: PackedOperand,
+    /// Extra arguments, if the call requires more than a single argument.
+    extra: ExtraArgsIndex,
+}
+
+impl fmt::Display for CallInstruction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LoadArg")
+    }
+}
+
+impl CallInstruction {
+    pub(crate) fn new(
+        m: &mut Module,
+        target: aot_ir::FuncIndex,
+        args: &[Operand],
+    ) -> CallInstruction {
+        let mut arg1 = PackedOperand::default();
+        let mut extra = ExtraArgsIndex::default();
+
+        if args.len() >= 1 {
+            arg1 = PackedOperand::new(&args[0]);
+        }
+        if args.len() >= 2 {
+            extra = m.push_extra_args(&args[1..]);
+        }
+        Self {
+            target: FuncIndex::from_aot(target),
+            arg1,
+            extra,
+        }
+    }
+
+    fn arg1(&self) -> PackedOperand {
+        let unaligned = ptr::addr_of!(self.arg1);
+        unsafe { ptr::read_unaligned(unaligned) }
+    }
+
+    /// Fetch the operand at the specified index.
+    ///
+    /// It is undefined behaviour to provide an out-of-bounds index.
+    pub(crate) fn operand(
+        &self,
+        aot_mod: &aot_ir::Module,
+        jit_mod: &Module,
+        idx: usize,
+    ) -> Option<Operand> {
+        #[cfg(debug_assertions)]
+        {
+            let ft = aot_mod.func_ty(self.target.into_aot());
+            debug_assert!(ft.num_args() > idx);
+        }
+        if idx == 0 {
+            Some(self.arg1().get())
+        } else {
+            Some(jit_mod.extra_args[usize::try_from(self.extra.0).unwrap() + idx - 1].clone())
+        }
     }
 }
 
 /// The `Module` is the top-level container for JIT IR.
+///
+/// The IR is conceptually a list of word-sized instructions containing indices into auxiliary
+/// vectors.
+///
+/// The instruction stream of a [Module] is partially mutable:
+/// - you may append new instructions to the end.
+/// - you may replace and instruction with another.
+/// - you may NOT remove an instruction.
 #[derive(Debug)]
 pub(crate) struct Module {
     /// The name of the module and the eventual symbol name for the JITted code.
     name: String,
     /// The IR trace as a linear sequence of instructions.
     instrs: Vec<Instruction>,
+    /// The extra argument table.
+    ///
+    /// Used when a [CallInstruction]'s arguments don't fit inline.
+    ///
+    /// An [ExtraArgsIndex] describes an index into this.
+    extra_args: Vec<Operand>,
+    /// The constant table.
+    ///
+    /// A [ConstIndex] describes an index into this.
+    consts: Vec<Constant>,
 }
 
 impl Module {
@@ -316,6 +402,8 @@ impl Module {
         Self {
             name,
             instrs: Vec::new(),
+            extra_args: Vec::new(),
+            consts: Vec::new(),
         }
     }
 
@@ -332,6 +420,33 @@ impl Module {
     /// Print the [Module] to `stderr`.
     pub(crate) fn dump(&self) {
         eprintln!("{}", self);
+    }
+
+    /// Push a slice of extra arguments into the extra arg table.
+    fn push_extra_args(&mut self, ops: &[Operand]) -> ExtraArgsIndex {
+        let idx = self.extra_args.len();
+        self.extra_args.extend_from_slice(ops); // FIXME: this clones.
+        ExtraArgsIndex(u16::try_from(idx).unwrap()) // FIXME: propagate error
+    }
+
+    /// Push a new constant into the constant table and return its index.
+    pub(crate) fn push_const(&mut self, constant: Constant) -> ConstIndex {
+        let idx = self.consts.len();
+        self.consts.push(constant);
+        ConstIndex(u16::try_from(idx).unwrap()) // FIXME: propagate error
+    }
+
+    /// Get the index of a type, inserting it in the type table if necessary.
+    pub fn const_index(&mut self, c: &Constant) -> ConstIndex {
+        // FIXME: can we optimise this?
+        for (idx, tc) in self.consts.iter().enumerate() {
+            if tc == c {
+                // const table hit.
+                return ConstIndex(u16::try_from(idx).unwrap()); // FIXME: propagate error
+            }
+        }
+        // type table miss, we need to insert it.
+        self.push_const(c.clone())
     }
 }
 
@@ -351,105 +466,137 @@ impl fmt::Display for Module {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem;
 
     #[test]
-    fn short_instruction() {
-        let op = Operand::new(OpKind::Local, 10);
-        let instr = Instruction::create_load(op);
-        assert_eq!(instr.opcode(), OpCode::Load);
-        assert_eq!(instr.operand(0).kind(), OpKind::Local);
-        assert_eq!(instr.operand(0).val(), 10);
-        assert!(instr.is_def());
-        assert_eq!(instr.0, 0xa201);
-        assert!(instr.is_short());
+    fn operand() {
+        let op = PackedOperand::new(&Operand::Local(InstrIndex(192)));
+        assert_eq!(op.get(), Operand::Local(InstrIndex(192)));
+
+        let op = PackedOperand::new(&Operand::Local(InstrIndex(0x7fff)));
+        assert_eq!(op.get(), Operand::Local(InstrIndex(0x7fff)));
+
+        let op = PackedOperand::new(&Operand::Local(InstrIndex(0)));
+        assert_eq!(op.get(), Operand::Local(InstrIndex(0)));
+
+        let op = PackedOperand::new(&Operand::Const(ConstIndex(192)));
+        assert_eq!(op.get(), Operand::Const(ConstIndex(192)));
+
+        let op = PackedOperand::new(&Operand::Const(ConstIndex(0x7fff)));
+        assert_eq!(op.get(), Operand::Const(ConstIndex(0x7fff)));
+
+        let op = PackedOperand::new(&Operand::Const(ConstIndex(0)));
+        assert_eq!(op.get(), Operand::Const(ConstIndex(0)));
     }
 
     #[test]
-    fn long_instruction() {
-        // FIXME: expand when long instructions are implemented.
-        let instr = Instruction(0);
-        assert!(!instr.is_short());
+    fn use_case_update_instr() {
+        let mut prog: Vec<Instruction> = vec![
+            LoadArgInstruction::new().into(),
+            LoadArgInstruction::new().into(),
+            LoadInstruction::new(
+                Operand::Local(InstrIndex(0)),
+                TypeIndex(U24::from_usize(0).unwrap()),
+            )
+            .into(),
+        ];
+        prog[2] = LoadInstruction::new(
+            Operand::Local(InstrIndex(1)),
+            TypeIndex(U24::from_usize(0).unwrap()),
+        )
+        .into();
     }
 
-    /// The IR encoding uses a LSB tag to determine if an instruction is short or not, and if it
-    /// isn't short then it's interpreted as a box pointer. So a box pointer had better be at least
-    /// 2-byte aligned!
-    ///
-    /// This test (somewhat) proves that we are safe by allocating a bunch of `Box<u8>` (which in
-    /// theory could be stored contiguously) and then checks their addresses don't have the LSB set
-    /// (as this would indicate 1-byte alignment!).
+    /// Ensure that any given instruction fits in 64-bits.
     #[test]
-    fn tagging_valid() {
-        let mut boxes = Vec::new();
-        for i in 0..8192 {
-            boxes.push(Box::new(i as u8));
-        }
-
-        for b in boxes {
-            assert_eq!((&*b as *const u8 as usize) & 1, 0);
-        }
-    }
-
-    #[test]
-    fn short_operand_getters() {
-        let mut word = 1; // short instruction.
-
-        // operand0:
-        word |= 0x0aaa8 << SHORT_INSTR_FIRST_OPERAND_SHIFT;
-        // operand1:
-        word |= 0x1bbb1 << SHORT_INSTR_FIRST_OPERAND_SHIFT + SHORT_OPERAND_SIZE;
-        // operand2:
-        word |= 0x2ccc8 << SHORT_INSTR_FIRST_OPERAND_SHIFT + SHORT_OPERAND_SIZE * 2;
-
-        let inst = Instruction(word);
-
-        assert_eq!(inst.operand(0), Operand::Short(ShortOperand(0x0aaa8)));
-        assert_eq!(inst.operand(0).kind() as u64, 0);
-        assert_eq!(inst.operand(0).val() as u64, 0x1555);
-
-        assert_eq!(inst.operand(1), Operand::Short(ShortOperand(0x1bbb1)));
-        assert_eq!(inst.operand(1).kind() as u64, 1);
-        assert_eq!(inst.operand(1).val() as u64, 0x3776);
-
-        assert_eq!(inst.operand(2), Operand::Short(ShortOperand(0x2ccc8)));
-        assert_eq!(inst.operand(2).kind() as u64, 0);
-        assert_eq!(inst.operand(2).val() as u64, 0x5999);
+    fn instr_size() {
+        assert_eq!(mem::size_of::<CallInstruction>(), 7);
+        assert!(mem::size_of::<Instruction>() <= mem::size_of::<u64>());
     }
 
     #[test]
-    fn short_operand_setters() {
-        let mut inst = Instruction::new_short(OpCode::Load);
-        inst.set_short_operand(Operand::Short(ShortOperand(0x3ffff)), 0);
-        debug_assert_eq!(inst.operand(0), Operand::Short(ShortOperand(0x3ffff)));
-        debug_assert_eq!(inst.operand(1), Operand::Short(ShortOperand(0)));
-        debug_assert_eq!(inst.operand(2), Operand::Short(ShortOperand(0)));
+    fn extra_call_args() {
+        let mut aot_mod = aot_ir::Module::default();
+        let arg_ty_idxs = vec![0, 0, 0];
+        let func_ty = aot_ir::Type::Func(aot_ir::FuncType::new(
+            arg_ty_idxs,
+            aot_ir::TypeIndex::new(0),
+            false,
+        ));
+        let func_ty_idx = aot_mod.push_type(func_ty);
+        let aot_func_idx = aot_mod.push_func(aot_ir::Function::new("", func_ty_idx));
 
-        let mut inst = Instruction::new_short(OpCode::Load);
-        inst.set_short_operand(Operand::Short(ShortOperand(0x3ffff)), 1);
-        debug_assert_eq!(inst.operand(0), Operand::Short(ShortOperand(0)));
-        debug_assert_eq!(inst.operand(1), Operand::Short(ShortOperand(0x3ffff)));
-        debug_assert_eq!(inst.operand(2), Operand::Short(ShortOperand(0)));
+        let mut jit_mod = Module::new("test".into());
+        let args = vec![
+            Operand::Local(InstrIndex(0)), // inline arg
+            Operand::Local(InstrIndex(1)), // first extra arg
+            Operand::Local(InstrIndex(2)),
+        ];
+        let ci = CallInstruction::new(&mut jit_mod, aot_func_idx, &args);
 
-        let mut inst = Instruction::new_short(OpCode::Load);
-        inst.set_short_operand(Operand::Short(ShortOperand(0x3ffff)), 2);
-        debug_assert_eq!(inst.operand(0), Operand::Short(ShortOperand(0)));
-        debug_assert_eq!(inst.operand(1), Operand::Short(ShortOperand(0)));
-        debug_assert_eq!(inst.operand(2), Operand::Short(ShortOperand(0x3ffff)));
-    }
-
-    #[test]
-    fn does_fit_short_operand() {
-        for i in 0..SHORT_OPERAND_VALUE_SIZE {
-            matches!(Operand::new(OpKind::Local, 1 << i), Operand::Short(_));
-        }
-    }
-
-    #[test]
-    #[should_panic] // Once long operands are implemented, remove.
-    fn doesnt_fit_short_operand() {
-        matches!(
-            Operand::new(OpKind::Local, 1 << SHORT_OPERAND_VALUE_SIZE),
-            Operand::Long(_)
+        assert_eq!(
+            ci.operand(&aot_mod, &jit_mod, 0),
+            Some(Operand::Local(InstrIndex(0)))
         );
+        assert_eq!(
+            ci.operand(&aot_mod, &jit_mod, 1),
+            Some(Operand::Local(InstrIndex(1)))
+        );
+        assert_eq!(
+            ci.operand(&aot_mod, &jit_mod, 2),
+            Some(Operand::Local(InstrIndex(2)))
+        );
+        assert_eq!(
+            jit_mod.extra_args,
+            vec![Operand::Local(InstrIndex(1)), Operand::Local(InstrIndex(2))]
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn call_args_out_of_bounds() {
+        let mut aot_mod = aot_ir::Module::default();
+        let arg_ty_idxs = vec![0, 0, 0];
+        let func_ty = aot_ir::Type::Func(aot_ir::FuncType::new(
+            arg_ty_idxs,
+            aot_ir::TypeIndex::new(0),
+            false,
+        ));
+        let func_ty_idx = aot_mod.push_type(func_ty);
+        let aot_func_idx = aot_mod.push_func(aot_ir::Function::new("", func_ty_idx));
+
+        let mut jit_mod = Module::new("test".into());
+        let args = vec![
+            Operand::Local(InstrIndex(0)), // inline arg
+            Operand::Local(InstrIndex(1)), // first extra arg
+            Operand::Local(InstrIndex(2)),
+        ];
+        let ci = CallInstruction::new(&mut jit_mod, aot_func_idx, &args);
+
+        ci.operand(&aot_mod, &jit_mod, 3);
+    }
+
+    #[test]
+    fn u24_from_usize() {
+        assert_eq!(U24::from_usize(0x000000), Some(U24([0x00, 0x00, 0x00])));
+        assert_eq!(U24::from_usize(0x123456), Some(U24([0x12, 0x34, 0x56])));
+        assert_eq!(U24::from_usize(0xffffff), Some(U24([0xff, 0xff, 0xff])));
+        assert_eq!(U24::from_usize(0x1000000), None);
+        assert_eq!(U24::from_usize(0x1234567), None);
+        assert_eq!(U24::from_usize(0xfffffff), None);
+    }
+
+    #[test]
+    fn u24_to_usize() {
+        assert_eq!(U24([0x00, 0x00, 0x00]).to_usize(), 0x000000);
+        assert_eq!(U24([0x12, 0x34, 0x56]).to_usize(), 0x123456);
+        assert_eq!(U24([0xff, 0xff, 0xff]).to_usize(), 0xffffff);
+    }
+
+    #[test]
+    fn u24_round_trip() {
+        assert_eq!(U24::from_usize(0x000000).unwrap().to_usize(), 0x000000);
+        assert_eq!(U24::from_usize(0x123456).unwrap().to_usize(), 0x123456);
+        assert_eq!(U24::from_usize(0xffffff).unwrap().to_usize(), 0xffffff);
     }
 }


### PR DESCRIPTION
This reworks the JIT IR, incorporating the wisdom we've absorbed through studying PyPy and LuaJIT's JIT IRs.

The JIT IR is now a vector of word-sized instructions that can be matched and destructured using Rust's type system. This differs slightly from PyPy and LuaJIT, which use bytestreams, but we want static type-safety.

Any information that can't fit inline in the instruction word (e.g. operands and their types) are referenced using indices into an auxiliary vector containing the overflow information. This idea was borrowed from LuaJIT.

Indices are all u16, and thus can only represent a limited number of elements. This is fine, as we don't expect traces to be so large that the indices grow beyond what a u16 can represent. If they do we can just abort the trace and remain sound.

A note on mutability: you may mutate the instruction stream so long as you don't cause any index skew. It's OK to replace/mutate an instruction, but you must NOT remove instructions.

The IR is not finished and has a lot of dead code, hence we mark the whole module `#![allow(dead_code)]`. This will eventually be deleted.

Probable follow up PRs:
 - propagate errors when indices overflow (and test).
 - implement missing operand and instruction types (get enough in to get a simple test loop to translate to JIT IR).
 - generate code :)