### PR TITLE
Update to the latest lang_tester.

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -36,7 +36,7 @@ yktracec = { path = "../yktracec", features = ["yk_testing"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
-lang_tester = "0.7.6"
+lang_tester = "0.8"
 ykcapi = { path = "../ykcapi", features = ["yk_testing"] }
 yktracec = { path = "../yktracec", features = ["yk_testing"] }
 ykrt = { path = "../ykrt", features = ["yk_testing", "yk_jitstate_debug"] }

--- a/tests/c/awkward_unmappable.c
+++ b/tests/c/awkward_unmappable.c
@@ -1,4 +1,5 @@
-// ignore: Fails with: Assertion `!CallStack.curMappableFrame()' failed
+// # Fails with: Assertion `!CallStack.curMappableFrame()' failed
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   status: success

--- a/tests/c/call_ext_varargs.c
+++ b/tests/c/call_ext_varargs.c
@@ -1,4 +1,5 @@
-// ignore: static strings: https://github.com/ykjit/yk/issues/382
+// # static strings: https://github.com/ykjit/yk/issues/382
+// ignore-if: true
 // Compiler:
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt

--- a/tests/c/constexpr.c.O0
+++ b/tests/c/constexpr.c.O0
@@ -1,1 +1,2 @@
-// ignore: -O0 doesn't make a constant expression.
+// # -O0 doesn't make a constant expression.
+// ignore-if: true

--- a/tests/c/indirect_branch.c
+++ b/tests/c/indirect_branch.c
@@ -1,4 +1,5 @@
-// ignore: guards for indirect branches not implemented.
+// # guards for indirect branches not implemented.
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_PRINT_JITSTATE=1

--- a/tests/c/lifetime_intrinsics.c.O0
+++ b/tests/c/lifetime_intrinsics.c.O0
@@ -1,1 +1,2 @@
-// ignore: no lifetime annotations at -O0.
+// # no lifetime annotations at -O0.
+// ignore-if: true

--- a/tests/c/many_threads_many_locs.c
+++ b/tests/c/many_threads_many_locs.c
@@ -1,4 +1,5 @@
-// ignore: Shadow stack doesn't currently support dynamically sized stack.
+// # Shadow stack doesn't currently support dynamically sized stack.
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:

--- a/tests/c/many_threads_one_loc.c
+++ b/tests/c/many_threads_one_loc.c
@@ -1,4 +1,5 @@
-// ignore: Shadow stack doesn't currently support dynamically sized stack.
+// # Shadow stack doesn't currently support dynamically sized stack.
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_PRINT_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/simple_interp_loop1.c
+++ b/tests/c/simple_interp_loop1.c
@@ -1,4 +1,5 @@
-// ignore: Shadow stack doesn't currently support dynamically sized stack.
+// # Shadow stack doesn't currently support dynamically sized stack.
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/simple_nested.c
+++ b/tests/c/simple_nested.c
@@ -1,4 +1,4 @@
-// ignore: dont
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_PRINT_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/stats2.c
+++ b/tests/c/stats2.c
@@ -1,4 +1,5 @@
-// ignore: Shadow stack not supported on non-main threads.
+// # Shadow stack not supported on non-main threads.
+// ignore-if: true
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_STATS=-

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -93,6 +93,7 @@ fn run_suite(opt: &'static str) {
     let wrapper_path = ccg.wrapper_path();
 
     LangTester::new()
+        .comment_prefix("#")
         .test_dir("c")
         .test_path_filter(filter)
         .test_extract(move |p| {

--- a/tests/langtest_trace_compiler.rs
+++ b/tests/langtest_trace_compiler.rs
@@ -29,6 +29,7 @@ fn main() {
 
     LangTester::new()
         .test_dir("trace_compiler")
+        .comment_prefix("#")
         .test_path_filter(|p| p.extension().and_then(|p| p.to_str()) == Some("ll"))
         .test_extract(move |p| {
             read_to_string(p)


### PR DESCRIPTION
Note that we don't use `comment_prefix("#")` in the IR tests as test lines in those tests begin with "#"! We could use another character but, at the moment, we have no need to add comments to any of those tests.