### PR TITLE
Use `TiVec` in the AOT IR.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -21,6 +21,7 @@ strum = { version = "0.25", features = ["derive"] }
 yktracec = { path = "../yktracec" }
 strum_macros = "0.25.3"
 static_assertions = "1.1.0"
+typed-index-collections = "3.1.0"
 
 [dependencies.llvm-sys]
 # note: using a git version to get llvm linkage features in llvm-sys (not in a

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -58,7 +58,7 @@ macro_rules! index_24bit {
         impl $struct {
             /// Convert an AOT index to a reduced-size JIT index (if possible).
             pub(crate) fn from_aot(aot_idx: aot_ir::$struct) -> $struct {
-                Self(U24::from_usize(aot_idx.to_usize()).unwrap()) // FIXME: propagate error
+                Self(U24::from_usize(usize::from(aot_idx)).unwrap()) // FIXME: propagate error
             }
 
             /// Convert a JIT index to an AOT index.

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -87,7 +87,7 @@ impl<'a> TraceBuilder<'a> {
     /// Walk over a traced AOT block, translating the constituent instructions into the JIT module.
     fn process_block(&mut self, bid: aot_ir::BlockID) {
         // unwrap safe: can't trace a block not in the AOT module.
-        let blk = self.aot_mod.block(&bid).unwrap();
+        let blk = self.aot_mod.block(&bid);
 
         // Decide how to translate each AOT instruction based upon its opcode.
         for (inst_idx, inst) in blk.instrs.iter().enumerate() {
@@ -152,7 +152,7 @@ impl<'a> TraceBuilder<'a> {
     fn build(mut self) -> Result<jit_ir::Module, Box<dyn Error>> {
         let firstblk = self.lookup_aot_block(&self.mtrace[0]);
         debug_assert!(firstblk.is_some());
-        self.create_trace_header(self.aot_mod.block(&firstblk.unwrap()).unwrap());
+        self.create_trace_header(self.aot_mod.block(&firstblk.unwrap()));
 
         for tblk in self.mtrace {
             match self.lookup_aot_block(tblk) {


### PR DESCRIPTION
This change replaces auxilliary vectors of the form `Vec<T>` with `TiVec<T>` from the `typed_index_collections` crate.

`TiVec` is like `IndexVec` from rustc: it uses type-safe indices to prevent you from mixing incompatible indices by accident.

I looked at a few crates that provide this kind of functionality, and `typed_index_collections` seemed the best for our needs. Also it appears to be maintained.

For now we only use `TiVec` for the AOT IR. We may do the same for the JIT IR later, if we find that it makes sense.

While here, homogonise functions that index in to a vector, making them panic if the element isn't found (instead of returning `Option`, which I see no need for at the moment).