### PR TITLE
Further simplify the LLVM trace compiler

### DIFF
--- a/yktracec/src/ykllvmwrap.cc
+++ b/yktracec/src/ykllvmwrap.cc
@@ -401,10 +401,10 @@ void rewriteDebugInfo(Module *M, string TraceName, int FD,
 // trace.
 //
 // Returns a pointer to the compiled function.
-void *compileIRTrace(char *FuncNames[], size_t BBs[], size_t TraceLen,
-                     void *BitcodeData, size_t BitcodeLen, int DebugInfoFD,
-                     char *DebugInfoPath, void *CallStack, void *AOTValsPtr,
-                     size_t AOTValsLen) {
+extern "C" void *__yktracec_irtrace_compile(
+    char *FuncNames[], size_t BBs[], size_t TraceLen, void *BitcodeData,
+    uint64_t BitcodeLen, int DebugInfoFD, char *DebugInfoPath, void *CallStack,
+    void *AOTValsPtr, size_t AOTValsLen) {
   DebugIRPrinter DIP;
 
   struct BitcodeSection Bitcode = {BitcodeData, BitcodeLen};
@@ -463,13 +463,4 @@ void *compileIRTrace(char *FuncNames[], size_t BBs[], size_t TraceLen,
   // Compile IR trace and return a pointer to its function.
   return compileModule(TraceName, JITMod, AOTMappingVec, GuardCount,
                        ThreadAOTMod);
-}
-
-extern "C" void *__yktracec_irtrace_compile(
-    char *FuncNames[], size_t BBs[], size_t TraceLen, void *BitcodeData,
-    uint64_t BitcodeLen, int DebugInfoFD, char *DebugInfoPath, void *CallStack,
-    void *AOTValsPtr, size_t AOTValsLen) {
-  return compileIRTrace(FuncNames, BBs, TraceLen, BitcodeData, BitcodeLen,
-                        DebugInfoFD, DebugInfoPath, CallStack, AOTValsPtr,
-                        AOTValsLen);
 }

--- a/yktracec/src/ykllvmwrap.cc
+++ b/yktracec/src/ykllvmwrap.cc
@@ -401,8 +401,7 @@ void rewriteDebugInfo(Module *M, string TraceName, int FD,
 // trace.
 //
 // Returns a pointer to the compiled function.
-template <typename FN>
-void *compileIRTrace(FN Func, char *FuncNames[], size_t BBs[], size_t TraceLen,
+void *compileIRTrace(char *FuncNames[], size_t BBs[], size_t TraceLen,
                      void *BitcodeData, size_t BitcodeLen, int DebugInfoFD,
                      char *DebugInfoPath, void *CallStack, void *AOTValsPtr,
                      size_t AOTValsLen) {
@@ -422,7 +421,7 @@ void *compileIRTrace(FN Func, char *FuncNames[], size_t BBs[], size_t TraceLen,
   // it isn't needed for compilation.
   ThreadAOTMod->withModuleDo([&](Module &AOTMod) {
     DIP.print(DebugIR::AOT, &AOTMod);
-    std::tie(JITMod, TraceName, AOTMappingVec, GuardCount) = Func(
+    std::tie(JITMod, TraceName, AOTMappingVec, GuardCount) = createModule(
         &AOTMod, FuncNames, BBs, TraceLen, CallStack, AOTValsPtr, AOTValsLen);
   });
 
@@ -470,7 +469,7 @@ extern "C" void *__yktracec_irtrace_compile(
     char *FuncNames[], size_t BBs[], size_t TraceLen, void *BitcodeData,
     uint64_t BitcodeLen, int DebugInfoFD, char *DebugInfoPath, void *CallStack,
     void *AOTValsPtr, size_t AOTValsLen) {
-  return compileIRTrace(createModule, FuncNames, BBs, TraceLen, BitcodeData,
-                        BitcodeLen, DebugInfoFD, DebugInfoPath, CallStack,
-                        AOTValsPtr, AOTValsLen);
+  return compileIRTrace(FuncNames, BBs, TraceLen, BitcodeData, BitcodeLen,
+                        DebugInfoFD, DebugInfoPath, CallStack, AOTValsPtr,
+                        AOTValsLen);
 }


### PR DESCRIPTION
This turned out to be a) easier than I expected b) to have fewer tentacles than I suspected.