### PR TITLE
Move control point block removal to hwt

### DIFF
--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -134,7 +134,21 @@ impl HWTMapper {
     ) -> Result<Vec<TracedAOTBlock>, Box<dyn Error>> {
         let mut ret: Vec<TracedAOTBlock> = Vec::new();
 
-        for (i, block) in trace.iter_blocks().enumerate() {
+        let mut trace_iter = trace.iter_blocks();
+        // The first block contains the control point so we need to remove that.
+        match trace_iter.next() {
+            Some(Ok(x)) => {
+                // As a rough proxy for "check that we removed only the thing we want to remove",
+                // we know that the control point will be contained in a single mappable block.
+                assert!(matches!(
+                    self.map_block(&x).as_slice(),
+                    &[Some(TracedAOTBlock::Mapped { .. })]
+                ));
+            }
+            _ => unreachable!(),
+        }
+
+        for (i, block) in trace_iter.enumerate() {
             if i > crate::mt::DEFAULT_TRACE_TOO_LONG {
                 return Err("Trace too long".into());
             }
@@ -182,8 +196,6 @@ impl HWTMapper {
                 }
             }
         }
-        // The first block contains the control point so we need to remove that.
-        ret.remove(0);
         Ok(ret)
     }
 }

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -182,6 +182,8 @@ impl HWTMapper {
                 }
             }
         }
+        // The first block contains the control point so we need to remove that.
+        ret.remove(0);
         Ok(ret)
     }
 }

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -1052,9 +1052,7 @@ public:
   Module *createModule() {
     size_t CurBBIdx;
     size_t CurInstrIdx;
-    // Iterate over the blocks of the trace. The first block contains the
-    // control point so we want to start copying instructions just after that.
-    for (size_t Idx = 1; Idx < InpTrace.Length(); Idx++) {
+    for (size_t Idx = 0; Idx < InpTrace.Length(); Idx++) {
       // Update the previously executed BB in the most-recent frame (if it's
       // mappable).
       TraceLoc Loc = InpTrace[Idx];


### PR DESCRIPTION
This PR moves the "ignore the first block" logic, which is only relevant for hwt, into hwt. The first commit does this brutally but makes what's going on clear; the second commit does so more elegantly and does a partial check that we've removed the right thing.