### PR TITLE
Encapsulate the trace vector.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 use super::aot_ir;
+use super::tracevec::TraceVec;
 use std::{fmt, mem, ptr};
 
 /// Bit fiddling.
@@ -383,7 +384,7 @@ pub(crate) struct Module {
     /// The name of the module and the eventual symbol name for the JITted code.
     name: String,
     /// The IR trace as a linear sequence of instructions.
-    instrs: Vec<Instruction>,
+    instrs: TraceVec,
     /// The extra argument table.
     ///
     /// Used when a [CallInstruction]'s arguments don't fit inline.
@@ -401,7 +402,7 @@ impl Module {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            instrs: Vec::new(),
+            instrs: TraceVec::new(),
             extra_args: Vec::new(),
             consts: Vec::new(),
         }

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -51,6 +51,7 @@ static PHASES_TO_PRINT: LazyLock<HashSet<IRPhase>> = LazyLock::new(|| {
 pub mod aot_ir;
 pub mod jit_ir;
 mod trace_builder;
+pub mod tracevec;
 
 pub(crate) struct JITCYk;
 

--- a/ykrt/src/compile/jitc_yk/tracevec.rs
+++ b/ykrt/src/compile/jitc_yk/tracevec.rs
@@ -1,0 +1,25 @@
+use super::jit_ir::Instruction;
+
+/// A wrapper around a vector of instructions used to store a trace. Since we disallow removal and
+/// insertion (with the exception of appending at the end) into the vector, the wrapper only
+/// exposes the pushing and replacing of instructions.
+#[derive(Debug)]
+pub struct TraceVec(Vec<Instruction>);
+
+impl TraceVec {
+    pub fn new() -> Self {
+        TraceVec(Vec::new())
+    }
+
+    pub fn push(&mut self, instr: Instruction) {
+        self.0.push(instr);
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Instruction> {
+        self.0.iter()
+    }
+}

--- a/ykrt/src/compile/jitc_yk/tracevec.rs
+++ b/ykrt/src/compile/jitc_yk/tracevec.rs
@@ -1,14 +1,17 @@
+use super::aot_ir::InstrIdx;
+use typed_index_collections::TiVec;
+
 use super::jit_ir::Instruction;
 
 /// A wrapper around a vector of instructions used to store a trace. Since we disallow removal and
 /// insertion (with the exception of appending at the end) into the vector, the wrapper only
 /// exposes the pushing and replacing of instructions.
 #[derive(Debug)]
-pub struct TraceVec(Vec<Instruction>);
+pub struct TraceVec(TiVec<InstrIdx, Instruction>);
 
 impl TraceVec {
     pub fn new() -> Self {
-        TraceVec(Vec::new())
+        TraceVec(Vec::new().into())
     }
 
     pub fn push(&mut self, instr: Instruction) {


### PR DESCRIPTION
Since references to instructions inside a trace are represented by their index, certain operations, like removal and insertion of instructions (except appending at the end), are disallowed. In order to make it more difficult to accidentally do that, this commit encapsulates the vector storing the instructions of a trace, only exposing operations that are safe to do.

Additional notes: I kinda cheated here, since I manually implemented an `iter` method which just returns the underlying vec's `iter`. If we wanted to iterate over the trace vector using a simple for loop, e.g. `for instr in tracevec`, then we would have to implement `Iterator`, which is a teeny bit more involved. But I decided to wait and see how we are going to access a trace, once we moved to the optimisation/compilation stages for our new IR, to see if it's really needed.