### PR TITLE
First block bug

### DIFF
--- a/tests/c/simple.newcg.c
+++ b/tests/c/simple.newcg.c
@@ -1,7 +1,6 @@
 // # Currently this test breaks CI entirely, so we temporarily ignore it
 // # completely.
-// ignore-if: true
-// # ignore-if: test $YK_JIT_COMPILER != "yk"
+// ignore-if: test $YK_JIT_COMPILER != "yk"
 // Run-time:
 //   env-var: YKD_PRINT_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -171,7 +171,22 @@ impl<'a> TraceBuilder<'a> {
             Some(b) => Ok(b),
             None => Err(CompilationError::Unrecoverable("empty trace".into())),
         }?;
-        let firstblk = self.lookup_aot_block(first_blk);
+
+        // Find the block containing the control point call. This is the (sole) predecessor of the
+        // first (guaranteed mappable) block in the trace.
+        let prev = match first_blk {
+            TracedAOTBlock::Mapped { func_name, bb } => {
+                debug_assert!(*bb > 0);
+                // It's `- 1` due to the way the ykllvm block splitting pass works.
+                TracedAOTBlock::Mapped {
+                    func_name: func_name.clone(),
+                    bb: bb - 1,
+                }
+            }
+            TracedAOTBlock::Unmappable => panic!(),
+        };
+
+        let firstblk = self.lookup_aot_block(&prev);
         // FIXME: This unwrap assumes the first block is mappable, but Laurie just merged a change
         // that strips the initial block (the block we return to from the control point), so I
         // don't think this assumption necessarily holds any more. Investigate.


### PR DESCRIPTION
This fixes the bug where the new JIT compiler expects the first block in the trace to contain the control point.

This requires an upcoming change from Laurie before it can be merged.