### PR TITLE
Move "ignore the very last block" into the hwt mapper.

### DIFF
--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -196,6 +196,16 @@ impl HWTMapper {
                 }
             }
         }
+
+        // The last block contains pointless unmappable code (the stop tracing call).
+        match ret.pop() {
+            Some(x) => {
+                // This is a rough proxy for "check that we removed only the thing we want to
+                // remove".
+                assert!(matches!(x, TracedAOTBlock::Unmappable));
+            }
+            _ => unreachable!(),
+        }
         Ok(ret)
     }
 }

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -1293,7 +1293,7 @@ public:
           continue;
         }
 
-        if (Idx > 0 && Idx < InpTrace.Length() - 1) {
+        if (Idx < InpTrace.Length()) {
           // Stores into YkCtrlPointVars only need to be copied if they appear
           // at the beginning or end of the trace. Any YkCtrlPointVars stores
           // inbetween come from tracing over the control point and aren't
@@ -1314,8 +1314,7 @@ public:
                 I++;
                 CurInstrIdx++;
               }
-              assert(InpTrace.Length() > 2);
-              if (Idx == InpTrace.Length() - 2) {
+              if (Idx == InpTrace.Length() - 1) {
                 // Once we reached the YkCtrlPointVars stores at the end of the
                 // trace, we're done. We don't need to copy those instructions
                 // over, since all YkCtrlPointVars are stored on the shadow


### PR DESCRIPTION
The last PT-mapped block contains unmappable code that stops tracing. Other backends will not have this block, so handling it in jitmodbuilder is wrong. This commit removes this block in `hwt/mappper.rs` instead.