### PR TITLE
Remove unused method.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -108,13 +108,6 @@ fn deserialise_into_ti_vec<I, T>(v: Vec<T>) -> Result<TiVec<I, T>, DekuError> {
 pub(crate) trait IRDisplay {
     /// Return a human-readable string.
     fn to_str(&self, m: &Module) -> String;
-
-    /// Print myself to stderr in human-readable form.
-    ///
-    /// This is provided as a debugging convenience.
-    fn dump(&self, m: &Module) {
-        eprintln!("{}", self.to_str(m));
-    }
 }
 
 /// An instruction opcode.


### PR DESCRIPTION
Newer Rust nightlies spot that this is unused, causing our `.buildbot.sh` to fail.

This is responsible for the recent failure of https://github.com/ykjit/yk/pull/959 to pass CI.