### PR TITLE
`bb = usize::MAX` isn't a special value.

### DIFF
--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -57,8 +57,6 @@ pub enum TracedAOTBlock {
         /// PERF: Use a string pool to avoid duplicated function names in traces.
         func_name: CString,
         /// The index of the block within the function.
-        ///
-        /// The special value `usize::MAX` indicates unmappable code.
         bb: usize,
     },
     /// One or more machine blocks that could not be mapped.
@@ -69,6 +67,10 @@ pub enum TracedAOTBlock {
 
 impl TracedAOTBlock {
     pub fn new_mapped(func_name: CString, bb: usize) -> Self {
+        // At one point, `bb = usize::MAX` was a special value, but it no longer is. We believe
+        // that no part of the code sets/checks for this value, but just in case there is a
+        // laggardly part of the code which does so, we've left this `assert` behind to catch it.
+        debug_assert_ne!(bb, usize::MAX);
         Self::Mapped { func_name, bb }
     }
 


### PR DESCRIPTION
At some point in the past `bb = usize::MAX` was used to represent "unmappable" but it's now a separate `enum` item. Nowhere in yk seems to check/set `bb` for/to `usize::MAX` so this commit removes the (hopefully) misleading comment. In case we're wrong, I've left behind an `assert` that's likely to catch any old code. One day far in the future our successors might feel confident enough to remove the `assert`!