### PR TITLE
Mark `IRDisplay::dump()` as "allowed dead code" and justify.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -111,7 +111,8 @@ pub(crate) trait IRDisplay {
 
     /// Print myself to stderr in human-readable form.
     ///
-    /// This is provided as a debugging convenience.
+    /// This isn't used during normal operation of the system: it is provided as a debugging aid.
+    #[allow(dead_code)]
     fn dump(&self, m: &Module) {
         eprintln!("{}", self.to_str(m));
     }


### PR DESCRIPTION
Thank you Laurie :)