### PR TITLE
Slightly fiddle with `yk_promote`.

### DIFF
--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -67,11 +67,9 @@ YkLocation yk_location_new(void);
 // will occur.
 void yk_location_drop(YkLocation);
 
-// Promote a value to a constant.
-//
-// Yk will attempt to promote the argument to a constant when the call is
-// traced and compiled. The call to `yk_promote()` itself is also omitted from
-// compiled traces.
+// Promote a value to a constant. This is a generic macro that will
+// automatically select the right `yk_promote` function to call based on the
+// type of the value passed.
 #define yk_promote(X) _Generic((X), size_t: __yk_promote_size_t)(X)
 void __yk_promote_size_t(size_t);
 

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -70,7 +70,8 @@ void yk_location_drop(YkLocation);
 // Promote a value to a constant. This is a generic macro that will
 // automatically select the right `yk_promote` function to call based on the
 // type of the value passed.
-#define yk_promote(X) _Generic((X), size_t: __yk_promote_size_t)(X)
-void __yk_promote_size_t(size_t);
+#define yk_promote(X) _Generic((X), uintptr_t: __yk_promote_usize)(X)
+// Rust defines `usize` to be layout compatible with `uintptr_t`.
+void __yk_promote_usize(uintptr_t);
 
 #endif

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -72,7 +72,7 @@ void yk_location_drop(YkLocation);
 // Yk will attempt to promote the argument to a constant when the call is
 // traced and compiled. The call to `yk_promote()` itself is also omitted from
 // compiled traces.
-#define yk_promote(X) __yk_promote(X)
-void __yk_promote(size_t);
+#define yk_promote(X) _Generic((X), size_t: __yk_promote_size_t)(X)
+void __yk_promote_size_t(size_t);
 
 #endif

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -40,7 +40,7 @@ uint64_t getNewTraceIdx() {
 #define JITFUNC_ARG_COMPILEDTRACE_IDX 1
 #define JITFUNC_ARG_FRAMEADDR_IDX 2
 
-const char *PromoteRecFnName = "__yk_promote";
+const char *PromoteRecFnName = "__yk_promote_size_t";
 
 #define YK_OUTLINE_FNATTR "yk_outline"
 

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -40,7 +40,8 @@ uint64_t getNewTraceIdx() {
 #define JITFUNC_ARG_COMPILEDTRACE_IDX 1
 #define JITFUNC_ARG_FRAMEADDR_IDX 2
 
-const char *PromoteRecFnName = "__yk_promote_size_t";
+/// Any function with this prefix will be considered as a promotion function.
+const char *PromoteRecFnPrefix = "__yk_promote_";
 
 #define YK_OUTLINE_FNATTR "yk_outline"
 
@@ -1255,7 +1256,7 @@ public:
                               CurInstrIdx);
               break;
             }
-          } else if (CF->getName() == PromoteRecFnName) {
+          } else if (CF->getName().starts_with(PromoteRecFnPrefix)) {
             // A value is being promoted to a constant.
             handlePromote(CI, BB, CurBBIdx, CurInstrIdx);
             break;

--- a/yktracec/src/promote.rs
+++ b/yktracec/src/promote.rs
@@ -67,7 +67,7 @@ pub extern "C" fn __yk_lookup_promote_usize() -> usize {
 ///
 /// The user sees this as `yk_promote` via a macro.
 #[no_mangle]
-pub extern "C" fn __yk_promote_size_t(val: usize) {
+pub extern "C" fn __yk_promote_usize(val: usize) {
     VAL_REC.with_borrow_mut(|r| {
         r.push(val);
     });

--- a/yktracec/src/promote.rs
+++ b/yktracec/src/promote.rs
@@ -67,7 +67,7 @@ pub extern "C" fn __yk_lookup_promote_usize() -> usize {
 ///
 /// The user sees this as `yk_promote` via a macro.
 #[no_mangle]
-pub extern "C" fn __yk_promote(val: usize) {
+pub extern "C" fn __yk_promote_size_t(val: usize) {
     VAL_REC.with_borrow_mut(|r| {
         r.push(val);
     });


### PR DESCRIPTION
This PR slightly fiddles with `yk_promote`, including making it properly generic (though we currently only have 1 implementation!). If this is OK, I will probably then try and move `promote.rs` from `yktracec` to `ykrt`, which seems like a more natural home for it (but maybe difficult for reasons I don't yet know).

[`yktracec` is an annoying crate because any changes to it cause long compile times. I might try and address that separately at some point, but ultimately I'm not sure we want this crate to exist as a separate thing anyway.]