### PR TITLE
Make promotion a non-global variable.

### DIFF
--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -32,11 +32,11 @@ impl Compiler for JITCLLVM {
     fn compile(
         &self,
         mt: Arc<MT>,
-        aottrace_iter: Box<dyn AOTTraceIterator>,
+        aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, CompilationError> {
-        let irtrace = aottrace_iter.collect::<Vec<_>>();
+        let irtrace = aottrace_iter.0.collect::<Vec<_>>();
         let (func_names, bbs, trace_len) = self.encode_trace(&irtrace);
 
         let llvmbc = llvmbc_section();
@@ -59,6 +59,8 @@ impl Compiler for JITCLLVM {
                 callstack,
                 aotvalsptr,
                 aotvalslen,
+                aottrace_iter.1.as_ptr(),
+                aottrace_iter.1.len(),
             )
         };
         if ret.is_null() {

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -60,7 +60,7 @@ impl Compiler for JITCYk {
     fn compile(
         &self,
         _mt: Arc<MT>,
-        aottrace_iter: Box<dyn AOTTraceIterator>,
+        aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         _hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, CompilationError> {
@@ -77,7 +77,7 @@ impl Compiler for JITCYk {
             eprintln!("--- End aot ---");
         }
 
-        let mtrace = aottrace_iter.collect::<Vec<_>>();
+        let mtrace = aottrace_iter.0.collect::<Vec<_>>();
         let jit_mod = trace_builder::build(&aot_mod, &mtrace)?;
 
         if PHASES_TO_PRINT.contains(&IRPhase::PreOpt) {

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -41,7 +41,7 @@ pub(crate) trait Compiler: Send + Sync {
     fn compile(
         &self,
         mt: Arc<MT>,
-        aottrace_iter: Box<dyn AOTTraceIterator>,
+        aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
     ) -> Result<CompiledTrace, CompilationError>;

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -1,64 +1,6 @@
-//! Software constant recorder.
-//!
-//! This is used for promoting values to constants when compiling a trace.
+//! Trace promotion: promote values to constants when recording and compiling a trace.
 
-use std::{cell::RefCell, collections::VecDeque};
-
-// FIXME: Try to move this into ykrt in the existing thread local.
-thread_local! {
-    /// The thread's value recorder.
-    ///
-    /// This has to be specific to a thread to avoid cross-talk from other threads which may be
-    /// executing functions with promoted arguments at the same time.
-    pub static VAL_REC: RefCell<ValueRecorder> = RefCell::new(ValueRecorder::default());
-}
-
-/// A value recorder observes and records constant values during tracing. The trace compiler
-/// queries this when building a trace to replace promoted values with the observed constants.
-#[derive(Debug, Default)]
-pub struct ValueRecorder {
-    // `true` when recording promotions.
-    record_enable: bool,
-    // A vector of to-be-promoted values, in the order their `yk_promote()` calls were encountered
-    // in the trace through the AOT module.
-    //
-    // FIXME: currently you may only promote pointer-sized integers.
-    pbuf: VecDeque<usize>,
-}
-
-impl ValueRecorder {
-    /// Enable (`record=true`) or disable (`record=false`) observations.
-    pub fn record_enable(&mut self, record: bool) {
-        debug_assert_ne!(self.record_enable, record);
-        self.record_enable = record;
-    }
-
-    /// Record a constant for a value that will be promoted.
-    pub fn push(&mut self, val: usize) {
-        if self.record_enable {
-            self.pbuf.push_back(val);
-        }
-    }
-
-    /// Remove and return the oldest recorded constant.
-    pub fn pop(&mut self) -> usize {
-        debug_assert!(!self.record_enable);
-        self.pbuf.pop_front().expect("promote buffer undeflow")
-    }
-}
-
-/// For the current thread, enable or disable constant recording.
-pub fn thread_record_enable(record: bool) {
-    VAL_REC.with_borrow_mut(|r| {
-        r.record_enable(record);
-    })
-}
-
-/// For the current thread, remove and return the oldest recorded value.
-#[no_mangle]
-pub extern "C" fn __yk_lookup_promote_usize() -> usize {
-    VAL_REC.with_borrow_mut(|r| r.pop())
-}
+use crate::mt::THREAD_MTTHREAD;
 
 /// Promote a value.
 ///
@@ -68,7 +10,11 @@ pub extern "C" fn __yk_lookup_promote_usize() -> usize {
 /// The user sees this as `yk_promote` via a macro.
 #[no_mangle]
 pub extern "C" fn __yk_promote_usize(val: usize) {
-    VAL_REC.with_borrow_mut(|r| {
-        r.push(val);
+    THREAD_MTTHREAD.with(|mtt| {
+        if let Some(tt) = mtt.thread_tracer.borrow().as_ref() {
+            // We ignore the return value for `promote_usize` as we can't really cancel tracing from
+            // this function.
+            tt.promote_usize(val);
+        }
     });
 }

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,7 +1,7 @@
 //! Hardware tracing via hwtracer.
 
 use super::{errors::InvalidTraceError, AOTTraceIterator, TraceCollector, TracedAOTBlock};
-use std::{error::Error, sync::Arc};
+use std::{cell::RefCell, error::Error, sync::Arc};
 
 pub(crate) mod mapper;
 pub(crate) use mapper::HWTMapper;
@@ -9,14 +9,6 @@ mod testing;
 
 pub(crate) struct HWTracer {
     backend: Arc<dyn hwtracer::Tracer>,
-}
-
-impl super::Tracer for HWTracer {
-    fn start_collector(self: Arc<Self>) -> Result<Box<dyn TraceCollector>, Box<dyn Error>> {
-        Ok(Box::new(HWTTraceCollector {
-            thread_tracer: Arc::clone(&self.backend).start_collector()?,
-        }))
-    }
 }
 
 impl HWTracer {
@@ -27,13 +19,25 @@ impl HWTracer {
     }
 }
 
+impl super::Tracer for HWTracer {
+    fn start_collector(self: Arc<Self>) -> Result<Box<dyn TraceCollector>, Box<dyn Error>> {
+        Ok(Box::new(HWTTraceCollector {
+            thread_tracer: Arc::clone(&self.backend).start_collector()?,
+            promotions: RefCell::new(Vec::new()),
+        }))
+    }
+}
+
 /// Hardware thread tracer.
 struct HWTTraceCollector {
     thread_tracer: Box<dyn hwtracer::ThreadTracer>,
+    promotions: RefCell<Vec<usize>>,
 }
 
 impl TraceCollector for HWTTraceCollector {
-    fn stop_collector(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError> {
+    fn stop_collector(
+        self: Box<Self>,
+    ) -> Result<(Box<dyn AOTTraceIterator>, Box<[usize]>), InvalidTraceError> {
         let tr = self.thread_tracer.stop_collector().unwrap();
         let mut mt = HWTMapper::new();
         let mapped = mt
@@ -42,10 +46,18 @@ impl TraceCollector for HWTTraceCollector {
         if mapped.is_empty() {
             Err(InvalidTraceError::EmptyTrace)
         } else {
-            Ok(Box::new(HWTTraceIterator {
-                trace: mapped.into_iter(),
-            }))
+            Ok((
+                Box::new(HWTTraceIterator {
+                    trace: mapped.into_iter(),
+                }),
+                self.promotions.into_inner().into_boxed_slice(),
+            ))
         }
+    }
+
+    fn promote_usize(&self, val: usize) -> bool {
+        self.promotions.borrow_mut().push(val);
+        true
     }
 }
 

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -41,7 +41,14 @@ pub(crate) fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 pub(crate) trait TraceCollector {
     /// Stop collecting a trace of the current thread and return an iterator which successively
     /// produces the traced blocks.
-    fn stop_collector(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError>;
+    fn stop_collector(
+        self: Box<Self>,
+    ) -> Result<(Box<dyn AOTTraceIterator>, Box<[usize]>), InvalidTraceError>;
+    /// Records `val` as a value to be promoted at this point in the trace. Returns `true` if
+    /// recording succeeded or `false` otherwise. If `false` is returned, this `TraceCollector` is
+    /// no longer able to trace successfully and further calls are probably pointless, though they
+    /// must not cause the tracer to enter undefined behaviour territory.
+    fn promote_usize(&self, val: usize) -> bool;
 }
 
 /// An iterator which takes an underlying raw trace and successively produces [TracedAOTBlock]s.

--- a/yktracec/src/jitmodbuilder.cc
+++ b/yktracec/src/jitmodbuilder.cc
@@ -20,8 +20,6 @@
 using namespace llvm;
 using namespace std;
 
-extern "C" size_t __yk_lookup_promote_usize();
-
 // An atomic counter used to issue compiled traces with unique names.
 atomic<uint64_t> NextTraceIdx(0);
 uint64_t getNewTraceIdx() {
@@ -136,8 +134,13 @@ private:
   size_t Len;
 
 public:
-  InputTrace(char **FuncNames, size_t *BBs, size_t Len)
-      : FuncNames(FuncNames), BBs(BBs), Len(Len) {}
+  uintptr_t *Promotions;
+  size_t PromotionsLen;
+
+  InputTrace(char **FuncNames, size_t *BBs, size_t Len, uintptr_t *Promotions,
+             size_t PromotionsLen)
+      : FuncNames(FuncNames), BBs(BBs), Len(Len), Promotions(Promotions),
+        PromotionsLen(PromotionsLen) {}
   size_t Length() { return Len; }
 
   // Returns the optional IRBlock at index `Idx` in the trace. No value is
@@ -961,10 +964,10 @@ class JITModBuilder {
                 size_t TraceLen, CallInst *CPCI,
                 std::optional<std::tuple<size_t, CallInst *>> InitialResume,
                 Value *TraceInputs, void *CallStackPtr, void *AOTValsPtr,
-                size_t AOTValsLen)
+                size_t AOTValsLen, uintptr_t *Promotions, size_t PromotionsLen)
       : AOTMod(AOTMod), Builder(AOTMod->getContext()),
-        InpTrace(FuncNames, BBs, TraceLen), TraceInputs(TraceInputs),
-        ControlPointCallInst(CPCI) {
+        InpTrace(FuncNames, BBs, TraceLen, Promotions, PromotionsLen),
+        TraceInputs(TraceInputs), ControlPointCallInst(CPCI) {
     LLVMContext &Context = AOTMod->getContext();
     JITMod = new Module("", Context);
 
@@ -1033,19 +1036,22 @@ public:
   AOTInfo *LiveAOTArray = nullptr;
   size_t LiveAOTNum = 0;
   size_t GuardCount = 0;
+  // What position in the Promotions buffer are we currently at?
+  size_t PromotionsOff = 0;
 
   JITModBuilder(JITModBuilder &&);
 
   static JITModBuilder Create(Module *AOTMod, char *FuncNames[], size_t BBs[],
                               size_t TraceLen, void *CallStack,
-                              void *AOTValsPtr, size_t AOTValsLen) {
+                              void *AOTValsPtr, size_t AOTValsLen,
+                              uintptr_t *Promotions, size_t PromotionsLen) {
     CallInst *CPCI;
     Value *TI;
     size_t CPCIIdx;
     std::tie(CPCI, CPCIIdx, TI) = GetControlPointInfo(AOTMod);
     return JITModBuilder(AOTMod, FuncNames, BBs, TraceLen, CPCI,
                          make_tuple(CPCIIdx, CPCI), TI, CallStack, AOTValsPtr,
-                         AOTValsLen);
+                         AOTValsLen, Promotions, PromotionsLen);
   }
 
   // Generate the JIT module by "glueing together" blocks that the trace
@@ -1385,7 +1391,8 @@ public:
   void handlePromote(CallInst *CI, BasicBlock *BB, size_t CurBBIdx,
                      size_t CurInstrIdx) {
     // First lookup the constant value the trace is going to use.
-    uint64_t PConst = __yk_lookup_promote_usize();
+    assert(PromotionsOff < InpTrace.PromotionsLen);
+    uint64_t PConst = InpTrace.Promotions[PromotionsOff++];
     Value *PConstLL =
         Builder.getIntN(PointerSizedIntTy->getIntegerBitWidth(), PConst);
     Value *PromoteVar = CI->getArgOperand(0);
@@ -1428,9 +1435,11 @@ public:
 
 tuple<Module *, string, void *, size_t>
 createModule(Module *AOTMod, char *FuncNames[], size_t BBs[], size_t TraceLen,
-             void *CallStack, void *AOTValsPtr, size_t AOTValsLen) {
-  JITModBuilder JB = JITModBuilder::Create(AOTMod, FuncNames, BBs, TraceLen,
-                                           CallStack, AOTValsPtr, AOTValsLen);
+             void *CallStack, void *AOTValsPtr, size_t AOTValsLen,
+             uintptr_t *Promotions, size_t PromotionsLen) {
+  JITModBuilder JB =
+      JITModBuilder::Create(AOTMod, FuncNames, BBs, TraceLen, CallStack,
+                            AOTValsPtr, AOTValsLen, Promotions, PromotionsLen);
   auto JITMod = JB.createModule();
   return make_tuple(JITMod, std::move(JB.TraceName), JB.LiveAOTArray,
                     JB.GuardCount);

--- a/yktracec/src/jitmodbuilder.h
+++ b/yktracec/src/jitmodbuilder.h
@@ -12,5 +12,6 @@ using namespace llvm;
 
 std::tuple<Module *, std::string, void *, size_t>
 createModule(Module *AOTMod, char *FuncNames[], size_t BBs[], size_t TraceLen,
-             void *CallStack, void *AOTValsPtr, size_t AOTValsLen);
+             void *CallStack, void *AOTValsPtr, size_t AOTValsLen,
+             uintptr_t *Promotions, size_t PromotionsLen);
 #endif

--- a/yktracec/src/lib.rs
+++ b/yktracec/src/lib.rs
@@ -21,5 +21,7 @@ extern "C" {
         jitcallstack: *const c_void,
         aotvalsptr: *const c_void,
         aotvalslen: usize,
+        promotions: *const usize,
+        promotionslen: usize,
     ) -> *const c_void;
 }

--- a/yktracec/src/ykllvmwrap.cc
+++ b/yktracec/src/ykllvmwrap.cc
@@ -401,10 +401,12 @@ void rewriteDebugInfo(Module *M, string TraceName, int FD,
 // trace.
 //
 // Returns a pointer to the compiled function.
-extern "C" void *__yktracec_irtrace_compile(
-    char *FuncNames[], size_t BBs[], size_t TraceLen, void *BitcodeData,
-    uint64_t BitcodeLen, int DebugInfoFD, char *DebugInfoPath, void *CallStack,
-    void *AOTValsPtr, size_t AOTValsLen) {
+extern "C" void *
+__yktracec_irtrace_compile(char *FuncNames[], size_t BBs[], size_t TraceLen,
+                           void *BitcodeData, uint64_t BitcodeLen,
+                           int DebugInfoFD, char *DebugInfoPath,
+                           void *CallStack, void *AOTValsPtr, size_t AOTValsLen,
+                           void *Promotions, size_t PromotionsLen) {
   DebugIRPrinter DIP;
 
   struct BitcodeSection Bitcode = {BitcodeData, BitcodeLen};
@@ -421,8 +423,9 @@ extern "C" void *__yktracec_irtrace_compile(
   // it isn't needed for compilation.
   ThreadAOTMod->withModuleDo([&](Module &AOTMod) {
     DIP.print(DebugIR::AOT, &AOTMod);
-    std::tie(JITMod, TraceName, AOTMappingVec, GuardCount) = createModule(
-        &AOTMod, FuncNames, BBs, TraceLen, CallStack, AOTValsPtr, AOTValsLen);
+    std::tie(JITMod, TraceName, AOTMappingVec, GuardCount) =
+        createModule(&AOTMod, FuncNames, BBs, TraceLen, CallStack, AOTValsPtr,
+                     AOTValsLen, (uintptr_t *)Promotions, PromotionsLen);
   });
 
   // If we failed to build the trace, return null.


### PR DESCRIPTION
Although it's not obvious at first `promote.rs`'s use of a `thread_local!` is a simple global variable. That is problematic because it means that the compilation process has to run in the same thread as the tracing thread which only works if serialised compilation is turned on. If you ran a program which uses promotion without serialised compilation turned on you got a "promotion buffer underflowed" panic.

This PR makes the promotion array a non-global variable, so that serialised compilation is no longer required. This PR makes the change in the most bone-headed minimalistic manner possible: as this shows, this isn't a good fit with our current architecture and makes the structure a lot messier. I intend addressing this soon but at least this PR unbreaks the system.