### PR TITLE
Rename collection to recording

### DIFF
--- a/tests/c/stats1.c
+++ b/tests/c/stats1.c
@@ -5,10 +5,10 @@
 //     {
 //       ...
 //       "trace_executions": 1,
-//       "traces_collected_err": 0,
-//       "traces_collected_ok": 1,
 //       "traces_compiled_err": 0,
-//       "traces_compiled_ok": 1
+//       "traces_compiled_ok": 1,
+//       "traces_recorded_err": 0,
+//       "traces_recorded_ok": 1
 //       ...
 //     }
 

--- a/tests/c/stats2.c
+++ b/tests/c/stats2.c
@@ -7,10 +7,10 @@
 //     {
 //       ...
 //       "trace_executions": 1,
-//       "traces_collected_err": 1,
-//       "traces_collected_ok": 1,
 //       "traces_compiled_err": 0,
-//       "traces_compiled_ok": 1
+//       "traces_compiled_ok": 1,
+//       "traces_recorded_err": 1,
+//       "traces_recorded_ok": 1
 //       ...
 //     }
 

--- a/tests/c/stats3.c
+++ b/tests/c/stats3.c
@@ -5,10 +5,10 @@
 //     {
 //       ...
 //       "trace_executions": 0,
-//       "traces_collected_err": 0,
-//       "traces_collected_ok": 1,
 //       "traces_compiled_err": 1,
-//       "traces_compiled_ok": 0
+//       "traces_compiled_ok": 0,
+//       "traces_recorded_err": 0,
+//       "traces_recorded_ok": 1
 //       ...
 //     }
 

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -4,7 +4,7 @@ use crate::mt::THREAD_MTTHREAD;
 
 /// Promote a value.
 ///
-/// When encountered during trace collection, the returned value will be considered constant in the
+/// When encountered during trace recording, the returned value will be considered constant in the
 /// resulting compiled trace.
 ///
 /// The user sees this as `yk_promote` via a macro.

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -1,4 +1,4 @@
-//! Utilities for collecting and decoding traces.
+//! Record and process traces.
 
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::new_without_default)]
@@ -20,8 +20,8 @@ pub(crate) use errors::InvalidTraceError;
 /// backend may have its own configuration options, which is why `Tracer` does not have a `new`
 /// method.
 pub(crate) trait Tracer: Send + Sync {
-    /// Start collecting a trace of the current thread.
-    fn start_collector(self: Arc<Self>) -> Result<Box<dyn TraceCollector>, Box<dyn Error>>;
+    /// Start recording a trace of the current thread.
+    fn start_recorder(self: Arc<Self>) -> Result<Box<dyn TraceRecorder>, Box<dyn Error>>;
 }
 
 /// Return a [Tracer] instance or `Err` if none can be found. The [Tracer] returned will be
@@ -38,14 +38,14 @@ pub(crate) fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 }
 
 /// Represents a thread which is currently tracing.
-pub(crate) trait TraceCollector {
-    /// Stop collecting a trace of the current thread and return an iterator which successively
+pub(crate) trait TraceRecorder {
+    /// Stop recording a trace of the current thread and return an iterator which successively
     /// produces the traced blocks.
-    fn stop_collector(
+    fn stop(
         self: Box<Self>,
     ) -> Result<(Box<dyn AOTTraceIterator>, Box<[usize]>), InvalidTraceError>;
     /// Records `val` as a value to be promoted at this point in the trace. Returns `true` if
-    /// recording succeeded or `false` otherwise. If `false` is returned, this `TraceCollector` is
+    /// recording succeeded or `false` otherwise. If `false` is returned, this `TraceRecorder` is
     /// no longer able to trace successfully and further calls are probably pointless, though they
     /// must not cause the tracer to enter undefined behaviour territory.
     fn promote_usize(&self, val: usize) -> bool;

--- a/ykrt/src/ykstats.rs
+++ b/ykrt/src/ykstats.rs
@@ -28,10 +28,10 @@ pub(crate) struct YkStats {
 struct YkStatsInner {
     /// The path to write output. If exactly equal to `-`, output will be written to stderr.
     output_path: String,
-    /// How many traces were collected successfully?
-    traces_collected_ok: u64,
-    /// How many traces were collected unsuccessfully?
-    traces_collected_err: u64,
+    /// How many traces were recorded successfully?
+    traces_recorded_ok: u64,
+    /// How many traces were recorded unsuccessfully?
+    traces_recorded_err: u64,
     /// How many traces were compiled successfully?
     traces_compiled_ok: u64,
     /// How many traces were compiled unsuccessfully?
@@ -71,14 +71,14 @@ impl YkStats {
             .map(|x| f(x.lock().unwrap().deref_mut()))
     }
 
-    /// Increment the "a trace has been collected successfully" count.
-    pub fn trace_collected_ok(&self) {
-        self.lock(|inner| inner.traces_collected_ok += 1);
+    /// Increment the "a trace has been recorded successfully" count.
+    pub fn trace_recorded_ok(&self) {
+        self.lock(|inner| inner.traces_recorded_ok += 1);
     }
 
-    /// Increment the "a trace has been collected unsuccessfully" count.
-    pub fn trace_collected_err(&self) {
-        self.lock(|inner| inner.traces_collected_err += 1);
+    /// Increment the "a trace has been recorded unsuccessfully" count.
+    pub fn trace_recorded_err(&self) {
+        self.lock(|inner| inner.traces_recorded_err += 1);
     }
 
     /// Increment the "a trace has been compiled successfully" count.
@@ -112,8 +112,8 @@ impl YkStatsInner {
     fn new(output_path: String) -> Self {
         Self {
             output_path,
-            traces_collected_ok: 0,
-            traces_collected_err: 0,
+            traces_recorded_ok: 0,
+            traces_recorded_err: 0,
             traces_compiled_ok: 0,
             traces_compiled_err: 0,
             trace_executions: 0,
@@ -130,12 +130,12 @@ impl YkStatsInner {
 
         let mut fields = vec![
             (
-                "traces_collected_ok".to_owned(),
-                self.traces_collected_ok.to_string(),
+                "traces_recorded_ok".to_owned(),
+                self.traces_recorded_ok.to_string(),
             ),
             (
-                "traces_collected_err".to_owned(),
-                self.traces_collected_err.to_string(),
+                "traces_recorded_err".to_owned(),
+                self.traces_recorded_err.to_string(),
             ),
             (
                 "traces_compiled_ok".to_owned(),


### PR DESCRIPTION
Needs #972 to be merged first.

[Warning: I will admit that "collection" as a term has never quite resonated with me, so I'm biased in favour of this commit from the off.]
 
Trace "collection", to me, implies a slightly passive view of what's going on, but promotion is a much more active view of what's going on. In particular, some tracing backends can potentially "decode" (another term we might want to revisit one day) a trace in such a way that they successively generate AOT blocks and promotions in one go. That means that we're going to have to rename the `TracedAOTBlock` enum, probably to something like `RecordedTraceThingy` where "recorded" might be an AOT block or a promoted variable (or ... who knows what else in the future!).

Note that I have chosen not to rename anything in the `hwtracer` crate. That crate is a bit separate from everything else and I'm not sure I want to rethink what it's doing at the moment.
