### PR TITLE
Make the compilation wrapper more resilient.

### DIFF
--- a/ykbuild/src/completion_wrapper.rs
+++ b/ykbuild/src/completion_wrapper.rs
@@ -10,6 +10,8 @@ use std::{
 };
 use tempfile::TempDir;
 
+static SRC_EXTS: [&str; 8] = ["c", "C", "cpp", "CPP", "cc", "CC", "cxx", "CXX"];
+
 /// Wrap C compiler commands to help LSP. At the moment this produces output suitable for
 /// [clangd](https://clangd.llvm.org/) into (typically)
 /// `target/<debug|release>/clangd/<crate-name>/compile_commands.json`.
@@ -84,38 +86,35 @@ impl CompletionWrapper {
     /// Call when the build is done to generate the `compile_commands.json` file.
     pub fn generate(self) {
         let mut entries = Vec::new();
-
         for path in glob(&format!("{}/*", self.tmpdir.path().to_str().unwrap())).unwrap() {
             let mut infile = File::open(path.unwrap()).unwrap();
             let mut buf = String::new();
             infile.read_to_string(&mut buf).unwrap();
             let buf = buf.trim();
 
-            // We assume (and assert) that the source file is the last argument.
-            let ccfile = buf.split(' ').last().unwrap();
-            let ext = Path::new(ccfile).extension();
-            // FIXME: This section of code has had extra panic messages added in an attempt to
-            // diagnose an allusive crash: https://github.com/ykjit/yk/issues/903
-            match ext {
-                None => panic!("source file has no extension: '{}', buf='{}'", ccfile, buf),
-                Some(ext) => {
-                    let ext = ext.to_str().unwrap();
-                    if !["c", "cpp", "cxx", "cc"].iter().any(|e| e == &ext) {
-                        panic!("unkonwn source file extension: '{}', buf='{}'", ext, buf);
-                    }
-                }
-            }
+            // Search for C or C++ source files.
+            //
+            // Note that it's also OK for there to be no source files. Sometimes build systems run
+            // things like "clang --version".
+            //
+            // This assumes there are no spaces in filenames.
+            let srcs = buf.split(' ').filter(|f| match Path::new(f).extension() {
+                Some(ext) => SRC_EXTS.contains(&ext.to_str().unwrap()),
+                _ => false,
+            });
 
-            let mut entry = String::new();
-            entry.push_str("  {\n");
-            entry.push_str(&format!(
-                "    \"directory\": \"{}\",\n",
-                env::var("CARGO_MANIFEST_DIR").unwrap()
-            ));
-            entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
-            entry.push_str(&format!("    \"file\": \"{ccfile}\",\n"));
-            entry.push_str("  }");
-            entries.push(entry);
+            for sfile in srcs {
+                let mut entry = String::new();
+                entry.push_str("  {\n");
+                entry.push_str(&format!(
+                    "    \"directory\": \"{}\",\n",
+                    env::var("CARGO_MANIFEST_DIR").unwrap()
+                ));
+                entry.push_str(&format!("    \"command\": \"{buf}\",\n"));
+                entry.push_str(&format!("    \"file\": \"{sfile}\",\n"));
+                entry.push_str("  }");
+                entries.push(entry);
+            }
         }
 
         // Write JSON to compile_commands.json.


### PR DESCRIPTION
 - Don't assume the source file is the last argument.
 - Don't assume there will be a source file.