### PR TITLE
Process ptradd instructions and global operands.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -595,6 +595,10 @@ pub(crate) struct IntegerType {
 }
 
 impl IntegerType {
+    pub(crate) fn num_bits(&self) -> u32 {
+        self.num_bits
+    }
+
     fn const_to_str(&self, c: &Constant) -> String {
         // FIXME: For now we just handle common integer types, but eventually we will need to
         // implement printing of aribitrarily-sized (in bits) integers. Consider using a bigint
@@ -768,6 +772,12 @@ pub(crate) struct Constant {
     bytes: Vec<u8>,
 }
 
+impl Constant {
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
 impl IRDisplay for Constant {
     fn to_str(&self, m: &Module) -> String {
         m.types[self.type_idx].const_to_str(self)
@@ -897,6 +907,14 @@ impl Module {
     /// It is UB to pass an `instr` that is not from the `Module` referenced by `self`.
     pub(crate) fn instr_type(&self, instr: &Instruction) -> &Type {
         &self.types[instr.type_idx]
+    }
+
+    pub(crate) fn constant(&self, co: &ConstantOperand) -> &Constant {
+        &self.consts[co.const_idx]
+    }
+
+    pub(crate) fn const_type(&self, c: &Constant) -> &Type {
+        &self.types[c.type_idx]
     }
 
     // FIXME: rename this to `is_def()`, which we've decided is a beter name.

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -340,18 +340,12 @@ impl LoadArgInstruction {
 pub struct LoadGlobalInstruction {
     /// The pointer to load from.
     global_idx: GlobalIdx,
-    /// The type of the pointee.
-    ty_idx: TypeIdx,
 }
 
 impl LoadGlobalInstruction {
-    pub(crate) fn new(
-        global_idx: aot_ir::GlobalIdx,
-        ty_idx: TypeIdx,
-    ) -> Result<Self, CompilationError> {
+    pub(crate) fn new(global_idx: aot_ir::GlobalIdx) -> Result<Self, CompilationError> {
         Ok(Self {
             global_idx: GlobalIdx::from_aot(global_idx)?,
-            ty_idx,
         })
     }
 }
@@ -380,7 +374,7 @@ pub struct CallInstruction {
 
 impl fmt::Display for CallInstruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "LoadArg")
+        write!(f, "Call")
     }
 }
 
@@ -520,8 +514,16 @@ impl PtrAddInstruction {
         let ptr = self.ptr;
         ptr.get()
     }
+
     fn offset(&self) -> u32 {
         self.off
+    }
+
+    pub(crate) fn new(ptr: Operand, off: u32) -> Self {
+        Self {
+            ptr: PackedOperand::new(&ptr),
+            off,
+        }
     }
 }
 


### PR DESCRIPTION
Add processing of AOT PtrAdd instructions. Since the JIT PtrAdd instruction is limited to 32 bit offsets, do the conversion here and return an error in case of a failure so we can abort the trace.

While we are here, handle global operands by emitting a LoadGlobal instruction and replacing the global operand with an instruction operand referencing the just emitted instruction.

I'm assigning @vext01 too, since there's a bit of a design question here in regards to globals. In previous PRs we decided to separate globals from constants, the way LLVM does, where a global is a subclass of constant. The idea was that this makes it easier in the codegen to know what we are dealing with. However, we couldn't add another `Operand` type due to space constraints. We thought that wasn't an issue since there's only two instruction using globals, load and store, and so made special versions for them. We thought wrong, as globals can be arguments to functions for example.

I've solved this now by emitting a `LoadGlobal` instruction whenever we see a global operand. So for example and AOT instruction like

```
call fprintf(Global(stderr), Global(str))
```

would be turned into (inside the JIT IR)

```
$1 = LoadGlobal(stderr)
$2 = LoadGlobal(str)
call fprintf($1, $2)
```

Whether this is a good idea or not isn't quite clear to me as I don't yet know how globals will be codegenned. All we got is a string and likely have to do some sort of lookup (`dlsym`?), in which case doing the above should be fine. But there's also a good argument here for why globals should have maybe remained constants. Thoughts?