### PR TITLE
Move data recorded with `yk_promote` into `MTThread`.

### DIFF
--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -11,10 +11,8 @@ use crate::mt::THREAD_MTTHREAD;
 #[no_mangle]
 pub extern "C" fn __yk_promote_usize(val: usize) {
     THREAD_MTTHREAD.with(|mtt| {
-        if let Some(tt) = mtt.thread_tracer.borrow().as_ref() {
-            // We ignore the return value for `promote_usize` as we can't really cancel tracing from
-            // this function.
-            tt.promote_usize(val);
-        }
+        // We ignore the return value for `promote_usize` as we can't really cancel tracing from
+        // this function.
+        mtt.promote_usize(val);
     });
 }

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,7 +1,7 @@
 //! Hardware tracing via hwtracer.
 
 use super::{errors::InvalidTraceError, AOTTraceIterator, TraceRecorder, TracedAOTBlock};
-use std::{cell::RefCell, error::Error, sync::Arc};
+use std::{error::Error, sync::Arc};
 
 pub(crate) mod mapper;
 pub(crate) use mapper::HWTMapper;
@@ -23,7 +23,6 @@ impl super::Tracer for HWTracer {
     fn start_recorder(self: Arc<Self>) -> Result<Box<dyn TraceRecorder>, Box<dyn Error>> {
         Ok(Box::new(HWTTraceRecorder {
             thread_tracer: Arc::clone(&self.backend).start_collector()?,
-            promotions: RefCell::new(Vec::new()),
         }))
     }
 }
@@ -31,13 +30,10 @@ impl super::Tracer for HWTracer {
 /// Hardware thread tracer.
 struct HWTTraceRecorder {
     thread_tracer: Box<dyn hwtracer::ThreadTracer>,
-    promotions: RefCell<Vec<usize>>,
 }
 
 impl TraceRecorder for HWTTraceRecorder {
-    fn stop(
-        self: Box<Self>,
-    ) -> Result<(Box<dyn AOTTraceIterator>, Box<[usize]>), InvalidTraceError> {
+    fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError> {
         let tr = self.thread_tracer.stop_collector().unwrap();
         let mut mt = HWTMapper::new();
         let mapped = mt
@@ -46,18 +42,10 @@ impl TraceRecorder for HWTTraceRecorder {
         if mapped.is_empty() {
             Err(InvalidTraceError::EmptyTrace)
         } else {
-            Ok((
-                Box::new(HWTTraceIterator {
-                    trace: mapped.into_iter(),
-                }),
-                self.promotions.into_inner().into_boxed_slice(),
-            ))
+            Ok(Box::new(HWTTraceIterator {
+                trace: mapped.into_iter(),
+            }))
         }
-    }
-
-    fn promote_usize(&self, val: usize) -> bool {
-        self.promotions.borrow_mut().push(val);
-        true
     }
 }
 

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -41,14 +41,7 @@ pub(crate) fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 pub(crate) trait TraceRecorder {
     /// Stop recording a trace of the current thread and return an iterator which successively
     /// produces the traced blocks.
-    fn stop(
-        self: Box<Self>,
-    ) -> Result<(Box<dyn AOTTraceIterator>, Box<[usize]>), InvalidTraceError>;
-    /// Records `val` as a value to be promoted at this point in the trace. Returns `true` if
-    /// recording succeeded or `false` otherwise. If `false` is returned, this `TraceRecorder` is
-    /// no longer able to trace successfully and further calls are probably pointless, though they
-    /// must not cause the tracer to enter undefined behaviour territory.
-    fn promote_usize(&self, val: usize) -> bool;
+    fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError>;
 }
 
 /// An iterator which takes an underlying raw trace and successively produces [TracedAOTBlock]s.


### PR DESCRIPTION
I've slowly come to realise that calls to `yk_promote` could (but don't currently!) end up being in compiled in two different ways:

  1. A literal call to `yk_promote_*`.
  2. An inlined call to a side-band recording mechanism (e.g. `PTWRITE`).

Because I hadn't teased these two apart in my mind, my previous attempt had kind-of tried to merge the two together in one API. It's now clear that was entirely misguided on my part.

This commit can be seen as partly undoing my previous attempt: literal calls to `yk_promote_*` now record the data in `MTThread` which is a thread local. However, when tracing stops, the promotion data is now extracted from `MTThread` so it can safely be moved to another thread.

That means we can now handle #1 above: but we don't yet have an API that can handle #2.