### PR TITLE
Rework `TracedAOTBlock` enum.

### DIFF
--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -5,7 +5,7 @@ use crate::{
     compile::{CompilationError, CompiledTrace, Compiler},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
-    trace::{AOTTraceIterator, ProcessedItem},
+    trace::{AOTTraceIterator, TraceAction},
 };
 use object::{Object, ObjectSection};
 use parking_lot::Mutex;
@@ -79,23 +79,23 @@ impl JITCLLVM {
         Arc::new(JITCLLVM)
     }
 
-    fn encode_trace(&self, irtrace: &Vec<ProcessedItem>) -> (Vec<*const i8>, Vec<usize>, usize) {
+    fn encode_trace(&self, irtrace: &Vec<TraceAction>) -> (Vec<*const i8>, Vec<usize>, usize) {
         let trace_len = irtrace.len();
         let mut func_names = Vec::with_capacity(trace_len);
         let mut bbs = Vec::with_capacity(trace_len);
         for blk in irtrace {
             match blk {
-                ProcessedItem::MappedAOTBlock { func_name, bb } => {
+                TraceAction::MappedAOTBlock { func_name, bb } => {
                     func_names.push(func_name.as_ptr());
                     bbs.push(*bb);
                 }
-                ProcessedItem::UnmappableBlock => {
+                TraceAction::UnmappableBlock => {
                     // The block was unmappable. Indicate this with a null function name.
                     func_names.push(ptr::null());
                     // Block indices for unmappable blocks are irrelevant so we may pass anything here.
                     bbs.push(0);
                 }
-                ProcessedItem::Promotion => todo!(),
+                TraceAction::Promotion => todo!(),
             }
         }
         (func_names, bbs, trace_len)

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -5,7 +5,7 @@ use crate::{
     compile::{CompilationError, CompiledTrace, Compiler},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
-    trace::{AOTTraceIterator, TracedAOTBlock},
+    trace::{AOTTraceIterator, ProcessedItem},
 };
 use object::{Object, ObjectSection};
 use parking_lot::Mutex;
@@ -79,7 +79,7 @@ impl JITCLLVM {
         Arc::new(JITCLLVM)
     }
 
-    fn encode_trace(&self, irtrace: &Vec<TracedAOTBlock>) -> (Vec<*const i8>, Vec<usize>, usize) {
+    fn encode_trace(&self, irtrace: &Vec<ProcessedItem>) -> (Vec<*const i8>, Vec<usize>, usize) {
         let trace_len = irtrace.len();
         let mut func_names = Vec::with_capacity(trace_len);
         let mut bbs = Vec::with_capacity(trace_len);

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -1,4 +1,4 @@
-//! An LLVM JIT backend. Currently a minimal wrapper around the fact that [MappedTrace]s are hardcoded
+//! An LLVM JIT backend. Currently a minimal wrapper around the fact that [MappedAOTBlockTrace]s are hardcoded
 //! to be compiled with LLVM.
 
 use crate::{

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -84,14 +84,18 @@ impl JITCLLVM {
         let mut func_names = Vec::with_capacity(trace_len);
         let mut bbs = Vec::with_capacity(trace_len);
         for blk in irtrace {
-            if blk.is_unmappable() {
-                // The block was unmappable. Indicate this with a null function name.
-                func_names.push(ptr::null());
-                // Block indices for unmappable blocks are irrelevant so we may pass anything here.
-                bbs.push(0);
-            } else {
-                func_names.push(blk.func_name().as_ptr());
-                bbs.push(blk.bb());
+            match blk {
+                ProcessedItem::MappedAOTBlock { func_name, bb } => {
+                    func_names.push(func_name.as_ptr());
+                    bbs.push(*bb);
+                }
+                ProcessedItem::UnmappableBlock => {
+                    // The block was unmappable. Indicate this with a null function name.
+                    func_names.push(ptr::null());
+                    // Block indices for unmappable blocks are irrelevant so we may pass anything here.
+                    bbs.push(0);
+                }
+                ProcessedItem::Promotion => todo!(),
             }
         }
         (func_names, bbs, trace_len)

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -46,7 +46,7 @@ impl<'a> TraceBuilder<'a> {
                 let func = self.aot_mod.func_idx(func_name);
                 Some(aot_ir::BlockID::new(func, aot_ir::BlockIdx::new(*bb)))
             }
-            ProcessedItem::Unmappable { .. } => None,
+            ProcessedItem::UnmappableBlock { .. } => None,
         }
     }
 
@@ -201,7 +201,7 @@ impl<'a> TraceBuilder<'a> {
                     bb: bb - 1,
                 }
             }
-            ProcessedItem::Unmappable => panic!(),
+            ProcessedItem::UnmappableBlock => panic!(),
         };
 
         let firstblk = self.lookup_aot_block(&prev);
@@ -214,7 +214,7 @@ impl<'a> TraceBuilder<'a> {
                     self.process_block(bid)?;
                 }
                 None => {
-                    // Unmappable block
+                    // UnmappableBlock block
                     todo!();
                 }
             }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -47,6 +47,7 @@ impl<'a> TraceBuilder<'a> {
                 Some(aot_ir::BlockID::new(func, aot_ir::BlockIdx::new(*bb)))
             }
             ProcessedItem::UnmappableBlock { .. } => None,
+            ProcessedItem::Promotion => todo!(),
         }
     }
 
@@ -202,6 +203,7 @@ impl<'a> TraceBuilder<'a> {
                 }
             }
             ProcessedItem::UnmappableBlock => panic!(),
+            ProcessedItem::Promotion => todo!(),
         };
 
         let firstblk = self.lookup_aot_block(&prev);

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -41,7 +41,7 @@ impl<'a> TraceBuilder<'a> {
     // Given a mapped block, find the AOT block ID, or return `None` if it is unmapped.
     fn lookup_aot_block(&self, tb: &ProcessedItem) -> Option<aot_ir::BlockID> {
         match tb {
-            ProcessedItem::Mapped { func_name, bb } => {
+            ProcessedItem::MappedAOTBlock { func_name, bb } => {
                 let func_name = func_name.to_str().unwrap(); // safe: func names are valid UTF-8.
                 let func = self.aot_mod.func_idx(func_name);
                 Some(aot_ir::BlockID::new(func, aot_ir::BlockIdx::new(*bb)))
@@ -193,10 +193,10 @@ impl<'a> TraceBuilder<'a> {
         // Find the block containing the control point call. This is the (sole) predecessor of the
         // first (guaranteed mappable) block in the trace.
         let prev = match first_blk {
-            ProcessedItem::Mapped { func_name, bb } => {
+            ProcessedItem::MappedAOTBlock { func_name, bb } => {
                 debug_assert!(*bb > 0);
                 // It's `- 1` due to the way the ykllvm block splitting pass works.
-                ProcessedItem::Mapped {
+                ProcessedItem::MappedAOTBlock {
                     func_name: func_name.clone(),
                     bb: bb - 1,
                 }
@@ -210,7 +210,7 @@ impl<'a> TraceBuilder<'a> {
         for tblk in self.mtrace {
             match self.lookup_aot_block(tblk) {
                 Some(bid) => {
-                    // Mapped block
+                    // MappedAOTBlock block
                     self.process_block(bid)?;
                 }
                 None => {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -3,7 +3,7 @@
 use super::aot_ir::{self, IRDisplay, Module};
 use super::jit_ir;
 use crate::compile::CompilationError;
-use crate::trace::ProcessedItem;
+use crate::trace::TraceAction;
 use std::collections::HashMap;
 
 /// The argument index of the trace inputs struct in the control point call.
@@ -17,7 +17,7 @@ struct TraceBuilder<'a> {
     /// The JIT IR this struct builds.
     jit_mod: jit_ir::Module,
     /// The mapped trace.
-    mtrace: &'a Vec<ProcessedItem>,
+    mtrace: &'a Vec<TraceAction>,
     // Maps an AOT instruction to a jit instruction via their index-based IDs.
     local_map: HashMap<aot_ir::InstructionID, jit_ir::InstrIdx>,
 }
@@ -29,7 +29,7 @@ impl<'a> TraceBuilder<'a> {
     ///  - `trace_name`: The eventual symbol name for the JITted code.
     ///  - `aot_mod`: The AOT IR module that the trace flows through.
     ///  - `mtrace`: The mapped trace.
-    fn new(trace_name: String, aot_mod: &'a Module, mtrace: &'a Vec<ProcessedItem>) -> Self {
+    fn new(trace_name: String, aot_mod: &'a Module, mtrace: &'a Vec<TraceAction>) -> Self {
         Self {
             aot_mod,
             mtrace,
@@ -39,15 +39,15 @@ impl<'a> TraceBuilder<'a> {
     }
 
     // Given a mapped block, find the AOT block ID, or return `None` if it is unmapped.
-    fn lookup_aot_block(&self, tb: &ProcessedItem) -> Option<aot_ir::BlockID> {
+    fn lookup_aot_block(&self, tb: &TraceAction) -> Option<aot_ir::BlockID> {
         match tb {
-            ProcessedItem::MappedAOTBlock { func_name, bb } => {
+            TraceAction::MappedAOTBlock { func_name, bb } => {
                 let func_name = func_name.to_str().unwrap(); // safe: func names are valid UTF-8.
                 let func = self.aot_mod.func_idx(func_name);
                 Some(aot_ir::BlockID::new(func, aot_ir::BlockIdx::new(*bb)))
             }
-            ProcessedItem::UnmappableBlock { .. } => None,
-            ProcessedItem::Promotion => todo!(),
+            TraceAction::UnmappableBlock { .. } => None,
+            TraceAction::Promotion => todo!(),
         }
     }
 
@@ -194,16 +194,16 @@ impl<'a> TraceBuilder<'a> {
         // Find the block containing the control point call. This is the (sole) predecessor of the
         // first (guaranteed mappable) block in the trace.
         let prev = match first_blk {
-            ProcessedItem::MappedAOTBlock { func_name, bb } => {
+            TraceAction::MappedAOTBlock { func_name, bb } => {
                 debug_assert!(*bb > 0);
                 // It's `- 1` due to the way the ykllvm block splitting pass works.
-                ProcessedItem::MappedAOTBlock {
+                TraceAction::MappedAOTBlock {
                     func_name: func_name.clone(),
                     bb: bb - 1,
                 }
             }
-            ProcessedItem::UnmappableBlock => panic!(),
-            ProcessedItem::Promotion => todo!(),
+            TraceAction::UnmappableBlock => panic!(),
+            TraceAction::Promotion => todo!(),
         };
 
         let firstblk = self.lookup_aot_block(&prev);
@@ -228,7 +228,7 @@ impl<'a> TraceBuilder<'a> {
 /// Given a mapped trace (through `aot_mod`), assemble and return a Yk IR trace.
 pub(super) fn build(
     aot_mod: &Module,
-    mtrace: &Vec<ProcessedItem>,
+    mtrace: &Vec<TraceAction>,
 ) -> Result<jit_ir::Module, CompilationError> {
     // FIXME: the XXX below should be a thread-safe monotonically incrementing integer.
     TraceBuilder::new("__yk_compiled_trace_XXX".into(), aot_mod, mtrace).build()

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -142,7 +142,7 @@ impl HWTMapper {
                 // we know that the control point will be contained in a single mappable block.
                 assert!(matches!(
                     self.map_block(&x).as_slice(),
-                    &[Some(ProcessedItem::Mapped { .. })]
+                    &[Some(ProcessedItem::MappedAOTBlock { .. })]
                 ));
             }
             _ => unreachable!(),

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -103,7 +103,7 @@ impl HWTMapper {
                 );
                 if let Some(sym_name) = sio.dli_sname() {
                     for bb in ent.value.corr_bbs() {
-                        ret.push(Some(ProcessedItem::new_mapped(
+                        ret.push(Some(ProcessedItem::new_mapped_aot_block(
                             sym_name.to_owned(),
                             usize::try_from(*bb).unwrap(),
                         )));

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -160,7 +160,7 @@ impl HWTMapper {
                 // also take care to collapse consecutive unmappable blocks into one.
                 if let Some(last) = ret.last_mut() {
                     if !last.is_unmappable() {
-                        ret.push(ProcessedItem::new_unmappable());
+                        ret.push(ProcessedItem::new_unmappable_block());
                     }
                 }
             } else {

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -202,7 +202,7 @@ impl HWTMapper {
             Some(x) => {
                 // This is a rough proxy for "check that we removed only the thing we want to
                 // remove".
-                assert!(matches!(x, ProcessedItem::Unmappable));
+                assert!(matches!(x, ProcessedItem::UnmappableBlock));
             }
             _ => unreachable!(),
         }

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -159,8 +159,12 @@ impl HWTMapper {
                 // trace isn't empty (we never report the leading unmappable code in a trace). We
                 // also take care to collapse consecutive unmappable blocks into one.
                 if let Some(last) = ret.last_mut() {
-                    if !last.is_unmappable() {
-                        ret.push(ProcessedItem::new_unmappable_block());
+                    match last {
+                        ProcessedItem::MappedAOTBlock { .. } => {
+                            ret.push(ProcessedItem::new_unmappable_block());
+                        }
+                        ProcessedItem::UnmappableBlock => (),
+                        ProcessedItem::Promotion => todo!(),
                     }
                 }
             } else {

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,6 +1,6 @@
 //! Hardware tracing via hwtracer.
 
-use super::{errors::InvalidTraceError, AOTTraceIterator, TraceRecorder, TracedAOTBlock};
+use super::{errors::InvalidTraceError, AOTTraceIterator, ProcessedItem, TraceRecorder};
 use std::{error::Error, sync::Arc};
 
 pub(crate) mod mapper;
@@ -50,13 +50,13 @@ impl TraceRecorder for HWTTraceRecorder {
 }
 
 struct HWTTraceIterator {
-    trace: std::vec::IntoIter<TracedAOTBlock>,
+    trace: std::vec::IntoIter<ProcessedItem>,
 }
 
 impl AOTTraceIterator for HWTTraceIterator {}
 
 impl Iterator for HWTTraceIterator {
-    type Item = TracedAOTBlock;
+    type Item = ProcessedItem;
     fn next(&mut self) -> Option<Self::Item> {
         self.trace.next()
     }

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -1,6 +1,6 @@
 //! Hardware tracing via hwtracer.
 
-use super::{errors::InvalidTraceError, AOTTraceIterator, ProcessedItem, TraceRecorder};
+use super::{errors::InvalidTraceError, AOTTraceIterator, TraceAction, TraceRecorder};
 use std::{error::Error, sync::Arc};
 
 pub(crate) mod mapper;
@@ -50,13 +50,13 @@ impl TraceRecorder for HWTTraceRecorder {
 }
 
 struct HWTTraceIterator {
-    trace: std::vec::IntoIter<ProcessedItem>,
+    trace: std::vec::IntoIter<TraceAction>,
 }
 
 impl AOTTraceIterator for HWTTraceIterator {}
 
 impl Iterator for HWTTraceIterator {
-    type Item = ProcessedItem;
+    type Item = TraceAction;
     fn next(&mut self) -> Option<Self::Item> {
         self.trace.next()
     }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -75,6 +75,13 @@ pub enum ProcessedItem {
     ///
     /// This usually means that the blocks were compiled outside of ykllvm.
     UnmappableBlock,
+    /// A value promoted and recorded within the low-level trace (e.g. `PTWRITE`). In essence these
+    /// are calls to `yk_promote` that have been inlined so that the tracer backend can handle them
+    /// rather than being handled by yk's generic run-time support for `yk_promote`.
+    ///
+    /// While no tracer backend currently uses this variant, it's present to remind us that this a
+    /// useful possibility.
+    Promotion,
 }
 
 impl ProcessedItem {

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -44,12 +44,12 @@ pub(crate) trait TraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError>;
 }
 
-/// An iterator which takes an underlying raw trace and successively produces [TracedAOTBlock]s.
-pub(crate) trait AOTTraceIterator: Iterator<Item = TracedAOTBlock> + Send {}
+/// An iterator which takes an underlying raw trace and successively produces [ProcessedItem]s.
+pub(crate) trait AOTTraceIterator: Iterator<Item = ProcessedItem> + Send {}
 
 /// An AOT LLVM IR block that has been traced at JIT time.
 #[derive(Debug, Eq, PartialEq)]
-pub enum TracedAOTBlock {
+pub enum ProcessedItem {
     /// A sucessfully mapped block.
     Mapped {
         /// The name of the function containing the block.
@@ -65,7 +65,7 @@ pub enum TracedAOTBlock {
     Unmappable,
 }
 
-impl TracedAOTBlock {
+impl ProcessedItem {
     pub fn new_mapped(func_name: CString, bb: usize) -> Self {
         // At one point, `bb = usize::MAX` was a special value, but it no longer is. We believe
         // that no part of the code sets/checks for this value, but just in case there is a

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -62,7 +62,7 @@ pub enum ProcessedItem {
     /// One or more machine blocks that could not be mapped.
     ///
     /// This usually means that the blocks were compiled outside of ykllvm.
-    Unmappable,
+    UnmappableBlock,
 }
 
 impl ProcessedItem {
@@ -75,7 +75,7 @@ impl ProcessedItem {
     }
 
     pub fn new_unmappable() -> Self {
-        Self::Unmappable
+        Self::UnmappableBlock
     }
 
     /// If `self` is a mapped block, return the function name, otherwise panic.
@@ -98,6 +98,6 @@ impl ProcessedItem {
 
     /// Determines whether `self` represents unmappable code.
     pub fn is_unmappable(&self) -> bool {
-        matches!(self, Self::Unmappable)
+        matches!(self, Self::UnmappableBlock)
     }
 }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -74,7 +74,7 @@ impl ProcessedItem {
         Self::Mapped { func_name, bb }
     }
 
-    pub fn new_unmappable() -> Self {
+    pub fn new_unmappable_block() -> Self {
         Self::UnmappableBlock
     }
 

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -7,7 +7,7 @@
 //!    PT or a software tracer). The tracer backend stores the recorded low-level trace in an
 //!    internal format of its choosing.
 //! 2. *Process* the recorded trace. The tracer backend returns an iterator which produces
-//!    [ProcessedItem]s.
+//!    [TraceAction]s.
 //! 3. *Compile* the processed trace. That happens in [compile](crate::compile) module.
 //!
 //! This module thus contains tracing backends which can record and process traces.
@@ -48,16 +48,16 @@ pub(crate) fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 /// An instance of a [Tracer] which is currently recording a trace of the current thread.
 pub(crate) trait TraceRecorder {
     /// Stop recording a trace of the current thread and return an iterator which successively
-    /// produces [ProcessedItem]s.
+    /// produces [TraceAction]s.
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError>;
 }
 
-/// An iterator which [TraceRecord]s use to process a trace into [ProcessedItem]s.
-pub(crate) trait AOTTraceIterator: Iterator<Item = ProcessedItem> + Send {}
+/// An iterator which [TraceRecord]s use to process a trace into [TraceAction]s.
+pub(crate) trait AOTTraceIterator: Iterator<Item = TraceAction> + Send {}
 
 /// A processed item from a trace.
 #[derive(Debug, Eq, PartialEq)]
-pub enum ProcessedItem {
+pub enum TraceAction {
     /// A sucessfully mapped block.
     MappedAOTBlock {
         /// The name of the function containing the block.
@@ -80,7 +80,7 @@ pub enum ProcessedItem {
     Promotion,
 }
 
-impl ProcessedItem {
+impl TraceAction {
     pub fn new_mapped_aot_block(func_name: CString, bb: usize) -> Self {
         // At one point, `bb = usize::MAX` was a special value, but it no longer is. We believe
         // that no part of the code sets/checks for this value, but just in case there is a

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -66,7 +66,7 @@ pub enum ProcessedItem {
 }
 
 impl ProcessedItem {
-    pub fn new_mapped(func_name: CString, bb: usize) -> Self {
+    pub fn new_mapped_aot_block(func_name: CString, bb: usize) -> Self {
         // At one point, `bb = usize::MAX` was a special value, but it no longer is. We believe
         // that no part of the code sets/checks for this value, but just in case there is a
         // laggardly part of the code which does so, we've left this `assert` behind to catch it.

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -51,7 +51,7 @@ pub(crate) trait AOTTraceIterator: Iterator<Item = ProcessedItem> + Send {}
 #[derive(Debug, Eq, PartialEq)]
 pub enum ProcessedItem {
     /// A sucessfully mapped block.
-    Mapped {
+    MappedAOTBlock {
         /// The name of the function containing the block.
         ///
         /// PERF: Use a string pool to avoid duplicated function names in traces.
@@ -71,7 +71,7 @@ impl ProcessedItem {
         // that no part of the code sets/checks for this value, but just in case there is a
         // laggardly part of the code which does so, we've left this `assert` behind to catch it.
         debug_assert_ne!(bb, usize::MAX);
-        Self::Mapped { func_name, bb }
+        Self::MappedAOTBlock { func_name, bb }
     }
 
     pub fn new_unmappable_block() -> Self {
@@ -80,7 +80,7 @@ impl ProcessedItem {
 
     /// If `self` is a mapped block, return the function name, otherwise panic.
     pub fn func_name(&self) -> &CStr {
-        if let Self::Mapped { func_name, .. } = self {
+        if let Self::MappedAOTBlock { func_name, .. } = self {
             func_name.as_c_str()
         } else {
             panic!();
@@ -89,7 +89,7 @@ impl ProcessedItem {
 
     /// If `self` is a mapped block, return the basic block index, otherwise panic.
     pub fn bb(&self) -> usize {
-        if let Self::Mapped { bb, .. } = self {
+        if let Self::MappedAOTBlock { bb, .. } = self {
             *bb
         } else {
             panic!();

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -17,11 +17,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 mod errors;
-use std::{
-    error::Error,
-    ffi::{CStr, CString},
-    sync::Arc,
-};
+use std::{error::Error, ffi::CString, sync::Arc};
 
 #[cfg(tracer_hwt)]
 pub(crate) mod hwt;
@@ -95,28 +91,5 @@ impl ProcessedItem {
 
     pub fn new_unmappable_block() -> Self {
         Self::UnmappableBlock
-    }
-
-    /// If `self` is a mapped block, return the function name, otherwise panic.
-    pub fn func_name(&self) -> &CStr {
-        if let Self::MappedAOTBlock { func_name, .. } = self {
-            func_name.as_c_str()
-        } else {
-            panic!();
-        }
-    }
-
-    /// If `self` is a mapped block, return the basic block index, otherwise panic.
-    pub fn bb(&self) -> usize {
-        if let Self::MappedAOTBlock { bb, .. } = self {
-            *bb
-        } else {
-            panic!();
-        }
-    }
-
-    /// Determines whether `self` represents unmappable code.
-    pub fn is_unmappable(&self) -> bool {
-        matches!(self, Self::UnmappableBlock)
     }
 }


### PR DESCRIPTION
This PR reworks (and renames) the `TracedAOTBlock` enum. My initial aim was to make it plausible for this to record in-band promotion (e.g . `PTWRITE`) but as I looked in more depth I realised there were more things we could improve, including extra documentation (https://github.com/ykjit/yk/commit/63589b919908e4f24910e3fd4ad48d8bee4cb040) and improving static guarantees (https://github.com/ykjit/yk/commit/cb564566bc0bbba1d8113fd899cd05c4656440bb).