### PR TITLE
Fix errors/warnings related to latest rust.

### DIFF
--- a/hwtracer/src/llvm_blockmap.rs
+++ b/hwtracer/src/llvm_blockmap.rs
@@ -2,7 +2,7 @@
 
 use byteorder::{NativeEndian, ReadBytesExt};
 use intervaltree::IntervalTree;
-use object::{self, Object, ObjectSection};
+use object::{Object, ObjectSection};
 use std::{
     io::{prelude::*, Cursor, SeekFrom},
     sync::LazyLock,

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -10,7 +10,7 @@ use crate::{
     Block, ThreadTracer, Trace, Tracer,
 };
 use libc::{c_void, free, geteuid, malloc, size_t};
-use std::{convert::TryFrom, fs::read_to_string, slice, sync::Arc};
+use std::{fs::read_to_string, slice, sync::Arc};
 
 #[cfg(pt)]
 extern "C" {
@@ -213,7 +213,7 @@ impl Drop for PerfTrace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{errors::HWTracerError, perf::collect::PerfTracer, work_loop, Tracer};
+    use crate::work_loop;
 
     /// Check that a long trace causes the trace buffer to reallocate.
     #[test]

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -48,7 +48,6 @@ use crate::{
 use intervaltree::IntervalTree;
 use std::{
     collections::VecDeque,
-    convert::TryFrom,
     ffi::CString,
     fmt::{self, Debug},
     ops::Range,
@@ -57,10 +56,7 @@ use std::{
     sync::LazyLock,
 };
 use thiserror::Error;
-use ykaddr::{
-    self,
-    obj::{PHDR_MAIN_OBJ, PHDR_OBJECT_CACHE, SELF_BIN_PATH},
-};
+use ykaddr::obj::{PHDR_MAIN_OBJ, PHDR_OBJECT_CACHE, SELF_BIN_PATH};
 
 use packets::{Bitness, Packet, PacketKind};
 use parser::PacketParser;

--- a/hwtracer/src/pt/ykpt/packets.rs
+++ b/hwtracer/src/pt/ykpt/packets.rs
@@ -1,7 +1,6 @@
 //! Intel PT packets and their constituents.
 
 use deku::prelude::*;
-use std::convert::TryFrom;
 
 /// The `IPBytes` field common to all IP packets.
 ///

--- a/hwtracer/src/pt/ykpt/parser.rs
+++ b/hwtracer/src/pt/ykpt/parser.rs
@@ -5,7 +5,7 @@ use deku::{
     bitvec::{BitSlice, Msb0},
     DekuRead,
 };
-use std::{cmp::min, iter::Iterator};
+use std::cmp::min;
 
 use super::packets::*;
 

--- a/ykaddr/src/addr.rs
+++ b/ykaddr/src/addr.rs
@@ -2,9 +2,8 @@
 
 use crate::obj::{PHDR_OBJECT_CACHE, SELF_BIN_PATH};
 use cached::proc_macro::cached;
-use libc::{self, c_void, dlsym, Dl_info, RTLD_DEFAULT};
+use libc::{c_void, dlsym, Dl_info, RTLD_DEFAULT};
 use std::{
-    convert::{From, TryFrom},
     ffi::CStr,
     mem::MaybeUninit,
     path::{Path, PathBuf},
@@ -143,7 +142,7 @@ pub fn vaddr_to_sym_and_obj(vaddr: usize) -> Option<DLInfo> {
 mod tests {
     use super::{off_to_vaddr, vaddr_to_obj_and_off, vaddr_to_sym_and_obj, MaybeUninit};
     use crate::obj::PHDR_MAIN_OBJ;
-    use libc::{self, dlsym, Dl_info};
+    use libc::{dlsym, Dl_info};
     use std::{ffi::CString, ptr};
 
     #[test]

--- a/ykaddr/src/obj.rs
+++ b/ykaddr/src/obj.rs
@@ -6,8 +6,6 @@ use libc::c_void;
 use libc::{
     Elf64_Addr as Elf_Addr, Elf64_Off as Elf_Off, Elf64_Word as Elf_Word, Elf64_Xword as Elf_Xword,
 };
-use memmap2;
-use phdrs;
 use std::{
     ffi::{CStr, CString},
     fs,

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -628,7 +628,6 @@ impl fmt::Display for Module {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem;
 
     #[test]
     fn operand() {

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -3,7 +3,7 @@
 
 use llvm_sys::{core::*, prelude::LLVMValueRef};
 use object::{Object, ObjectSection};
-use std::{convert::TryFrom, ffi::c_void, ptr, sync::LazyLock, thread};
+use std::{ffi::c_void, ptr, sync::LazyLock, thread};
 use ykaddr::obj::SELF_BIN_MMAP;
 use yksmp::{Location as SMLocation, PrologueInfo, Record, StackMapParser};
 

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -1,7 +1,6 @@
 //! Trace location: track the state of a program location (counting, tracing, compiled, etc).
 
 use std::{
-    convert::TryFrom,
     mem,
     sync::{
         atomic::{AtomicUsize, Ordering},

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -682,8 +682,7 @@ impl PartialEq for TransitionControlPoint {
 mod tests {
     extern crate test;
     use super::*;
-    use crate::location::HotLocationKind;
-    use std::{convert::TryFrom, hint::black_box, sync::atomic::AtomicU64, thread};
+    use std::{hint::black_box, sync::atomic::AtomicU64};
     use test::bench::Bencher;
 
     #[test]

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -3,7 +3,7 @@
 use crate::trace::TracedAOTBlock;
 use hwtracer::llvm_blockmap::LLVM_BLOCK_MAP;
 use hwtracer::Trace;
-use std::{convert::TryFrom, error::Error};
+use std::error::Error;
 use ykaddr::{
     addr::{vaddr_to_obj_and_off, vaddr_to_sym_and_obj},
     obj::SELF_BIN_PATH,

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -8,8 +8,6 @@
 compile_error!("The stackmap parser currently only supports x86_64.");
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::convert::TryInto;
 use std::error;
 
 struct Function {


### PR DESCRIPTION
The latest version of rust introduces some changes to imports, e.g. things like `TryFrom` are imported by default, and `self` is not longer required either, e.g. there's no need to do `use std::{self, ...}` anymore.