### PR TITLE
Run serialised compilation in another thread.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -548,7 +548,11 @@ impl MT {
 
         #[cfg(feature = "yk_testing")]
         if *SERIALISE_COMPILATION {
-            do_compile();
+            // To ensure that we properly test that compilation can occur in another thread, we
+            // spin up a new thread for each compilation. This is only acceptable because a)
+            // `SERIALISE_COMPILATION` is an internal yk testing feature b) when we use it we're
+            // checking correctness, not performance.
+            thread::spawn(|| do_compile()).join().unwrap();
             return;
         }
 


### PR DESCRIPTION
In retrospect I should have added this to 7eff5624e42bc3f3591b97e424be0748e78bb9bb, but it didn't occur to me at the time.

In essence, to avoid multi-threading bugs, this commit makes testing serialised compilation more realistic in that compilation is now run in a different thread. Indeed, we spin up a new thread each time, which is a slightly tougher test than normal yk (which reuses threads for compilation). Clearly this wouldn't be a good idea in general, but for internal testing it should be fine.