### PR TITLE
Tweak hwtracer iterators.

### DIFF
--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -91,7 +91,7 @@ pub trait ThreadTracer {
 /// Each trace decoder has its own concrete implementation.
 pub trait Trace: Debug + Send {
     /// Iterate over the blocks of the trace.
-    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>>>;
+    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send>;
 
     #[cfg(test)]
     fn bytes(&self) -> &[u8];

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -91,7 +91,7 @@ pub trait ThreadTracer {
 /// Each trace decoder has its own concrete implementation.
 pub trait Trace: Debug + Send {
     /// Iterate over the blocks of the trace.
-    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a>;
+    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>>>;
 
     #[cfg(test)]
     fn bytes(&self) -> &[u8];

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -180,7 +180,7 @@ impl PerfTrace {
 
 impl Trace for PerfTrace {
     #[cfg(ykpt)]
-    fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a> {
+    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>>> {
         let bytes =
             unsafe { slice::from_raw_parts(self.buf.0, usize::try_from(self.len).unwrap()) };
         Box::new(YkPTBlockIterator::new(bytes))

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -180,7 +180,7 @@ impl PerfTrace {
 
 impl Trace for PerfTrace {
     #[cfg(ykpt)]
-    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>>> {
+    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send> {
         let bytes =
             unsafe { slice::from_raw_parts(self.buf.0, usize::try_from(self.len).unwrap()) };
         Box::new(YkPTBlockIterator::new(bytes))


### PR DESCRIPTION
This PR first removes unnecessary, and restrictive, lifetimes (https://github.com/ykjit/yk/commit/10db3e13900d1c6cb11bf50e25ee8bab39295e0f) before making hwtracer iterators `Send`able (https://github.com/ykjit/yk/commit/bf52e2119399774b3844f925ab6765d81eb68528).