### PR TITLE
Fix the lifetime of a "trace".

### DIFF
--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -91,7 +91,9 @@ pub trait ThreadTracer {
 /// Each trace decoder has its own concrete implementation.
 pub trait Trace: Debug + Send {
     /// Iterate over the blocks of the trace.
-    fn iter_blocks(&self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send>;
+    fn iter_blocks(
+        self: Box<Self>,
+    ) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send>;
 
     #[cfg(test)]
     fn bytes(&self) -> &[u8];


### PR DESCRIPTION
This one took me a while to hunt down and even longer to fix. In essence, `PerfTrace` allocates a block of memory M and hands it to `YKPTBlockIterator`, but `PerfTrace` frees M itself. In a fully synchronous program this happens to work, but as soon as the iterator is passed off to some other bit of code (e.g. another thread), the trace can be freed while the PT parser is still active.

The fundamental problem is that the trace is represented by a `*mut u8` which disguises the implicit lifetime in this structure. One fix would be to change `iter_blocks` to:

```rust
fn iter_blocks<'a>(&'a self) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + 'a Send>;
```

but that makes using `iter_blocks` rather hard (since `PerfTrace` has to be kept alive too), and is also not really the API we want: we never want to iterate over a trace's blocks more than once.

This commit thus changes `iter_blocks` to:

```rust
fn iter_blocks(self: Box<Self>) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send>;
```

Ideally we might prefer `self: Self` (i.e. without `Box<Self>`) but then this method isn't object safe, so it's (almost?) impossible to use.

`PerfTrace` then has to hand responsibility for `free`ing the block to `YKPTBlockIterator`. Theoretically there is still a tiny possibility of this not being correct (see one of the `FIXME`s) but addressing that theoretical possibility would probably require a huge restructure that I don't want to undertake now. This commit, at the very least, makes it much more difficult for us to hit segfaults.

Fixes https://github.com/ykjit/yk/issues/1002.