### PR TITLE
Fix hidden panics

### DIFF
--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -3,7 +3,9 @@
 
 use llvm_sys::{core::*, prelude::LLVMValueRef};
 use object::{Object, ObjectSection};
-use std::{ffi::c_void, ptr, sync::LazyLock, thread};
+#[cfg(not(test))]
+use std::thread;
+use std::{ffi::c_void, ptr, sync::LazyLock};
 use ykaddr::obj::SELF_BIN_MMAP;
 use yksmp::{Location as SMLocation, PrologueInfo, Record, StackMapParser};
 
@@ -58,6 +60,8 @@ static AOT_STACKMAPS: LazyLock<Result<AOTStackmapInfo, String>> = LazyLock::new(
 });
 
 pub(crate) fn load_aot_stackmaps() {
+    // Rust unit test binaries will not contain stackmaps, so don't try to load them.
+    #[cfg(not(test))]
     thread::spawn(|| LazyLock::force(&AOT_STACKMAPS));
 }
 

--- a/ykrt/src/frame/mod.rs
+++ b/ykrt/src/frame/mod.rs
@@ -24,24 +24,37 @@ impl AOTStackmapInfo {
     }
 }
 
-static AOT_STACKMAPS: LazyLock<AOTStackmapInfo> = LazyLock::new(|| {
-    // Load the stackmap from the binary to parse in tthe stackmaps.
-    let object = object::File::parse(&**SELF_BIN_MMAP).unwrap();
-    let sec = object.section_by_name(".llvm_stackmaps").unwrap();
-
-    // Parse the stackmap.
-    let (entries, numrecs) = StackMapParser::get_entries(sec.data().unwrap());
-    let mut pinfos = Vec::new();
-    let mut records = Vec::new();
-    records.resize_with(usize::try_from(numrecs).unwrap(), || (Record::empty(), 0));
-    for entry in entries {
-        pinfos.push(entry.pinfo);
-        for r in entry.records {
-            let idx = usize::try_from(r.id).unwrap();
-            records[idx] = (r, pinfos.len() - 1);
-        }
+static AOT_STACKMAPS: LazyLock<Result<AOTStackmapInfo, String>> = LazyLock::new(|| {
+    fn errstr(msg: &str) -> String {
+        format!("failed to load stackmaps: {}", msg)
     }
-    AOTStackmapInfo { pinfos, records }
+
+    // We use an inner function so that we can use the `?` operator for errors.
+    fn load_stackmaps() -> Result<AOTStackmapInfo, String> {
+        // Load the stackmap from the binary to parse in tthe stackmaps.
+        let object = object::File::parse(&**SELF_BIN_MMAP).map_err(|e| errstr(&e.to_string()))?;
+        let sec = object
+            .section_by_name(".llvm_stackmaps")
+            .ok_or_else(|| errstr("can't find section"))?;
+
+        // Parse the stackmap.
+        let data = sec.data().map_err(|e| errstr(&e.to_string()))?;
+        let (entries, numrecs) = StackMapParser::get_entries(data);
+        let mut pinfos = Vec::new();
+        let mut records = Vec::new();
+        let numrecs_usize = usize::try_from(numrecs).map_err(|e| errstr(&e.to_string()))?;
+        records.resize_with(numrecs_usize, || (Record::empty(), 0));
+        for entry in entries {
+            pinfos.push(entry.pinfo);
+            for r in entry.records {
+                let idx = usize::try_from(r.id).map_err(|e| errstr(&e.to_string()))?;
+                records[idx] = (r, pinfos.len() - 1);
+            }
+        }
+        Ok(AOTStackmapInfo { pinfos, records })
+    }
+
+    load_stackmaps()
 });
 
 pub(crate) fn load_aot_stackmaps() {
@@ -133,7 +146,8 @@ impl FrameReconstructor {
             debug_assert!(smcall.is_intrinsic());
             let smid = unsafe { LLVMConstIntGetZExtValue(smcall.get_operand(0).get()) };
             // Find prologue info and stackmap record for this frame.
-            let (rec, pinfo) = AOT_STACKMAPS.get(usize::try_from(smid).unwrap());
+            let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
+            let (rec, pinfo) = aot_smaps.get(usize::try_from(smid).unwrap());
             // We don't need to allocate memory for the bottom-most frame, i.e. the frame
             // containing the control point, since this frame already exists and doesn't need to be
             // reconstructed.


### PR DESCRIPTION
See commit messages.

By the way @ltratt, after this fix, I still see stats in the `--nocapture` output of passing tests where we have no requested stats. e.g.:

```
$ cargo test dont_trace_execution_of_a_trace -- --nocapture
...
running 1 test
{
    "duration_compiling": 0.000,
    "duration_deopting": 0.000,
    "duration_jit_executing": 0.000,
    "duration_outside_yk": 0.000,
    "duration_trace_mapping": 0.000,
    "trace_executions": 0,
    "traces_compiled_err": 0,
    "traces_compiled_ok": 0,
    "traces_recorded_err": 0,
    "traces_recorded_ok": 0
}
test mt::tests::dont_trace_execution_of_a_trace ... ok
```

A fix for that should be a separate PR, but any ideas?