### PR TITLE
Update cargo deny settings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,4 @@
 [licenses]
-unlicensed = "deny"
 confidence-threshold = 1.0
 allow = [
     "Apache-2.0",

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ confidence-threshold = 1.0
 allow = [
     "Apache-2.0",
     "MIT",
+    "MPL-2.0",
     "BSD-3-Clause",
     "Unicode-DFS-2016",
 ]


### PR DESCRIPTION
Two minor changes to stop cargo deny outputting warnings (i.e. this commit doesn't *change* behaviour, yet, though it does mean we'll keep working with future versions of cargo deny).