### PR TITLE
Make trace mapping a true iterator

### DIFF
--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -5,7 +5,8 @@
 //   env-var: YKD_PRINT_JITSTATE=1
 //   stderr:
 //     ...
-//     jit-state: stop-tracing-aborted
+//     jit-state: stop-tracing
+//     jit-state: trace-compilation-aborted: Encountered longjmp
 //     ...
 
 // Tests that we can deal with setjmp/longjmp.

--- a/tests/c/trace_too_long.c
+++ b/tests/c/trace_too_long.c
@@ -1,0 +1,46 @@
+// # This tests that traces that generate too many blocks cause "trace too
+// # long" warnings. This can be very slow (e.g. on swt), so ignore it except
+// # where we know it'll run # fast enough.
+// ignore-if: test "$YKB_TRACER" != "hwt"
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     jit-state: stop-tracing
+//     jit-state: trace-compilation-aborted: Trace too long
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc1 = yk_location_new();
+  YkLocation loc2 = yk_location_new();
+
+  int i = 2000;
+  NOOPT_VAL(loc1);
+  NOOPT_VAL(loc2);
+  NOOPT_VAL(i);
+  YkLocation *loc = &loc1;
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    if (i == 2000)
+      loc = &loc2;
+    else if (i == 2)
+      loc = &loc1;
+    fprintf(stdout, "i=%d\n", i);
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(i);
+  yk_location_drop(loc1);
+  yk_location_drop(loc2);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/trace_too_long_hwt.c
+++ b/tests/c/trace_too_long_hwt.c
@@ -1,0 +1,45 @@
+// # This test checks that an overflowing PT buffer is caught at the point
+// # where a trace is stopped, not after trace mapping. It therefore only works
+// # on hwt.
+// ignore-if: test "$YKB_TRACER" != hwt
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_PRINT_JITSTATE=1
+//   stderr:
+//     ...
+//     jit-state: stop-tracing-aborted: Trace too long
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc1 = yk_location_new();
+  YkLocation loc2 = yk_location_new();
+
+  int i = 100000;
+  NOOPT_VAL(loc1);
+  NOOPT_VAL(loc2);
+  NOOPT_VAL(i);
+  YkLocation *loc = &loc1;
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    if (i == 100000)
+      loc = &loc2;
+    else if (i == 2)
+      loc = &loc1;
+    fprintf(stdout, "i=%d\n", i);
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(i);
+  yk_location_drop(loc1);
+  yk_location_drop(loc2);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -6,7 +6,8 @@
 //     jit-state: start-tracing
 //     set jump point
 //     jumped!
-//     jit-state: stop-tracing-aborted
+//     jit-state: stop-tracing
+//     jit-state: trace-compilation-aborted: Encountered longjmp
 //     ...
 
 // Check that we bork on a call to setjmp in unmapped code.

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -282,7 +282,6 @@ impl MT {
                         mtt.promotions.take().unwrap(),
                     )
                 });
-                self.stats.timing_state(TimingState::TraceMapping);
                 match thrdtrcr.stop() {
                     Ok(utrace) => {
                         self.stats.timing_state(TimingState::None);
@@ -298,7 +297,7 @@ impl MT {
                         self.stats.timing_state(TimingState::None);
                         self.stats.trace_recorded_err();
                         #[cfg(feature = "yk_jitstate_debug")]
-                        print_jit_state("stop-tracing-aborted");
+                        print_jit_state(&format!("stop-tracing-aborted: {_e}"));
                     }
                 }
             }
@@ -549,9 +548,14 @@ impl MT {
                     mt.stats.trace_compiled_err();
                     hl_arc.lock().trace_failed(&mt);
                     #[cfg(feature = "yk_jitstate_debug")]
-                    print_jit_state(&format!("trace-compilation-aborted<reason=\"{}\">", _e));
+                    print_jit_state(&format!("trace-compilation-aborted: {_e}"));
                 }
-                Err(CompilationError::Unrecoverable(e)) => panic!("{}", e),
+                Err(CompilationError::Unrecoverable(_e)) => {
+                    mt.stats.trace_compiled_err();
+                    hl_arc.lock().trace_failed(&mt);
+                    #[cfg(feature = "yk_jitstate_debug")]
+                    print_jit_state(&format!("trace-compilation-aborted: {_e}"));
+                }
             }
 
             mt.stats.timing_state(TimingState::None);

--- a/ykrt/src/trace/errors.rs
+++ b/ykrt/src/trace/errors.rs
@@ -5,6 +5,8 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Debug)]
 /// Reasons that a trace can be invalidated.
 pub enum InvalidTraceError {
+    /// Nothing was recorded.
+    TraceEmpty,
     /// The trace being recorded was too long and tracing was aborted.
     TraceTooLong,
 }
@@ -12,6 +14,7 @@ pub enum InvalidTraceError {
 impl Display for InvalidTraceError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
+            InvalidTraceError::TraceEmpty => write!(f, "Trace empty"),
             InvalidTraceError::TraceTooLong => write!(f, "Trace too long"),
         }
     }

--- a/ykrt/src/trace/errors.rs
+++ b/ykrt/src/trace/errors.rs
@@ -5,20 +5,14 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Debug)]
 /// Reasons that a trace can be invalidated.
 pub enum InvalidTraceError {
-    /// An empty trace was recorded.
-    EmptyTrace,
     /// The trace being recorded was too long and tracing was aborted.
     TraceTooLong,
-    /// Something went wrong in the compiler's tracing code.
-    InternalError,
 }
 
 impl Display for InvalidTraceError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            InvalidTraceError::EmptyTrace => write!(f, "Empty trace"),
             InvalidTraceError::TraceTooLong => write!(f, "Trace too long"),
-            InvalidTraceError::InternalError => write!(f, "Internal tracing error"),
         }
     }
 }

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -36,38 +36,7 @@ impl Iterator for HWTTraceIterator {
         while self.upcoming.len() < 2 {
             match self.hwt_iter.next() {
                 Some(Ok(x)) => {
-                    let mapped = map_block(&x);
-                    if mapped.is_empty() {
-                        // The block is unmappable. Note that we collapse consecutive unmappable
-                        // blocks.
-                        if self.upcoming.last() != Some(&TraceAction::new_unmappable_block()) {
-                            self.upcoming.push(TraceAction::new_unmappable_block());
-                            self.tas_generated += 1;
-                        }
-                    } else {
-                        for b in map_block(&x) {
-                            match b {
-                                Some(b) => {
-                                    if self.upcoming.last() != Some(&b) {
-                                        self.upcoming.push(b);
-                                        self.tas_generated += 1;
-                                    }
-                                }
-                                None => {
-                                    // Part of an hwtracer block mapped to a machine block in the
-                                    // LLVM block address map, but the machine block has no
-                                    // corresponding AOT LLVM IR blocks.
-                                    //
-                                    // FIXME: https://github.com/ykjit/yk/issues/388
-                                    // We *think* this happens because LLVM can introduce extra
-                                    // `MachineBasicBlock`s to help with laying out machine code.
-                                    // If that's the case, then for our purposes these extra blocks
-                                    // can be ignored. However, we should really investigate to be
-                                    // sure.
-                                }
-                            }
-                        }
-                    }
+                    self.map_block(&x);
                 }
                 Some(Err(HWTracerError::Unrecoverable(x)))
                     if x == "longjmp within traces currently unsupported" =>
@@ -102,123 +71,153 @@ impl Iterator for HWTTraceIterator {
 
 impl HWTTraceIterator {
     pub fn new(trace: Box<dyn Trace>) -> Result<Self, InvalidTraceError> {
-        let mut hwt_iter = trace.iter_blocks();
-
+        let mut hwti = HWTTraceIterator {
+            hwt_iter: trace.iter_blocks(),
+            upcoming: Vec::new(),
+            tas_generated: 0,
+        };
         // The first block contains the control point, which we need to remove.
         // As a rough proxy for "check that we removed only the thing we want to remove", we know
         // that the control point will be contained in a single mappable block. The `unwrap` can
         // only fail if our assumption about the block is incorrect (i.e. some part of the system
         // doesn't work as expected).
-        let first = hwt_iter.next().map(|x| map_block(&x.unwrap())).unwrap();
-        match first.as_slice() {
-            &[Some(TraceAction::MappedAOTBlock { .. })] => (),
-            _ => panic!(),
-        }
-        Ok(HWTTraceIterator {
-            hwt_iter,
-            upcoming: Vec::new(),
-            tas_generated: 0,
-        })
-    }
-}
-
-/// Maps one hwtracer block to one or more AOT LLVM IR blocks.
-///
-/// Mapping an hwtracer block to AOT LLVM IR blocks occurs in two phases. First the mapper
-/// tries to find machine blocks whose address ranges overlap with the address range of the
-/// hwtracer block (by using the LLVM block address map section). Once machine blocks have been
-/// found, the mapper then tries to find which LLVM IR blocks the machine blocks are part of.
-///
-/// A `Some` element in the returned vector means that the mapper found a machine block that
-/// maps to part of the hwtracer block and that the machine block could be directly mapped
-/// to an AOT LLVM IR block.
-///
-/// A `None` element in the returned vector means that the mapper found a machine block that
-/// corresponds with part of the hwtracer block but that the machine block could *not* be
-/// directly mapped to an AOT LLVM IR block. This happens when
-/// `MachineBasicBlock::getBasicBlock()` returns `nullptr`.
-///
-/// This function returns an empty vector if the hwtracer block was unmappable (no matching
-/// machine blocks could be found).
-///
-/// The reason we cannot simply ignore the `None` case is that it is important to differentiate
-/// "there were no matching machine blocks" from "there were matching machine blocks, but we
-/// were unable to find IR blocks for them".
-///
-/// The reason that there may be many corresponding blocks is due to the following scenario.
-///
-/// Suppose that the LLVM IR looked like this:
-///
-///   bb1:
-///     ...
-///     br bb2;
-///   bb2:
-///     ...
-///
-/// During codegen LLVM may remove the unconditional jump and simply place bb1 and bb2
-/// consecutively, allowing bb1 to fall-thru to bb2. In the eyes of hwtracer, a fall-thru does
-/// not terminate a block, so whereas LLVM sees two blocks, hwtracer sees only one.
-fn map_block(block: &hwtracer::Block) -> Vec<Option<TraceAction>> {
-    let b_rng = block.vaddr_range();
-    if b_rng.is_none() {
-        // If the address range of the block isn't known, then it follows that we can't map
-        // back to an IRBlock. We return the empty vector to flag this.
-        return Vec::new();
-    }
-    let (block_vaddr, block_last_instr) = b_rng.unwrap();
-
-    let (obj_name, block_off) = vaddr_to_obj_and_off(block_vaddr as usize).unwrap();
-
-    // Currently we only read in a block map and IR for the currently running binary (and not
-    // for dynamically linked shared objects). Thus, if we see code from another object, we
-    // can't map it.
-    //
-    // FIXME: https://github.com/ykjit/yk/issues/413
-    // In the future we could inline code from shared objects if they were built for use with
-    // yk (i.e. they have a blockmap and IR embedded).
-    if obj_name != *SELF_BIN_PATH {
-        return Vec::new();
-    }
-
-    let block_len = block_last_instr - block_vaddr;
-    let mut ret = Vec::new();
-    let mut ents = LLVM_BLOCK_MAP
-        .query(block_off, block_off + block_len)
-        .collect::<Vec<_>>();
-
-    // In the case that an hwtracer block maps to multiple machine blocks, it may be tempting
-    // to check that they are at consecutive address ranges. Unfortunately we can't do this
-    // because LLVM sometimes appends `nop` sleds (e.g. `nop word cs:[rax + rax]; nop`) to the
-    // ends of blocks for alignment. This padding is not reflected in the LLVM block address
-    // map, so blocks may not appear consecutive.
-    ents.sort_by(|x, y| x.range.start.partial_cmp(&y.range.start).unwrap());
-    for ent in ents {
-        if !ent.value.corr_bbs().is_empty() {
-            // OPT: This could probably be sped up with caching. If we use an interval tree
-            // keyed virtual address ranges, then we could take advantage of the fact that all
-            // blocks belonging to the same function will fall within the address range of the
-            // function's symbol. If the cache knows that block A and B are from the same
-            // function, and a block X has a start address between blocks A and B, then X must
-            // also belong to the same function and there's no need to query the linker.
-            // FIXME: Is this `unwrap` safe?
-            let sio = vaddr_to_sym_and_obj(usize::try_from(block_vaddr).unwrap()).unwrap();
-            debug_assert_eq!(
-                obj_name.to_str().unwrap(),
-                sio.dli_fname().unwrap().to_str().unwrap()
-            );
-            if let Some(sym_name) = sio.dli_sname() {
-                for bb in ent.value.corr_bbs() {
-                    ret.push(Some(TraceAction::new_mapped_aot_block(
-                        sym_name.to_owned(),
-                        usize::try_from(*bb).unwrap(),
-                    )));
+        match hwti.hwt_iter.next() {
+            Some(Ok(x)) => {
+                hwti.map_block(&x);
+                match hwti.upcoming.as_slice() {
+                    &[TraceAction::MappedAOTBlock { .. }] => {
+                        hwti.upcoming.pop();
+                        Ok(hwti)
+                    }
+                    _ => panic!(),
                 }
-            } else {
-                ret.push(None);
             }
-        } else {
-            ret.push(None);
+            Some(Err(_)) => todo!(),
+            None => Err(InvalidTraceError::TraceEmpty),
         }
     }
-    ret
+
+    /// Maps one hwtracer block to one or more AOT LLVM IR blocks.
+    ///
+    /// Mapping an hwtracer block to AOT LLVM IR blocks occurs in two phases. First the mapper
+    /// tries to find machine blocks whose address ranges overlap with the address range of the
+    /// hwtracer block (by using the LLVM block address map section). Once machine blocks have been
+    /// found, the mapper then tries to find which LLVM IR blocks the machine blocks are part of.
+    ///
+    /// A `Some` element in the returned vector means that the mapper found a machine block that
+    /// maps to part of the hwtracer block and that the machine block could be directly mapped
+    /// to an AOT LLVM IR block.
+    ///
+    /// A `None` element in the returned vector means that the mapper found a machine block that
+    /// corresponds with part of the hwtracer block but that the machine block could *not* be
+    /// directly mapped to an AOT LLVM IR block. This happens when
+    /// `MachineBasicBlock::getBasicBlock()` returns `nullptr`.
+    ///
+    /// This function returns an empty vector if the hwtracer block was unmappable (no matching
+    /// machine blocks could be found).
+    ///
+    /// The reason we cannot simply ignore the `None` case is that it is important to differentiate
+    /// "there were no matching machine blocks" from "there were matching machine blocks, but we
+    /// were unable to find IR blocks for them".
+    ///
+    /// The reason that there may be many corresponding blocks is due to the following scenario.
+    ///
+    /// Suppose that the LLVM IR looked like this:
+    ///
+    ///   bb1:
+    ///     ...
+    ///     br bb2;
+    ///   bb2:
+    ///     ...
+    ///
+    /// During codegen LLVM may remove the unconditional jump and simply place bb1 and bb2
+    /// consecutively, allowing bb1 to fall-thru to bb2. In the eyes of hwtracer, a fall-thru does
+    /// not terminate a block, so whereas LLVM sees two blocks, hwtracer sees only one.
+    fn map_block(&mut self, block: &hwtracer::Block) {
+        let b_rng = block.vaddr_range();
+        if b_rng.is_none() {
+            // If the address range of the block isn't known, then it follows that we can't map
+            // back to an IRBlock. We return the empty vector to flag this.
+            self.push_upcoming(TraceAction::new_unmappable_block());
+            return;
+        }
+        let (block_vaddr, block_last_instr) = b_rng.unwrap();
+
+        let (obj_name, block_off) = vaddr_to_obj_and_off(block_vaddr as usize).unwrap();
+
+        // Currently we only read in a block map and IR for the currently running binary (and not
+        // for dynamically linked shared objects). Thus, if we see code from another object, we
+        // can't map it.
+        //
+        // FIXME: https://github.com/ykjit/yk/issues/413
+        // In the future we could inline code from shared objects if they were built for use with
+        // yk (i.e. they have a blockmap and IR embedded).
+        if obj_name != *SELF_BIN_PATH {
+            self.push_upcoming(TraceAction::new_unmappable_block());
+            return;
+        }
+
+        let block_len = block_last_instr - block_vaddr;
+        let mut ents = LLVM_BLOCK_MAP
+            .query(block_off, block_off + block_len)
+            .collect::<Vec<_>>();
+
+        // In the case that an hwtracer block maps to multiple machine blocks, it may be tempting
+        // to check that they are at consecutive address ranges. Unfortunately we can't do this
+        // because LLVM sometimes appends `nop` sleds (e.g. `nop word cs:[rax + rax]; nop`) to the
+        // ends of blocks for alignment. This padding is not reflected in the LLVM block address
+        // map, so blocks may not appear consecutive.
+        ents.sort_by(|x, y| x.range.start.partial_cmp(&y.range.start).unwrap());
+        for ent in ents {
+            if !ent.value.corr_bbs().is_empty() {
+                // OPT: This could probably be sped up with caching. If we use an interval tree
+                // keyed virtual address ranges, then we could take advantage of the fact that all
+                // blocks belonging to the same function will fall within the address range of the
+                // function's symbol. If the cache knows that block A and B are from the same
+                // function, and a block X has a start address between blocks A and B, then X must
+                // also belong to the same function and there's no need to query the linker.
+                // FIXME: Is this `unwrap` safe?
+                let sio = vaddr_to_sym_and_obj(usize::try_from(block_vaddr).unwrap()).unwrap();
+                debug_assert_eq!(
+                    obj_name.to_str().unwrap(),
+                    sio.dli_fname().unwrap().to_str().unwrap()
+                );
+                if let Some(sym_name) = sio.dli_sname() {
+                    for bb in ent.value.corr_bbs() {
+                        self.push_upcoming(TraceAction::new_mapped_aot_block(
+                            sym_name.to_owned(),
+                            usize::try_from(*bb).unwrap(),
+                        ));
+                    }
+                    continue;
+                }
+            }
+            // If we got here, it is because part of an hwtracer block mapped to a machine block in the
+            // LLVM block address map, but the machine block has no corresponding AOT LLVM IR blocks.
+            //
+            // FIXME: https://github.com/ykjit/yk/issues/388 We *think* this happens because LLVM can
+            // introduce extra `MachineBasicBlock`s to help with laying out machine code. If that's the
+            // case, then for our purposes these extra blocks can be ignored. However, we should really
+            // investigate to be sure.
+        }
+    }
+
+    /// Push `new` into `self.upcoming` *unless* `new` is equal to `self.upcoming.last`, at which
+    /// point `new` will be ignored. In other words, this function can be thought of as "push and
+    /// deduplicate".
+    ///
+    /// Note that duplication can happen for two reasons:
+    ///
+    ///   1. Repeated unmappable blocks.
+    ///   2. Repeated mappable blocks. The `BlockDisambiguate` pass in ykllvm ensures that no
+    ///      high-level LLVM IR block ever branches straight back to itself, so if we see the same
+    ///      high-level block more than once consecutively in a trace, then we know that the IR
+    ///      block has been lowered to multiple machine blocks during code-gen, and that we should
+    ///      only push the IR block once.
+    fn push_upcoming(&mut self, new: TraceAction) {
+        if self.upcoming.last() != Some(&new) {
+            self.upcoming.push(new);
+            self.tas_generated += 1;
+        }
+    }
 }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -57,7 +57,16 @@ pub(crate) trait TraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, InvalidTraceError>;
 }
 
-/// An iterator which [TraceRecord]s use to process a trace into [TraceAction]s.
+/// An iterator which [TraceRecord]s use to process a trace into [TraceAction]s. The iterator must
+/// respect the following:
+///
+/// 1. The first [TraceAction] returned by the iterator should be the mapped block immediately
+///    after the call to the control point. Note that the (almost certainly unmappable, though that
+///    depends on the backend) block representing the control point's body must not be returned by
+///    the iterator.
+/// 2. Consecutive `TraceAction`s must not compare equal (i.e. the iterator must have deduplicated
+///    consecutive `TraceAction`s).
+/// 3. The call to the "stop tracing" function must not appear at the tail of the trace.
 pub(crate) trait AOTTraceIterator:
     Iterator<Item = Result<TraceAction, AOTTraceIteratorError>> + Send
 {

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -63,7 +63,10 @@ pub(crate) trait AOTTraceIterator:
 {
 }
 
-pub(crate) enum AOTTraceIteratorError {}
+pub(crate) enum AOTTraceIteratorError {
+    TraceTooLong,
+    LongJmpEncountered,
+}
 
 /// A processed item from a trace.
 #[derive(Debug, Eq, PartialEq)]

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -115,11 +115,7 @@ impl TraceRecorder for SWTTraceRecorder {
                     .collect();
             })
         });
-        if aot_blocks.is_empty() {
-            Err(InvalidTraceError::EmptyTrace)
-        } else {
-            Ok(Box::new(SWTraceIterator::new(aot_blocks)))
-        }
+        Ok(Box::new(SWTraceIterator::new(aot_blocks)))
     }
 }
 


### PR DESCRIPTION
This PR turns hwt mapping into a true iterator. The most obvious benefit is that this allows mapping to happen in the compilation thread rather than pausing the interpreter (@Pavel-Durov you may want to make a similar change to swt). It will also allow us, if we later want to, to put trace mapping into a separate thread altogether.

The main commit is https://github.com/ykjit/yk/commit/934f3db4bfce6d968d20712e5002241f30175354; https://github.com/ykjit/yk/commit/e14cf139859a1446ff48b58ccb06119a1f23ca9e is a minor optimisation and simplification that has a bit more churn than I anticipated but still seems worthwhile.