### PR TITLE
Make `CompiledTrace` a trait.

### DIFF
--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -2,7 +2,7 @@
 //! to be compiled with LLVM.
 
 use crate::{
-    compile::{CompilationError, CompiledTrace, Compiler},
+    compile::{CompilationError, Compiler, LLVMCompiledTrace},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
     trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction},
@@ -36,7 +36,7 @@ impl Compiler for JITCLLVM {
         aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
-    ) -> Result<CompiledTrace, CompilationError> {
+    ) -> Result<LLVMCompiledTrace, CompilationError> {
         let mut irtrace = Vec::new();
         mt.stats.timing_state(TimingState::TraceMapping);
         for ta in aottrace_iter.0 {
@@ -85,7 +85,7 @@ impl Compiler for JITCLLVM {
             // recoverable/temporary. So for now we say any error is temporary.
             Err(CompilationError::Temporary("llvm backend error".into()))
         } else {
-            Ok(CompiledTrace::new(mt, ret, di_tmp, Arc::downgrade(&hl)))
+            Ok(LLVMCompiledTrace::new(mt, ret, di_tmp, Arc::downgrade(&hl)))
         }
     }
 }

--- a/ykrt/src/compile/jitc_llvm.rs
+++ b/ykrt/src/compile/jitc_llvm.rs
@@ -2,7 +2,7 @@
 //! to be compiled with LLVM.
 
 use crate::{
-    compile::{CompilationError, CompiledTrace, Compiler, LLVMCompiledTrace},
+    compile::{CompilationError, CompiledTrace, Compiler, Guard, GuardId},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
     trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction},
@@ -12,20 +12,209 @@ use object::{Object, ObjectSection};
 use parking_lot::Mutex;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(not(test))]
+use std::slice;
 use std::{
+    collections::HashMap,
     env,
-    ffi::{c_char, c_int},
-    ptr,
-    sync::{Arc, LazyLock},
+    ffi::{c_char, c_int, c_void},
+    fmt, ptr,
+    sync::{Arc, LazyLock, Weak},
 };
 use tempfile::NamedTempFile;
 use ykaddr::obj::SELF_BIN_MMAP;
+use yksmp::LiveVar;
+#[cfg(not(test))]
+use yksmp::StackMapParser;
 
 pub static LLVM_BITCODE: LazyLock<&[u8]> = LazyLock::new(|| {
     let object = object::File::parse(&**SELF_BIN_MMAP).unwrap();
     let sec = object.section_by_name(".llvmbc").unwrap();
     sec.data().unwrap()
 });
+
+#[cfg(not(test))]
+struct SendSyncConstPtr<T>(*const T);
+#[cfg(not(test))]
+unsafe impl<T> Send for SendSyncConstPtr<T> {}
+#[cfg(not(test))]
+unsafe impl<T> Sync for SendSyncConstPtr<T> {}
+
+/// A trace compiled into machine code. Note that these are passed around as raw pointers and
+/// potentially referenced by multiple threads so, once created, instances of this struct can only
+/// be updated if a lock is held or a field is atomic.
+#[cfg(not(test))]
+pub(crate) struct LLVMCompiledTrace {
+    // Reference to the meta-tracer required for side tracing.
+    mt: Arc<MT>,
+    /// A function which when called, executes the compiled trace.
+    ///
+    /// The argument to the function is a pointer to a struct containing the live variables at the
+    /// control point. The exact definition of this struct is not known to Rust: the struct is
+    /// generated at interpreter compile-time by ykllvm.
+    entry: SendSyncConstPtr<c_void>,
+    /// Parsed stackmap of this trace. We only need to read this once, and can then use it to
+    /// lookup stackmap information for each guard failure as needed.
+    smap: HashMap<u64, Vec<LiveVar>>,
+    /// Pointer to heap allocated live AOT values.
+    aotvals: SendSyncConstPtr<c_void>,
+    /// List of guards containing hotness counts and compiled side traces.
+    guards: Vec<Guard>,
+    /// If requested, a temporary file containing the "source code" for the trace, to be shown in
+    /// debuggers when stepping over the JITted code.
+    ///
+    /// (rustc incorrectly identifies this field as dead code. Although it isn't being "used", the
+    /// act of storing it is preventing the deletion of the file via its `Drop`)
+    #[allow(dead_code)]
+    di_tmpfile: Option<NamedTempFile>,
+    /// Reference to the HotLocation, required for side tracing.
+    hl: Weak<Mutex<HotLocation>>,
+}
+
+#[cfg(not(test))]
+impl LLVMCompiledTrace {
+    /// Create a `CompiledTrace` from a pointer to an array containing: the pointer to the compiled
+    /// trace, the pointer to the stackmap and the size of the stackmap, and the pointer to the
+    /// live AOT values. The arguments `mt` and `hl` are required for side-tracing.
+    pub(crate) fn new(
+        mt: Arc<MT>,
+        data: *const c_void,
+        di_tmpfile: Option<NamedTempFile>,
+        hl: Weak<Mutex<HotLocation>>,
+    ) -> Self {
+        let slice = unsafe { slice::from_raw_parts(data as *const usize, 5) };
+        let funcptr = slice[0] as *const c_void;
+        let smptr = slice[1] as *const c_void;
+        let smsize = slice[2];
+        let aotvals = slice[3] as *mut c_void;
+        let guardcount = slice[4];
+
+        // Parse the stackmap of this trace and cache it.
+        let smslice = unsafe { slice::from_raw_parts(smptr as *mut u8, smsize) };
+        let smap = StackMapParser::parse(smslice).unwrap();
+
+        // We heap allocated this array in yktracec to pass the data here. Now that we've
+        // extracted it we no longer need to keep the array around.
+        unsafe { libc::free(data as *mut c_void) };
+        let mut guards = Vec::new();
+        for _ in 0..=guardcount {
+            guards.push(Guard {
+                failed: 0.into(),
+                ct: None.into(),
+            });
+        }
+        Self {
+            mt,
+            entry: SendSyncConstPtr(funcptr),
+            smap,
+            aotvals: SendSyncConstPtr(aotvals),
+            di_tmpfile,
+            guards,
+            hl,
+        }
+    }
+}
+
+#[cfg(not(test))]
+impl CompiledTrace for LLVMCompiledTrace {
+    fn mt(&self) -> &Arc<MT> {
+        &self.mt
+    }
+
+    fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
+        &self.smap
+    }
+
+    /// Return a reference to the guard `id`.
+    fn guard(&self, id: GuardId) -> &Guard {
+        &self.guards[id.0]
+    }
+
+    /// Is the guard `id` the last guard in this `CompiledTrace`?
+    fn is_last_guard(&self, id: GuardId) -> bool {
+        id.0 + 1 == self.guards.len()
+    }
+
+    fn aotvals(&self) -> *const c_void {
+        self.aotvals.0
+    }
+
+    fn entry(&self) -> *const c_void {
+        self.entry.0
+    }
+
+    fn hl(&self) -> &Weak<Mutex<HotLocation>> {
+        &self.hl
+    }
+}
+
+#[cfg(not(test))]
+impl Drop for LLVMCompiledTrace {
+    fn drop(&mut self) {
+        // The memory holding the AOT live values needs to live as long as the trace. Now that we
+        // no longer need the trace, this can be freed too.
+        unsafe { libc::free(self.aotvals.0 as *mut c_void) };
+        // FIXME: This should drop the JITted code.
+    }
+}
+
+impl fmt::Debug for LLVMCompiledTrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LLVMCompiledTrace {{ ... }}")
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct LLVMCompiledTrace;
+
+#[cfg(test)]
+impl LLVMCompiledTrace {
+    pub(crate) fn new(
+        _mt: Arc<MT>,
+        _data: *const c_void,
+        _di_tmpfile: Option<NamedTempFile>,
+        _hl: Weak<Mutex<HotLocation>>,
+    ) -> Self {
+        todo!();
+    }
+
+    /// Create a `CompiledTrace` suitable for testing purposes. The resulting instance is not
+    /// useful other than as a placeholder: calling any of its methods will cause a panic.
+    pub(crate) fn new_testing() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+impl CompiledTrace for LLVMCompiledTrace {
+    fn mt(&self) -> &Arc<MT> {
+        todo!();
+    }
+
+    fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
+        todo!();
+    }
+
+    fn guard(&self, _id: GuardId) -> &Guard {
+        todo!();
+    }
+
+    fn is_last_guard(&self, _id: GuardId) -> bool {
+        todo!();
+    }
+
+    fn aotvals(&self) -> *const c_void {
+        todo!();
+    }
+
+    fn entry(&self) -> *const c_void {
+        todo!();
+    }
+
+    fn hl(&self) -> &Weak<Mutex<HotLocation>> {
+        todo!();
+    }
+}
 
 pub(crate) struct JITCLLVM;
 

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,7 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{CompiledTrace, Compiler},
+    compile::{Compiler, LLVMCompiledTrace},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
     trace::AOTTraceIterator,
@@ -64,7 +64,7 @@ impl Compiler for JITCYk {
         aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         _hl: Arc<Mutex<HotLocation>>,
-    ) -> Result<CompiledTrace, CompilationError> {
+    ) -> Result<LLVMCompiledTrace, CompilationError> {
         if sti.is_some() {
             todo!();
         }

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,7 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{Compiler, LLVMCompiledTrace},
+    compile::{CompiledTrace, Compiler},
     location::HotLocation,
     mt::{SideTraceInfo, MT},
     trace::AOTTraceIterator,
@@ -64,7 +64,7 @@ impl Compiler for JITCYk {
         aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         _hl: Arc<Mutex<HotLocation>>,
-    ) -> Result<LLVMCompiledTrace, CompilationError> {
+    ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         if sti.is_some() {
             todo!();
         }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -5,8 +5,6 @@ use crate::{
 };
 use libc::c_void;
 use parking_lot::Mutex;
-#[cfg(not(test))]
-use std::slice;
 use std::{
     collections::HashMap,
     env, fmt,
@@ -15,10 +13,7 @@ use std::{
         Arc, Weak,
     },
 };
-use tempfile::NamedTempFile;
 use yksmp::LiveVar;
-#[cfg(not(test))]
-use yksmp::StackMapParser;
 
 #[cfg(jitc_llvm)]
 pub(crate) mod jitc_llvm;
@@ -70,13 +65,6 @@ pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, CompilationError> 
     }
 }
 
-#[cfg(not(test))]
-struct SendSyncConstPtr<T>(*const T);
-#[cfg(not(test))]
-unsafe impl<T> Send for SendSyncConstPtr<T> {}
-#[cfg(not(test))]
-unsafe impl<T> Sync for SendSyncConstPtr<T> {}
-
 /// Responsible for tracking how often a guard in a `CompiledTrace` fails. A hotness counter is
 /// incremented each time the matching guard failure in a `CompiledTrace` is triggered. Also stores
 /// the side-trace once its compiled.
@@ -120,182 +108,6 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     fn entry(&self) -> *const c_void;
 
     fn hl(&self) -> &Weak<Mutex<HotLocation>>;
-}
-
-/// A trace compiled into machine code. Note that these are passed around as raw pointers and
-/// potentially referenced by multiple threads so, once created, instances of this struct can only
-/// be updated if a lock is held or a field is atomic.
-#[cfg(not(test))]
-pub(crate) struct LLVMCompiledTrace {
-    // Reference to the meta-tracer required for side tracing.
-    mt: Arc<MT>,
-    /// A function which when called, executes the compiled trace.
-    ///
-    /// The argument to the function is a pointer to a struct containing the live variables at the
-    /// control point. The exact definition of this struct is not known to Rust: the struct is
-    /// generated at interpreter compile-time by ykllvm.
-    entry: SendSyncConstPtr<c_void>,
-    /// Parsed stackmap of this trace. We only need to read this once, and can then use it to
-    /// lookup stackmap information for each guard failure as needed.
-    smap: HashMap<u64, Vec<LiveVar>>,
-    /// Pointer to heap allocated live AOT values.
-    aotvals: SendSyncConstPtr<c_void>,
-    /// List of guards containing hotness counts and compiled side traces.
-    guards: Vec<Guard>,
-    /// If requested, a temporary file containing the "source code" for the trace, to be shown in
-    /// debuggers when stepping over the JITted code.
-    ///
-    /// (rustc incorrectly identifies this field as dead code. Although it isn't being "used", the
-    /// act of storing it is preventing the deletion of the file via its `Drop`)
-    #[allow(dead_code)]
-    di_tmpfile: Option<NamedTempFile>,
-    /// Reference to the HotLocation, required for side tracing.
-    hl: Weak<Mutex<HotLocation>>,
-}
-
-#[cfg(not(test))]
-impl LLVMCompiledTrace {
-    /// Create a `CompiledTrace` from a pointer to an array containing: the pointer to the compiled
-    /// trace, the pointer to the stackmap and the size of the stackmap, and the pointer to the
-    /// live AOT values. The arguments `mt` and `hl` are required for side-tracing.
-    pub(crate) fn new(
-        mt: Arc<MT>,
-        data: *const c_void,
-        di_tmpfile: Option<NamedTempFile>,
-        hl: Weak<Mutex<HotLocation>>,
-    ) -> Self {
-        let slice = unsafe { slice::from_raw_parts(data as *const usize, 5) };
-        let funcptr = slice[0] as *const c_void;
-        let smptr = slice[1] as *const c_void;
-        let smsize = slice[2];
-        let aotvals = slice[3] as *mut c_void;
-        let guardcount = slice[4];
-
-        // Parse the stackmap of this trace and cache it.
-        let smslice = unsafe { slice::from_raw_parts(smptr as *mut u8, smsize) };
-        let smap = StackMapParser::parse(smslice).unwrap();
-
-        // We heap allocated this array in yktracec to pass the data here. Now that we've
-        // extracted it we no longer need to keep the array around.
-        unsafe { libc::free(data as *mut c_void) };
-        let mut guards = Vec::new();
-        for _ in 0..=guardcount {
-            guards.push(Guard {
-                failed: 0.into(),
-                ct: None.into(),
-            });
-        }
-        Self {
-            mt,
-            entry: SendSyncConstPtr(funcptr),
-            smap,
-            aotvals: SendSyncConstPtr(aotvals),
-            di_tmpfile,
-            guards,
-            hl,
-        }
-    }
-}
-
-#[cfg(not(test))]
-impl CompiledTrace for LLVMCompiledTrace {
-    fn mt(&self) -> &Arc<MT> {
-        &self.mt
-    }
-
-    fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
-        &self.smap
-    }
-
-    /// Return a reference to the guard `id`.
-    fn guard(&self, id: GuardId) -> &Guard {
-        &self.guards[id.0]
-    }
-
-    /// Is the guard `id` the last guard in this `CompiledTrace`?
-    fn is_last_guard(&self, id: GuardId) -> bool {
-        id.0 + 1 == self.guards.len()
-    }
-
-    fn aotvals(&self) -> *const c_void {
-        self.aotvals.0
-    }
-
-    fn entry(&self) -> *const c_void {
-        self.entry.0
-    }
-
-    fn hl(&self) -> &Weak<Mutex<HotLocation>> {
-        &self.hl
-    }
-}
-
-#[cfg(not(test))]
-impl Drop for LLVMCompiledTrace {
-    fn drop(&mut self) {
-        // The memory holding the AOT live values needs to live as long as the trace. Now that we
-        // no longer need the trace, this can be freed too.
-        unsafe { libc::free(self.aotvals.0 as *mut c_void) };
-        // FIXME: This should drop the JITted code.
-    }
-}
-
-impl fmt::Debug for LLVMCompiledTrace {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LLVMCompiledTrace {{ ... }}")
-    }
-}
-
-#[cfg(test)]
-pub(crate) struct LLVMCompiledTrace;
-
-#[cfg(test)]
-impl LLVMCompiledTrace {
-    pub(crate) fn new(
-        _mt: Arc<MT>,
-        _data: *const c_void,
-        _di_tmpfile: Option<NamedTempFile>,
-        _hl: Weak<Mutex<HotLocation>>,
-    ) -> Self {
-        todo!();
-    }
-
-    /// Create a `CompiledTrace` suitable for testing purposes. The resulting instance is not
-    /// useful other than as a placeholder: calling any of its methods will cause a panic.
-    pub(crate) fn new_testing() -> Self {
-        Self
-    }
-}
-
-#[cfg(test)]
-impl CompiledTrace for LLVMCompiledTrace {
-    fn mt(&self) -> &Arc<MT> {
-        todo!();
-    }
-
-    fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
-        todo!();
-    }
-
-    fn guard(&self, _id: GuardId) -> &Guard {
-        todo!();
-    }
-
-    fn is_last_guard(&self, _id: GuardId) -> bool {
-        todo!();
-    }
-
-    fn aotvals(&self) -> *const c_void {
-        todo!();
-    }
-
-    fn entry(&self) -> *const c_void {
-        todo!();
-    }
-
-    fn hl(&self) -> &Weak<Mutex<HotLocation>> {
-        todo!();
-    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -44,7 +44,7 @@ pub(crate) trait Compiler: Send + Sync {
         aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
-    ) -> Result<LLVMCompiledTrace, CompilationError>;
+    ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 
 pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, CompilationError> {

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -291,10 +291,6 @@ unsafe extern "C" fn __ykrt_deopt(
     retaddr: usize,
     rsp: *const c_void,
 ) -> NewFramesInfo {
-    // The `ctr` argument is a `Arc<CompiledTrace>` that is being cloned prior to each trace
-    // execution. Traces can only return via this deopt, so we can (and must) turn this back into
-    // an `Arc` so it will be dropped at the end of this function. Unless, we are going to execute
-    // a side-trace. In that case this function will not return and we need to drop `ctr` manually.
     let ctr = crate::mt::THREAD_MTTHREAD.with(|mtt| mtt.running_trace().unwrap());
     ctr.mt().stats.timing_state(TimingState::Deopting);
 

--- a/ykrt/src/deopt.rs
+++ b/ykrt/src/deopt.rs
@@ -160,7 +160,7 @@ extern "C" fn __llvm_deoptimize(
 /// Struct storing information we need to pass via the `LLVMOrcThreadSafeModuleWithModuleDo`
 /// function.
 struct ReconstructInfo<'a> {
-    ctr: Arc<CompiledTrace>,
+    ctr: Arc<dyn CompiledTrace>,
     frameaddr: *mut c_void,
     aotvals: &'a LiveAOTVals,
     actframes: &'a CVec,
@@ -266,9 +266,6 @@ extern "C" fn ts_reconstruct(ctx: *mut c_void, _module: LLVMModuleRef) -> LLVMEr
 ///
 /// The arguments are as follows:
 ///
-///   * `ctr`: An `Arc<CompiledTrace>` that has been cast to a `*const CompiledTrace`. Will be cast
-///      back into an `Arc` by this function and then dropped before deoptimisation or execution of
-///      a side-trace.
 ///   * `frameaddr`: Address of the control point's frame.
 ///   * `aotvals`: Struct describing the location of the AOT live variables.
 ///   * `actframes`: Address and size of vector holding active AOT frame information needed to

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -223,7 +223,7 @@ impl HotLocation {
 pub(crate) enum HotLocationKind {
     /// Points to executable machine code that can be executed instead of the interpreter for this
     /// HotLocation.
-    Compiled(Arc<CompiledTrace>),
+    Compiled(Arc<dyn CompiledTrace>),
     /// A trace for this HotLocation is being compiled in another trace. When compilation is
     /// complete, the compiling thread will update the state of this HotLocation.
     Compiling,
@@ -234,7 +234,11 @@ pub(crate) enum HotLocationKind {
     Tracing,
     /// While executing JIT compiled code, a guard failed often enough for us to want to generate a
     /// side trace for this HotLocation.
-    SideTracing(Arc<CompiledTrace>, SideTraceInfo, Arc<CompiledTrace>),
+    SideTracing(
+        Arc<dyn CompiledTrace>,
+        SideTraceInfo,
+        Arc<dyn CompiledTrace>,
+    ),
 }
 
 /// When a [HotLocation] has failed to compile a valid trace, should the [HotLocation] be tried

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -257,8 +257,6 @@ impl MT {
                 unsafe {
                     // FIXME: Calling this function overwrites the current (Rust) function frame,
                     // rather than unwinding it. https://github.com/ykjit/yk/issues/778.
-                    // The `Arc<CompiledTrace>` passed into the trace here will be safely dropped
-                    // upon deoptimisation, which is the only way to exit a trace.
                     f(ctrlp_vars, frameaddr);
                 }
             }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -482,7 +482,7 @@ impl MT {
         self: &Arc<Self>,
         hl: Arc<Mutex<HotLocation>>,
         sti: SideTraceInfo,
-        parent: Arc<CompiledTrace>,
+        parent: Arc<dyn CompiledTrace>,
     ) -> TransitionGuardFailure {
         THREAD_MTTHREAD.with(|mtt| {
             // This thread should not be tracing anything.
@@ -502,14 +502,14 @@ impl MT {
     ///   * `utrace` is the trace to be compiled.
     ///   * `hl_arc` is the [HotLocation] this compilation job is related to.
     ///   * `sidetrace`, if not `None`, specifies that this is a side-trace compilation job.
-    ///     The `Arc<CompiledTrace>` is the parent [CompiledTrace] for the side-trace. Because
+    ///     The `Arc<dyn CompiledTrace>` is the parent [CompiledTrace] for the side-trace. Because
     ///     side-traces can nest, this may or may not be the same [CompiledTrace] as contained
     ///     in the `hl_arc`.
     fn queue_compile_job(
         self: &Arc<Self>,
         trace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         hl_arc: Arc<Mutex<HotLocation>>,
-        sidetrace: Option<(SideTraceInfo, Arc<CompiledTrace>)>,
+        sidetrace: Option<(SideTraceInfo, Arc<dyn CompiledTrace>)>,
     ) {
         self.stats.trace_recorded_ok();
         let mt = Arc::clone(self);
@@ -582,7 +582,7 @@ impl MT {
         self: &Arc<Self>,
         hl: Arc<Mutex<HotLocation>>,
         sti: SideTraceInfo,
-        parent: Arc<CompiledTrace>,
+        parent: Arc<dyn CompiledTrace>,
     ) {
         match self.transition_guard_failure(hl, sti, parent) {
             TransitionGuardFailure::NoAction => todo!(),
@@ -624,7 +624,7 @@ impl Drop for MT {
 pub(crate) struct MTThread {
     /// If this thread is executing a trace this will be set to `Some(...)` such that deopt can
     /// know what the parent trace of a side-trace is.
-    running_trace: RefCell<Option<Arc<CompiledTrace>>>,
+    running_trace: RefCell<Option<Arc<dyn CompiledTrace>>>,
     /// Is this thread currently tracing something? If so, this will be a `Some<...>`. This allows
     /// another thread to tell whether the thread that started tracing a [Location] is still alive
     /// or not by inspecting its strong count (if the strong count is equal to 1 then the thread
@@ -658,12 +658,12 @@ impl MTThread {
     }
 
     /// If a trace is currently running, return a reference to its `CompiledTrace`.
-    pub(crate) fn running_trace(&self) -> Option<Arc<CompiledTrace>> {
+    pub(crate) fn running_trace(&self) -> Option<Arc<dyn CompiledTrace>> {
         self.running_trace.borrow().as_ref().map(|x| Arc::clone(&x))
     }
 
     /// Update the currently running trace: `None` means that no trace is running.
-    pub(crate) fn set_running_trace(&self, ct: Option<Arc<CompiledTrace>>) {
+    pub(crate) fn set_running_trace(&self, ct: Option<Arc<dyn CompiledTrace>>) {
         *self.running_trace.borrow_mut() = ct;
     }
 
@@ -685,10 +685,14 @@ impl MTThread {
 #[derive(Debug)]
 enum TransitionControlPoint {
     NoAction,
-    Execute(Arc<CompiledTrace>),
+    Execute(Arc<dyn CompiledTrace>),
     StartTracing,
     StopTracing(Arc<Mutex<HotLocation>>),
-    StopSideTracing(Arc<Mutex<HotLocation>>, SideTraceInfo, Arc<CompiledTrace>),
+    StopSideTracing(
+        Arc<Mutex<HotLocation>>,
+        SideTraceInfo,
+        Arc<dyn CompiledTrace>,
+    ),
 }
 
 /// What action should a caller of [MT::transition_guard_failure] take?
@@ -717,6 +721,7 @@ impl PartialEq for TransitionControlPoint {
 mod tests {
     extern crate test;
     use super::*;
+    use crate::compile::LLVMCompiledTrace;
     use std::{hint::black_box, sync::atomic::AtomicU64};
     use test::bench::Bencher;
 
@@ -748,7 +753,7 @@ mod tests {
                     HotLocationKind::Compiling
                 ));
                 loc.hot_location().unwrap().lock().kind =
-                    HotLocationKind::Compiled(Arc::new(CompiledTrace::new_testing()));
+                    HotLocationKind::Compiled(Arc::new(LLVMCompiledTrace::new_testing()));
             }
             _ => unreachable!(),
         }
@@ -766,7 +771,7 @@ mod tests {
             mt.transition_guard_failure(
                 loc.hot_location_arc_clone().unwrap(),
                 sti,
-                Arc::new(CompiledTrace::new_testing()),
+                Arc::new(LLVMCompiledTrace::new_testing()),
             ),
             TransitionGuardFailure::StartSideTracing
         ));
@@ -1072,7 +1077,7 @@ mod tests {
                                     ));
                                     loc.hot_location().unwrap().lock().kind =
                                         HotLocationKind::Compiled(Arc::new(
-                                            CompiledTrace::new_testing(),
+                                            LLVMCompiledTrace::new_testing(),
                                         ));
                                 }
                                 x => unreachable!("Reached incorrect state {:?}", x),
@@ -1185,7 +1190,7 @@ mod tests {
                         HotLocationKind::Compiling
                     ));
                     loc.hot_location().unwrap().lock().kind =
-                        HotLocationKind::Compiled(Arc::new(CompiledTrace::new_testing()));
+                        HotLocationKind::Compiled(Arc::new(LLVMCompiledTrace::new_testing()));
                 }
                 _ => unreachable!(),
             }
@@ -1208,7 +1213,7 @@ mod tests {
                     mt.transition_guard_failure(
                         loc1.hot_location_arc_clone().unwrap(),
                         sti,
-                        Arc::new(CompiledTrace::new_testing()),
+                        Arc::new(LLVMCompiledTrace::new_testing()),
                     ),
                     TransitionGuardFailure::StartSideTracing
                 ));
@@ -1227,7 +1232,7 @@ mod tests {
             mt.transition_guard_failure(
                 loc2.hot_location_arc_clone().unwrap(),
                 sti,
-                Arc::new(CompiledTrace::new_testing()),
+                Arc::new(LLVMCompiledTrace::new_testing()),
             ),
             TransitionGuardFailure::StartSideTracing
         ));
@@ -1287,7 +1292,7 @@ mod tests {
         ));
         if let TransitionControlPoint::StopTracing(_) = mt.transition_control_point(&loc1) {
             loc1.hot_location().unwrap().lock().kind =
-                HotLocationKind::Compiled(Arc::new(CompiledTrace::new_testing()));
+                HotLocationKind::Compiled(Arc::new(LLVMCompiledTrace::new_testing()));
         } else {
             panic!();
         }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -721,7 +721,7 @@ impl PartialEq for TransitionControlPoint {
 mod tests {
     extern crate test;
     use super::*;
-    use crate::compile::LLVMCompiledTrace;
+    use crate::compile::jitc_llvm::LLVMCompiledTrace;
     use std::{hint::black_box, sync::atomic::AtomicU64};
     use test::bench::Bencher;
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -538,10 +538,10 @@ impl MT {
                             // then `hl_arc.kind` is `Compiled`.
                             let ctr = sidetrace.map(|x| x.1).unwrap();
                             let guard = ctr.guard(guardid.unwrap());
-                            guard.setct(Arc::new(ct));
+                            guard.setct(ct);
                         }
                         _ => {
-                            hl.kind = HotLocationKind::Compiled(Arc::new(ct));
+                            hl.kind = HotLocationKind::Compiled(ct);
                         }
                     }
                     mt.stats.trace_compiled_ok();


### PR DESCRIPTION
This enables multiple compiler backends co-existing. Note that this isn't *all* of the dependencies one would need to do this, but it is one of the major ones.