### PR TITLE
Hook in the new codegen.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -4,24 +4,27 @@
 #![allow(dead_code)]
 
 use super::{jit_ir, CompilationError};
+use dynasmrt::{ExecutableBuffer, Executor};
 use reg_alloc::RegisterAllocator;
+use std::fmt;
 
 mod abs_stack;
-mod reg_alloc;
+pub(crate) mod reg_alloc;
 
 // Note that we make no attempt to cross-arch-test code generators.
 #[cfg(target_arch = "x86_64")]
-mod x86_64;
+pub(crate) mod x86_64;
 
 /// A trait that defines access to JIT compiled code.
-pub(crate) trait CodeGenOutput {
+pub(crate) trait CodeGenOutput: fmt::Debug + Send + Sync {
     /// Disassemble the code-genned trace into a string.
     #[cfg(any(debug_assertions, test))]
     fn disassemble(&self) -> Result<String, CompilationError>;
+    fn ptr(&self) -> *const libc::c_void;
 }
 
 /// All code generators conform to this contract.
-trait CodeGen<'a> {
+pub(crate) trait CodeGen<'a> {
     /// Instantiate a code generator for the specified JIT module.
     fn new(
         jit_mod: &'a jit_ir::Module,

--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -4,9 +4,9 @@
 #![allow(dead_code)]
 
 use super::{jit_ir, CompilationError};
-use dynasmrt::{ExecutableBuffer, Executor};
+use crate::compile::CompiledTrace;
 use reg_alloc::RegisterAllocator;
-use std::fmt;
+use std::sync::Arc;
 
 mod abs_stack;
 pub(crate) mod reg_alloc;
@@ -14,14 +14,6 @@ pub(crate) mod reg_alloc;
 // Note that we make no attempt to cross-arch-test code generators.
 #[cfg(target_arch = "x86_64")]
 pub(crate) mod x86_64;
-
-/// A trait that defines access to JIT compiled code.
-pub(crate) trait CodeGenOutput: fmt::Debug + Send + Sync {
-    /// Disassemble the code-genned trace into a string.
-    #[cfg(any(debug_assertions, test))]
-    fn disassemble(&self) -> Result<String, CompilationError>;
-    fn ptr(&self) -> *const libc::c_void;
-}
 
 /// All code generators conform to this contract.
 pub(crate) trait CodeGen<'a> {
@@ -34,23 +26,5 @@ pub(crate) trait CodeGen<'a> {
         Self: Sized;
 
     /// Perform code generation.
-    fn codegen(self) -> Result<Box<dyn CodeGenOutput>, CompilationError>;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::CodeGenOutput;
-    use fm::FMatcher;
-
-    /// Test helper to use `fm` to match a disassembled trace.
-    pub(crate) fn match_asm(cgo: Box<dyn CodeGenOutput>, pattern: &str) {
-        let dis = cgo.disassemble().unwrap();
-        match FMatcher::new(pattern).unwrap().matches(&dis) {
-            Ok(()) => (),
-            Err(e) => panic!(
-                "\n!!! Emitted code didn't match !!!\n\n{}\nFull asm:\n{}\n",
-                e, dis
-            ),
-        }
-    }
+    fn codegen(self) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
@@ -6,7 +6,7 @@
 
 use super::{super::jit_ir, abs_stack::AbstractStack};
 
-mod spill_alloc;
+pub(crate) mod spill_alloc;
 #[cfg(test)]
 pub(crate) use spill_alloc::SpillAllocator;
 

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -46,7 +46,7 @@ const SYSV_CALL_STACK_ALIGN: usize = 16;
 const STACK_DIRECTION: StackDirection = StackDirection::GrowsDown;
 
 /// The X86_64 code generator.
-pub(super) struct X64CodeGen<'a> {
+pub(crate) struct X64CodeGen<'a> {
     jit_mod: &'a jit_ir::Module,
     asm: dynasmrt::x64::Assembler,
     /// Abstract stack pointer, as a relative offset from `RBP`. The higher this number, the larger
@@ -483,6 +483,7 @@ impl<'a> X64CodeGen<'a> {
     }
 }
 
+#[derive(Debug)]
 pub(super) struct X64CodeGenOutput {
     /// The executable code itself.
     buf: ExecutableBuffer,
@@ -500,6 +501,9 @@ impl CodeGenOutput for X64CodeGenOutput {
     #[cfg(any(debug_assertions, test))]
     fn disassemble(&self) -> Result<String, CompilationError> {
         AsmPrinter::new(&self.buf, &self.comments).to_string()
+    }
+    fn ptr(&self) -> *const libc::c_void {
+        self.buf.ptr(AssemblyOffset(0)) as *const libc::c_void
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -11,12 +11,14 @@ use super::{
     },
     abs_stack::AbstractStack,
     reg_alloc::{LocalAlloc, RegisterAllocator, StackDirection},
-    CodeGen, CodeGenOutput,
+    CodeGen,
 };
+use crate::compile::CompiledTrace;
 use dynasmrt::{
     dynasm, x64::Rq, AssemblyOffset, DynasmApi, DynasmLabelApi, ExecutableBuffer, Register,
 };
 use std::ffi::CString;
+use std::sync::Arc;
 #[cfg(any(debug_assertions, test))]
 use std::{cell::Cell, collections::HashMap, slice};
 use ykaddr::addr::symbol_vaddr;
@@ -79,7 +81,7 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
         })
     }
 
-    fn codegen(mut self) -> Result<Box<dyn CodeGenOutput>, CompilationError> {
+    fn codegen(mut self) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         let alloc_off = self.emit_prologue();
 
         // FIXME: we'd like to be able to assemble code backwards as this would simplify register
@@ -104,11 +106,11 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
             .map_err(|_| CompilationError::Unrecoverable("failed to finalize assembler".into()))?;
 
         #[cfg(not(any(debug_assertions, test)))]
-        return Ok(Box::new(X64CodeGenOutput { buf }));
+        return Ok(Arc::new(X64CodeGenOutput { buf }));
         #[cfg(any(debug_assertions, test))]
         {
             let comments = self.comments.take();
-            return Ok(Box::new(X64CodeGenOutput { buf, comments }));
+            return Ok(Arc::new(X64CodeGenOutput { buf, comments }));
         }
     }
 }
@@ -497,13 +499,38 @@ pub(super) struct X64CodeGenOutput {
     comments: HashMap<usize, Vec<String>>,
 }
 
-impl CodeGenOutput for X64CodeGenOutput {
+impl CompiledTrace for X64CodeGenOutput {
+    fn entry(&self) -> *const libc::c_void {
+        self.buf.ptr(AssemblyOffset(0)) as *const libc::c_void
+    }
+
+    fn aotvals(&self) -> *const libc::c_void {
+        todo!()
+    }
+
+    fn guard(&self, _id: crate::compile::GuardId) -> &crate::compile::Guard {
+        todo!()
+    }
+
+    fn mt(&self) -> &std::sync::Arc<crate::MT> {
+        todo!()
+    }
+
+    fn hl(&self) -> &std::sync::Weak<parking_lot::Mutex<crate::location::HotLocation>> {
+        todo!()
+    }
+    fn is_last_guard(&self, _id: crate::compile::GuardId) -> bool {
+        todo!()
+    }
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
+        self
+    }
+}
+
+impl X64CodeGenOutput {
     #[cfg(any(debug_assertions, test))]
     fn disassemble(&self) -> Result<String, CompilationError> {
         AsmPrinter::new(&self.buf, &self.comments).to_string()
-    }
-    fn ptr(&self) -> *const libc::c_void {
-        self.buf.ptr(AssemblyOffset(0)) as *const libc::c_void
     }
 }
 
@@ -558,16 +585,30 @@ impl<'a> AsmPrinter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CodeGen, X64CodeGen, STACK_DIRECTION};
+    use super::{CodeGen, X64CodeGen, X64CodeGenOutput, STACK_DIRECTION};
     use crate::compile::jitc_yk::{
-        codegen::{reg_alloc::RegisterAllocator, tests::match_asm},
+        codegen::reg_alloc::RegisterAllocator,
         jit_ir::{self, IntegerType, Type},
     };
+    use fm::FMatcher;
     use std::ffi::CString;
+    use std::sync::Arc;
     use ykaddr::addr::symbol_vaddr;
 
     fn test_module() -> jit_ir::Module {
         jit_ir::Module::new("test".into())
+    }
+
+    /// Test helper to use `fm` to match a disassembled trace.
+    pub(crate) fn match_asm(cgo: Arc<X64CodeGenOutput>, pattern: &str) {
+        let dis = cgo.disassemble().unwrap();
+        match FMatcher::new(pattern).unwrap().matches(&dis) {
+            Ok(()) => (),
+            Err(e) => panic!(
+                "\n!!! Emitted code didn't match !!!\n\n{}\nFull asm:\n{}\n",
+                e, dis
+            ),
+        }
     }
 
     mod with_spillalloc {
@@ -582,6 +623,9 @@ mod tests {
                 X64CodeGen::new(&jit_mod, &mut ra)
                     .unwrap()
                     .codegen()
+                    .unwrap()
+                    .as_any()
+                    .downcast::<X64CodeGenOutput>()
                     .unwrap(),
                 &patt_lines.join("\n"),
             );

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     compile::{
         jitc_yk::codegen::{
             reg_alloc::{spill_alloc::SpillAllocator, RegisterAllocator, StackDirection},
-            CodeGen, CodeGenOutput,
+            CodeGen,
         },
         CompiledTrace, Compiler,
     },
@@ -62,35 +62,6 @@ static PHASES_TO_PRINT: LazyLock<HashSet<IRPhase>> = LazyLock::new(|| {
     }
 });
 
-#[derive(Debug)]
-struct YkCompiledTrace {
-    cgo: Box<dyn CodeGenOutput>,
-}
-
-impl CompiledTrace for YkCompiledTrace {
-    fn is_last_guard(&self, _id: super::GuardId) -> bool {
-        todo!()
-    }
-    fn smap(&self) -> &std::collections::HashMap<u64, Vec<yksmp::LiveVar>> {
-        todo!()
-    }
-    fn hl(&self) -> &std::sync::Weak<Mutex<HotLocation>> {
-        todo!()
-    }
-    fn mt(&self) -> &Arc<MT> {
-        todo!()
-    }
-    fn guard(&self, _id: super::GuardId) -> &super::Guard {
-        todo!()
-    }
-    fn aotvals(&self) -> *const libc::c_void {
-        todo!()
-    }
-    fn entry(&self) -> *const libc::c_void {
-        self.cgo.ptr()
-    }
-}
-
 pub(crate) struct JITCYk;
 
 impl Compiler for JITCYk {
@@ -124,8 +95,8 @@ impl Compiler for JITCYk {
 
         let mut ra = SpillAllocator::new(StackDirection::GrowsDown);
         let cg = codegen::x86_64::X64CodeGen::new(&jit_mod, &mut ra).unwrap();
-        let cgo = cg.codegen()?;
-        Ok(Arc::new(YkCompiledTrace { cgo }))
+        let ct = cg.codegen()?;
+        Ok(ct)
     }
 }
 


### PR DESCRIPTION
This is an attempt to hook the new codegen into the normal pipeline. This will allow us to test the new codegen on actual test files, e.g. `simple.newcg.c`. There is still some more work to be done before this actually returns an executable trace. At the moment we are still hitting some `todo`s inside the codegen. But at least this allows us to see what those are so we can go and implement them.

Making this a draft, since these changes still trouble me:
- I don't like how there's two traits `CompiledTrace` and `CodeGenOutput`, which appear to mean the same thing. We can probably combine them, but at the cost of having to pass more stuff into `compiler.codegen`.
- The implementation of `YkCodeGenOutput::ptr` is possibly unsafe. 