### PR TITLE
Ensure that worker threads don't keep `MT` alive.

### DIFF
--- a/tests/c/stats4.c
+++ b/tests/c/stats4.c
@@ -1,0 +1,35 @@
+// Run-time:
+//   env-var: YKD_STATS=-
+//   stderr:
+//     {
+//       ...
+//       "traces_compiled_ok": ...
+//       ...
+//     }
+
+// This tests that spun-up compile workers still cause stats to be printed out
+// (i.e. that, because of reference counting, they don't keep `Mt` alive
+// forever).
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  for (uint64_t i = 0; i < 2; i += 1) {
+    yk_mt_control_point(mt, &loc);
+  }
+
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
If a worker thread (in non-synchronised-compilation) started working, it gained a strong reference to an `MT` instance which stopped the `MT` instance from being dropped. That in turn meant that `YKD_STATS` weren't printed.

This commit fixes things by only handing a weak reference to worker threads, ensuring they can't spuriously keep an `MT` instance alive. The new test `stats4.c` ensures we can't regress in this regard.