### PR TITLE
Audit `unsafe` code in swt.

### DIFF
--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -80,21 +80,19 @@ impl TraceRecorder for SWTTraceRecorder {
                     let mut functions: *mut IRFunctionNameIndex = std::ptr::null_mut();
                     let bc_section = crate::compile::jitc_llvm::llvmbc_section();
                     let mut functions_len: usize = 0;
-                    unsafe {
-                        get_function_names(
-                            &BitcodeSection {
-                                data: bc_section.as_ptr(),
-                                len: u64::try_from(bc_section.len()).unwrap(),
-                            },
-                            &mut functions,
-                            &mut functions_len,
+                    get_function_names(
+                        &BitcodeSection {
+                            data: bc_section.as_ptr(),
+                            len: u64::try_from(bc_section.len()).unwrap(),
+                        },
+                        &mut functions,
+                        &mut functions_len,
+                    );
+                    for entry in unsafe { std::slice::from_raw_parts(functions, functions_len) } {
+                        fnames.borrow_mut().insert(
+                            entry.index,
+                            unsafe { std::ffi::CStr::from_ptr(entry.name) }.to_owned(),
                         );
-                        for entry in std::slice::from_raw_parts(functions, functions_len) {
-                            fnames.borrow_mut().insert(
-                                entry.index,
-                                std::ffi::CStr::from_ptr(entry.name).to_owned(),
-                            );
-                        }
                     }
                 });
 

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -80,14 +80,11 @@ impl TraceRecorder for SWTTraceRecorder {
                     let mut functions: *mut IRFunctionNameIndex = std::ptr::null_mut();
                     let bc_section = crate::compile::jitc_llvm::llvmbc_section();
                     let mut functions_len: usize = 0;
-                    get_function_names(
-                        &BitcodeSection {
-                            data: bc_section.as_ptr(),
-                            len: u64::try_from(bc_section.len()).unwrap(),
-                        },
-                        &mut functions,
-                        &mut functions_len,
-                    );
+                    let bs = &BitcodeSection {
+                        data: bc_section.as_ptr(),
+                        len: u64::try_from(bc_section.len()).unwrap(),
+                    };
+                    unsafe { get_function_names(bs, &mut functions, &mut functions_len) };
                     for entry in unsafe { std::slice::from_raw_parts(functions, functions_len) } {
                         fnames.borrow_mut().insert(
                             entry.index,


### PR DESCRIPTION
This first reduces, then partly enlarges, `unsafe` in swt. There's no functional change, but this does give us a little more confidence in the code's correctness.