### PR TITLE
Implement a preliminary codegen for guards.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -967,8 +967,12 @@ impl GuardInstruction {
         }
     }
 
-    fn cond(&self) -> Operand {
+    pub(crate) fn cond(&self) -> Operand {
         self.cond.get()
+    }
+
+    pub(crate) fn expect(&self) -> bool {
+        self.expect
     }
 }
 


### PR DESCRIPTION
This guard simply crashes if the condition fails.