### PR TITLE
Handle and codegen globals.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -951,6 +951,15 @@ impl IRDisplay for GlobalDecl {
     }
 }
 
+impl GlobalDecl {
+    pub(crate) fn is_threadlocal(&self) -> bool {
+        self.is_threadlocal
+    }
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 /// A bytecode module.
 ///
 /// This is the top-level container for the AOT IR.

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -133,7 +133,6 @@ impl<'a> X64CodeGen<'a> {
             jit_ir::Instruction::PtrAdd(i) => self.codegen_ptradd_instr(instr_idx, &i),
             jit_ir::Instruction::Store(i) => self.codegen_store_instr(&i),
             jit_ir::Instruction::LoadGlobal(_) => todo!(),
-            jit_ir::Instruction::StoreGlobal(_) => todo!(),
             jit_ir::Instruction::Call(i) => self.codegen_call_instr(instr_idx, &i)?,
             jit_ir::Instruction::Icmp(i) => self.codegen_icmp_instr(instr_idx, &i),
             jit_ir::Instruction::Guard(i) => self.codegen_guard_instr(&i),

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -132,7 +132,7 @@ impl<'a> X64CodeGen<'a> {
             jit_ir::Instruction::Load(i) => self.codegen_load_instr(instr_idx, &i),
             jit_ir::Instruction::PtrAdd(i) => self.codegen_ptradd_instr(instr_idx, &i),
             jit_ir::Instruction::Store(i) => self.codegen_store_instr(&i),
-            jit_ir::Instruction::LoadGlobal(_) => todo!(),
+            jit_ir::Instruction::LookupGlobal(_) => todo!(),
             jit_ir::Instruction::Call(i) => self.codegen_call_instr(instr_idx, &i)?,
             jit_ir::Instruction::Icmp(i) => self.codegen_icmp_instr(instr_idx, &i),
             jit_ir::Instruction::Guard(i) => self.codegen_guard_instr(&i),

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -172,7 +172,7 @@ index_24bit!(GlobalDeclIdx);
 /// An instruction index.
 ///
 /// One of these is an index into the [Module::instrs].
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, PartialOrd)]
 pub(crate) struct InstrIdx(u16);
 index_16bit!(InstrIdx);
 

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -465,7 +465,7 @@ impl Instruction {
     pub(crate) fn def_type_idx(&self, m: &Module) -> TypeIdx {
         match self {
             Self::Load(li) => li.type_idx(),
-            Self::LookupGlobal(..) => todo!(),
+            Self::LookupGlobal(..) => m.ptr_type_idx(),
             Self::LoadTraceInput(li) => li.ty_idx(),
             Self::Call(ci) => ci.target().func_type(m).ret_type_idx(),
             Self::PtrAdd(..) => m.ptr_type_idx(),
@@ -654,6 +654,9 @@ pub struct LookupGlobalInstruction {
 impl LookupGlobalInstruction {
     pub(crate) fn new(global_decl_idx: GlobalDeclIdx) -> Result<Self, CompilationError> {
         Ok(Self { global_decl_idx })
+    }
+    pub(crate) fn decl<'a>(&self, m: &'a Module) -> &'a GlobalDecl {
+        m.globaldecl(self.global_decl_idx)
     }
 }
 
@@ -1059,6 +1062,10 @@ impl Module {
     /// Panics if the index is out of bounds.
     pub(crate) fn type_(&self, idx: TypeIdx) -> &Type {
         &self.types[idx]
+    }
+
+    pub(crate) fn globaldecl(&self, idx: GlobalDeclIdx) -> &GlobalDecl {
+        &self.global_decls[idx]
     }
 
     /// Push an instruction to the end of the [Module].

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -424,7 +424,6 @@ pub enum Instruction {
     Call(CallInstruction),
     PtrAdd(PtrAddInstruction),
     Store(StoreInstruction),
-    StoreGlobal(StoreGlobalInstruction),
     Add(AddInstruction),
     Icmp(IcmpInstruction),
     Guard(GuardInstruction),
@@ -444,7 +443,6 @@ impl Instruction {
             Self::Call(..) => true, // FIXME: May or may not define. Ask func sig.
             Self::PtrAdd(..) => true,
             Self::Store(..) => false,
-            Self::StoreGlobal(..) => false,
             Self::Add(..) => true,
             Self::Icmp(..) => true,
             Self::Guard(..) => false,
@@ -472,7 +470,6 @@ impl Instruction {
             Self::Call(ci) => ci.target().func_type(m).ret_type_idx(),
             Self::PtrAdd(..) => m.ptr_type_idx(),
             Self::Store(..) => m.void_type_idx(),
-            Self::StoreGlobal(..) => m.void_type_idx(),
             Self::Add(ai) => ai.type_idx(m),
             Self::Icmp(_) => m.int8_type_idx(), // always returns a 0/1 valued byte.
             Self::Guard(..) => m.void_type_idx(),
@@ -508,7 +505,6 @@ impl fmt::Display for Instruction {
             Self::Call(i) => write!(f, "{}", i),
             Self::PtrAdd(i) => write!(f, "{}", i),
             Self::Store(i) => write!(f, "{}", i),
-            Self::StoreGlobal(i) => write!(f, "{}", i),
             Self::Add(i) => write!(f, "{}", i),
             Self::Icmp(i) => write!(f, "{}", i),
             Self::Guard(i) => write!(f, "{}", i),
@@ -529,7 +525,6 @@ macro_rules! instr {
 instr!(Load, LoadInstruction);
 instr!(LoadGlobal, LoadGlobalInstruction);
 instr!(Store, StoreInstruction);
-instr!(StoreGlobal, StoreGlobalInstruction);
 instr!(LoadTraceInput, LoadTraceInputInstruction);
 instr!(Call, CallInstruction);
 instr!(PtrAdd, PtrAddInstruction);
@@ -769,43 +764,6 @@ impl StoreInstruction {
 impl fmt::Display for StoreInstruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Store {}, {}", self.val.unpack(), self.ptr.unpack())
-    }
-}
-
-/// The operands for a [Instruction::StoreGlobal]
-///
-/// # Semantics
-///
-/// Stores a value into a global.
-///
-#[derive(Debug)]
-pub struct StoreGlobalInstruction {
-    /// The value to store.
-    val: PackedOperand,
-    /// The pointer to store into.
-    global_decl_idx: GlobalDeclIdx,
-}
-
-impl StoreGlobalInstruction {
-    pub(crate) fn new(
-        val: Operand,
-        global_decl_idx: GlobalDeclIdx,
-    ) -> Result<Self, CompilationError> {
-        Ok(Self {
-            val: PackedOperand::new(&val),
-            global_decl_idx,
-        })
-    }
-}
-
-impl fmt::Display for StoreGlobalInstruction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "StoreGlobal {}, {}",
-            self.val.unpack(),
-            usize::from(self.global_decl_idx)
-        )
     }
 }
 
@@ -1300,7 +1258,6 @@ mod tests {
         assert_eq!(mem::size_of::<StoreInstruction>(), 4);
         assert_eq!(mem::size_of::<LoadInstruction>(), 6);
         assert_eq!(mem::size_of::<LoadGlobalInstruction>(), 3);
-        assert_eq!(mem::size_of::<StoreGlobalInstruction>(), 6);
         assert_eq!(mem::size_of::<PtrAddInstruction>(), 6);
         assert!(mem::size_of::<Instruction>() <= mem::size_of::<u64>());
     }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -207,7 +207,7 @@ impl<'a> TraceBuilder<'a> {
                 jit_ir::Operand::Const(cidx)
             }
             aot_ir::Operand::Global(go) => {
-                let load = jit_ir::LoadGlobalInstruction::new(self.handle_global(go.index())?)?;
+                let load = jit_ir::LookupGlobalInstruction::new(self.handle_global(go.index())?)?;
                 self.jit_mod.push_and_make_operand(load.into())?
             }
             aot_ir::Operand::Unimplemented(_) => {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -322,14 +322,9 @@ impl<'a> TraceBuilder<'a> {
     ) -> Result<(), CompilationError> {
         let aot_op = inst.operand(0);
         let aot_ty = inst.type_idx();
-        let instr = if let aot_ir::Operand::Global(go) = aot_op {
-            // Generate a special load instruction for globals.
-            jit_ir::LoadGlobalInstruction::new(self.handle_global(go.index())?)?.into()
-        } else {
-            let jit_op = self.handle_operand(aot_op)?;
-            let jit_ty = self.handle_type(aot_ty)?;
-            jit_ir::LoadInstruction::new(jit_op, jit_ty).into()
-        };
+        let jit_op = self.handle_operand(aot_op)?;
+        let jit_ty = self.handle_type(aot_ty)?;
+        let instr = jit_ir::LoadInstruction::new(jit_op, jit_ty).into();
         self.copy_instruction(instr, bid, aot_inst_idx)
     }
 
@@ -359,13 +354,8 @@ impl<'a> TraceBuilder<'a> {
         aot_inst_idx: usize,
     ) -> Result<(), CompilationError> {
         let val = self.handle_operand(inst.operand(0))?;
-        let instr = if let aot_ir::Operand::Global(go) = inst.operand(1) {
-            // Generate a special store instruction for globals.
-            jit_ir::StoreGlobalInstruction::new(val, self.handle_global(go.index())?)?.into()
-        } else {
-            let ptr = self.handle_operand(inst.operand(1))?;
-            jit_ir::StoreInstruction::new(val, ptr).into()
-        };
+        let ptr = self.handle_operand(inst.operand(1))?;
+        let instr = jit_ir::StoreInstruction::new(val, ptr).into();
         self.copy_instruction(instr, bid, aot_inst_idx)
     }
 


### PR DESCRIPTION
This PR changes the `LoadGlobal` instruction into a `LookupGlobal` instruction which allows us to get rid of special global instructions, e.g. `StoreGlobal`, `LoadGlobal`, etc.

However, this comes with a slight performance penalty in the codegen. `LookupGlobal` simply copies a constant pointer into a register and then immediately uses that register. So we would get something like:
```
mov rax, 0x123abc
mov [rax], 0x1
```
rather than

```
mov [0x123abc], 0x1
```

To fix this we need to change the JIT IR to allow globals inside operands (we don't want to implement a special global version for each instruction, e.g. LoadGlobal/StoreGlobal/etc). The easiest way to do this is to make globals a subclass of constants, similarly to what LLVM does.