### PR TITLE
Remove an old assert.

### DIFF
--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -107,10 +107,6 @@ pub enum TraceAction {
 
 impl TraceAction {
     pub fn new_mapped_aot_block(func_name: CString, bb: usize) -> Self {
-        // At one point, `bb = usize::MAX` was a special value, but it no longer is. We believe
-        // that no part of the code sets/checks for this value, but just in case there is a
-        // laggardly part of the code which does so, we've left this `assert` behind to catch it.
-        debug_assert_ne!(bb, usize::MAX);
         Self::MappedAOTBlock { func_name, bb }
     }
 


### PR DESCRIPTION
This has been in the code long enough that I feel confident that it will never trigger.

Fixes #960.