### PR TITLE
Deal with trace overflow in the first packet.

### DIFF
--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -46,7 +46,7 @@ impl Iterator for HWTTraceIterator {
                 Some(Err(HWTracerError::Temporary(TemporaryErrorKind::TraceBufferOverflow))) => {
                     return Some(Err(AOTTraceIteratorError::TraceTooLong));
                 }
-                Some(Err(_)) => todo!(),
+                Some(Err(e)) => todo!("{e:?}"),
                 None => {
                     // The last block contains pointless unmappable code (the stop tracing call).
                     match self.upcoming.pop() {
@@ -95,7 +95,10 @@ impl HWTTraceIterator {
                     _ => panic!(),
                 }
             }
-            Some(Err(_)) => todo!(),
+            Some(Err(HWTracerError::Temporary(TemporaryErrorKind::TraceBufferOverflow))) => {
+                Err(InvalidTraceError::TraceTooLong)
+            }
+            Some(Err(e)) => todo!("{e:?}"),
             None => Err(InvalidTraceError::TraceEmpty),
         }
     }


### PR DESCRIPTION
I haven't seen this case before, but we seem to have had a test failure because of it on https://github.com/ykjit/yk/pull/1027.

In case we see other errors, I've also done something I should have done originally: print out what error states we're seeing in the `todo!`s.