### PR TITLE
Symlink `.gitignore` to `.dockerignore` for quicker `tryci` builds.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
Most notably this stops `target/` being copied into CI, which can be a huge performance win.