### PR TITLE
Stop the test producing pointless voluminous output when it fails.

### DIFF
--- a/tests/c/trace_too_long_hwt.c
+++ b/tests/c/trace_too_long_hwt.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
       loc = &loc2;
     else if (i == 2)
       loc = &loc1;
-    fprintf(stdout, "i=%d\n", i);
+    NOOPT_VAL(i);
     i--;
   }
   printf("exit");


### PR DESCRIPTION
When this test fails (when I'm changing code that should make it fail!), it produces such massive output that it overwhelms my terminal. This commit reduces the output, but does not change the overall states the test covers.