### PR TITLE
Fix an indexing bug.

### DIFF
--- a/tests/c/simple.newcg.c
+++ b/tests/c/simple.newcg.c
@@ -1,8 +1,8 @@
 // # Currently this test breaks CI entirely, so we temporarily ignore it
 // # completely.
-// ignore-if: test $YK_JIT_COMPILER != "yk"
+// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
-//   env-var: YKD_PRINT_IR=aot
+//   env-var: YKD_PRINT_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1
 //   status: error
@@ -14,6 +14,11 @@
 //     func main($arg0: i32, $arg1: ptr) -> i32 {
 //     ...
 //     --- End aot ---
+//     --- Begin jit-pre-opt ---
+//     ...
+//     %{{var1}}: i32 = Call @puts(%{{var2}})
+//     ...
+//     --- End jit-pre-opt ---
 //     ...
 
 // Check that basic trace compilation works.

--- a/ykrt/src/compile/jitc_llvm/mod.rs
+++ b/ykrt/src/compile/jitc_llvm/mod.rs
@@ -10,6 +10,8 @@ use crate::{
 };
 use object::{Object, ObjectSection};
 use parking_lot::Mutex;
+#[cfg(any(debug_assertions, test))]
+use std::error::Error;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 #[cfg(not(test))]
@@ -154,6 +156,11 @@ impl CompiledTrace for LLVMCompiledTrace {
     fn hl(&self) -> &Weak<Mutex<HotLocation>> {
         &self.hl
     }
+
+    #[cfg(any(debug_assertions, test))]
+    fn disassemble(&self) -> Result<String, Box<dyn Error>> {
+        todo!()
+    }
 }
 
 #[cfg(not(test))]
@@ -224,6 +231,10 @@ impl CompiledTrace for LLVMCompiledTrace {
     }
 
     fn hl(&self) -> &Weak<Mutex<HotLocation>> {
+        todo!();
+    }
+
+    fn disassemble(&self) -> Result<String, Box<dyn Error>> {
         todo!();
     }
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -6,20 +6,22 @@
 
 use super::{
     super::{
-        jit_ir::{self, InstrIdx, JitIRDisplay, Operand, Type},
+        jit_ir::{self, InstrIdx, Operand, Type},
         CompilationError,
     },
     abs_stack::AbstractStack,
     reg_alloc::{LocalAlloc, RegisterAllocator, StackDirection},
     CodeGen,
 };
+#[cfg(any(debug_assertions, test))]
+use crate::compile::jitc_yk::jit_ir::JitIRDisplay;
 use crate::compile::CompiledTrace;
 use dynasmrt::{
     dynasm, x64::Rq, AssemblyOffset, DynasmApi, DynasmLabelApi, ExecutableBuffer, Register,
 };
 #[cfg(any(debug_assertions, test))]
-use std::{cell::Cell, collections::HashMap, slice};
-use std::{error::Error, ffi::CString, sync::Arc};
+use std::{cell::Cell, collections::HashMap, error::Error, slice};
+use std::{ffi::CString, sync::Arc};
 use ykaddr::addr::symbol_vaddr;
 
 /// Argument registers as defined by the X86_64 SysV ABI.

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -584,10 +584,7 @@ impl<'a> AsmPrinter<'a> {
         let dec = zydis::Decoder::new64();
         for insn_info in dec.decode_all::<zydis::VisibleOperands>(code, 0) {
             let (off, _raw_bytes, insn) = insn_info.unwrap();
-            if let Some(lines) = self.comments.get(
-                // FIXME: This could fail if we test on an arch where usize is less than 64-bit.
-                &usize::try_from(off).unwrap(),
-            ) {
+            if let Some(lines) = self.comments.get(&usize::try_from(off).unwrap()) {
                 for line in lines {
                     out.push(format!("; {line}"));
                 }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -554,9 +554,7 @@ impl CompiledTrace for X64CompiledTrace {
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
         self
     }
-}
 
-impl X64CompiledTrace {
     #[cfg(any(debug_assertions, test))]
     fn disassemble(&self) -> Result<String, Box<dyn Error>> {
         AsmPrinter::new(&self.buf, &self.comments).to_string()
@@ -579,7 +577,6 @@ impl<'a> AsmPrinter<'a> {
     /// Returns the disassembled trace.
     fn to_string(&self) -> Result<String, Box<dyn Error>> {
         let mut out = Vec::new();
-        out.push("--- Begin jit-asm ---".to_string());
         let len = self.buf.len();
         let bptr = self.buf.ptr(AssemblyOffset(0));
         let code = unsafe { slice::from_raw_parts(bptr, len) };
@@ -603,7 +600,6 @@ impl<'a> AsmPrinter<'a> {
                 istr
             ));
         }
-        out.push("--- End jit-asm ---".into());
         Ok(out.join("\n"))
     }
 }
@@ -611,9 +607,12 @@ impl<'a> AsmPrinter<'a> {
 #[cfg(test)]
 mod tests {
     use super::{CodeGen, X64CodeGen, X64CompiledTrace, STACK_DIRECTION};
-    use crate::compile::jitc_yk::{
-        codegen::reg_alloc::RegisterAllocator,
-        jit_ir::{self, IntegerType, Type},
+    use crate::compile::{
+        jitc_yk::{
+            codegen::reg_alloc::RegisterAllocator,
+            jit_ir::{self, IntegerType, Type},
+        },
+        CompiledTrace,
     };
     use fm::FMatcher;
     use std::ffi::CString;
@@ -670,7 +669,6 @@ mod tests {
                 "... mov r12, [rbp-0x08]",
                 "... mov r12, [r12]",
                 "... mov [rbp-0x10], r12",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -691,7 +689,6 @@ mod tests {
                 "... movzx r12, byte ptr [rbp-0x01]",
                 "... movzx r12, byte ptr [r12]",
                 "... mov [rbp-0x02], r12b",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -712,7 +709,6 @@ mod tests {
                 "... mov r12d, [rbp-0x04]",
                 "... mov r12d, [r12]",
                 "... mov [rbp-0x08], r12d",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -731,7 +727,6 @@ mod tests {
                 "... mov r12, [rbp-0x08]",
                 "... add r12, 0x40",
                 "... mov [rbp-0x10], r12",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -753,7 +748,6 @@ mod tests {
                 "... mov r12, [rbp-0x10]",
                 "... mov r13, [rbp-0x08]",
                 "... mov [r12], r13",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -770,7 +764,6 @@ mod tests {
                 &format!("; %0: i8 = LoadTraceInput 0, i8"),
                 "... movzx r12, byte ptr [rdi]",
                 "... mov [rbp-0x01], r12b",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -787,7 +780,6 @@ mod tests {
                 &format!("; %0: i16 = LoadTraceInput 32, i16"),
                 "... movzx r12d, word ptr [rdi+0x20]",
                 "... mov [rbp-0x02], r12w",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -821,7 +813,6 @@ mod tests {
                 &format!("; %4: ptr = LoadTraceInput 8, ptr"),
                 "... mov r12, [rdi+0x08]",
                 "... mov [rbp-0x10], r12",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -848,7 +839,6 @@ mod tests {
                 "... movzx r13, word ptr [rbp-0x04]",
                 "... add r12w, r13w",
                 "... mov [rbp-0x06], r12w",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -875,7 +865,6 @@ mod tests {
                 "... mov r13, [rbp-0x10]",
                 "... add r12, r13",
                 "... mov [rbp-0x18], r12",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1219,7 +1208,6 @@ mod tests {
                 "... cmp r12, r13",
                 "... setz r12b",
                 "... mov [rbp-0x09], r12b",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1244,7 +1232,6 @@ mod tests {
                 "... cmp r12b, r13b",
                 "... setz r12b",
                 "... mov [rbp-0x02], r12b",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1309,7 +1296,6 @@ mod tests {
                 "... 00000020: ud2",
                 "... 00000022: cmp r12b, 0x01",
                 "... 00000026: jnz 0x0000000000000020",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1330,7 +1316,6 @@ mod tests {
                 "... 00000020: ud2",
                 "... 00000022: cmp r12b, 0x00",
                 "... 00000026: jnz 0x0000000000000020",
-                "--- End jit-asm ---",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -92,6 +92,9 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
             self.codegen_inst(jit_ir::InstrIdx::new(idx)?, inst)?;
         }
 
+        // FIXME: until we implement trace looping, just crash.
+        dynasm!(self.asm; ud2);
+
         // Now we know the size of the stack frame (i.e. self.asp), patch the allocation with the
         // correct amount.
         self.patch_frame_allocation(alloc_off);
@@ -668,6 +671,7 @@ mod tests {
                 "... mov r12, [rbp-0x08]",
                 "... mov r12, [r12]",
                 "... mov [rbp-0x10], r12",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -688,6 +692,7 @@ mod tests {
                 "... movzx r12, byte ptr [rbp-0x01]",
                 "... movzx r12, byte ptr [r12]",
                 "... mov [rbp-0x02], r12b",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -708,6 +713,7 @@ mod tests {
                 "... mov r12d, [rbp-0x04]",
                 "... mov r12d, [r12]",
                 "... mov [rbp-0x08], r12d",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -726,6 +732,7 @@ mod tests {
                 "... mov r12, [rbp-0x08]",
                 "... add r12, 0x40",
                 "... mov [rbp-0x10], r12",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -747,6 +754,7 @@ mod tests {
                 "... mov r12, [rbp-0x10]",
                 "... mov r13, [rbp-0x08]",
                 "... mov [r12], r13",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -763,6 +771,7 @@ mod tests {
                 &format!("; %0: i8 = LoadTraceInput 0, i8"),
                 "... movzx r12, byte ptr [rdi]",
                 "... mov [rbp-0x01], r12b",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -779,6 +788,7 @@ mod tests {
                 &format!("; %0: i16 = LoadTraceInput 32, i16"),
                 "... movzx r12d, word ptr [rdi+0x20]",
                 "... mov [rbp-0x02], r12w",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -812,6 +822,7 @@ mod tests {
                 &format!("; %4: ptr = LoadTraceInput 8, ptr"),
                 "... mov r12, [rdi+0x08]",
                 "... mov [rbp-0x10], r12",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -838,6 +849,7 @@ mod tests {
                 "... movzx r13, word ptr [rbp-0x04]",
                 "... add r12w, r13w",
                 "... mov [rbp-0x06], r12w",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -864,6 +876,7 @@ mod tests {
                 "... mov r13, [rbp-0x10]",
                 "... add r12, r13",
                 "... mov [rbp-0x18], r12",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1207,6 +1220,7 @@ mod tests {
                 "... cmp r12, r13",
                 "... setz r12b",
                 "... mov [rbp-0x09], r12b",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1231,6 +1245,7 @@ mod tests {
                 "... cmp r12b, r13b",
                 "... setz r12b",
                 "... mov [rbp-0x02], r12b",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1295,6 +1310,7 @@ mod tests {
                 "... 00000020: ud2",
                 "... 00000022: cmp r12b, 0x01",
                 "... 00000026: jnz 0x0000000000000020",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }
@@ -1315,6 +1331,7 @@ mod tests {
                 "... 00000020: ud2",
                 "... 00000022: cmp r12b, 0x00",
                 "... 00000026: jnz 0x0000000000000020",
+                "... ud2",
             ];
             test_with_spillalloc(&jit_mod, &patt_lines);
         }

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -1457,7 +1457,7 @@ impl Module {
         decl: GlobalDecl,
     ) -> Result<GlobalDeclIdx, CompilationError> {
         assert!(GlobalDeclIdx::new(self.global_decls.len()).is_ok());
-        let idx = self.consts.len();
+        let idx = self.global_decls.len();
         self.global_decls.push(decl);
         GlobalDeclIdx::new(idx)
     }

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -88,11 +88,11 @@ impl Compiler for JITCYk {
         let jit_mod = trace_builder::build(&aot_mod, aottrace_iter.0)?;
 
         if PHASES_TO_PRINT.contains(&IRPhase::PreOpt) {
-            eprintln!("--- Begin pre-opt ---");
+            eprintln!("--- Begin jit-pre-opt ---");
             // FIXME: If the `unwrap` fails, something rather bad has happened: does recovery even
             // make sense?
             jit_mod.dump().unwrap();
-            eprintln!("--- End pre-opt ---");
+            eprintln!("--- End jit-pre-opt ---");
         }
 
         let mut ra = SpillAllocator::new(StackDirection::GrowsDown);

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -103,6 +103,10 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     fn entry(&self) -> *const c_void;
 
     fn hl(&self) -> &Weak<Mutex<HotLocation>>;
+
+    /// Disassemble the JITted code into a string, for testing and deubgging.
+    #[cfg(any(debug_assertions, test))]
+    fn disassemble(&self) -> Result<String, Box<dyn Error>>;
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
@ptersilie tasked me with finding out why `puts()` doesn't work in JITted code.

 - The first commit gave me some more tooling that helped me find the bug fixed in the third commit.
 - The second commit is something I noticed along the way.

`puts()` still doesn't work, but it's broken in one less way, and we should get the fix in now in case it fixes what @ptersilie is looking at now.