### PR TITLE
Event based testing

### DIFF
--- a/tests/c/simple_non_serialised.c
+++ b/tests/c/simple_non_serialised.c
@@ -1,0 +1,54 @@
+// Run-time:
+//   env-var: YKD_PRINT_JITSTATE=1
+//   env-var: YKD_STATS=1
+//   stderr:
+//     jit-state: start-tracing
+//     i=4
+//     jit-state: stop-tracing
+//     i=3
+//     jit-state: enter-jit-code
+//     i=2
+//     i=1
+//     jit-state: deoptimise
+//   stdout:
+//     exit
+
+// Check that basic trace compilation in a thread works.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+bool test_compiled_event(YkCStats);
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    if (i == 3)
+      __ykstats_wait_until(mt, test_compiled_event);
+    fprintf(stderr, "i=%d\n", i);
+    res += 2;
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}
+
+bool test_compiled_event(YkCStats stats) {
+  return stats.traces_compiled_ok == 1;
+}

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+// This function will only exist if the `hwt` tracer is compiled in to ykrt.
 size_t __yktrace_hwt_mapper_blockmap_len();
 
 // Blocks the compiler from optimising the specified value or expression.

--- a/ykcapi/yk_testing.h
+++ b/ykcapi/yk_testing.h
@@ -3,6 +3,38 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <yk.h>
+
+/// The statistics passed to the `test` function in `ykstats_wait_until`.
+// Note: this struct *must* stay in sync with `YkCStats` in `ykstats.rs`.
+typedef struct {
+  /// How many traces were recorded successfully?
+  uint64_t traces_recorded_ok;
+  /// How many traces were recorded unsuccessfully?
+  uint64_t traces_recorded_err;
+  /// How many traces were compiled successfully?
+  uint64_t traces_compiled_ok;
+  /// How many traces were compiled unsuccessfully?
+  uint64_t traces_compiled_err;
+  /// How many times have traces been executed? Note that the same trace can
+  /// count arbitrarily many times to this.
+  uint64_t trace_executions;
+} YkCStats;
+
+/// Iff `YKD_STATS` is set, suspend this thread's execution until
+/// `test(YkCStats)` returns true. The `test` function will be called one or
+/// more times: as soon as `test` returns `true`, `__ykstats_wait_until` itself
+/// returns. This allows a test to wait for e.g. a certain number of traces to
+/// be recorded/compiled, even if that happens in another thread.
+///
+/// Note that a lock is held on yk's statistics while `test` is called, so
+/// `test` should not perform lengthy calculations (if it does, it may block
+/// other threads). Note also that the `YkCStats` struct it is passed only has
+/// valid values for the duration of `test`'s execution: those stats may become
+/// invalid immediately after `test` returns.
+///
+/// This function will panic if `YKD_STATS` is not set.
+void __ykstats_wait_until(YkMT *mt, bool test(YkCStats));
 
 // This function will only exist if the `hwt` tracer is compiled in to ykrt.
 size_t __yktrace_hwt_mapper_blockmap_len();


### PR DESCRIPTION
Because yk tries to do as much work as possible in threads, many of our tests have *had* to use `YKD_SERIALISED_COMPILATION` in order that they can guarantee that they're testing (e.g.) compiled code.

This commit adds a crude, but effective, ability for a test thread to suspend itself (without consuming undue CPU!) until a set of yk events have happened.

The `simple_non_serialised` test is an example of this:

```c
while (i > 0) {
  yk_mt_control_point(mt, &loc);
  if (i == 3)
    __ykstats_wait_until(mt, test_compiled_event);
  ...
}

bool test_compiled_event(YkCStats stats) {
  return stats.traces_compiled_ok == 1;
}
```

In essence, `__ykstats_wait_until` runs the `test_compiled_event` whenever a yk event such as "a trace has been compiled" has occurred. If `test_compiled_event` returns false, the thread will be parked until another event has occurred. If and when `test_compiled_event` returns true, `__ykstats_wait_until` itself returns.

At the moment the "events" one can wait on are crude: you can detect, for example, the number of traces that have been compiled, but not that a *particular* location has been compiled. Will this turn out to be flexible enough in the long run? Time will tell. In the interim, this relatively simple mechanism should allow us to write tests that more accurately model yk running in the real-world.
