### PR TITLE
If `yk_testing` is enabled, also enable it in dependencies.

### DIFF
--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -16,4 +16,4 @@ ykrt = { path = "../ykrt" }
 ykbuild = { path = "../ykbuild" }
 
 [features]
-yk_testing = []
+yk_testing = ["ykrt/yk_testing"]

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -44,8 +44,8 @@ regex = "1.9"
 ykbuild = { path = "../ykbuild" }
 
 [features]
-yk_jitstate_debug = []
-yk_testing = []
+yk_jitstate_debug = ["yktracec/yk_testing"]
+yk_testing = ["yktracec/yk_testing"]
 
 [dev-dependencies]
 fm = "0.2.2"


### PR DESCRIPTION
If you included (say) ykrt with yk_testing, ykrt depended on yktracec without yk_testing. In practise, we happened to compile things in a way that doesn't seem to have ended up miscompiling things, but I think that's mostly down to luck.

[See https://doc.rust-lang.org/cargo/reference/features.html#dependency-features for the syntax used in this PR.]