### PR TITLE
Add additional information to the guards.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -189,7 +189,7 @@ impl AotIRDisplay for ConstantOperand {
 }
 
 #[deku_derive(DekuRead)]
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub(crate) struct InstructionID {
     #[deku(skip)] // computed after deserialisation.
     func_idx: FuncIdx,

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -631,7 +631,7 @@ mod tests {
     use crate::compile::{
         jitc_yk::{
             codegen::reg_alloc::RegisterAllocator,
-            jit_ir::{self, IntegerType, Type},
+            jit_ir::{self, GuardInfoIdx, IntegerType, Type},
         },
         CompiledTrace,
     };
@@ -1321,7 +1321,7 @@ mod tests {
                     jit_ir::LoadTraceInputInstruction::new(0, jit_mod.int8_type_idx()).into(),
                 )
                 .unwrap();
-            jit_mod.push(jit_ir::GuardInstruction::new(cond_op, true).into());
+            jit_mod.push(jit_ir::GuardInstruction::new(cond_op, true, GuardInfoIdx(0)).into());
             let patt_lines = [
                 "...",
                 "; Guard %0, true",
@@ -1345,7 +1345,7 @@ mod tests {
                     jit_ir::LoadTraceInputInstruction::new(0, jit_mod.int8_type_idx()).into(),
                 )
                 .unwrap();
-            jit_mod.push(jit_ir::GuardInstruction::new(cond_op, false).into());
+            jit_mod.push(jit_ir::GuardInstruction::new(cond_op, false, GuardInfoIdx(0)).into());
             let patt_lines = [
                 "...",
                 "; Guard %0, false",

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -145,6 +145,11 @@ impl<'a> X64CodeGen<'a> {
             jit_ir::Instruction::Call(i) => self.codegen_call_instr(instr_idx, &i)?,
             jit_ir::Instruction::Icmp(i) => self.codegen_icmp_instr(instr_idx, &i),
             jit_ir::Instruction::Guard(i) => self.codegen_guard_instr(&i),
+            jit_ir::Instruction::Arg(_i) => {
+                // FIXME: Reserve argument in the register allocator. E.g. the argument with index
+                // 0 is passed via RDI so we need to tell the register allocator that this register
+                // is taken.
+            }
         }
         Ok(())
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -592,6 +592,10 @@ pub enum Instruction {
     Add(AddInstruction),
     Icmp(IcmpInstruction),
     Guard(GuardInstruction),
+    /// Describes an argument into the trace function. Its main use is to allow us to track trace
+    /// function arguments in case we need to deoptimise them. At this moment the only trace
+    /// function argument requiring tracking is the trace inputs.
+    Arg(u16),
 }
 
 impl Instruction {
@@ -611,6 +615,7 @@ impl Instruction {
             Self::Add(..) => true,
             Self::Icmp(..) => true,
             Self::Guard(..) => false,
+            Self::Arg(..) => true,
         }
     }
 
@@ -638,6 +643,7 @@ impl Instruction {
             Self::Add(ai) => ai.type_idx(m),
             Self::Icmp(_) => m.int8_type_idx(), // always returns a 0/1 valued byte.
             Self::Guard(..) => m.void_type_idx(),
+            Self::Arg(..) => m.void_type_idx(),
         }
     }
 
@@ -686,6 +692,7 @@ impl JitIRDisplay for Instruction {
             Self::Add(i) => i.to_string_impl(m, s, nums)?,
             Self::Icmp(i) => i.to_string_impl(m, s, nums)?,
             Self::Guard(i) => i.to_string_impl(m, s, nums)?,
+            Self::Arg(i) => s.push_str(&format!("Arg({})", i)),
         }
         Ok(())
     }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -1,6 +1,6 @@
 //! The trace builder.
 
-use super::aot_ir::{self, AotIRDisplay, Module};
+use super::aot_ir::{self, AotIRDisplay, InstrIdx, Module};
 use super::jit_ir;
 use crate::compile::CompilationError;
 use crate::trace::{AOTTraceIterator, TraceAction};
@@ -145,7 +145,11 @@ impl<'a> TraceBuilder<'a> {
                 }
                 aot_ir::Opcode::Add => self.handle_binop(inst, &bid, inst_idx),
                 aot_ir::Opcode::Icmp => self.handle_icmp(inst, &bid, inst_idx),
-                aot_ir::Opcode::CondBr => self.handle_condbr(inst, nextbb.as_ref().unwrap()),
+                aot_ir::Opcode::CondBr => {
+                    let sm = &blk.instrs[InstrIdx::new(inst_idx - 1)];
+                    debug_assert!(sm.is_stackmap_call(self.aot_mod));
+                    self.handle_condbr(inst, sm, nextbb.as_ref().unwrap())
+                }
                 _ => todo!("{:?}", inst),
             }?;
         }
@@ -287,6 +291,7 @@ impl<'a> TraceBuilder<'a> {
     fn handle_condbr(
         &mut self,
         inst: &aot_ir::Instruction,
+        sm: &aot_ir::Instruction,
         nextbb: &aot_ir::BlockID,
     ) -> Result<(), CompilationError> {
         let cond = match &inst.operand(0) {
@@ -299,8 +304,43 @@ impl<'a> TraceBuilder<'a> {
             aot_ir::Operand::Block(aot_ir::BlockOperand { bb_idx }) => bb_idx,
             _ => panic!(),
         };
+
+        // Find live variables in the current stack frame and add them into the guard.
+        // FIXME: Once we handle mappable calls we need to push the live variables of other stack
+        // frames too.
+        let mut smids = Vec::new(); // List of stackmap ids of the current call stack.
+        let mut lives = Vec::new(); // List of live JIT variables.
+
+        match sm.operand(1) {
+            aot_ir::Operand::Constant(co) => {
+                let c = self.aot_mod.constant(co);
+                match self.aot_mod.const_type(c) {
+                    aot_ir::Type::Integer(it) => {
+                        let id: u64 = match it.num_bits() {
+                            // This unwrap can't fail unless we did something wrong during lowering.
+                            64 => u64::from_ne_bytes(c.bytes()[0..8].try_into().unwrap()),
+                            _ => panic!(),
+                        };
+                        smids.push(id);
+                    }
+                    _ => panic!(),
+                }
+            }
+            _ => panic!(),
+        }
+        for op in sm.remaining_operands(3) {
+            match op {
+                aot_ir::Operand::LocalVariable(lvo) => {
+                    lives.push(self.local_map[&lvo.0]);
+                }
+                _ => panic!(),
+            }
+        }
+
+        let gi = jit_ir::GuardInfo::new(smids, lives);
+        let gi_idx = self.jit_mod.push_guardinfo(gi)?;
         let expect = *succ_bb == nextbb.block_idx();
-        let guard = jit_ir::GuardInstruction::new(jit_ir::Operand::Local(cond), expect);
+        let guard = jit_ir::GuardInstruction::new(jit_ir::Operand::Local(cond), expect, gi_idx);
         Ok(self.jit_mod.push(guard.into()))
     }
 
@@ -343,6 +383,8 @@ impl<'a> TraceBuilder<'a> {
         aot_inst_idx: usize,
     ) -> Result<(), CompilationError> {
         if inst.is_stackmap_call(self.aot_mod) || inst.is_debug_call(self.aot_mod) {
+            // FIXME: If this is a mappable call that we are going to inline, push its stackmap
+            // onto the callstack.
             return Ok(());
         }
         let mut args = Vec::new();


### PR DESCRIPTION
Prerequisite work for deoptimisation. See commits for more information.

Note that we currently have no meaningful way to test this. I could have added stuff to the guard display function and check the trace output via lang tester, but we probably don't want guard to print this stuff all the time when looking at JIT IR as the guards can become quite big. We will be adding tests for this stuff in due time anyway.

Ignore the first commit. This is from https://github.com/ykjit/yk/pull/1030 which needs to be merged first and is itself waiting for https://github.com/ykjit/yk/pull/1043.