### PR TITLE
Print out why side tracing aborted.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -333,7 +333,7 @@ impl MT {
                         self.stats.timing_state(TimingState::None);
                         self.stats.trace_recorded_err();
                         #[cfg(feature = "yk_jitstate_debug")]
-                        print_jit_state("stop-side-tracing-aborted");
+                        print_jit_state(&format!("stop-side-tracing-aborted: {_e}"));
                     }
                 }
             }


### PR DESCRIPTION
I think the leading `_` on `_e` had allowed us to overlook that we don't print out a useful error here.