### PR TITLE
Only use "always lock" when `yk_testing` is set.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use parking_lot::{Condvar, Mutex, MutexGuard};
-#[cfg(not(feature = "yk_jitstate_debug"))]
+#[cfg(not(all(feature = "yk_testing", not(test))))]
 use parking_lot_core::SpinWait;
 #[cfg(feature = "yk_jitstate_debug")]
 use std::sync::LazyLock;
@@ -355,7 +355,7 @@ impl MT {
                     // mode only we guarantee to grab the lock.
                     let mut lk;
 
-                    #[cfg(not(feature = "yk_testing"))]
+                    #[cfg(not(all(feature = "yk_testing", not(test))))]
                     {
                         // If this thread is not tracing anything, however, it's not worth
                         // contending too much with other threads: we try moderately hard to grab
@@ -387,7 +387,7 @@ impl MT {
                         };
                     }
 
-                    #[cfg(feature = "yk_testing")]
+                    #[cfg(all(feature = "yk_testing", not(test)))]
                     {
                         lk = hl.lock();
                     }


### PR DESCRIPTION
`mt.rs`'s unit tests need to test the "real-world sometimes-can-fail" locking, but ff72e72f accidentally caused those unit tests with the same "always lock" code as when `yk_testing` is set. This commit fixes that.

Happily this commit also restores the speed of mt's unit tests. In particular, the `only_one_thread_starts_tracing` test is hugely slow when `yk_testing` is enabled, taking up to 80-90s to run on my machine, instead of the 2-3 when `yk_testing` is disabled.