### PR TITLE
Don't write `YKD_STATS` output to a file called 1.

### DIFF
--- a/tests/c/simple_non_serialised.c
+++ b/tests/c/simple_non_serialised.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_PRINT_JITSTATE=1
-//   env-var: YKD_STATS=1
+//   env-var: YKD_STATS=/dev/null
 //   stderr:
 //     jit-state: start-tracing
 //     i=4


### PR DESCRIPTION
This tests needs to turn `YKD_STATS` on for the event based logging to work, and it's better if that output doesn't appear on stderr, as it muddies the test. However `YKD_STATS=1` writes to a file called `1`! This commit changes it so that `YKD_STATS` output is written to `/dev/null`, satisfying both constraints.