### PR TITLE
Implement basic deoptimisation.

### DIFF
--- a/tests/c/simple.newcg.c
+++ b/tests/c/simple.newcg.c
@@ -3,7 +3,6 @@
 //   env-var: YKD_PRINT_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_PRINT_JITSTATE=1
-//   status: error
 //   stderr:
 //     jit-state: start-tracing
 //     foo
@@ -20,7 +19,10 @@
 //     jit-state: enter-jit-code
 //     foo
 //     foo
-//     deopt
+//     ...
+//     jit-state: deoptimise
+//     ...
+//     exit
 
 // Check that basic trace compilation works.
 
@@ -53,7 +55,7 @@ int main(int argc, char **argv) {
     res += 2;
     i--;
   }
-  printf("exit");
+  fprintf(stderr, "exit\n");
   NOOPT_VAL(res);
   yk_location_drop(loc);
   yk_mt_drop(mt);

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
@@ -24,6 +24,8 @@ pub(crate) enum LocalAlloc {
         /// OPT: consider addressing relative to the stack pointer, thus freeing up the base
         /// pointer for general purpose use.
         frame_off: usize,
+        /// Size in bytes of the allocation.
+        size: usize,
     },
     /// The local variable is in a register.
     ///
@@ -33,8 +35,8 @@ pub(crate) enum LocalAlloc {
 
 impl LocalAlloc {
     /// Create a [Self::Stack] allocation.
-    pub(crate) fn new_stack(frame_off: usize) -> Self {
-        Self::Stack { frame_off }
+    pub(crate) fn new_stack(frame_off: usize, size: usize) -> Self {
+        Self::Stack { frame_off, size }
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/spill_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/spill_alloc.rs
@@ -45,7 +45,7 @@ impl RegisterAllocator for SpillAllocator {
             StackDirection::GrowsDown => post_grow_off,
         };
 
-        let alloc = LocalAlloc::new_stack(alloc_off);
+        let alloc = LocalAlloc::new_stack(alloc_off, size);
         self.allocs.insert(local, alloc);
         alloc
     }
@@ -79,12 +79,24 @@ mod tests {
         let idx = InstrIdx::new(0).unwrap();
         sa.allocate(idx, 8, &mut stack);
         debug_assert_eq!(stack.size(), 8);
-        debug_assert_eq!(sa.allocation(idx), &LocalAlloc::Stack { frame_off: 8 });
+        debug_assert_eq!(
+            sa.allocation(idx),
+            &LocalAlloc::Stack {
+                frame_off: 8,
+                size: 8
+            }
+        );
 
         let idx = InstrIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 9);
-        debug_assert_eq!(sa.allocation(idx), &LocalAlloc::Stack { frame_off: 9 });
+        debug_assert_eq!(
+            sa.allocation(idx),
+            &LocalAlloc::Stack {
+                frame_off: 9,
+                size: 1
+            }
+        );
     }
 
     #[test]
@@ -95,12 +107,24 @@ mod tests {
         let idx = InstrIdx::new(0).unwrap();
         sa.allocate(idx, 8, &mut stack);
         debug_assert_eq!(stack.size(), 8);
-        debug_assert_eq!(sa.allocation(idx), &LocalAlloc::Stack { frame_off: 0 });
+        debug_assert_eq!(
+            sa.allocation(idx),
+            &LocalAlloc::Stack {
+                frame_off: 0,
+                size: 8
+            }
+        );
 
         let idx = InstrIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 9);
-        debug_assert_eq!(sa.allocation(idx), &LocalAlloc::Stack { frame_off: 8 });
+        debug_assert_eq!(
+            sa.allocation(idx),
+            &LocalAlloc::Stack {
+                frame_off: 8,
+                size: 1
+            }
+        );
     }
 
     #[test]
@@ -114,7 +138,13 @@ mod tests {
         let idx = InstrIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 33);
-        debug_assert_eq!(sa.allocation(idx), &LocalAlloc::Stack { frame_off: 33 });
+        debug_assert_eq!(
+            sa.allocation(idx),
+            &LocalAlloc::Stack {
+                frame_off: 33,
+                size: 1
+            }
+        );
     }
 
     #[test]
@@ -128,6 +158,12 @@ mod tests {
         let idx = InstrIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 33);
-        debug_assert_eq!(sa.allocation(idx), &LocalAlloc::Stack { frame_off: 32 });
+        debug_assert_eq!(
+            sa.allocation(idx),
+            &LocalAlloc::Stack {
+                frame_off: 32,
+                size: 1
+            }
+        );
     }
 }


### PR DESCRIPTION
This allows us to run and exit from `simple.newcg.c` properly. However, deoptimisation is currently limited to tests that only trace a single function, i.e. we can't deoptimise multiple stack frames yet.