### PR TITLE
Differentiate compiler errors

### DIFF
--- a/ykrt/src/compile/jitc_llvm/mod.rs
+++ b/ykrt/src/compile/jitc_llvm/mod.rs
@@ -264,10 +264,10 @@ impl Compiler for JITCLLVM {
             match ta {
                 Ok(x) => irtrace.push(x),
                 Err(AOTTraceIteratorError::LongJmpEncountered) => {
-                    return Err(CompilationError("Encountered longjmp".to_owned()));
+                    return Err(CompilationError::General("Encountered longjmp".to_owned()));
                 }
                 Err(AOTTraceIteratorError::TraceTooLong) => {
-                    return Err(CompilationError("Trace too long".to_owned()))
+                    return Err(CompilationError::General("Trace too long".to_owned()))
                 }
             }
         }
@@ -302,7 +302,7 @@ impl Compiler for JITCLLVM {
             // The LLVM backend is now legacy code and is pending deletion, so it's not worth us
             // spending time auditing all of the failure modes and categorising them into
             // recoverable/temporary. So for now we say any error is temporary.
-            Err(CompilationError("llvm backend error".into()))
+            Err(CompilationError::General("LLVM backend error".into()))
         } else {
             Ok(Arc::new(LLVMCompiledTrace::new(
                 mt,

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -261,8 +261,10 @@ impl U24 {
 }
 
 /// Helper to create index overflow errors.
+///
+/// FIXME: all of these should be checked at compile time.
 fn index_overflow(typ: &str) -> CompilationError {
-    CompilationError(format!("index overflow: {}", typ))
+    CompilationError::LimitExceeded(format!("index overflow: {}", typ))
 }
 
 // Generate common methods for 24-bit index types.

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -23,7 +23,20 @@ pub mod jitc_yk;
 
 /// A failure to compile a trace.
 #[derive(Debug)]
-pub(crate) struct CompilationError(pub(crate) String);
+pub(crate) enum CompilationError {
+    /// Compilation failed for reasons that might be of interest to a programmer augmenting an
+    /// interpreter with yk but not to the end user running a program on the interpreter.
+    General(String),
+    /// Something went wrong when compiling that is probably the result of a bug in yk.
+    InternalError(String),
+    /// A limit was exceeded (e.g. a pointer add that went beyond a struct). We try and check for
+    /// as many of these as possible at compile time, but some can only be detected at JIT time.
+    /// Most, perhaps all, of these suggest bugs in the interpreter.
+    LimitExceeded(String),
+    /// Compilation failed because an external resource was exhausted: the end user running the
+    /// interpreter probably wants to be informed of this.
+    ResourceExhausted(Box<dyn Error>),
+}
 
 /// The trait that every JIT compiler backend must implement.
 pub(crate) trait Compiler: Send + Sync {


### PR DESCRIPTION
Needs #1061 to be merged first.

This PR (in https://github.com/ykjit/yk/commit/688d5bfae91ad9c318dae0a385cc15d26a082085) uses `CompilationError` in a more meaningful way than previously. Please see that commit for details.