### PR TITLE
Use `debian:latest` so that we stay up-to date.

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:latest
 ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci
 RUN apt-get update && \


### PR DESCRIPTION
Docker defines `debian:latest`:

> The debian:latest tag will always point [sic] the latest stable
> release.