### PR TITLE
Reenable thread sanitiser in CI.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -142,12 +142,12 @@ for tracer in $TRACERS; do
       -Z build-std \
       --target x86_64-unknown-linux-gnu
 
-    # RUST_TEST_THREADS=1 \
-    #   RUSTFLAGS="-Z sanitizer=thread" \
-    #   TSAN_OPTIONS="suppressions=$suppressions_path" \
-    #   cargo test \
-    #   -Z build-std \
-    #   --target x86_64-unknown-linux-gnu
+    RUST_TEST_THREADS=1 \
+      RUSTFLAGS="-Z sanitizer=thread" \
+      TSAN_OPTIONS="suppressions=$suppressions_path" \
+      cargo test \
+      -Z build-std \
+      --target x86_64-unknown-linux-gnu
 done
 
 # We now want to test building with `--release`.


### PR DESCRIPTION
Upstream rustc (via its integrated LLVM) has fixed the problem that caused thread sanitiser to stop working, so we can now happily reenable it.

Note: this does require a recent-ish nightly.