### PR TITLE
Clarify integer types

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -713,8 +713,11 @@ pub(crate) fn const_int_bytes_to_str(num_bits: u32, bytes: &[u8]) -> String {
 
 /// A fixed-width integer type.
 ///
-/// Signedness is not specified. Interpretation of the bit pattern is delegated to operations upon
-/// the integer.
+/// Note:
+///   1. These integers range in size from 1..2^23 (inc.) bits. This is inherited [from LLVM's
+///      integer type](https://llvm.org/docs/LangRef.html#integer-type).
+///   2. Signedness is not specified. Interpretation of the bit pattern is delegated to operations
+///      upon the integer.
 #[deku_derive(DekuRead)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct IntegerType {
@@ -722,7 +725,9 @@ pub(crate) struct IntegerType {
 }
 
 impl IntegerType {
+    /// Return the number of bits (1..2^23 (inc.)) this integer spans.
     pub(crate) fn num_bits(&self) -> u32 {
+        debug_assert!(self.num_bits > 0 && self.num_bits <= 0x800000);
         self.num_bits
     }
 
@@ -743,6 +748,7 @@ impl IntegerType {
     /// Create a new integer type with the specified number of bits.
     #[cfg(test)]
     pub(crate) fn new(num_bits: u32) -> Self {
+        debug_assert!(num_bits > 0 && num_bits <= 0x800000);
         Self { num_bits }
     }
 
@@ -1549,7 +1555,6 @@ func bar();
 
     #[test]
     fn integer_type_sizes() {
-        assert_eq!(IntegerType::new(0).byte_size(), 0);
         for i in 1..8 {
             assert_eq!(IntegerType::new(i).byte_size(), 1);
         }

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -22,15 +22,18 @@ pub(crate) use super::aot_ir::Predicate;
 
 /// A fixed-width integer type.
 ///
-/// Signedness is not specified. Interpretation of the bit pattern is delegated to operations upon
-/// the integer.
+/// Note:
+///   1. These integers range in size from 1..2^23 (inc.) bits. This is inherited [from LLVM's
+///      integer type](https://llvm.org/docs/LangRef.html#integer-type).
+///   2. Signedness is not specified. Interpretation of the bit pattern is delegated to operations
+///      upon the integer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct IntegerType {
     num_bits: u32,
 }
 
 impl IntegerType {
-    /// Return the size of the integer type in bits.
+    /// Return the number of bits (1..2^23 (inc.)) this integer spans.
     pub(crate) fn num_bits(&self) -> u32 {
         self.num_bits
     }
@@ -50,6 +53,7 @@ impl IntegerType {
 
     /// Create a new integer type with the specified number of bits.
     pub(crate) fn new(num_bits: u32) -> Self {
+        debug_assert!(num_bits > 0 && num_bits <= 0x800000);
         Self { num_bits }
     }
 
@@ -1995,7 +1999,6 @@ mod tests {
 
     #[test]
     fn int_type_size() {
-        assert_eq!(Type::Integer(IntegerType::new(0)).byte_size(), Some(0));
         for i in 1..8 {
             assert_eq!(Type::Integer(IntegerType::new(i)).byte_size(), Some(1));
         }
@@ -2075,7 +2078,6 @@ mod tests {
 
     #[test]
     fn integer_type_sizes() {
-        assert_eq!(IntegerType::new(0).byte_size(), 0);
         for i in 1..8 {
             assert_eq!(IntegerType::new(i).byte_size(), 1);
         }

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -1997,19 +1997,6 @@ mod tests {
         assert_eq!(Type::Void.byte_size(), Some(0));
     }
 
-    #[test]
-    fn int_type_size() {
-        for i in 1..8 {
-            assert_eq!(Type::Integer(IntegerType::new(i)).byte_size(), Some(1));
-        }
-        for i in 9..16 {
-            assert_eq!(Type::Integer(IntegerType::new(i)).byte_size(), Some(2));
-        }
-        assert_eq!(Type::Integer(IntegerType::new(127)).byte_size(), Some(16));
-        assert_eq!(Type::Integer(IntegerType::new(128)).byte_size(), Some(16));
-        assert_eq!(Type::Integer(IntegerType::new(129)).byte_size(), Some(17));
-    }
-
     #[cfg(debug_assertions)]
     #[should_panic(expected = "type already exists")]
     #[test]


### PR DESCRIPTION
We clearly inherit LLVM's restrictions on integer type sizes, so this PR documents that, and adds some asserts to check that we don't exceed those restrictions.