### PR TITLE
Kill `Instruction::is_def()` in the JIT IR.

### DIFF
--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -190,7 +190,7 @@ impl<'a> TraceBuilder<'a> {
         aot_inst_idx: usize,
     ) -> Result<(), CompilationError> {
         // If the AOT instruction defines a new value, then add it to the local map.
-        if jit_inst.is_def() {
+        if jit_inst.def_type(&self.jit_mod).is_some() {
             let aot_iid = aot_ir::InstructionID::new(
                 bid.func_idx(),
                 bid.block_idx(),


### PR DESCRIPTION
We did the same for the AOT IR recently, so we may as well do the same here.

Kills some FIXME comments in doing so.

No functional change.