### PR TITLE
Inline sub-structs of `enum Operand`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -217,20 +217,7 @@ impl BlockID {
     }
 }
 
-/// An operand that is an argument to the parent function.
-#[deku_derive(DekuRead)]
-#[derive(Debug)]
-pub(crate) struct ArgOperand {
-    arg_idx: ArgIdx,
-}
-
-impl AotIRDisplay for ArgOperand {
-    fn to_string(&self, _m: &Module) -> String {
-        format!("$arg{}", usize::from(self.arg_idx))
-    }
-}
-
-/// Predictaes for use in numeric comparisons.
+/// Predicates for use in numeric comparisons.
 #[deku_derive(DekuRead)]
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[deku(type = "u8")]
@@ -298,7 +285,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_BLOCK")]
     Block(BlockIdx),
     #[deku(id = "OPKIND_ARG")]
-    Arg(ArgOperand),
+    Arg(ArgIdx),
     #[deku(id = "OPKIND_GLOBAL")]
     Global(GlobalOperand),
     #[deku(id = "OPKIND_PREDICATE")]
@@ -354,8 +341,8 @@ impl AotIRDisplay for Operand {
             Self::Type(type_idx) => m.types[*type_idx].to_string(m),
             Self::Func(func_idx) => m.funcs[*func_idx].name.to_owned(),
             Self::Block(bb_idx) => format!("bb{}", usize::from(*bb_idx)),
+            Self::Arg(arg_idx) => format!("$arg{}", usize::from(*arg_idx)),
             Self::Global(g) => g.to_string(m),
-            Self::Arg(a) => a.to_string(m),
             Self::Predicate(p) => p.to_string(m),
             Self::Unimplemented(s) => format!("?op<{}>", s),
         }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -241,25 +241,6 @@ impl AotIRDisplay for Predicate {
     }
 }
 
-/// A global variable operand.
-#[deku_derive(DekuRead)]
-#[derive(Debug)]
-pub(crate) struct GlobalOperand {
-    global_decl_idx: GlobalDeclIdx,
-}
-
-impl GlobalOperand {
-    pub(crate) fn index(&self) -> GlobalDeclIdx {
-        self.global_decl_idx
-    }
-}
-
-impl AotIRDisplay for GlobalOperand {
-    fn to_string(&self, m: &Module) -> String {
-        m.global_decls[self.global_decl_idx].to_string(m)
-    }
-}
-
 const OPKIND_CONST: u8 = 0;
 const OPKIND_LOCAL_VARIABLE: u8 = 1;
 const OPKIND_TYPE: u8 = 2;
@@ -287,7 +268,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_ARG")]
     Arg(ArgIdx),
     #[deku(id = "OPKIND_GLOBAL")]
-    Global(GlobalOperand),
+    Global(GlobalDeclIdx),
     #[deku(id = "OPKIND_PREDICATE")]
     Predicate(Predicate),
     #[deku(id = "OPKIND_UNIMPLEMENTED")]
@@ -342,7 +323,7 @@ impl AotIRDisplay for Operand {
             Self::Func(func_idx) => m.funcs[*func_idx].name.to_owned(),
             Self::Block(bb_idx) => format!("bb{}", usize::from(*bb_idx)),
             Self::Arg(arg_idx) => format!("$arg{}", usize::from(*arg_idx)),
-            Self::Global(g) => g.to_string(m),
+            Self::Global(gd_idx) => m.global_decls[*gd_idx].to_string(m),
             Self::Predicate(p) => p.to_string(m),
             Self::Unimplemented(s) => format!("?op<{}>", s),
         }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -219,12 +219,6 @@ impl BlockID {
 
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
-pub(crate) struct TypeOperand {
-    type_idx: TypeIdx,
-}
-
-#[deku_derive(DekuRead)]
-#[derive(Debug)]
 pub(crate) struct BlockOperand {
     pub(crate) bb_idx: BlockIdx,
 }
@@ -316,7 +310,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_LOCAL_VARIABLE")]
     LocalVariable(InstructionID),
     #[deku(id = "OPKIND_TYPE")]
-    Type(TypeOperand),
+    Type(TypeIdx),
     #[deku(id = "OPKIND_FUNC")]
     Func(FuncOperand),
     #[deku(id = "OPKIND_BLOCK")]
@@ -353,7 +347,7 @@ impl Operand {
                 // The `unwrap` can't fail for a `LocalVariable`.
                 self.to_instr(m).def_type(m).unwrap()
             }
-            Self::Type(t) => m.type_(t.type_idx),
+            Self::Type(type_idx) => m.type_(*type_idx),
             _ => todo!(),
         }
     }
@@ -375,7 +369,7 @@ impl AotIRDisplay for Operand {
             Self::LocalVariable(iid) => {
                 format!("${}_{}", usize::from(iid.bb_idx), usize::from(iid.inst_idx))
             }
-            Self::Type(t) => m.types[t.type_idx].to_string(m),
+            Self::Type(type_idx) => m.types[*type_idx].to_string(m),
             Self::Func(f) => m.funcs[f.func_idx].name.to_owned(),
             Self::Block(bb) => bb.to_string(m),
             Self::Global(g) => g.to_string(m),

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -217,18 +217,6 @@ impl BlockID {
     }
 }
 
-#[deku_derive(DekuRead)]
-#[derive(Debug)]
-pub(crate) struct BlockOperand {
-    pub(crate) bb_idx: BlockIdx,
-}
-
-impl AotIRDisplay for BlockOperand {
-    fn to_string(&self, _m: &Module) -> String {
-        format!("bb{}", usize::from(self.bb_idx))
-    }
-}
-
 /// An operand that is an argument to the parent function.
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
@@ -308,7 +296,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_FUNC")]
     Func(FuncIdx),
     #[deku(id = "OPKIND_BLOCK")]
-    Block(BlockOperand),
+    Block(BlockIdx),
     #[deku(id = "OPKIND_ARG")]
     Arg(ArgOperand),
     #[deku(id = "OPKIND_GLOBAL")]
@@ -365,7 +353,7 @@ impl AotIRDisplay for Operand {
             }
             Self::Type(type_idx) => m.types[*type_idx].to_string(m),
             Self::Func(func_idx) => m.funcs[*func_idx].name.to_owned(),
-            Self::Block(bb) => bb.to_string(m),
+            Self::Block(bb_idx) => format!("bb{}", usize::from(*bb_idx)),
             Self::Global(g) => g.to_string(m),
             Self::Arg(a) => a.to_string(m),
             Self::Predicate(p) => p.to_string(m),

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -248,8 +248,8 @@ impl<'a> TraceBuilder<'a> {
                 let jit_const = self.handle_const(self.aot_mod.constant(cidx))?;
                 jit_ir::Operand::Const(self.jit_mod.const_idx(&jit_const)?)
             }
-            aot_ir::Operand::Global(go) => {
-                let load = jit_ir::LookupGlobalInstruction::new(self.handle_global(go.index())?)?;
+            aot_ir::Operand::Global(gd_idx) => {
+                let load = jit_ir::LookupGlobalInstruction::new(self.handle_global(*gd_idx)?)?;
                 self.jit_mod.push_and_make_operand(load.into())?
             }
             aot_ir::Operand::Unimplemented(_) => {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -333,7 +333,7 @@ impl<'a> TraceBuilder<'a> {
             _ => panic!(),
         };
         let succ_bb = match inst.operand(1) {
-            aot_ir::Operand::Block(aot_ir::BlockOperand { bb_idx }) => bb_idx,
+            aot_ir::Operand::Block(bb_idx) => *bb_idx,
             _ => panic!(),
         };
 
@@ -371,7 +371,7 @@ impl<'a> TraceBuilder<'a> {
 
         let gi = jit_ir::GuardInfo::new(smids, lives);
         let gi_idx = self.jit_mod.push_guardinfo(gi)?;
-        let expect = *succ_bb == nextbb.block_idx();
+        let expect = succ_bb == nextbb.block_idx();
         let guard = jit_ir::GuardInstruction::new(jit_ir::Operand::Local(cond), expect, gi_idx);
         self.jit_mod.push(guard.into());
         Ok(())

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -240,8 +240,8 @@ impl<'a> TraceBuilder<'a> {
         op: &aot_ir::Operand,
     ) -> Result<jit_ir::Operand, CompilationError> {
         let ret = match op {
-            aot_ir::Operand::LocalVariable(lvo) => {
-                let instridx = self.local_map[lvo.instr_id()];
+            aot_ir::Operand::LocalVariable(iid) => {
+                let instridx = self.local_map[iid];
                 jit_ir::Operand::Local(instridx)
             }
             aot_ir::Operand::Constant(cidx) => {
@@ -329,9 +329,7 @@ impl<'a> TraceBuilder<'a> {
         nextbb: &aot_ir::BlockID,
     ) -> Result<(), CompilationError> {
         let cond = match &inst.operand(0) {
-            aot_ir::Operand::LocalVariable(aot_ir::LocalVariableOperand(iid)) => {
-                self.local_map[iid]
-            }
+            aot_ir::Operand::LocalVariable(iid) => self.local_map[iid],
             _ => panic!(),
         };
         let succ_bb = match inst.operand(1) {
@@ -364,8 +362,8 @@ impl<'a> TraceBuilder<'a> {
         }
         for op in sm.remaining_operands(3) {
             match op {
-                aot_ir::Operand::LocalVariable(lvo) => {
-                    lives.push(self.local_map[&lvo.0]);
+                aot_ir::Operand::LocalVariable(iid) => {
+                    lives.push(self.local_map[iid]);
                 }
                 _ => panic!(),
             }


### PR DESCRIPTION
It now seems fairly clear that most of the `struct *Operand` structs aren't serving a useful structural purpose, in that their variants in `enum Operand` adequately disambiguate things. This PR inlines those structs.