### PR TITLE
Consistent basic block naming

### DIFF
--- a/ykrt/src/compile/jitc_llvm/mod.rs
+++ b/ykrt/src/compile/jitc_llvm/mod.rs
@@ -1,4 +1,4 @@
-//! An LLVM JIT backend. Currently a minimal wrapper around the fact that [MappedAOTBlockTrace]s are hardcoded
+//! An LLVM JIT backend. Currently a minimal wrapper around the fact that [MappedAOTBBlockTrace]s are hardcoded
 //! to be compiled with LLVM.
 
 use crate::{
@@ -325,14 +325,14 @@ impl JITCLLVM {
         let mut bbs = Vec::with_capacity(trace_len);
         for blk in irtrace {
             match blk {
-                TraceAction::MappedAOTBlock { func_name, bb } => {
+                TraceAction::MappedAOTBBlock { func_name, bb } => {
                     func_names.push(func_name.as_ptr());
                     bbs.push(*bb);
                 }
-                TraceAction::UnmappableBlock => {
+                TraceAction::UnmappableBBlock => {
                     // The block was unmappable. Indicate this with a null function name.
                     func_names.push(ptr::null());
-                    // Block indices for unmappable blocks are irrelevant so we may pass anything here.
+                    // BBlock indices for unmappable blocks are irrelevant so we may pass anything here.
                     bbs.push(0);
                 }
                 TraceAction::Promotion => todo!(),

--- a/ykrt/src/compile/jitc_llvm/mod.rs
+++ b/ykrt/src/compile/jitc_llvm/mod.rs
@@ -332,7 +332,8 @@ impl JITCLLVM {
                 TraceAction::UnmappableBBlock => {
                     // The block was unmappable. Indicate this with a null function name.
                     func_names.push(ptr::null());
-                    // BBlock indices for unmappable blocks are irrelevant so we may pass anything here.
+                    // BBlock indices for unmappable basic blocks are irrelevant so we may pass
+                    // anything here.
                     bbs.push(0);
                 }
                 TraceAction::Promotion => todo!(),

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -193,27 +193,24 @@ impl InstructionID {
 #[derive(Debug, PartialEq)]
 pub(crate) struct BlockID {
     func_idx: FuncIdx,
-    block_idx: BBIdx,
+    bb_idx: BBIdx,
 }
 
 impl BlockID {
-    pub(crate) fn new(func_idx: FuncIdx, block_idx: BBIdx) -> Self {
-        Self {
-            func_idx,
-            block_idx,
-        }
+    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBIdx) -> Self {
+        Self { func_idx, bb_idx }
     }
 
     pub(crate) fn func_idx(&self) -> FuncIdx {
         self.func_idx
     }
 
-    pub(crate) fn block_idx(&self) -> BBIdx {
-        self.block_idx
+    pub(crate) fn bb_idx(&self) -> BBIdx {
+        self.bb_idx
     }
 
     pub(crate) fn is_entry(&self) -> bool {
-        self.block_idx == BBIdx(0)
+        self.bb_idx == BBIdx(0)
     }
 }
 
@@ -1009,7 +1006,7 @@ impl Module {
 
     /// Return the block uniquely identified (in this module) by the specified [BlockID].
     pub(crate) fn block(&self, bid: &BlockID) -> &Block {
-        self.funcs[bid.func_idx].block(bid.block_idx)
+        self.funcs[bid.func_idx].block(bid.bb_idx)
     }
 
     /// Fill in the function index of local variable operands of instructions.

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -191,12 +191,12 @@ impl InstructionID {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct BlockID {
+pub(crate) struct BBlockId {
     func_idx: FuncIdx,
     bb_idx: BBIdx,
 }
 
-impl BlockID {
+impl BBlockId {
     pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBIdx) -> Self {
         Self { func_idx, bb_idx }
     }
@@ -1004,8 +1004,8 @@ impl Module {
             .unwrap()
     }
 
-    /// Return the block uniquely identified (in this module) by the specified [BlockID].
-    pub(crate) fn block(&self, bid: &BlockID) -> &Block {
+    /// Return the block uniquely identified (in this module) by the specified [BBlockId].
+    pub(crate) fn block(&self, bid: &BBlockId) -> &Block {
         self.funcs[bid.func_idx].block(bid.bb_idx)
     }
 

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -65,7 +65,7 @@ index!(TypeIdx);
 pub(crate) struct BBIdx(usize);
 index!(BBIdx);
 
-/// An index into [Block::instrs].
+/// An index into [BBlock::instrs].
 #[deku_derive(DekuRead)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct InstrIdx(usize);
@@ -261,7 +261,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_FUNC")]
     Func(FuncIdx),
     #[deku(id = "OPKIND_BLOCK")]
-    Block(BBIdx),
+    BBlock(BBIdx),
     #[deku(id = "OPKIND_ARG")]
     Arg(ArgIdx),
     #[deku(id = "OPKIND_GLOBAL")]
@@ -318,7 +318,7 @@ impl AotIRDisplay for Operand {
             }
             Self::Type(type_idx) => m.types[*type_idx].to_string(m),
             Self::Func(func_idx) => m.funcs[*func_idx].name.to_owned(),
-            Self::Block(bb_idx) => format!("bb{}", usize::from(*bb_idx)),
+            Self::BBlock(bb_idx) => format!("bb{}", usize::from(*bb_idx)),
             Self::Arg(arg_idx) => format!("$arg{}", usize::from(*arg_idx)),
             Self::Global(gd_idx) => m.global_decls[*gd_idx].to_string(m),
             Self::Predicate(p) => p.to_string(m),
@@ -510,14 +510,14 @@ impl AotIRDisplay for Instruction {
 /// A basic block containing bytecode instructions.
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
-pub(crate) struct Block {
+pub(crate) struct BBlock {
     #[deku(temp)]
     num_instrs: usize,
     #[deku(count = "num_instrs", map = "deserialise_into_ti_vec")]
     pub(crate) instrs: TiVec<InstrIdx, Instruction>,
 }
 
-impl AotIRDisplay for Block {
+impl AotIRDisplay for BBlock {
     fn to_string(&self, m: &Module) -> String {
         let mut ret = String::new();
         for i in &self.instrs {
@@ -537,7 +537,7 @@ pub(crate) struct Func {
     #[deku(temp)]
     num_blocks: usize,
     #[deku(count = "num_blocks", map = "deserialise_into_ti_vec")]
-    blocks: TiVec<BBIdx, Block>,
+    blocks: TiVec<BBIdx, BBlock>,
 }
 
 impl Func {
@@ -545,12 +545,12 @@ impl Func {
         self.blocks.is_empty()
     }
 
-    /// Return the [Block] at the specified index.
+    /// Return the [BBlock] at the specified index.
     ///
     /// # Panics
     ///
     /// Panics if the index is out of range.
-    pub(crate) fn block(&self, bb_idx: BBIdx) -> &Block {
+    pub(crate) fn block(&self, bb_idx: BBIdx) -> &BBlock {
         &self.blocks[bb_idx]
     }
 
@@ -1005,7 +1005,7 @@ impl Module {
     }
 
     /// Return the block uniquely identified (in this module) by the specified [BBlockId].
-    pub(crate) fn block(&self, bid: &BBlockId) -> &Block {
+    pub(crate) fn block(&self, bid: &BBlockId) -> &BBlock {
         self.funcs[bid.func_idx].block(bid.bb_idx)
     }
 

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -550,7 +550,7 @@ impl Func {
     /// # Panics
     ///
     /// Panics if the index is out of range.
-    pub(crate) fn block(&self, bb_idx: BBIdx) -> &BBlock {
+    pub(crate) fn bblock(&self, bb_idx: BBIdx) -> &BBlock {
         &self.bblocks[bb_idx]
     }
 
@@ -1005,8 +1005,8 @@ impl Module {
     }
 
     /// Return the block uniquely identified (in this module) by the specified [BBlockId].
-    pub(crate) fn block(&self, bid: &BBlockId) -> &BBlock {
-        self.funcs[bid.func_idx].block(bid.bb_idx)
+    pub(crate) fn bblock(&self, bid: &BBlockId) -> &BBlock {
+        self.funcs[bid.func_idx].bblock(bid.bb_idx)
     }
 
     /// Fill in the function index of local variable operands of instructions.

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -62,8 +62,8 @@ index!(TypeIdx);
 /// An index into [Func::blocks].
 #[deku_derive(DekuRead)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct BlockIdx(usize);
-index!(BlockIdx);
+pub(crate) struct BBIdx(usize);
+index!(BBIdx);
 
 /// An index into [Block::instrs].
 #[deku_derive(DekuRead)]
@@ -176,12 +176,12 @@ impl AotIRDisplay for Opcode {
 pub(crate) struct InstructionID {
     #[deku(skip)] // computed after deserialisation.
     func_idx: FuncIdx,
-    bb_idx: BlockIdx,
+    bb_idx: BBIdx,
     inst_idx: InstrIdx,
 }
 
 impl InstructionID {
-    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BlockIdx, inst_idx: InstrIdx) -> Self {
+    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBIdx, inst_idx: InstrIdx) -> Self {
         Self {
             func_idx,
             bb_idx,
@@ -193,11 +193,11 @@ impl InstructionID {
 #[derive(Debug, PartialEq)]
 pub(crate) struct BlockID {
     func_idx: FuncIdx,
-    block_idx: BlockIdx,
+    block_idx: BBIdx,
 }
 
 impl BlockID {
-    pub(crate) fn new(func_idx: FuncIdx, block_idx: BlockIdx) -> Self {
+    pub(crate) fn new(func_idx: FuncIdx, block_idx: BBIdx) -> Self {
         Self {
             func_idx,
             block_idx,
@@ -208,12 +208,12 @@ impl BlockID {
         self.func_idx
     }
 
-    pub(crate) fn block_idx(&self) -> BlockIdx {
+    pub(crate) fn block_idx(&self) -> BBIdx {
         self.block_idx
     }
 
     pub(crate) fn is_entry(&self) -> bool {
-        self.block_idx == BlockIdx(0)
+        self.block_idx == BBIdx(0)
     }
 }
 
@@ -264,7 +264,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_FUNC")]
     Func(FuncIdx),
     #[deku(id = "OPKIND_BLOCK")]
-    Block(BlockIdx),
+    Block(BBIdx),
     #[deku(id = "OPKIND_ARG")]
     Arg(ArgIdx),
     #[deku(id = "OPKIND_GLOBAL")]
@@ -540,7 +540,7 @@ pub(crate) struct Func {
     #[deku(temp)]
     num_blocks: usize,
     #[deku(count = "num_blocks", map = "deserialise_into_ti_vec")]
-    blocks: TiVec<BlockIdx, Block>,
+    blocks: TiVec<BBIdx, Block>,
 }
 
 impl Func {
@@ -553,7 +553,7 @@ impl Func {
     /// # Panics
     ///
     /// Panics if the index is out of range.
-    pub(crate) fn block(&self, bb_idx: BlockIdx) -> &Block {
+    pub(crate) fn block(&self, bb_idx: BBIdx) -> &Block {
         &self.blocks[bb_idx]
     }
 

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -62,8 +62,8 @@ index!(TypeIdx);
 /// An index into [Func::bblocks].
 #[deku_derive(DekuRead)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct BBIdx(usize);
-index!(BBIdx);
+pub(crate) struct BBlockIdx(usize);
+index!(BBlockIdx);
 
 /// An index into [BBlock::instrs].
 #[deku_derive(DekuRead)]
@@ -176,12 +176,12 @@ impl AotIRDisplay for Opcode {
 pub(crate) struct InstructionID {
     #[deku(skip)] // computed after deserialisation.
     func_idx: FuncIdx,
-    bb_idx: BBIdx,
+    bb_idx: BBlockIdx,
     inst_idx: InstrIdx,
 }
 
 impl InstructionID {
-    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBIdx, inst_idx: InstrIdx) -> Self {
+    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBlockIdx, inst_idx: InstrIdx) -> Self {
         Self {
             func_idx,
             bb_idx,
@@ -193,11 +193,11 @@ impl InstructionID {
 #[derive(Debug, PartialEq)]
 pub(crate) struct BBlockId {
     func_idx: FuncIdx,
-    bb_idx: BBIdx,
+    bb_idx: BBlockIdx,
 }
 
 impl BBlockId {
-    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBIdx) -> Self {
+    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBlockIdx) -> Self {
         Self { func_idx, bb_idx }
     }
 
@@ -205,12 +205,12 @@ impl BBlockId {
         self.func_idx
     }
 
-    pub(crate) fn bb_idx(&self) -> BBIdx {
+    pub(crate) fn bb_idx(&self) -> BBlockIdx {
         self.bb_idx
     }
 
     pub(crate) fn is_entry(&self) -> bool {
-        self.bb_idx == BBIdx(0)
+        self.bb_idx == BBlockIdx(0)
     }
 }
 
@@ -261,7 +261,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_FUNC")]
     Func(FuncIdx),
     #[deku(id = "OPKIND_BLOCK")]
-    BBlock(BBIdx),
+    BBlock(BBlockIdx),
     #[deku(id = "OPKIND_ARG")]
     Arg(ArgIdx),
     #[deku(id = "OPKIND_GLOBAL")]
@@ -537,7 +537,7 @@ pub(crate) struct Func {
     #[deku(temp)]
     num_bblocks: usize,
     #[deku(count = "num_bblocks", map = "deserialise_into_ti_vec")]
-    bblocks: TiVec<BBIdx, BBlock>,
+    bblocks: TiVec<BBlockIdx, BBlock>,
 }
 
 impl Func {
@@ -550,7 +550,7 @@ impl Func {
     /// # Panics
     ///
     /// Panics if the index is out of range.
-    pub(crate) fn bblock(&self, bb_idx: BBIdx) -> &BBlock {
+    pub(crate) fn bblock(&self, bb_idx: BBlockIdx) -> &BBlock {
         &self.bblocks[bb_idx]
     }
 

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -68,7 +68,7 @@ impl<'a> TraceBuilder<'a> {
             TraceAction::MappedAOTBlock { func_name, bb } => {
                 let func_name = func_name.to_str().unwrap(); // safe: func names are valid UTF-8.
                 let func = self.aot_mod.func_idx(func_name);
-                Some(aot_ir::BlockID::new(func, aot_ir::BlockIdx::new(*bb)))
+                Some(aot_ir::BlockID::new(func, aot_ir::BBIdx::new(*bb)))
             }
             TraceAction::UnmappableBlock { .. } => None,
             TraceAction::Promotion => todo!(),

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -21,8 +21,8 @@ impl Frame<'_> {
     }
 }
 
-/// Given a mapped trace and an AOT module, assembles an in-memory Yk IR trace by copying blocks
-/// from the AOT IR. The output of this process will be the input to the code generator.
+/// Given a mapped trace and an AOT module, assembles an in-memory Yk IR trace by copying basic
+/// blocks from the AOT IR. The output of this process will be the input to the code generator.
 struct TraceBuilder<'a> {
     /// The AOR IR.
     aot_mod: &'a Module,
@@ -606,8 +606,8 @@ impl<'a> TraceBuilder<'a> {
                             self.last_block_mappable = false;
                             // UnmappableBBlock block
                             // Ignore for now. May be later used to make sense of the control flow. Though
-                            // ideally we remove unmappable blocks from the trace so we can handle software
-                            // and hardware traces the same.
+                            // ideally we remove unmappable basic blocks from the trace so we can
+                            // handle software and hardware traces the same.
                         }
                     }
                 }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -208,7 +208,7 @@ impl<'a> TraceBuilder<'a> {
         if jit_inst.def_type(&self.jit_mod).is_some() {
             let aot_iid = aot_ir::InstructionID::new(
                 bid.func_idx(),
-                bid.block_idx(),
+                bid.bb_idx(),
                 aot_ir::InstrIdx::new(aot_inst_idx),
             );
             self.local_map.insert(aot_iid, self.next_instr_id()?);
@@ -396,7 +396,7 @@ impl<'a> TraceBuilder<'a> {
 
         let gi = jit_ir::GuardInfo::new(smids, lives);
         let gi_idx = self.jit_mod.push_guardinfo(gi)?;
-        let expect = succ_bb == nextbb.block_idx();
+        let expect = succ_bb == nextbb.bb_idx();
         let guard = jit_ir::GuardInstruction::new(jit_ir::Operand::Local(cond), expect, gi_idx);
         self.jit_mod.push(guard.into());
         Ok(())

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -165,7 +165,7 @@ impl<'a> TraceBuilder<'a> {
     ) -> Result<(), CompilationError> {
         // unwrap safe: can't trace a block not in the AOT module.
         self.last_instr_return = false;
-        let blk = self.aot_mod.block(&bid);
+        let blk = self.aot_mod.bblock(&bid);
 
         // Decide how to translate each AOT instruction based upon its opcode.
         for (inst_idx, inst) in blk.instrs.iter().enumerate() {
@@ -555,7 +555,7 @@ impl<'a> TraceBuilder<'a> {
         self.cp_block = self.lookup_aot_block(&prev);
         // This unwrap can't fail. If it does that means the tracer has given us a mappable block
         // that doesn't exist in the AOT module.
-        self.create_trace_header(self.aot_mod.block(self.cp_block.as_ref().unwrap()))?;
+        self.create_trace_header(self.aot_mod.bblock(self.cp_block.as_ref().unwrap()))?;
 
         while let Some(tblk) = trace_iter.next() {
             match tblk {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -68,7 +68,7 @@ impl<'a> TraceBuilder<'a> {
             TraceAction::MappedAOTBBlock { func_name, bb } => {
                 let func_name = func_name.to_str().unwrap(); // safe: func names are valid UTF-8.
                 let func = self.aot_mod.func_idx(func_name);
-                Some(aot_ir::BBlockId::new(func, aot_ir::BBIdx::new(*bb)))
+                Some(aot_ir::BBlockId::new(func, aot_ir::BBlockIdx::new(*bb)))
             }
             TraceAction::UnmappableBBlock { .. } => None,
             TraceAction::Promotion => todo!(),

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -43,7 +43,7 @@ type AtomicHotThreshold = AtomicU32;
 pub type TraceFailureThreshold = u16;
 pub type AtomicTraceFailureThreshold = AtomicU16;
 
-/// How many blocks long can a trace be before we give up trying to compile it? Note that the
+/// How many basic blocks long can a trace be before we give up trying to compile it? Note that the
 /// slower our compiler, the lower this will have to be in order to give the perception of
 /// reasonable performance.
 /// FIXME: needs to be configurable.

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -7,7 +7,7 @@ use ykaddr::{
     obj::SELF_BIN_PATH,
 };
 
-/// Map the *machine* blocks of the specified trace into LLVM IR blocks.
+/// Map the *machine* basic blocks of the specified trace into LLVM IR basic blocks.
 ///
 /// Each entry in the returned trace is either a "mapped block" identifying a successfully
 /// mapped LLVM IR block, or an unsuccessfully mapped "unmappable block" (an unknown region of
@@ -15,7 +15,7 @@ use ykaddr::{
 pub(crate) struct HWTTraceIterator {
     hwt_iter: Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send>,
     /// The next [TraceAction]`s we will produce when `next` is called. We need this intermediary
-    /// to allow us to deduplicate mapped/unmapped blocks. This will be empty on the first
+    /// to allow us to deduplicate mapped/unmapped basic blocks. This will be empty on the first
     /// iteration and from then on will always have at least one [TraceAction] in it at all times,
     /// since we only need to check if the next [TraceAction] is a duplicate of the last element in
     /// this `Vec`.
@@ -103,12 +103,13 @@ impl HWTTraceIterator {
         }
     }
 
-    /// Maps one hwtracer block to one or more AOT LLVM IR blocks.
+    /// Maps one hwtracer block to one or more AOT LLVM IR basic blocks.
     ///
-    /// Mapping an hwtracer block to AOT LLVM IR blocks occurs in two phases. First the mapper
-    /// tries to find machine blocks whose address ranges overlap with the address range of the
-    /// hwtracer block (by using the LLVM block address map section). Once machine blocks have been
-    /// found, the mapper then tries to find which LLVM IR blocks the machine blocks are part of.
+    /// Mapping an hwtracer basic block to AOT LLVM IR basic blocks occurs in two phases. First the
+    /// mapper tries to find machine basic blocks whose address ranges overlap with the address
+    /// range of the hwtracer block (by using the LLVM block address map section). Once machine
+    /// basic blocks have been found, the mapper then tries to find which LLVM IR basic blocks the
+    /// machine basic blocks are part of.
     ///
     /// A `Some` element in the returned vector means that the mapper found a machine block that
     /// maps to part of the hwtracer block and that the machine block could be directly mapped
@@ -117,16 +118,17 @@ impl HWTTraceIterator {
     /// A `None` element in the returned vector means that the mapper found a machine block that
     /// corresponds with part of the hwtracer block but that the machine block could *not* be
     /// directly mapped to an AOT LLVM IR block. This happens when
-    /// `MachineBasicBlock::getBasicBBlock()` returns `nullptr`.
+    /// `MachineBasicBlock::getBasicBlock()` returns `nullptr`.
     ///
     /// This function returns an empty vector if the hwtracer block was unmappable (no matching
-    /// machine blocks could be found).
+    /// machine basic blocks could be found).
     ///
     /// The reason we cannot simply ignore the `None` case is that it is important to differentiate
-    /// "there were no matching machine blocks" from "there were matching machine blocks, but we
-    /// were unable to find IR blocks for them".
+    /// "there were no matching machine basic blocks" from "there were matching machine basic
+    /// blocks, but we were unable to find IR basic blocks for them".
     ///
-    /// The reason that there may be many corresponding blocks is due to the following scenario.
+    /// The reason that there may be many corresponding basic blocks is due to the following
+    /// scenario.
     ///
     /// Suppose that the LLVM IR looked like this:
     ///
@@ -138,12 +140,12 @@ impl HWTTraceIterator {
     ///
     /// During codegen LLVM may remove the unconditional jump and simply place bb1 and bb2
     /// consecutively, allowing bb1 to fall-thru to bb2. In the eyes of hwtracer, a fall-thru does
-    /// not terminate a block, so whereas LLVM sees two blocks, hwtracer sees only one.
+    /// not terminate a block, so whereas LLVM sees two basic blocks, hwtracer sees only one.
     fn map_block(&mut self, block: &hwtracer::Block) {
         let b_rng = block.vaddr_range();
         if b_rng.is_none() {
             // If the address range of the block isn't known, then it follows that we can't map
-            // back to an IRBBlock. We return the empty vector to flag this.
+            // back to an IRBlock. We return the empty vector to flag this.
             self.push_upcoming(TraceAction::new_unmappable_block());
             return;
         }
@@ -168,20 +170,21 @@ impl HWTTraceIterator {
             .query(block_off, block_off + block_len)
             .collect::<Vec<_>>();
 
-        // In the case that an hwtracer block maps to multiple machine blocks, it may be tempting
-        // to check that they are at consecutive address ranges. Unfortunately we can't do this
-        // because LLVM sometimes appends `nop` sleds (e.g. `nop word cs:[rax + rax]; nop`) to the
-        // ends of blocks for alignment. This padding is not reflected in the LLVM block address
-        // map, so blocks may not appear consecutive.
+        // In the case that an hwtracer block maps to multiple machine basic blocks, it may be
+        // tempting to check that they are at consecutive address ranges. Unfortunately we can't do
+        // this because LLVM sometimes appends `nop` sleds (e.g. `nop word cs:[rax + rax]; nop`) to
+        // the ends of basic blocks for alignment. This padding is not reflected in the LLVM block
+        // address map, so basic blocks may not appear consecutive.
         ents.sort_by(|x, y| x.range.start.partial_cmp(&y.range.start).unwrap());
         for ent in ents {
             if !ent.value.corr_bbs().is_empty() {
                 // OPT: This could probably be sped up with caching. If we use an interval tree
                 // keyed virtual address ranges, then we could take advantage of the fact that all
-                // blocks belonging to the same function will fall within the address range of the
-                // function's symbol. If the cache knows that block A and B are from the same
-                // function, and a block X has a start address between blocks A and B, then X must
-                // also belong to the same function and there's no need to query the linker.
+                // basic blocks belonging to the same function will fall within the address range
+                // of the function's symbol. If the cache knows that block A and B are from the
+                // same function, and a block X has a start address between basic blocks A and B,
+                // then X must also belong to the same function and there's no need to query the
+                // linker.
                 // FIXME: Is this `unwrap` safe?
                 let sio = vaddr_to_sym_and_obj(usize::try_from(block_vaddr).unwrap()).unwrap();
                 debug_assert_eq!(
@@ -199,12 +202,13 @@ impl HWTTraceIterator {
                 }
             }
             // If we got here, it is because part of an hwtracer block mapped to a machine block in the
-            // LLVM block address map, but the machine block has no corresponding AOT LLVM IR blocks.
+            // LLVM block address map, but the machine block has no corresponding AOT LLVM IR basic
+            // blocks.
             //
             // FIXME: https://github.com/ykjit/yk/issues/388 We *think* this happens because LLVM can
             // introduce extra `MachineBasicBlock`s to help with laying out machine code. If that's the
-            // case, then for our purposes these extra blocks can be ignored. However, we should really
-            // investigate to be sure.
+            // case, then for our purposes these extra basic blocks can be ignored. However, we
+            // should really investigate to be sure.
         }
     }
 
@@ -214,12 +218,12 @@ impl HWTTraceIterator {
     ///
     /// Note that duplication can happen for two reasons:
     ///
-    ///   1. Repeated unmappable blocks.
-    ///   2. Repeated mappable blocks. The `BlockDisambiguate` pass in ykllvm ensures that no
+    ///   1. Repeated unmappable basic blocks.
+    ///   2. Repeated mappable basic blocks. The `BlockDisambiguate` pass in ykllvm ensures that no
     ///      high-level LLVM IR block ever branches straight back to itself, so if we see the same
     ///      high-level block more than once consecutively in a trace, then we know that the IR
-    ///      block has been lowered to multiple machine blocks during code-gen, and that we should
-    ///      only push the IR block once.
+    ///      block has been lowered to multiple machine basic blocks during code-gen, and that we
+    ///      should only push the IR block once.
     fn push_upcoming(&mut self, new: TraceAction) {
         if self.upcoming.last() != Some(&new) {
             self.upcoming.push(new);

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -53,7 +53,7 @@ impl Iterator for HWTTraceIterator {
                         Some(x) => {
                             // This is a rough proxy for "check that we removed only the thing we want to
                             // remove".
-                            assert!(matches!(x, TraceAction::UnmappableBlock));
+                            assert!(matches!(x, TraceAction::UnmappableBBlock));
                         }
                         _ => unreachable!(),
                     }
@@ -88,7 +88,7 @@ impl HWTTraceIterator {
             Some(Ok(x)) => {
                 hwti.map_block(&x);
                 match hwti.upcoming.as_slice() {
-                    &[TraceAction::MappedAOTBlock { .. }] => {
+                    &[TraceAction::MappedAOTBBlock { .. }] => {
                         hwti.upcoming.pop();
                         Ok(hwti)
                     }
@@ -117,7 +117,7 @@ impl HWTTraceIterator {
     /// A `None` element in the returned vector means that the mapper found a machine block that
     /// corresponds with part of the hwtracer block but that the machine block could *not* be
     /// directly mapped to an AOT LLVM IR block. This happens when
-    /// `MachineBasicBlock::getBasicBlock()` returns `nullptr`.
+    /// `MachineBasicBlock::getBasicBBlock()` returns `nullptr`.
     ///
     /// This function returns an empty vector if the hwtracer block was unmappable (no matching
     /// machine blocks could be found).
@@ -143,7 +143,7 @@ impl HWTTraceIterator {
         let b_rng = block.vaddr_range();
         if b_rng.is_none() {
             // If the address range of the block isn't known, then it follows that we can't map
-            // back to an IRBlock. We return the empty vector to flag this.
+            // back to an IRBBlock. We return the empty vector to flag this.
             self.push_upcoming(TraceAction::new_unmappable_block());
             return;
         }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -100,7 +100,7 @@ pub(crate) enum AOTTraceIteratorError {
 #[derive(Debug, Eq, PartialEq)]
 pub enum TraceAction {
     /// A sucessfully mapped block.
-    MappedAOTBlock {
+    MappedAOTBBlock {
         /// The name of the function containing the block.
         ///
         /// PERF: Use a string pool to avoid duplicated function names in traces.
@@ -111,7 +111,7 @@ pub enum TraceAction {
     /// One or more machine blocks that could not be mapped.
     ///
     /// This usually means that the blocks were compiled outside of ykllvm.
-    UnmappableBlock,
+    UnmappableBBlock,
     /// A value promoted and recorded within the low-level trace (e.g. `PTWRITE`). In essence these
     /// are calls to `yk_promote` that have been inlined so that the tracer backend can handle them
     /// rather than being handled by yk's generic run-time support for `yk_promote`.
@@ -123,10 +123,10 @@ pub enum TraceAction {
 
 impl TraceAction {
     pub fn new_mapped_aot_block(func_name: CString, bb: usize) -> Self {
-        Self::MappedAOTBlock { func_name, bb }
+        Self::MappedAOTBBlock { func_name, bb }
     }
 
     pub fn new_unmappable_block() -> Self {
-        Self::UnmappableBlock
+        Self::UnmappableBBlock
     }
 }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -108,9 +108,9 @@ pub enum TraceAction {
         /// The index of the block within the function.
         bb: usize,
     },
-    /// One or more machine blocks that could not be mapped.
+    /// One or more machine basic blocks that could not be mapped.
     ///
-    /// This usually means that the blocks were compiled outside of ykllvm.
+    /// This usually means that the basic blocks were compiled outside of ykllvm.
     UnmappableBBlock,
     /// A value promoted and recorded within the low-level trace (e.g. `PTWRITE`). In essence these
     /// are calls to `yk_promote` that have been inlined so that the tracer backend can handle them

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -42,7 +42,7 @@ static FUNC_NAMES: LazyLock<HashMap<usize, CString>> = LazyLock::new(|| {
 });
 
 thread_local! {
-    // Collection of traced basicblocks.
+    // Collection of traced basic blocks.
     static BASIC_BLOCKS: RefCell<Vec<TracingBBlock>> = RefCell::new(vec![]);
 }
 

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-struct TracingBlock {
+struct TracingBBlock {
     function_index: usize,
     block_index: usize,
 }
@@ -43,7 +43,7 @@ static FUNC_NAMES: LazyLock<HashMap<usize, CString>> = LazyLock::new(|| {
 
 thread_local! {
     // Collection of traced basicblocks.
-    static BASIC_BLOCKS: RefCell<Vec<TracingBlock>> = RefCell::new(vec![]);
+    static BASIC_BLOCKS: RefCell<Vec<TracingBBlock>> = RefCell::new(vec![]);
 }
 
 /// Inserts LLVM IR basicblock metadata into a thread-local BASIC_BLOCKS vector.
@@ -57,7 +57,7 @@ pub extern "C" fn yk_trace_basicblock(function_index: usize, block_index: usize)
     MTThread::with(|mtt| {
         if mtt.is_tracing() {
             BASIC_BLOCKS.with(|v| {
-                v.borrow_mut().push(TracingBlock {
+                v.borrow_mut().push(TracingBBlock {
                     function_index,
                     block_index,
                 });
@@ -113,11 +113,11 @@ impl TraceRecorder for SWTTraceRecorder {
 }
 
 struct SWTraceIterator {
-    bbs: std::vec::IntoIter<TracingBlock>,
+    bbs: std::vec::IntoIter<TracingBBlock>,
 }
 
 impl SWTraceIterator {
-    fn new(bbs: Vec<TracingBlock>) -> SWTraceIterator {
+    fn new(bbs: Vec<TracingBBlock>) -> SWTraceIterator {
         return SWTraceIterator {
             bbs: bbs.into_iter(),
         };
@@ -131,7 +131,7 @@ impl Iterator for SWTraceIterator {
         self.bbs
             .next()
             .map(|tb| match FUNC_NAMES.get(&tb.function_index) {
-                Some(name) => Ok(TraceAction::MappedAOTBlock {
+                Some(name) => Ok(TraceAction::MappedAOTBBlock {
                     func_name: name.to_owned(),
                     bb: tb.block_index,
                 }),


### PR DESCRIPTION
Previously we were inconsistent in using "block" or "basic block" as our terminology, including in type names and attributes. This PR moves [*] most of yk across to "basic block". Most of this PR is `srep`, but a number of manual changes were necessary, including, but not only, in comments.

[*] Except hwtracer because I don't want to poke that beast for other reasons.