### PR TITLE
Rename "deserialise" to "map"

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -103,8 +103,10 @@ fn deserialise_string(v: Vec<u8>) -> Result<String, DekuError> {
     }
 }
 
-/// Helper function to convert a vector into a `TiVec` during deku parsing.
-fn deserialise_into_ti_vec<I, T>(v: Vec<T>) -> Result<TiVec<I, T>, DekuError> {
+/// Helper function for deku `map` attribute. It is necessary to write all the types out in full to
+/// avoid type inference errors, so it's easier to have a single helper function rather than inline
+/// this into each `map` attribute.
+fn map_to_tivec<I, T>(v: Vec<T>) -> Result<TiVec<I, T>, DekuError> {
     Ok(TiVec::from(v))
 }
 
@@ -513,7 +515,7 @@ impl AotIRDisplay for Instruction {
 pub(crate) struct BBlock {
     #[deku(temp)]
     num_instrs: usize,
-    #[deku(count = "num_instrs", map = "deserialise_into_ti_vec")]
+    #[deku(count = "num_instrs", map = "map_to_tivec")]
     pub(crate) instrs: TiVec<InstrIdx, Instruction>,
 }
 
@@ -536,7 +538,7 @@ pub(crate) struct Func {
     type_idx: TypeIdx,
     #[deku(temp)]
     num_bblocks: usize,
-    #[deku(count = "num_bblocks", map = "deserialise_into_ti_vec")]
+    #[deku(count = "num_bblocks", map = "map_to_tivec")]
     bblocks: TiVec<BBlockIdx, BBlock>,
 }
 
@@ -950,19 +952,19 @@ pub(crate) struct Module {
     version: u32,
     #[deku(temp)]
     num_funcs: usize,
-    #[deku(count = "num_funcs", map = "deserialise_into_ti_vec")]
+    #[deku(count = "num_funcs", map = "map_to_tivec")]
     funcs: TiVec<FuncIdx, Func>,
     #[deku(temp)]
     num_consts: usize,
-    #[deku(count = "num_consts", map = "deserialise_into_ti_vec")]
+    #[deku(count = "num_consts", map = "map_to_tivec")]
     consts: TiVec<ConstIdx, Constant>,
     #[deku(temp)]
     num_global_decls: usize,
-    #[deku(count = "num_global_decls", map = "deserialise_into_ti_vec")]
+    #[deku(count = "num_global_decls", map = "map_to_tivec")]
     global_decls: TiVec<GlobalDeclIdx, GlobalDecl>,
     #[deku(temp)]
     num_types: usize,
-    #[deku(count = "num_types", map = "deserialise_into_ti_vec")]
+    #[deku(count = "num_types", map = "map_to_tivec")]
     types: TiVec<TypeIdx, Type>,
     /// Have local variable names been computed?
     ///

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -92,7 +92,10 @@ index!(GlobalDeclIdx);
 pub(crate) struct ArgIdx(usize);
 index!(ArgIdx);
 
-fn deserialise_string(v: Vec<u8>) -> Result<String, DekuError> {
+/// Helper function for deku `map` attribute. It is necessary to write all the types out in full to
+/// avoid type inference errors, so it's easier to have a single helper function rather than inline
+/// this into each `map` attribute.
+fn map_to_string(v: Vec<u8>) -> Result<String, DekuError> {
     let err = Err(DekuError::Parse("failed to parse string".to_owned()));
     match CStr::from_bytes_until_nul(v.as_slice()) {
         Ok(c) => match c.to_str() {
@@ -271,7 +274,7 @@ pub(crate) enum Operand {
     #[deku(id = "OPKIND_PREDICATE")]
     Predicate(Predicate),
     #[deku(id = "OPKIND_UNIMPLEMENTED")]
-    Unimplemented(#[deku(until = "|v: &u8| *v == 0", map = "deserialise_string")] String),
+    Unimplemented(#[deku(until = "|v: &u8| *v == 0", map = "map_to_string")] String),
 }
 
 impl Operand {
@@ -533,7 +536,7 @@ impl AotIRDisplay for BBlock {
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
 pub(crate) struct Func {
-    #[deku(until = "|v: &u8| *v == 0", map = "deserialise_string")]
+    #[deku(until = "|v: &u8| *v == 0", map = "map_to_string")]
     name: String,
     type_idx: TypeIdx,
     #[deku(temp)]
@@ -836,7 +839,7 @@ pub(crate) enum Type {
     #[deku(id = "TYKIND_STRUCT")]
     Struct(StructType),
     #[deku(id = "TYKIND_UNIMPLEMENTED")]
-    Unimplemented(#[deku(until = "|v: &u8| *v == 0", map = "deserialise_string")] String),
+    Unimplemented(#[deku(until = "|v: &u8| *v == 0", map = "map_to_string")] String),
 }
 
 impl Type {
@@ -918,7 +921,7 @@ impl AotIRDisplay for Constant {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct GlobalDecl {
     is_threadlocal: bool,
-    #[deku(until = "|v: &u8| *v == 0", map = "deserialise_string")]
+    #[deku(until = "|v: &u8| *v == 0", map = "map_to_string")]
     name: String,
 }
 
@@ -1436,7 +1439,7 @@ func bar();
     fn string_deser() {
         let check = |s: &str| {
             assert_eq!(
-                &deserialise_string(CString::new(s).unwrap().into_bytes_with_nul()).unwrap(),
+                &map_to_string(CString::new(s).unwrap().into_bytes_with_nul()).unwrap(),
                 s
             );
         };


### PR DESCRIPTION
This PR renames a couple of "deserialise" functions that are really "map"s, before then optimising one of them (https://github.com/ykjit/yk/commit/350041c257230aae2fbdfc178b44acb884fe7d2c).