### PR TITLE
Remove duplicate binary operation opcode.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -195,7 +195,6 @@ pub(crate) enum Opcode {
     Br,
     CondBr,
     Icmp,
-    BinaryOperator,
     Ret,
     InsertValue,
     PtrAdd,


### PR DESCRIPTION
In my last PR I didn't spot this unused binary operator opcode, and added another.

This kills the unused one.

Requires a ykllvm change, ~~coming in a moment~~: https://github.com/ykjit/ykllvm/pull/131