### PR TITLE
Give compiled traces a unique integer ID.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64.rs
@@ -967,7 +967,7 @@ mod tests {
     use ykaddr::addr::symbol_to_ptr;
 
     fn test_module() -> jit_ir::Module {
-        jit_ir::Module::new_testing("test".into())
+        jit_ir::Module::new_testing()
     }
 
     /// Test helper to use `fm` to match a disassembled trace.

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -47,7 +47,7 @@ impl JITCYk {
 impl Compiler for JITCYk {
     fn compile(
         &self,
-        _mt: Arc<MT>,
+        mt: Arc<MT>,
         aottrace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         sti: Option<SideTraceInfo>,
         _hl: Arc<Mutex<HotLocation>>,
@@ -66,7 +66,7 @@ impl Compiler for JITCYk {
             ));
         }
 
-        let jit_mod = trace_builder::build(&aot_mod, aottrace_iter.0)?;
+        let jit_mod = trace_builder::build(mt.next_compiled_trace_id(), &aot_mod, aottrace_iter.0)?;
 
         if should_log_ir(IRPhase::PreOpt) {
             // FIXME: If the `unwrap` fails, something rather bad has happened: does recovery even

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -24,7 +24,7 @@ impl<'a> Frame<'a> {
 
 /// Given a mapped trace and an AOT module, assembles an in-memory Yk IR trace by copying basic
 /// blocks from the AOT IR. The output of this process will be the input to the code generator.
-struct TraceBuilder<'a> {
+pub(crate) struct TraceBuilder<'a> {
     /// The AOR IR.
     aot_mod: &'a Module,
     /// The JIT IR this struct builds.
@@ -47,13 +47,12 @@ impl<'a> TraceBuilder<'a> {
     /// Create a trace builder.
     ///
     /// Arguments:
-    ///  - `trace_name`: The eventual symbol name for the JITted code.
     ///  - `aot_mod`: The AOT IR module that the trace flows through.
     ///  - `mtrace`: The mapped trace.
-    fn new(trace_name: String, aot_mod: &'a Module) -> Self {
+    fn new(ctr_id: u64, aot_mod: &'a Module) -> Self {
         Self {
             aot_mod,
-            jit_mod: jit_ir::Module::new(trace_name, aot_mod.global_decls_len()),
+            jit_mod: jit_ir::Module::new(ctr_id, aot_mod.global_decls_len()),
             local_map: HashMap::new(),
             cp_block: None,
             first_ti_idx: 0,
@@ -638,11 +637,11 @@ impl<'a> TraceBuilder<'a> {
     }
 }
 
-/// Given a mapped trace (through `aot_mod`), assemble and return a Yk IR trace.
+/// Create JIT IR from the (`aot_mod`, `ta_iter`) tuple.
 pub(super) fn build(
+    ctr_id: u64,
     aot_mod: &Module,
     ta_iter: Box<dyn AOTTraceIterator>,
 ) -> Result<jit_ir::Module, CompilationError> {
-    // FIXME: the XXX below should be a thread-safe monotonically incrementing integer.
-    TraceBuilder::new("__yk_compiled_trace_XXX".into(), aot_mod).build(ta_iter)
+    TraceBuilder::new(ctr_id, aot_mod).build(ta_iter)
 }


### PR DESCRIPTION
In essence this PR fixes this `FIXME`:

> // FIXME: the XXX below should be a thread-safe monotonically incrementing integer.

Note that in testing mode, the ID is meaningless because -- at least so far! -- the JIT IR doesn't need to depend on `MT` and it does make testing easier for that to continue to be the case.