### PR TITLE
Make the Rust `_ykrt_control_point` match the C declaration.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -60,7 +60,7 @@ pub extern "C" fn __ykrt_control_point(
     ctrlp_vars: *mut c_void,
     // Frame address of caller.
     frameaddr: *mut c_void,
-) -> *const c_void {
+) {
     debug_assert!(!ctrlp_vars.is_null());
     if !loc.is_null() {
         let mt = unsafe { &*mt };
@@ -69,7 +69,6 @@ pub extern "C" fn __ykrt_control_point(
         arc.control_point(loc, ctrlp_vars, frameaddr);
         forget(arc);
     }
-    std::ptr::null()
 }
 
 #[no_mangle]


### PR DESCRIPTION
The C header declares this function as:

```c
void yk_mt_control_point(YkMT *, YkLocation *);
```

so returning a result in this way is wrong (*probably* it technically lands us in UB, though in practise I think returning `NULL` would have always gone in a register such that no part of the system actually noticed us getting this wrong).

Happily this also fixes #771.