### PR TITLE
Use a known-working version of Rust nightly.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -10,13 +10,13 @@ export RUSTUP_HOME="`pwd`/.rustup"
 export RUSTUP_INIT_SKIP_PATH_CHECK="yes"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
 sh rustup.sh --default-host x86_64-unknown-linux-gnu \
-    --default-toolchain nightly \
+    --default-toolchain nightly-2024-04-17 \
     --no-modify-path \
     --profile minimal \
     -y
 export PATH=${CARGO_HOME}/bin/:$PATH
 
-rustup toolchain install nightly --allow-downgrade --component rustfmt
+rustup toolchain install nightly-2024-04-17 --allow-downgrade --component rustfmt
 
 cargo fmt --all -- --check
 


### PR DESCRIPTION
Rust nightly, as of yesterday, breaks yk. We *think* this is because of https://github.com/rust-lang/rust/issues/124150 --- if so, hopefully we can switch back to "nightly nightly" in a day or two.