### PR TITLE
Make the AOT IR "static".

### DIFF
--- a/tests/ir_lowering/after_alloca.ll
+++ b/tests/ir_lowering/after_alloca.ll
@@ -3,7 +3,7 @@
 ;     ...
 ;     func main($arg0: i32, $arg1: ptr) -> i32 {
 ;       bb0:
-;         $0_0: ptr = alloca i32, 1i32
+;         $0_0: ptr = alloca i32, 1
 ;         store 1i32, $0_0
 ;         $0_2: i1 = icmp $arg0, Equal, 1i32
 ;         condbr $0_2, bb1, bb2

--- a/tests/ir_lowering/vararg_func_ty.ll
+++ b/tests/ir_lowering/vararg_func_ty.ll
@@ -11,6 +11,6 @@ define i32 @f(i32 %0, ...) {
 }
 
 define i32 @main() {
-    %1 = call i32 @f(i32 1, i32 2, i32 3);
+    %1 = call i32 (i32, ...) @f(i32 1, i32 2, i32 3);
     ret i32 %1
 }

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -1156,6 +1156,7 @@ impl JitIRDisplay for Constant {
     ) -> Result<(), Box<dyn Error>> {
         match self.type_idx().type_(m) {
             Type::Integer(it) => s.push_str(&it.const_to_str(self)),
+            Type::Ptr => s.push_str("const_ptr"),
             _ => todo!(),
         }
         Ok(())


### PR DESCRIPTION
Currently an AOT IR instruction is an opcode and a collection of generic operands. Whilst this is easy to lower to, it isn't easy to work with beyond that. You have to know which operand index is used for what.

This change makes an AOT IR instruction an enum with named, specialised fields. This is more type-safe and should be easier to work with.

Requires a ykllvm change ~~(coming soon)~~: https://github.com/ykjit/ykllvm/pull/133

(I'll point out some areas which require discussion)