### PR TITLE
Add an IR lowering test for non-byte-sized integer constants.

### DIFF
--- a/tests/ir_lowering/non_byte_sized_int_constant.ll
+++ b/tests/ir_lowering/non_byte_sized_int_constant.ll
@@ -1,0 +1,16 @@
+; Dump:
+;   stdout:
+;     ...
+;     func main() -> i1 {
+;       bb0:
+;         ret 0i1
+;     }
+;     ...
+
+; Check that lowering non-byte-sized integer constants works.
+
+define i1 @main() {
+entry:
+  ; Here we return a 1-bit constant integer.
+  ret i1 0
+}


### PR DESCRIPTION
Found when porting `simple_interp_loop2` to the new codegen.

Requires a ykllvm fix for the test to pass. ~~Coming in a moment~~: https://github.com/ykjit/ykllvm/pull/136