### PR TITLE
Expand binary operations in the JIT IR.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -177,7 +177,6 @@ impl<'a> X64CodeGen<'a> {
         self.comment(self.asm.offset(), inst.to_string(self.jit_mod).unwrap());
 
         match inst {
-            jit_ir::Instruction::BinOp(i) => self.codegen_binop_instr(instr_idx, i),
             jit_ir::Instruction::LoadTraceInput(i) => {
                 self.codegen_loadtraceinput_instr(instr_idx, i)
             }
@@ -191,6 +190,9 @@ impl<'a> X64CodeGen<'a> {
             jit_ir::Instruction::Guard(i) => self.codegen_guard_instr(i),
             jit_ir::Instruction::Arg(i) => self.codegen_arg(instr_idx, *i),
             jit_ir::Instruction::TraceLoopStart => self.codegen_traceloopstart_instr(),
+            // Binary operations
+            jit_ir::Instruction::Add(i) => self.codegen_add_instr(instr_idx, i),
+            x => todo!("{x:?}"),
         }
         Ok(())
     }
@@ -336,7 +338,7 @@ impl<'a> X64CodeGen<'a> {
         self.store_local(&l, reg, size);
     }
 
-    fn codegen_binop_instr(&mut self, inst_idx: jit_ir::InstrIdx, inst: &jit_ir::BinOpInstruction) {
+    fn codegen_add_instr(&mut self, inst_idx: jit_ir::InstrIdx, inst: &jit_ir::AddInstruction) {
         let lhs = inst.lhs();
         let rhs = inst.rhs();
 
@@ -346,14 +348,11 @@ impl<'a> X64CodeGen<'a> {
         self.operand_into_reg(WR0, &lhs); // FIXME: assumes value will fit in a reg.
         self.operand_into_reg(WR1, &rhs); // ^^^ same
 
-        match inst.binop() {
-            jit_ir::BinOp::Add => match lhs.byte_size(self.jit_mod) {
-                8 => dynasm!(self.asm; add Rq(WR0.code()), Rq(WR1.code())),
-                4 => dynasm!(self.asm; add Rd(WR0.code()), Rd(WR1.code())),
-                2 => dynasm!(self.asm; add Rw(WR0.code()), Rw(WR1.code())),
-                1 => dynasm!(self.asm; add Rb(WR0.code()), Rb(WR1.code())),
-                _ => todo!(),
-            },
+        match lhs.byte_size(self.jit_mod) {
+            8 => dynasm!(self.asm; add Rq(WR0.code()), Rq(WR1.code())),
+            4 => dynasm!(self.asm; add Rd(WR0.code()), Rd(WR1.code())),
+            2 => dynasm!(self.asm; add Rw(WR0.code()), Rw(WR1.code())),
+            1 => dynasm!(self.asm; add Rb(WR0.code()), Rb(WR1.code())),
             _ => todo!(),
         }
 
@@ -994,10 +993,10 @@ mod tests {
                     jit_ir::LoadTraceInputInstruction::new(16, i16_ty_idx).into(),
                 )
                 .unwrap();
-            jit_mod.push(jit_ir::BinOpInstruction::new(op1, jit_ir::BinOp::Add, op2).into());
+            jit_mod.push(jit_ir::AddInstruction::new(op1, op2).into());
             let patt_lines = [
                 "...",
-                "; %2: i16 = BinOp %0, add, %1",
+                "; %2: i16 = Add %0, %1",
                 "... movzx r12, word ptr [rbp-0x02]",
                 "... movzx r13, word ptr [rbp-0x04]",
                 "... add r12w, r13w",
@@ -1021,10 +1020,10 @@ mod tests {
                     jit_ir::LoadTraceInputInstruction::new(64, i64_ty_idx).into(),
                 )
                 .unwrap();
-            jit_mod.push(jit_ir::BinOpInstruction::new(op1, jit_ir::BinOp::Add, op2).into());
+            jit_mod.push(jit_ir::AddInstruction::new(op1, op2).into());
             let patt_lines = [
                 "...",
-                "; %2: i64 = BinOp %0, add, %1",
+                "; %2: i64 = Add %0, %1",
                 "... mov r12, [rbp-0x08]",
                 "... mov r13, [rbp-0x10]",
                 "... add r12, r13",
@@ -1053,7 +1052,7 @@ mod tests {
                     jit_ir::LoadTraceInputInstruction::new(64, i32_ty_idx).into(),
                 )
                 .unwrap();
-            jit_mod.push(jit_ir::BinOpInstruction::new(op1, jit_ir::BinOp::Add, op2).into());
+            jit_mod.push(jit_ir::AddInstruction::new(op1, op2).into());
 
             X64CodeGen::new(&jit_mod, Box::new(SpillAllocator::new(STACK_DIRECTION)))
                 .unwrap()
@@ -1528,15 +1527,13 @@ mod tests {
                 )
                 .unwrap();
             jit_mod.push(jit_ir::Instruction::TraceLoopStart);
-            jit_mod.push(
-                jit_ir::BinOpInstruction::new(ti_op.clone(), jit_ir::BinOp::Add, ti_op).into(),
-            );
+            jit_mod.push(jit_ir::AddInstruction::new(ti_op.clone(), ti_op).into());
             let patt_lines = [
                 "...",
                 "; %0: i8 = LoadTraceInput 0, i8",
                 "...",
                 "; TraceLoopStart",
-                "; %2: i8 = BinOp %0, add, %0",
+                "; %2: i8 = add %0, %0",
                 "...",
                 "; Trace loop backedge",
                 "...: jmp ...",

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -207,8 +207,13 @@ impl<'a> TraceBuilder<'a> {
                     }
                     self.handle_ptradd(&bid, inst_idx, ptr, off)
                 }
-                aot_ir::Instruction::BinaryOp { lhs, binop, rhs } => {
-                    self.handle_binop(&bid, inst_idx, lhs, binop, rhs)
+                aot_ir::Instruction::BinaryOp {
+                    lhs,
+                    binop: aot_ir::BinOp::Add,
+                    rhs,
+                } => self.handle_add(&bid, inst_idx, lhs, rhs),
+                aot_ir::Instruction::BinaryOp { binop, .. } => {
+                    todo!("{binop:?}");
                 }
                 aot_ir::Instruction::ICmp { lhs, pred, rhs, .. } => {
                     self.handle_icmp(&bid, inst_idx, lhs, pred, rhs)
@@ -345,19 +350,15 @@ impl<'a> TraceBuilder<'a> {
     }
 
     /// Translate binary operations such as add, sub, mul, etc.
-    fn handle_binop(
+    fn handle_add(
         &mut self,
         bid: &aot_ir::BBlockId,
         aot_inst_idx: usize,
         lhs: &aot_ir::Operand,
-        binop: &aot_ir::BinOp,
         rhs: &aot_ir::Operand,
     ) -> Result<(), CompilationError> {
-        let instr = jit_ir::BinOpInstruction::new(
-            self.handle_operand(lhs)?,
-            *binop,
-            self.handle_operand(rhs)?,
-        );
+        let instr =
+            jit_ir::AddInstruction::new(self.handle_operand(lhs)?, self.handle_operand(rhs)?);
         self.copy_instruction(instr.into(), bid, aot_inst_idx)
     }
 


### PR DESCRIPTION
In the AOT IR, compressing these into one seems reasonable, but it now looks likely that:

1. Having separate `*Instruction` structs is a good idea (we can pass them to functions as parameters, which we can't if they're just discriminants in an `enum`).
2. If we have those, we logically also will benefit from having one `*Instruction` struct per binary operation.

Mostly this commit transforms the old `BinaryOperation` struct into a macro. Currently only the `Add` instruction is "fully" (sort of) implemented.