### PR TITLE
Remove the `JitIRDisplay` trait.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -13,8 +13,6 @@ use super::{
     reg_alloc::{LocalAlloc, RegisterAllocator, StackDirection},
     CodeGen,
 };
-#[cfg(any(debug_assertions, test))]
-use crate::compile::jitc_yk::jit_ir::JitIRDisplay;
 use crate::compile::CompiledTrace;
 use byteorder::{NativeEndian, ReadBytesExt};
 use dynasmrt::{
@@ -174,7 +172,10 @@ impl<'a> X64CodeGen<'a> {
         inst: &jit_ir::Instruction,
     ) -> Result<(), CompilationError> {
         #[cfg(any(debug_assertions, test))]
-        self.comment(self.asm.offset(), inst.to_string(self.jit_mod).unwrap());
+        self.comment(
+            self.asm.offset(),
+            inst.display(instr_idx, self.jit_mod).to_string(),
+        );
 
         match inst {
             jit_ir::Instruction::LoadTraceInput(i) => {

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -66,11 +66,8 @@ impl Compiler for JITCYk {
         let jit_mod = trace_builder::build(mt.next_compiled_trace_id(), &aot_mod, aottrace_iter.0)?;
 
         if should_log_ir(IRPhase::PreOpt) {
-            // FIXME: If the `unwrap` fails, something rather bad has happened: does recovery even
-            // make sense?
             log_ir(&format!(
-                "--- Begin jit-pre-opt ---\n{}\n--- End jit-pre-opt ---",
-                jit_mod.to_string().unwrap()
+                "--- Begin jit-pre-opt ---\n{jit_mod}\n--- End jit-pre-opt ---",
             ));
         }
 


### PR DESCRIPTION
What I slowly realised is that most of this functionality is more concise if implemented on the "top level" `enum`s rather than the itty-bitty `struct`s. Doing this allows us to simplify a lot of the stringification code, both reducing the number of lines of code, and also flattening several layers of indirection.