### PR TITLE
Rename various things in the JIT IR

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod x86_64;
 pub(crate) trait CodeGen<'a> {
     /// Instantiate a code generator for the specified JIT module.
     fn new(
-        jit_mod: &'a jit_ir::Module,
+        m: &'a jit_ir::Module,
         ra: Box<dyn RegisterAllocator>,
     ) -> Result<Box<Self>, CompilationError>
     where

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
@@ -59,12 +59,12 @@ pub(crate) trait RegisterAllocator {
     /// index `local`.
     fn allocate(
         &mut self,
-        local: jit_ir::InstrIdx,
+        local: jit_ir::InstIdx,
         size: usize,
         stack: &mut AbstractStack,
     ) -> LocalAlloc;
 
     /// Return the allocation for the value computed by the instruction at the specified
     /// instruction index.
-    fn allocation(&self, idx: jit_ir::InstrIdx) -> &LocalAlloc;
+    fn allocation(&self, idx: jit_ir::InstIdx) -> &LocalAlloc;
 }

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/spill_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/spill_alloc.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 pub(crate) struct SpillAllocator {
     /// Maps a local variable (the instruction that defines it) to its allocation.
-    allocs: HashMap<jit_ir::InstrIdx, LocalAlloc>,
+    allocs: HashMap<jit_ir::InstIdx, LocalAlloc>,
     stack_dir: StackDirection,
 }
 
@@ -25,7 +25,7 @@ impl RegisterAllocator for SpillAllocator {
 
     fn allocate(
         &mut self,
-        local: jit_ir::InstrIdx,
+        local: jit_ir::InstIdx,
         size: usize,
         stack: &mut AbstractStack,
     ) -> LocalAlloc {
@@ -56,7 +56,7 @@ impl RegisterAllocator for SpillAllocator {
     /// # Panics
     ///
     /// Panics if there is no allocation for the specified index.
-    fn allocation(&self, idx: jit_ir::InstrIdx) -> &LocalAlloc {
+    fn allocation(&self, idx: jit_ir::InstIdx) -> &LocalAlloc {
         &self.allocs[&idx]
     }
 }
@@ -68,7 +68,7 @@ mod tests {
             abs_stack::AbstractStack,
             reg_alloc::{LocalAlloc, RegisterAllocator, SpillAllocator, StackDirection},
         },
-        jit_ir::InstrIdx,
+        jit_ir::InstIdx,
     };
 
     #[test]
@@ -76,7 +76,7 @@ mod tests {
         let mut stack = AbstractStack::default();
         let mut sa = SpillAllocator::new(StackDirection::GrowsDown);
 
-        let idx = InstrIdx::new(0).unwrap();
+        let idx = InstIdx::new(0).unwrap();
         sa.allocate(idx, 8, &mut stack);
         debug_assert_eq!(stack.size(), 8);
         debug_assert_eq!(
@@ -87,7 +87,7 @@ mod tests {
             }
         );
 
-        let idx = InstrIdx::new(1).unwrap();
+        let idx = InstIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 9);
         debug_assert_eq!(
@@ -104,7 +104,7 @@ mod tests {
         let mut stack = AbstractStack::default();
         let mut sa = SpillAllocator::new(StackDirection::GrowsUp);
 
-        let idx = InstrIdx::new(0).unwrap();
+        let idx = InstIdx::new(0).unwrap();
         sa.allocate(idx, 8, &mut stack);
         debug_assert_eq!(stack.size(), 8);
         debug_assert_eq!(
@@ -115,7 +115,7 @@ mod tests {
             }
         );
 
-        let idx = InstrIdx::new(1).unwrap();
+        let idx = InstIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 9);
         debug_assert_eq!(
@@ -132,10 +132,10 @@ mod tests {
         let mut stack = AbstractStack::default();
         let mut sa = SpillAllocator::new(StackDirection::GrowsDown);
 
-        sa.allocate(InstrIdx::new(0).unwrap(), 8, &mut stack);
+        sa.allocate(InstIdx::new(0).unwrap(), 8, &mut stack);
         stack.align(32);
 
-        let idx = InstrIdx::new(1).unwrap();
+        let idx = InstIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 33);
         debug_assert_eq!(
@@ -152,10 +152,10 @@ mod tests {
         let mut stack = AbstractStack::default();
         let mut sa = SpillAllocator::new(StackDirection::GrowsUp);
 
-        sa.allocate(InstrIdx::new(0).unwrap(), 8, &mut stack);
+        sa.allocate(InstIdx::new(0).unwrap(), 8, &mut stack);
         stack.align(32);
 
-        let idx = InstrIdx::new(1).unwrap();
+        let idx = InstIdx::new(1).unwrap();
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 33);
         debug_assert_eq!(

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -6,7 +6,7 @@
 
 use super::{
     super::{
-        jit_ir::{self, FuncDeclIdx, InstrIdx, Operand, Type},
+        jit_ir::{self, FuncDeclIdx, InstrIdx, Operand, Ty},
         CompilationError,
     },
     abs_stack::AbstractStack,
@@ -496,7 +496,7 @@ impl<'a> X64CodeGen<'a> {
         );
 
         // If the function we called has a return value, then store it into a local variable.
-        if fty.ret_type(self.jit_mod) != &Type::Void {
+        if fty.ret_type(self.jit_mod) != &Ty::Void {
             self.reg_into_new_local(inst_idx, Rq::RAX);
         }
 
@@ -546,7 +546,7 @@ impl<'a> X64CodeGen<'a> {
             "icmp of differing types"
         );
         debug_assert!(
-            matches!(left.type_(self.jit_mod), jit_ir::Type::Integer(_)),
+            matches!(left.type_(self.jit_mod), jit_ir::Ty::Integer(_)),
             "icmp of non-integer types"
         );
 
@@ -782,7 +782,7 @@ mod tests {
     use crate::compile::{
         jitc_yk::{
             codegen::reg_alloc::RegisterAllocator,
-            jit_ir::{self, IntegerType, Type},
+            jit_ir::{self, IntegerTy, Ty},
         },
         CompiledTrace,
     };
@@ -822,7 +822,7 @@ mod tests {
     }
 
     mod with_spillalloc {
-        use self::jit_ir::FuncType;
+        use self::jit_ir::FuncTy;
 
         use super::*;
         use crate::compile::jitc_yk::codegen::reg_alloc::SpillAllocator;
@@ -863,7 +863,7 @@ mod tests {
         fn codegen_load_i8() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(8)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let load_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
@@ -884,7 +884,7 @@ mod tests {
         fn codegen_load_i32() {
             let mut jit_mod = test_module();
             let i32_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(32)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(32)))
                 .unwrap();
             let ti_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i32_ty_idx).into())
@@ -946,7 +946,7 @@ mod tests {
         fn codegen_loadtraceinput_i8() {
             let mut jit_mod = test_module();
             let u8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(8)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(0, u8_ty_idx).into());
             let patt_lines = [
@@ -963,7 +963,7 @@ mod tests {
         fn codegen_loadtraceinput_i16_with_offset() {
             let mut jit_mod = test_module();
             let u16_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(16)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(16)))
                 .unwrap();
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(32, u16_ty_idx).into());
             let patt_lines = [
@@ -980,7 +980,7 @@ mod tests {
         fn codegen_loadtraceinput_many_offset() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(8)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let ptr_ty_idx = jit_mod.ptr_type_idx();
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into());
@@ -1014,7 +1014,7 @@ mod tests {
         fn codegen_add_i16() {
             let mut jit_mod = test_module();
             let i16_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(16)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(16)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i16_ty_idx).into())
@@ -1041,7 +1041,7 @@ mod tests {
         fn codegen_add_i64() {
             let mut jit_mod = test_module();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(64)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i64_ty_idx).into())
@@ -1070,10 +1070,10 @@ mod tests {
         fn codegen_add_wrong_types() {
             let mut jit_mod = test_module();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(64)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let i32_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(32)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(32)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i64_ty_idx).into())
@@ -1106,11 +1106,7 @@ mod tests {
             let mut jit_mod = test_module();
             let void_ty_idx = jit_mod.void_type_idx();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Func(FuncType::new(
-                    vec![],
-                    void_ty_idx,
-                    false,
-                )))
+                .type_idx(&jit_ir::Ty::Func(FuncTy::new(vec![], void_ty_idx, false)))
                 .unwrap();
 
             let func_decl_idx = jit_mod
@@ -1136,11 +1132,9 @@ mod tests {
         fn codegen_call_with_args() {
             let mut jit_mod = test_module();
             let void_ty_idx = jit_mod.void_type_idx();
-            let i32_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(32)))
-                .unwrap();
+            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Func(FuncType::new(
+                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![i32_ty_idx; 3],
                     void_ty_idx,
                     false,
@@ -1187,21 +1181,13 @@ mod tests {
         fn codegen_call_with_different_args() {
             let mut jit_mod = test_module();
             let void_ty_idx = jit_mod.void_type_idx();
-            let i8_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(8)))
-                .unwrap();
-            let i16_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(16)))
-                .unwrap();
-            let i32_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(32)))
-                .unwrap();
-            let i64_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(64)))
-                .unwrap();
+            let i8_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(8))).unwrap();
+            let i16_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(16))).unwrap();
+            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
+            let i64_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(64))).unwrap();
             let ptr_ty_idx = jit_mod.ptr_type_idx();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Func(FuncType::new(
+                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![
                         i8_ty_idx, i16_ty_idx, i32_ty_idx, i64_ty_idx, ptr_ty_idx, i8_ty_idx,
                     ],
@@ -1272,11 +1258,9 @@ mod tests {
         fn codegen_call_spill_args() {
             let mut jit_mod = test_module();
             let void_ty_idx = jit_mod.void_type_idx();
-            let i32_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(32)))
-                .unwrap();
+            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Func(FuncType::new(
+                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![i32_ty_idx; 7],
                     void_ty_idx,
                     false,
@@ -1308,15 +1292,9 @@ mod tests {
         #[test]
         fn codegen_call_ret() {
             let mut jit_mod = test_module();
-            let i32_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(32)))
-                .unwrap();
+            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Func(FuncType::new(
-                    vec![],
-                    i32_ty_idx,
-                    false,
-                )))
+                .type_idx(&jit_ir::Ty::Func(FuncTy::new(vec![], i32_ty_idx, false)))
                 .unwrap();
 
             let func_decl_idx = jit_mod
@@ -1345,11 +1323,9 @@ mod tests {
         fn codegen_call_bad_arg_type() {
             let mut jit_mod = test_module();
             let void_ty_idx = jit_mod.void_type_idx();
-            let i32_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(32)))
-                .unwrap();
+            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Func(FuncType::new(
+                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![i32_ty_idx],
                     void_ty_idx,
                     false,
@@ -1364,9 +1340,7 @@ mod tests {
                 .unwrap();
 
             // Make a call that passes a i8 argument, instead of an i32 as in the func sig.
-            let i8_ty_idx = jit_mod
-                .type_idx(&Type::Integer(IntegerType::new(8)))
-                .unwrap();
+            let i8_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(8))).unwrap();
             let arg1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
                 .unwrap();
@@ -1384,7 +1358,7 @@ mod tests {
         fn codegen_icmp_i64() {
             let mut jit_mod = test_module();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(64)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i64_ty_idx).into())
@@ -1409,7 +1383,7 @@ mod tests {
         fn codegen_icmp_i8() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(8)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
@@ -1454,10 +1428,10 @@ mod tests {
         fn codegen_icmp_diff_types() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(8)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Type::Integer(IntegerType::new(64)))
+                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -302,7 +302,7 @@ impl<'a> X64CodeGen<'a> {
     fn load_const(&mut self, reg: Rq, cidx: jit_ir::ConstIdx) {
         let cst = self.jit_mod.const_(cidx);
         let mut bytes = cst.bytes().as_slice();
-        let size = cst.type_idx().type_(self.jit_mod).byte_size().unwrap();
+        let size = cst.ty_idx().type_(self.jit_mod).byte_size().unwrap();
         debug_assert_eq!(bytes.len(), size);
         match size {
             8 => {
@@ -604,12 +604,12 @@ impl<'a> X64CodeGen<'a> {
         let from_type = from_val.type_(self.jit_mod);
         let from_size = from_type.byte_size().unwrap();
 
-        let to_type = self.jit_mod.type_(i.dest_type_idx());
+        let to_type = self.jit_mod.type_(i.dest_ty_idx());
         let to_size = to_type.byte_size().unwrap();
 
         // You can only sign-extend a smaller integer to a larger integer.
-        debug_assert!(matches!(to_type, jit_ir::Type::Integer(_)));
-        debug_assert!(matches!(from_type, jit_ir::Type::Integer(_)));
+        debug_assert!(matches!(to_type, jit_ir::Ty::Integer(_)));
+        debug_assert!(matches!(from_type, jit_ir::Ty::Integer(_)));
         debug_assert!(from_size < to_size);
 
         // FIXME: assumes the input and output fit in a register.
@@ -843,7 +843,7 @@ mod tests {
         #[test]
         fn codegen_load_ptr() {
             let mut jit_mod = test_module();
-            let ptr_ty_idx = jit_mod.ptr_type_idx();
+            let ptr_ty_idx = jit_mod.ptr_ty_idx();
             let load_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, ptr_ty_idx).into())
                 .unwrap();
@@ -863,7 +863,7 @@ mod tests {
         fn codegen_load_i8() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let load_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
@@ -884,7 +884,7 @@ mod tests {
         fn codegen_load_i32() {
             let mut jit_mod = test_module();
             let i32_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(32)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(32)))
                 .unwrap();
             let ti_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i32_ty_idx).into())
@@ -904,7 +904,7 @@ mod tests {
         #[test]
         fn codegen_ptradd() {
             let mut jit_mod = test_module();
-            let ptr_ty_idx = jit_mod.ptr_type_idx();
+            let ptr_ty_idx = jit_mod.ptr_ty_idx();
             let ti_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, ptr_ty_idx).into())
                 .unwrap();
@@ -923,7 +923,7 @@ mod tests {
         #[test]
         fn codegen_store_ptr() {
             let mut jit_mod = test_module();
-            let ptr_ty_idx = jit_mod.ptr_type_idx();
+            let ptr_ty_idx = jit_mod.ptr_ty_idx();
             let ti1_op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, ptr_ty_idx).into())
                 .unwrap();
@@ -946,7 +946,7 @@ mod tests {
         fn codegen_loadtraceinput_i8() {
             let mut jit_mod = test_module();
             let u8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(0, u8_ty_idx).into());
             let patt_lines = [
@@ -963,7 +963,7 @@ mod tests {
         fn codegen_loadtraceinput_i16_with_offset() {
             let mut jit_mod = test_module();
             let u16_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(16)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(16)))
                 .unwrap();
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(32, u16_ty_idx).into());
             let patt_lines = [
@@ -980,9 +980,9 @@ mod tests {
         fn codegen_loadtraceinput_many_offset() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
-            let ptr_ty_idx = jit_mod.ptr_type_idx();
+            let ptr_ty_idx = jit_mod.ptr_ty_idx();
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into());
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(1, i8_ty_idx).into());
             jit_mod.push(jit_ir::LoadTraceInputInstruction::new(2, i8_ty_idx).into());
@@ -1014,7 +1014,7 @@ mod tests {
         fn codegen_add_i16() {
             let mut jit_mod = test_module();
             let i16_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(16)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(16)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i16_ty_idx).into())
@@ -1041,7 +1041,7 @@ mod tests {
         fn codegen_add_i64() {
             let mut jit_mod = test_module();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i64_ty_idx).into())
@@ -1070,10 +1070,10 @@ mod tests {
         fn codegen_add_wrong_types() {
             let mut jit_mod = test_module();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let i32_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(32)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(32)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i64_ty_idx).into())
@@ -1104,9 +1104,9 @@ mod tests {
         #[test]
         fn codegen_call_simple() {
             let mut jit_mod = test_module();
-            let void_ty_idx = jit_mod.void_type_idx();
+            let void_ty_idx = jit_mod.void_ty_idx();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Func(FuncTy::new(vec![], void_ty_idx, false)))
+                .ty_idx(&jit_ir::Ty::Func(FuncTy::new(vec![], void_ty_idx, false)))
                 .unwrap();
 
             let func_decl_idx = jit_mod
@@ -1131,10 +1131,10 @@ mod tests {
         #[test]
         fn codegen_call_with_args() {
             let mut jit_mod = test_module();
-            let void_ty_idx = jit_mod.void_type_idx();
-            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
+            let void_ty_idx = jit_mod.void_ty_idx();
+            let i32_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
+                .ty_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![i32_ty_idx; 3],
                     void_ty_idx,
                     false,
@@ -1180,14 +1180,14 @@ mod tests {
         #[test]
         fn codegen_call_with_different_args() {
             let mut jit_mod = test_module();
-            let void_ty_idx = jit_mod.void_type_idx();
-            let i8_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(8))).unwrap();
-            let i16_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(16))).unwrap();
-            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
-            let i64_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(64))).unwrap();
-            let ptr_ty_idx = jit_mod.ptr_type_idx();
+            let void_ty_idx = jit_mod.void_ty_idx();
+            let i8_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(8))).unwrap();
+            let i16_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(16))).unwrap();
+            let i32_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
+            let i64_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(64))).unwrap();
+            let ptr_ty_idx = jit_mod.ptr_ty_idx();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
+                .ty_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![
                         i8_ty_idx, i16_ty_idx, i32_ty_idx, i64_ty_idx, ptr_ty_idx, i8_ty_idx,
                     ],
@@ -1257,10 +1257,10 @@ mod tests {
         #[test]
         fn codegen_call_spill_args() {
             let mut jit_mod = test_module();
-            let void_ty_idx = jit_mod.void_type_idx();
-            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
+            let void_ty_idx = jit_mod.void_ty_idx();
+            let i32_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
+                .ty_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![i32_ty_idx; 7],
                     void_ty_idx,
                     false,
@@ -1292,9 +1292,9 @@ mod tests {
         #[test]
         fn codegen_call_ret() {
             let mut jit_mod = test_module();
-            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
+            let i32_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Func(FuncTy::new(vec![], i32_ty_idx, false)))
+                .ty_idx(&jit_ir::Ty::Func(FuncTy::new(vec![], i32_ty_idx, false)))
                 .unwrap();
 
             let func_decl_idx = jit_mod
@@ -1322,10 +1322,10 @@ mod tests {
         #[test]
         fn codegen_call_bad_arg_type() {
             let mut jit_mod = test_module();
-            let void_ty_idx = jit_mod.void_type_idx();
-            let i32_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
+            let void_ty_idx = jit_mod.void_ty_idx();
+            let i32_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(32))).unwrap();
             let func_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Func(FuncTy::new(
+                .ty_idx(&jit_ir::Ty::Func(FuncTy::new(
                     vec![i32_ty_idx],
                     void_ty_idx,
                     false,
@@ -1340,7 +1340,7 @@ mod tests {
                 .unwrap();
 
             // Make a call that passes a i8 argument, instead of an i32 as in the func sig.
-            let i8_ty_idx = jit_mod.type_idx(&Ty::Integer(IntegerTy::new(8))).unwrap();
+            let i8_ty_idx = jit_mod.ty_idx(&Ty::Integer(IntegerTy::new(8))).unwrap();
             let arg1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
                 .unwrap();
@@ -1358,7 +1358,7 @@ mod tests {
         fn codegen_icmp_i64() {
             let mut jit_mod = test_module();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i64_ty_idx).into())
@@ -1383,7 +1383,7 @@ mod tests {
         fn codegen_icmp_i8() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
@@ -1409,7 +1409,7 @@ mod tests {
         #[should_panic(expected = "icmp of non-integer types")]
         fn codegen_icmp_non_ints() {
             let mut jit_mod = test_module();
-            let ptr_ty_idx = jit_mod.ptr_type_idx();
+            let ptr_ty_idx = jit_mod.ptr_ty_idx();
             let op = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, ptr_ty_idx).into())
                 .unwrap();
@@ -1428,10 +1428,10 @@ mod tests {
         fn codegen_icmp_diff_types() {
             let mut jit_mod = test_module();
             let i8_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(8)))
                 .unwrap();
             let i64_ty_idx = jit_mod
-                .type_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
+                .ty_idx(&jit_ir::Ty::Integer(IntegerTy::new(64)))
                 .unwrap();
             let op1 = jit_mod
                 .push_and_make_operand(jit_ir::LoadTraceInputInstruction::new(0, i8_ty_idx).into())
@@ -1453,7 +1453,7 @@ mod tests {
             let gi_idx = jit_mod.push_guardinfo(gi).unwrap();
             let cond_op = jit_mod
                 .push_and_make_operand(
-                    jit_ir::LoadTraceInputInstruction::new(0, jit_mod.int8_type_idx()).into(),
+                    jit_ir::LoadTraceInputInstruction::new(0, jit_mod.int8_ty_idx()).into(),
                 )
                 .unwrap();
             jit_mod.push(jit_ir::GuardInstruction::new(cond_op, true, gi_idx).into());
@@ -1480,7 +1480,7 @@ mod tests {
             let gi_idx = jit_mod.push_guardinfo(gi).unwrap();
             let cond_op = jit_mod
                 .push_and_make_operand(
-                    jit_ir::LoadTraceInputInstruction::new(0, jit_mod.int8_type_idx()).into(),
+                    jit_ir::LoadTraceInputInstruction::new(0, jit_mod.int8_ty_idx()).into(),
                 )
                 .unwrap();
             jit_mod.push(jit_ir::GuardInstruction::new(cond_op, false, gi_idx).into());
@@ -1525,7 +1525,7 @@ mod tests {
         #[test]
         fn looped_trace_bigger() {
             let mut jit_mod = test_module();
-            let int8_ty_idx = jit_mod.int8_type_idx();
+            let int8_ty_idx = jit_mod.int8_ty_idx();
             let ti_op = jit_mod
                 .push_and_make_operand(
                     jit_ir::LoadTraceInputInstruction::new(0, int8_ty_idx).into(),

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -1,6 +1,21 @@
-//! The Yk JIT IR
+//! The JIT's Intermediate Representation (IR).
 //!
-//! This is the in-memory trace IR constructed by the trace builder and mutated by optimisations.
+//! This is the IR created by [trace_builder] and which is then optimised. The IR can feel a little
+//! odd at first because we store indexes into vectors rather than use direct references. This
+//! allows us to squeeze the amount of the memory used down (and also bypasses issues with
+//! representing graph structures in Rust, but that's slightly accidental).
+//!
+//! Because using the IR can often involve getting hold of data nested several layers deep, we also
+//! use a number of abbreviations/conventions to keep the length of source down to something
+//! manageable (in alphabetical order):
+//!
+//!  * `const_`: a "constant"
+//!  * `decl`: a "declaration" (e.g. a "function declaration" is a reference to an existing
+//!    function somewhere else in the address space)
+//!  * `m`: the name conventionally given to the shared [Module] instance (i.e. `m: Module`)
+//!  * `Idx`: "index"
+//!  * `Instr`: "instructions"
+//!  * `Ty`: "type"
 
 // For now, don't swap others working in other areas of the system.
 // FIXME: eventually delete.

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -38,7 +38,7 @@ pub(crate) struct TraceBuilder<'a> {
     /// The JIT IR this struct builds.
     jit_mod: jit_ir::Module,
     /// Maps an AOT instruction to a jit instruction via their index-based IDs.
-    local_map: HashMap<aot_ir::InstructionID, jit_ir::InstrIdx>,
+    local_map: HashMap<aot_ir::InstructionID, jit_ir::InstIdx>,
     // BBlock containing the current control point (i.e. the control point that started this trace).
     cp_block: Option<aot_ir::BBlockId>,
     // Index of the first traceinput instruction.
@@ -265,8 +265,8 @@ impl<'a> TraceBuilder<'a> {
         Ok(())
     }
 
-    fn next_instr_id(&self) -> Result<jit_ir::InstrIdx, CompilationError> {
-        jit_ir::InstrIdx::new(self.jit_mod.len())
+    fn next_instr_id(&self) -> Result<jit_ir::InstIdx, CompilationError> {
+        jit_ir::InstIdx::new(self.jit_mod.len())
     }
 
     /// Translate a global variable use.

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -326,10 +326,7 @@ impl<'a> TraceBuilder<'a> {
     }
 
     /// Translate a type.
-    fn handle_type(
-        &mut self,
-        aot_idx: aot_ir::TypeIdx,
-    ) -> Result<jit_ir::TypeIdx, CompilationError> {
+    fn handle_type(&mut self, aot_idx: aot_ir::TypeIdx) -> Result<jit_ir::TyIdx, CompilationError> {
         let jit_ty = match self.aot_mod.type_(aot_idx) {
             aot_ir::Type::Void => jit_ir::Type::Void,
             aot_ir::Type::Integer(it) => {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -328,11 +328,9 @@ impl<'a> TraceBuilder<'a> {
     /// Translate a type.
     fn handle_type(&mut self, aot_idx: aot_ir::TypeIdx) -> Result<jit_ir::TyIdx, CompilationError> {
         let jit_ty = match self.aot_mod.type_(aot_idx) {
-            aot_ir::Type::Void => jit_ir::Type::Void,
-            aot_ir::Type::Integer(it) => {
-                jit_ir::Type::Integer(jit_ir::IntegerType::new(it.num_bits()))
-            }
-            aot_ir::Type::Ptr => jit_ir::Type::Ptr,
+            aot_ir::Type::Void => jit_ir::Ty::Void,
+            aot_ir::Type::Integer(it) => jit_ir::Ty::Integer(jit_ir::IntegerTy::new(it.num_bits())),
+            aot_ir::Type::Ptr => jit_ir::Ty::Ptr,
             aot_ir::Type::Func(ft) => {
                 let mut jit_args = Vec::new();
                 for aot_arg_ty_idx in ft.arg_ty_idxs() {
@@ -340,10 +338,10 @@ impl<'a> TraceBuilder<'a> {
                     jit_args.push(jit_ty);
                 }
                 let jit_retty = self.handle_type(ft.ret_ty())?;
-                jit_ir::Type::Func(jit_ir::FuncType::new(jit_args, jit_retty, ft.is_vararg()))
+                jit_ir::Ty::Func(jit_ir::FuncTy::new(jit_args, jit_retty, ft.is_vararg()))
             }
             aot_ir::Type::Struct(_st) => todo!(),
-            aot_ir::Type::Unimplemented(s) => jit_ir::Type::Unimplemented(s.to_owned()),
+            aot_ir::Type::Unimplemented(s) => jit_ir::Ty::Unimplemented(s.to_owned()),
         };
         self.jit_mod.type_idx(&jit_ty)
     }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -343,7 +343,7 @@ impl<'a> TraceBuilder<'a> {
             aot_ir::Type::Struct(_st) => todo!(),
             aot_ir::Type::Unimplemented(s) => jit_ir::Ty::Unimplemented(s.to_owned()),
         };
-        self.jit_mod.type_idx(&jit_ty)
+        self.jit_mod.ty_idx(&jit_ty)
     }
 
     /// Translate a function.


### PR DESCRIPTION
The JIT IR was previously rather inconsistent in how it named things. After documenting the "blessed" conventions in https://github.com/ykjit/yk/commit/5baa56c9b719cf5ea66424a60ababd2a9b002fd8, this PR then goes about making things more homogeneous. To my surprise, simply shortening various structs/functions shaves off 100LoC in the repo (mostly in the x86 backend), which suggests that the shorter names really are worthwhile!

This is bound to cause some conflicts for somebody, so it may amuse you to know that due to my own incompetence, I just spent 20 minutes rebasing this against master. I'll never learn...