### PR TITLE
Fold stack-map calls into the instruction they track

### DIFF
--- a/tests/c/switch_default.newcg.c
+++ b/tests/c/switch_default.newcg.c
@@ -9,7 +9,7 @@
 //     jitstate: stop-tracing
 //     --- Begin aot ---
 //     ...
-//     switch ${{9_1}}, bb{{bb14}}, [299 -> bb{{bb10}}, 298 -> bb{{bb12}}]
+//     switch ${{9_1}}, bb{{bb14}}, [299 -> bb{{bb10}}, 298 -> bb{{bb12}}] [safepoint: 0i64, ($0_0, $0_1, $0_3, $0_4, $0_5, $0_6, $9_1)]
 //     ...
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---

--- a/tests/c/switch_non_default.newcg.c
+++ b/tests/c/switch_non_default.newcg.c
@@ -9,7 +9,7 @@
 //     jitstate: stop-tracing
 //     --- Begin aot ---
 //     ...
-//     switch ${{10_1}}, bb{{bb14}}, [300 -> bb{{bb11}}, 299 -> bb{{bb12}}]
+//     switch ${{10_1}}, bb{{bb14}}, [300 -> bb{{bb11}}, 299 -> bb{{bb12}}] [safepoint: {{safepoint_id}}, ($0_0, $0_1, $0_3, $0_4, $0_5, $0_6, $10_1)]
 //     ...
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---

--- a/tests/ir_lowering/after_alloca.ll
+++ b/tests/ir_lowering/after_alloca.ll
@@ -6,11 +6,13 @@
 ;         $0_0: ptr = alloca i32, 1
 ;         store 1i32, $0_0
 ;         $0_2: i1 = icmp $arg0, Equal, 1i32
-;         condbr $0_2, bb1, bb2
+;         condbr $0_2, bb1, bb2 [safepoint: 1i64, ()]
 ;     ...
 
 
 ; Check that a instructions following a call are correctly lowered.
+
+declare void @llvm.experimental.stackmap(i64, i32, ...);
 
 define i32 @f(i32 %0) noinline {
   ret i32 %0
@@ -21,6 +23,7 @@ entry:
   %0 = alloca i32
   store i32 1, ptr %0
   %1 = icmp eq i32 %argc, 1
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0);
   br i1 %1, label %bb1, label %bb2
 
 bb1:

--- a/tests/ir_lowering/after_call.ll
+++ b/tests/ir_lowering/after_call.ll
@@ -3,13 +3,15 @@
 ;     ...
 ;     func main($arg0: i32, $arg1: ptr) -> i32 {
 ;       bb0:
-;         $0_0: i32 = call f($arg0)
+;         $0_0: i32 = call f($arg0) [safepoint: 1i64, ()]
 ;         $0_1: i1 = icmp $arg0, Equal, 1i32
-;         condbr $0_1, bb1, bb2
+;         condbr $0_1, bb1, bb2 [safepoint: 2i64, ()]
 ;     ...
 
 
 ; Check that a instructions following a call are correctly lowered.
+
+declare void @llvm.experimental.stackmap(i64, i32, ...);
 
 define i32 @f(i32 %0) noinline {
   ret i32 %0
@@ -18,7 +20,9 @@ define i32 @f(i32 %0) noinline {
 define i32 @main(i32 %argc, ptr %argv) {
 entry:
   %0 = call i32 @f(i32 %argc)
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0);
   %1 = icmp eq i32 %argc, 1
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0);
   br i1 %1, label %bb1, label %bb2
 
 bb1:

--- a/tests/ir_lowering/call_operands.ll
+++ b/tests/ir_lowering/call_operands.ll
@@ -3,9 +3,11 @@
 ;     ...
 ;     func main() -> i32 {
 ;       bb0:
-;         call f(1i32, 2i32, 3i32)
+;         call f(1i32, 2i32, 3i32) [safepoint: 1i64, ()]
 ;         ret 0i32
 ;     }
+;
+;     func llvm.experimental.stackmap($arg0: i64, $arg1: i32, ...);
 
 ; Check a call instruction lowers and prints correctly.
 ;
@@ -13,11 +15,13 @@
 ; the last operand, but in Yk's IR it's the first. A generic lowering would do
 ; the wrong thing.
 
+declare void @llvm.experimental.stackmap(i64, i32, ...);
 
 define void @f(i32 %0, i32 %1, i32 %2) { ret void }
 
 define i32 @main() {
 entry:
   call void @f(i32 1, i32 2, i32 3);
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0);
   ret i32 0
 }

--- a/tests/ir_lowering/vararg_call.ll
+++ b/tests/ir_lowering/vararg_call.ll
@@ -5,16 +5,18 @@
 ;     ...
 ;     func main(...
 ;     bb0:
-;       $0_0: i32 = call f($arg0)
+;       $0_0: i32 = call f($arg0) [safepoint: 1i64, ()]
 ;     ...
 
 
 ; Check that varargs calls lower properly.
 
+declare void @llvm.experimental.stackmap(i64, i32, ...);
 define i32 @f(i32 %0, ...) noinline { ret i32 6 }
 
 define i32 @main(i32 %argc, ptr %argv) {
 entry:
   %0 = call i32 (i32, ...) @f(i32 %argc)
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0);
   ret i32 1
 }

--- a/tests/ir_lowering/vararg_func_ty.ll
+++ b/tests/ir_lowering/vararg_func_ty.ll
@@ -6,11 +6,14 @@
 
 ; Check a vararg function type lowers correctly.
 
+declare void @llvm.experimental.stackmap(i64, i32, ...);
+
 define i32 @f(i32 %0, ...) {
     ret i32 %0
 }
 
 define i32 @main() {
     %1 = call i32 (i32, ...) @f(i32 1, i32 2, i32 3);
+    call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0);
     ret i32 %1
 }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -346,6 +346,28 @@ impl AotIRDisplay for Operand {
     }
 }
 
+#[deku_derive(DekuRead)]
+#[derive(Debug)]
+pub(crate) struct DeoptSafepoint {
+    pub(crate) id: Operand,
+    #[deku(temp)]
+    num_lives: u32,
+    #[deku(count = "num_lives")]
+    pub(crate) lives: Vec<Operand>,
+}
+
+impl AotIRDisplay for DeoptSafepoint {
+    fn to_string(&self, m: &Module) -> String {
+        let lives_s = self
+            .lives
+            .iter()
+            .map(|a| a.to_string(m))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[safepoint: {}, ({})]", self.id.to_string(m), lives_s)
+    }
+}
+
 /// An instruction.
 ///
 /// An instruction is conceptually an [Opcode] and a list of [Operand]s. The semantics of the
@@ -380,6 +402,10 @@ pub(crate) enum Instruction {
         num_args: u32,
         #[deku(count = "num_args")]
         args: Vec<Operand>,
+        #[deku(temp)]
+        has_safepoint: u8,
+        #[deku(cond = "*has_safepoint != 0", default = "None")]
+        safepoint: Option<DeoptSafepoint>,
     },
     #[deku(id = "5")]
     Br {
@@ -391,6 +417,7 @@ pub(crate) enum Instruction {
         cond: Operand,
         true_bb: BBlockIdx,
         false_bb: BBlockIdx,
+        safepoint: DeoptSafepoint,
     },
     #[deku(id = "7")]
     ICmp {
@@ -434,16 +461,6 @@ pub(crate) enum Instruction {
         dest_type_idx: TypeIdx,
     },
     #[deku(id = "13")]
-    DeoptSafepoint {
-        id: Operand,
-        // FIXME: this is never used, do we need to serialize this?
-        num_shadow_bytes: Operand,
-        #[deku(temp)]
-        num_lives: u32,
-        #[deku(count = "num_lives")]
-        lives: Vec<Operand>,
-    },
-    #[deku(id = "14")]
     Switch {
         test_val: Operand,
         default_dest: BBlockIdx,
@@ -453,6 +470,7 @@ pub(crate) enum Instruction {
         case_values: Vec<u64>,
         #[deku(count = "num_cases")]
         case_dests: Vec<BBlockIdx>,
+        safepoint: DeoptSafepoint,
     },
     #[deku(id = "255")]
     Unimplemented(#[deku(until = "|v: &u8| *v == 0", map = "map_to_string")] String),
@@ -509,7 +527,6 @@ impl Instruction {
             }
             Self::Store { .. } => None,
             Self::Cast { dest_type_idx, .. } => Some(m.type_(*dest_type_idx)),
-            Self::DeoptSafepoint { .. } => None,
             Self::Switch { .. } => None,
             Self::Unimplemented(_) => None,
             _ => todo!("{:?}", self),
@@ -527,7 +544,7 @@ impl Instruction {
     /// being passed to it. Otherwise return None.
     pub(crate) fn control_point_call_trace_inputs(&self, aot_mod: &Module) -> Option<&Operand> {
         match self {
-            Self::Call { callee, args } => {
+            Self::Call { callee, args, .. } => {
                 if aot_mod.func(*callee).name == CONTROL_POINT_NAME {
                     let arg = &args[CTRL_POINT_ARGIDX_INPUTS];
                     // It should be a pointer (to a struct, but we can't check that).
@@ -541,10 +558,11 @@ impl Instruction {
         }
     }
 
-    pub(crate) fn is_safepoint(&self) -> bool {
+    pub(crate) fn safepoint(&self) -> Option<&DeoptSafepoint> {
         match self {
-            Self::DeoptSafepoint { .. } => true,
-            _ => false,
+            Self::Call { safepoint, .. } => safepoint.as_ref(),
+            Self::CondBr { ref safepoint, .. } => Some(safepoint),
+            _ => None,
         }
     }
 
@@ -585,23 +603,37 @@ impl AotIRDisplay for Instruction {
                 rhs.to_string(m)
             )),
             Self::Br { succ } => ret.push_str(&format!("br bb{}", usize::from(*succ))),
-            Self::Call { callee, args } => {
+            Self::Call {
+                callee,
+                args,
+                safepoint,
+            } => {
                 let args_s = args
                     .iter()
                     .map(|a| a.to_string(m))
                     .collect::<Vec<_>>()
                     .join(", ");
-                ret.push_str(&format!("call {}({})", m.func(*callee).name(), args_s,));
+                let safepoint_s = safepoint
+                    .as_ref()
+                    .map_or("".to_string(), |sp| format!(" {}", sp.to_string(m)));
+                ret.push_str(&format!(
+                    "call {}({}){}",
+                    m.func(*callee).name(),
+                    args_s,
+                    safepoint_s
+                ));
             }
             Self::CondBr {
                 cond,
                 true_bb,
                 false_bb,
+                safepoint,
             } => ret.push_str(&format!(
-                "condbr {}, bb{}, bb{}",
+                "condbr {}, bb{}, bb{} {}",
                 cond.to_string(m),
                 usize::from(*true_bb),
-                usize::from(*false_bb)
+                usize::from(*false_bb),
+                safepoint.to_string(m)
             )),
             Self::ICmp { lhs, pred, rhs, .. } => ret.push_str(&format!(
                 "icmp {}, {}, {}",
@@ -637,19 +669,12 @@ impl AotIRDisplay for Instruction {
                 val.to_string(m),
                 m.types[*dest_type_idx].to_string(m)
             )),
-            Self::DeoptSafepoint { id, lives, .. } => {
-                let args_s = lives
-                    .iter()
-                    .map(|a| a.to_string(m))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                ret.push_str(&format!("safepoint {}, [{}]", id.to_string(m), args_s,));
-            }
             Self::Switch {
                 test_val,
                 default_dest,
                 case_values,
                 case_dests,
+                safepoint,
             } => {
                 let cases = case_values
                     .iter()
@@ -657,10 +682,11 @@ impl AotIRDisplay for Instruction {
                     .map(|(val, dest)| format!("{} -> bb{}", val, usize::from(*dest)))
                     .collect::<Vec<_>>();
                 ret.push_str(&format!(
-                    "switch {}, bb{}, [{}]",
+                    "switch {}, bb{}, [{}] {}",
                     test_val.to_string(m),
                     usize::from(*default_dest),
-                    cases.join(", ")
+                    cases.join(", "),
+                    safepoint.to_string(m)
                 ));
             }
             Self::Unimplemented(s) => ret.push_str(&format!("unimplemented <<{}>>", s)),


### PR DESCRIPTION
Calls to the llvm.experimental.stackmap intrinsic happen before conditional branches, and after regular function calls. This stack-map call encodes a 'safepoint' -- a record of all the live variables so that these instructions can safely deoptimise if a guard fails.

Conceptually, safepoints 'belong' to these instructions, and having to remember whether to go forward or back to find them is just LLVM complexity which doesn't fit with our mental model how AOT IR should look.

This commit refactors this and makes safepoints easier to work with. In essence it does two thing:

1) Removes the `DeoptSafepoint` instruction in the AOT IR, folding safepoint info into the relevant `CondBr` and `Call` instructions.
2) Renames uses of stack-map (an implementation detail) in the AOT IR to safepoint.