### PR TITLE
Remove vacall

### DIFF
--- a/tests/c/simple_fprintf.newcg.c
+++ b/tests/c/simple_fprintf.newcg.c
@@ -14,7 +14,7 @@
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{17}}: i32 = VACall @fprintf(%{{11}}, %{{16}}, %{{12}})
+//     %{{17}}: i32 = Call @fprintf(%{{11}}, %{{16}})
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -748,19 +748,6 @@ impl Func {
     pub(crate) fn type_idx(&self) -> TypeIdx {
         self.type_idx
     }
-
-    /// Return the [FuncType] for the function.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the function's type isn't a [FuncType]. This cannot happen in well-formed IR.
-    pub(crate) fn func_type<'a>(&self, m: &'a Module) -> &'a FuncType {
-        if let Type::Func(ft) = m.type_(self.type_idx) {
-            ft
-        } else {
-            panic!(); // IR is malformed.
-        }
-    }
 }
 
 impl AotIRDisplay for Func {

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -184,7 +184,6 @@ impl<'a> X64CodeGen<'a> {
             jit_ir::Inst::Store(i) => self.codegen_store_inst(i),
             jit_ir::Inst::LookupGlobal(i) => self.codegen_lookupglobal_inst(inst_idx, i),
             jit_ir::Inst::Call(i) => self.codegen_call_inst(inst_idx, i)?,
-            jit_ir::Inst::VACall(i) => self.codegen_vacall_inst(inst_idx, i)?,
             jit_ir::Inst::Icmp(i) => self.codegen_icmp_inst(inst_idx, i),
             jit_ir::Inst::Guard(i) => self.codegen_guard_inst(i),
             jit_ir::Inst::Arg(i) => self.codegen_arg(inst_idx, *i),
@@ -534,20 +533,6 @@ impl<'a> X64CodeGen<'a> {
         &mut self,
         inst_idx: InstIdx,
         inst: &jit_ir::CallInst,
-    ) -> Result<(), CompilationError> {
-        let func_decl_idx = inst.target();
-        let func_type = self.m.func_type(func_decl_idx);
-        let args = (0..(func_type.num_args()))
-            .map(|i| inst.operand(self.m, i))
-            .collect::<Vec<_>>();
-        self.emit_call(inst_idx, func_decl_idx, &args)
-    }
-
-    /// Codegen a varargs call.
-    pub(super) fn codegen_vacall_inst(
-        &mut self,
-        inst_idx: InstIdx,
-        inst: &jit_ir::VACallInst,
     ) -> Result<(), CompilationError> {
         let func_decl_idx = inst.target();
         let args = (0..(inst.num_args()))

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -572,16 +572,8 @@ impl<'a> TraceBuilder<'a> {
             }
 
             let jit_func_decl_idx = self.handle_func(*callee)?;
-            let instr = if !self
-                .aot_mod
-                .func(*callee)
-                .func_type(self.aot_mod)
-                .is_vararg()
-            {
-                jit_ir::CallInst::new(&mut self.jit_mod, jit_func_decl_idx, &jit_args)?.into()
-            } else {
-                jit_ir::VACallInst::new(&mut self.jit_mod, jit_func_decl_idx, &jit_args)?.into()
-            };
+            let instr =
+                jit_ir::CallInst::new(&mut self.jit_mod, jit_func_decl_idx, &jit_args)?.into();
             self.copy_instruction(instr, bid, aot_inst_idx)
         }
     }


### PR DESCRIPTION
In essence this semi-experimental PR flattens `VACall` into `Call`. That does simplify a lot of code, though it places more heap pressure for calls with exactly 1 argument (which now push an `Operand` into `m.extra_args`). My guess is that's such a small change that we couldn't benchmark it if we tried, and given that @ptersilie wants to add indirect calls, simplifying this code is probably worth whatever tiny performance penalty we might have to pay.

@ptersilie I did sort-of hope that I could encode an `enum CallKind` in `Call` but that doesn't work with [`repr(packed)`] on a surrounding struct (see [this SO post](https://stackoverflow.com/questions/77377069/how-to-pack-a-rust-enum-into-its-minimal-size)). So I think you'll want to split this into `DirectCall` (what's currently `Call`) and `IndirectCall`.