### PR TITLE
Tidy up `CallInst`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -1118,7 +1118,7 @@ mod tests {
             let func_decl_idx = m
                 .insert_func_decl(jit_ir::FuncDecl::new(CALL_TESTS_CALLEE.into(), func_ty_idx))
                 .unwrap();
-            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, &[]).unwrap();
+            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, vec![]).unwrap();
             m.push(call_inst.into()).unwrap();
 
             let sym_addr = symbol_to_ptr(CALL_TESTS_CALLEE).unwrap().addr();
@@ -1159,7 +1159,7 @@ mod tests {
                 .unwrap();
 
             let call_inst =
-                jit_ir::CallInst::new(&mut m, func_decl_idx, &[arg1, arg2, arg3]).unwrap();
+                jit_ir::CallInst::new(&mut m, func_decl_idx, vec![arg1, arg2, arg3]).unwrap();
             m.push(call_inst.into()).unwrap();
 
             let sym_addr = symbol_to_ptr(CALL_TESTS_CALLEE).unwrap().addr();
@@ -1218,9 +1218,12 @@ mod tests {
                 .push_and_make_operand(jit_ir::LoadTraceInputInst::new(40, i8_ty_idx).into())
                 .unwrap();
 
-            let call_inst =
-                jit_ir::CallInst::new(&mut m, func_decl_idx, &[arg1, arg2, arg3, arg4, arg5, arg6])
-                    .unwrap();
+            let call_inst = jit_ir::CallInst::new(
+                &mut m,
+                func_decl_idx,
+                vec![arg1, arg2, arg3, arg4, arg5, arg6],
+            )
+            .unwrap();
             m.push(call_inst.into()).unwrap();
 
             let sym_addr = symbol_to_ptr(CALL_TESTS_CALLEE).unwrap().addr();
@@ -1263,7 +1266,7 @@ mod tests {
                 .unwrap();
 
             let args = (0..7).map(|_| arg1.clone()).collect::<Vec<_>>();
-            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, &args).unwrap();
+            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, args).unwrap();
             m.push(call_inst.into()).unwrap();
 
             X64CodeGen::new(&m, Box::new(SpillAllocator::new(STACK_DIRECTION)))
@@ -1283,7 +1286,7 @@ mod tests {
             let func_decl_idx = m
                 .insert_func_decl(jit_ir::FuncDecl::new(CALL_TESTS_CALLEE.into(), func_ty_idx))
                 .unwrap();
-            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, &[]).unwrap();
+            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, vec![]).unwrap();
             m.push(call_inst.into()).unwrap();
 
             let sym_addr = symbol_to_ptr(CALL_TESTS_CALLEE).unwrap().addr();
@@ -1321,7 +1324,7 @@ mod tests {
             let arg1 = m
                 .push_and_make_operand(jit_ir::LoadTraceInputInst::new(0, i8_ty_idx).into())
                 .unwrap();
-            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, &[arg1]).unwrap();
+            let call_inst = jit_ir::CallInst::new(&mut m, func_decl_idx, vec![arg1]).unwrap();
             m.push(call_inst.into()).unwrap();
 
             X64CodeGen::new(&m, Box::new(SpillAllocator::new(STACK_DIRECTION)))

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -52,12 +52,8 @@ pub(crate) struct Module {
     ctr_id: u64,
     /// The IR trace as a linear sequence of instructions.
     insts: Vec<Inst>, // FIXME: this should be a TiVec.
-    /// The extra argument table.
-    ///
-    /// Used when a [CallInst]'s arguments don't fit inline.
-    ///
-    /// An [ExtraArgsIdx] describes an index into this.
-    extra_args: Vec<Operand>,
+    /// The arguments pool for [CallInst]s. Indexed by [ArgsIdx].
+    args: Vec<Operand>,
     /// The constant pool.
     ///
     /// A [ConstIdx] describes an index into this.
@@ -135,7 +131,7 @@ impl Module {
         Ok(Self {
             ctr_id,
             insts: Vec::new(),
-            extra_args: Vec::new(),
+            args: Vec::new(),
             consts: IndexSet::new(),
             types,
             void_ty_idx,
@@ -238,16 +234,15 @@ impl Module {
         &self.insts
     }
 
-    /// Push a slice of extra arguments into the extra arg table.
+    /// Push a slice of arguments into the args pool.
     ///
     /// # Panics
     ///
-    /// If `ops` would overflow the index type.
-    fn push_extra_args(&mut self, ops: &[Operand]) -> Result<ExtraArgsIdx, CompilationError> {
-        assert!(ExtraArgsIdx::new(self.types.len()).is_ok());
-        let idx = self.extra_args.len();
-        self.extra_args.extend_from_slice(ops); // FIXME: this clones.
-        ExtraArgsIdx::new(idx)
+    /// If `args` would overflow the index type.
+    fn push_args(&mut self, args: &[Operand]) -> Result<ArgsIdx, CompilationError> {
+        let idx = self.args.len();
+        self.args.extend_from_slice(args); // FIXME: this clones.
+        ArgsIdx::new(idx)
     }
 
     /// Add a [Ty] to the types pool and return its index. If the [Ty] already exists, an existing
@@ -599,12 +594,10 @@ index_24bit!(FuncDeclIdx);
 pub(crate) struct TyIdx(U24);
 index_24bit!(TyIdx);
 
-/// An extra argument index.
-///
-/// One of these is an index into the [Module::extra_args].
+/// An argument index. This denotes the start of a slice into [Module::args].
 #[derive(Copy, Clone, Debug, Default)]
-pub(crate) struct ExtraArgsIdx(u16);
-index_16bit!(ExtraArgsIdx);
+pub(crate) struct ArgsIdx(u16);
+index_16bit!(ArgsIdx);
 
 /// A constant index.
 ///
@@ -1286,10 +1279,10 @@ impl LookupGlobalInst {
 pub struct CallInst {
     /// The callee.
     target: FuncDeclIdx,
-    /// How many arguments in [Module::extra_args] is this call passing?
+    /// At what index do the contiguous operands in [Module::args] start?
+    args_idx: ArgsIdx,
+    /// How many arguments in [Module::args] is this call passing?
     num_args: u16,
-    /// At what index do the contiguous operands in [Module::extra_args] start?
-    extra_idx: ExtraArgsIdx,
 }
 
 impl CallInst {
@@ -1298,10 +1291,10 @@ impl CallInst {
         target: FuncDeclIdx,
         args: &[Operand],
     ) -> Result<CallInst, CompilationError> {
-        let extra_idx = ExtraArgsIdx::new(m.extra_args.len())?;
-        m.push_extra_args(args)?;
+        let args_idx = m.push_args(args)?;
         Ok(Self {
             target,
+            args_idx,
             num_args: u16::try_from(args.len()).map_err(|_| {
                 CompilationError::LimitExceeded(format!(
                     "{} arguments passed but at most {} can be handled",
@@ -1309,7 +1302,6 @@ impl CallInst {
                     u16::MAX
                 ))
             })?,
-            extra_idx,
         })
     }
 
@@ -1329,7 +1321,7 @@ impl CallInst {
     ///
     /// Panics if the operand index is out of bounds.
     pub(crate) fn operand(&self, m: &Module, idx: usize) -> Operand {
-        m.extra_args[usize::from(self.extra_idx) + idx].clone()
+        m.args[usize::from(self.args_idx) + idx].clone()
     }
 }
 
@@ -1651,7 +1643,7 @@ mod tests {
         assert_eq!(ci.operand(&m, 1), Operand::Local(InstIdx(1)));
         assert_eq!(ci.operand(&m, 2), Operand::Local(InstIdx(2)));
         assert_eq!(
-            m.extra_args,
+            m.args,
             vec![
                 Operand::Local(InstIdx(0)),
                 Operand::Local(InstIdx(1)),
@@ -1675,8 +1667,8 @@ mod tests {
 
         // Now build a call to the function.
         let args = vec![
-            Operand::Local(InstIdx(0)), // inline arg
-            Operand::Local(InstIdx(1)), // first extra arg
+            Operand::Local(InstIdx(0)),
+            Operand::Local(InstIdx(1)),
             Operand::Local(InstIdx(2)),
         ];
         let ci = CallInst::new(&mut m, func_decl_idx, &args).unwrap();
@@ -1728,18 +1720,18 @@ mod tests {
 
     #[test]
     fn index16_fits() {
-        assert!(ExtraArgsIdx::new(0).is_ok());
-        assert!(ExtraArgsIdx::new(1).is_ok());
-        assert!(ExtraArgsIdx::new(0x1234).is_ok());
-        assert!(ExtraArgsIdx::new(0xffff).is_ok());
+        assert!(ArgsIdx::new(0).is_ok());
+        assert!(ArgsIdx::new(1).is_ok());
+        assert!(ArgsIdx::new(0x1234).is_ok());
+        assert!(ArgsIdx::new(0xffff).is_ok());
     }
 
     #[test]
     fn index16_doesnt_fit() {
-        assert!(ExtraArgsIdx::new(0x10000).is_err());
-        assert!(ExtraArgsIdx::new(0x12345).is_err());
-        assert!(ExtraArgsIdx::new(0xffffff).is_err());
-        assert!(ExtraArgsIdx::new(usize::MAX).is_err());
+        assert!(ArgsIdx::new(0x10000).is_err());
+        assert!(ArgsIdx::new(0x12345).is_err());
+        assert!(ArgsIdx::new(0xffffff).is_err());
+        assert!(ArgsIdx::new(usize::MAX).is_err());
     }
 
     #[test]

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -54,13 +54,9 @@ pub(crate) struct Module {
     insts: Vec<Inst>, // FIXME: this should be a TiVec.
     /// The arguments pool for [CallInst]s. Indexed by [ArgsIdx].
     args: Vec<Operand>,
-    /// The constant pool.
-    ///
-    /// A [ConstIdx] describes an index into this.
+    /// The constant pool. Indexed by [ConstIdx].
     consts: IndexSet<Constant>,
-    /// The type pool.
-    ///
-    /// A [TyIdx] describes an index into this.
+    /// The type pool. Indexed by [TyIdx].
     types: IndexSet<Ty>,
     /// The type index of the void type. Cached for convenience.
     void_ty_idx: TyIdx,
@@ -68,12 +64,8 @@ pub(crate) struct Module {
     ptr_ty_idx: TyIdx,
     /// The type index of an 8-bit integer. Cached for convenience.
     int8_ty_idx: TyIdx,
-    /// The function declaration pool.
-    ///
-    /// These are declarations of externally compiled functions that the JITted trace might need to
-    /// call.
-    ///
-    /// A [FuncDeclIdx] is an index into this.
+    /// The function declaration pool. These are declarations of externally compiled functions that
+    /// the JITted trace might need to call. Indexed by [FuncDeclIdx].
     func_decls: IndexSet<FuncDecl>,
     /// The global variable declaration table.
     ///

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -573,7 +573,7 @@ impl<'a> TraceBuilder<'a> {
 
             let jit_func_decl_idx = self.handle_func(*callee)?;
             let instr =
-                jit_ir::CallInst::new(&mut self.jit_mod, jit_func_decl_idx, &jit_args)?.into();
+                jit_ir::CallInst::new(&mut self.jit_mod, jit_func_decl_idx, jit_args)?.into();
             self.copy_instruction(instr, bid, aot_inst_idx)
         }
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/ykjit/yk/pull/1130, further tidying up `CallInst`. It's mostly fairly mechanical.