### PR TITLE
Tidy x86_64 codegen

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -100,10 +100,6 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
     fn codegen(mut self: Box<Self>) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         let alloc_off = self.emit_prologue();
 
-        // FIXME: we'd like to be able to assemble code backwards as this would simplify register
-        // allocation and side-step the need to patch up the prolog after the fact. dynasmrs
-        // doesn't support this, but it's on their roadmap:
-        // https://github.com/CensoredUsername/dynasm-rs/issues/48
         for (idx, inst) in self.m.insts().iter().enumerate() {
             self.codegen_inst(jit_ir::InstIdx::new(idx)?, inst)?;
         }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -143,20 +143,12 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
         // This unwrap cannot fail if `commit` (above) succeeded.
         let buf = self.asm.finalize().unwrap();
 
-        #[cfg(not(any(debug_assertions, test)))]
-        return Ok(Arc::new(X64CompiledTrace {
+        Ok(Arc::new(X64CompiledTrace {
             buf,
             deoptinfo: self.deoptinfo,
-        }));
-        #[cfg(any(debug_assertions, test))]
-        {
-            let comments = self.comments.take();
-            Ok(Arc::new(X64CompiledTrace {
-                buf,
-                deoptinfo: self.deoptinfo,
-                comments,
-            }))
-        }
+            #[cfg(any(debug_assertions, test))]
+            comments: self.comments.take(),
+        }))
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -475,7 +475,7 @@ impl<'a> X64CodeGen<'a> {
         panic!("Cannot lookup globals in cfg(test) as ykllvm will not have compiled this binary");
     }
 
-    pub(super) fn emit_call(
+    fn emit_call(
         &mut self,
         inst_idx: InstIdx,
         func_decl_idx: FuncDeclIdx,
@@ -530,7 +530,7 @@ impl<'a> X64CodeGen<'a> {
     }
 
     /// Codegen a (non-varargs) call.
-    pub(super) fn codegen_call_inst(
+    fn codegen_call_inst(
         &mut self,
         inst_idx: InstIdx,
         inst: &jit_ir::CallInst,
@@ -542,7 +542,7 @@ impl<'a> X64CodeGen<'a> {
         self.emit_call(inst_idx, func_decl_idx, &args)
     }
 
-    pub(super) fn codegen_icmp_inst(&mut self, inst_idx: InstIdx, inst: &jit_ir::IcmpInst) {
+    fn codegen_icmp_inst(&mut self, inst_idx: InstIdx, inst: &jit_ir::IcmpInst) {
         let (left, pred, right) = (inst.left(), inst.predicate(), inst.right());
 
         // FIXME: We should be checking type equality here, but since constants currently don't
@@ -810,7 +810,7 @@ mod tests {
     }
 
     /// Test helper to use `fm` to match a disassembled trace.
-    pub(crate) fn match_asm(cgo: Arc<X64CompiledTrace>, pattern: &str) {
+    fn match_asm(cgo: Arc<X64CompiledTrace>, pattern: &str) {
         let dis = cgo.disassemble().unwrap();
 
         // Use `{{name}}` to match non-literal strings in tests.

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -655,12 +655,6 @@ impl<'a> X64CodeGen<'a> {
         );
     }
 
-    fn const_u64_into_reg(&mut self, reg: Rq, cv: u64) {
-        dynasm!(self.asm
-            ; mov Rq(reg.code()), QWORD cv as i64 // `as` intentional.
-        )
-    }
-
     /// Load an operand into a register.
     fn operand_into_reg(&mut self, reg: Rq, op: &Operand) {
         match op {


### PR DESCRIPTION
Needs https://github.com/ykjit/yk/pull/1132 merged first.

This PR has various tidy-ups of the x86_64 codegen. Mostly fairly minor, though they make the code at least somewhat easier to follow I hope.