### PR TITLE
Use a `TiVec` for `jit_ir::Module::insts`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -104,8 +104,8 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
     fn codegen(mut self: Box<Self>) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         let alloc_off = self.emit_prologue();
 
-        for (idx, inst) in self.m.insts().iter().enumerate() {
-            self.cg_inst(jit_ir::InstIdx::new(idx)?, inst)?;
+        for (idx, inst) in self.m.insts().iter_enumerated() {
+            self.cg_inst(idx, inst)?;
         }
 
         // Loop the JITted code if the backedge target label is present.

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -51,7 +51,7 @@ pub(crate) struct Module {
     /// semi-uniquely distinguish traces (see [MT::compiled_trace_id] for more details).
     ctr_id: u64,
     /// The IR trace as a linear sequence of instructions.
-    insts: Vec<Inst>, // FIXME: this should be a TiVec.
+    insts: TiVec<InstIdx, Inst>,
     /// The arguments pool for [CallInst]s. Indexed by [ArgsIdx].
     args: Vec<Operand>,
     /// The constant pool. Indexed by [ConstIdx].
@@ -122,7 +122,7 @@ impl Module {
 
         Ok(Self {
             ctr_id,
-            insts: Vec::new(),
+            insts: TiVec::new(),
             args: Vec::new(),
             consts: IndexSet::new(),
             types,
@@ -175,7 +175,7 @@ impl Module {
 
     /// Return the instruction at the specified index.
     pub(crate) fn inst(&self, idx: InstIdx) -> &Inst {
-        &self.insts[usize::from(idx)]
+        &self.insts[idx]
     }
 
     /// Push an instruction to the end of the [Module].
@@ -222,7 +222,7 @@ impl Module {
     }
 
     /// Returns a reference to the instruction stream.
-    pub(crate) fn insts(&self) -> &Vec<Inst> {
+    pub(crate) fn insts(&self) -> &TiVec<InstIdx, Inst> {
         &self.insts
     }
 
@@ -346,8 +346,8 @@ impl fmt::Display for Module {
             )?;
         }
         write!(f, "\nentry:")?;
-        for (i, inst) in self.insts().iter().enumerate() {
-            write!(f, "\n    {}", inst.display(InstIdx::from(i), self))?;
+        for (i, inst) in self.insts().iter_enumerated() {
+            write!(f, "\n    {}", inst.display(i, self))?;
         }
 
         Ok(())

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -29,7 +29,7 @@ use std::{
     ffi::{c_void, CStr, CString},
     fmt, mem,
 };
-use typed_index_collections::TiVec;
+use typed_index_collections::{TiSlice, TiVec};
 use ykaddr::addr::symbol_to_ptr;
 
 // This is simple and can be shared across both IRs.
@@ -221,8 +221,8 @@ impl Module {
         self.insts.len()
     }
 
-    /// Returns a reference to the instruction stream.
-    pub(crate) fn insts(&self) -> &TiVec<InstIdx, Inst> {
+    /// Return a slice of this module's instructions.
+    pub(crate) fn insts(&self) -> &TiSlice<InstIdx, Inst> {
         &self.insts
     }
 


### PR DESCRIPTION
This addresses a FIXME.