### PR TITLE
A more consistent Clippy approach

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -20,6 +20,8 @@ export PATH="${CARGO_HOME}"/bin/:"$PATH"
 
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 
+# Formatting problems are frequent in PRs, and easy to fix, so try and catch
+# those before doing anything complicated.
 cargo fmt --all -- --check
 
 # We now need a copy of ykllvm. Building this is quite slow so if there's a

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -79,13 +79,9 @@ YKLLVM_BIN_DIR=$(pwd)/../inst/bin
 export YKB_YKLLVM_BIN_DIR="${YKLLVM_BIN_DIR}"
 cd ../../
 
-# Check that clang-format is installed.
-PATH=${YKB_YKLLVM_BIN_DIR}:${PATH} clang-format --version
-# Check C/C++ formatting using xtask.
+# Check C/C++ formatting. First we run `xtask cfmt`...
 PATH=${YKB_YKLLVM_BIN_DIR}:${PATH} cargo xtask cfmt
-# This is used to check clang-tidy output, but the dirty submodule from building
-# ykllvm is also shown.
-# FIXME: Add build/ to .gitignore in ykllvm
+# ... and then we see if it caused any changes (i.e. caused the git repo to become dirty).
 git diff --exit-code --ignore-submodules
 
 for tracer in ${TRACERS}; do

--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,5 +1,7 @@
 FROM debian:latest
 ARG CI_UID
+ARG CI_RUNNER
+ENV CI_RUNNER=${CI_RUNNER}
 RUN useradd -m -u ${CI_UID} ci
 RUN apt-get update && \
 apt-get -y install clang-15 make curl procps file git cmake python3 \

--- a/ykrt/src/compile/jitc_llvm/deopt.rs
+++ b/ykrt/src/compile/jitc_llvm/deopt.rs
@@ -352,9 +352,10 @@ unsafe extern "C" fn __ykrt_deopt(
                 }
             }
             // Execute the side trace.
-            let f = mem::transmute::<_, unsafe extern "C" fn(*mut c_void, *const c_void) -> !>(
-                st.entry(),
-            );
+            let f = mem::transmute::<
+                *const c_void,
+                unsafe extern "C" fn(*mut c_void, *const c_void) -> !,
+            >(st.entry());
             ctr.mt().stats.timing_state(TimingState::JitExecuting);
             drop(ctr);
 

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -266,7 +266,7 @@ impl Module {
     ///
     /// Panics if the index is out of bounds.
     pub(crate) fn const_(&self, idx: ConstIdx) -> &Constant {
-        &self.consts.get_index(usize::from(idx)).unwrap()
+        self.consts.get_index(usize::from(idx)).unwrap()
     }
 
     /// Add a new [GlobalDecl] to the pool and return its index. If the [GlobalDecl] already
@@ -339,11 +339,7 @@ impl fmt::Display for Module {
             } else {
                 ""
             };
-            write!(
-                f,
-                "@{}{tl}\n",
-                g.name.to_str().unwrap_or("<not valid UTF-8>")
-            )?;
+            writeln!(f, "@{}{tl}", g.name.to_str().unwrap_or("<not valid UTF-8>"))?;
         }
         write!(f, "\nentry:")?;
         for (i, inst) in self.insts().iter_enumerated() {

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -7,7 +7,6 @@
 #![feature(strict_provenance)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]
-#![allow(clippy::missing_safety_doc)]
 #![allow(clippy::upper_case_acronyms)]
 
 pub(crate) mod aotsmp;

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -6,7 +6,6 @@
 #![feature(ptr_sub_ptr)]
 #![feature(strict_provenance)]
 #![allow(clippy::type_complexity)]
-#![allow(clippy::new_without_default)]
 #![allow(clippy::upper_case_acronyms)]
 
 pub(crate) mod aotsmp;

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -196,6 +196,12 @@ impl Location {
     }
 }
 
+impl Default for Location {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Drop for Location {
     fn drop(&mut self) {
         let x = self.inner.load(Ordering::Relaxed);

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -251,9 +251,10 @@ impl MT {
                 let f = unsafe {
                     #[cfg(feature = "yk_testing")]
                     assert_ne!(ctr.entry() as *const (), std::ptr::null());
-                    mem::transmute::<_, unsafe extern "C" fn(*mut c_void, *const c_void) -> !>(
-                        ctr.entry(),
-                    )
+                    mem::transmute::<
+                        *const c_void,
+                        unsafe extern "C" fn(*mut c_void, *const c_void) -> !,
+                    >(ctr.entry())
                 };
                 MTThread::with(|mtt| {
                     mtt.set_running_trace(Some(ctr));

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -12,10 +12,6 @@
 //!
 //! This module thus contains tracing backends which can record and process traces.
 
-#![allow(clippy::len_without_is_empty)]
-#![allow(clippy::new_without_default)]
-#![allow(clippy::missing_safety_doc)]
-
 use std::{error::Error, ffi::CString, sync::Arc};
 use thiserror::Error;
 

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -43,7 +43,7 @@ static FUNC_NAMES: LazyLock<HashMap<usize, CString>> = LazyLock::new(|| {
 
 thread_local! {
     // Collection of traced basic blocks.
-    static BASIC_BLOCKS: RefCell<Vec<TracingBBlock>> = RefCell::new(vec![]);
+    static BASIC_BLOCKS: RefCell<Vec<TracingBBlock>> = const { RefCell::new(vec![]) };
 }
 
 /// Inserts LLVM IR basicblock metadata into a thread-local BASIC_BLOCKS vector.
@@ -118,9 +118,9 @@ struct SWTraceIterator {
 
 impl SWTraceIterator {
     fn new(bbs: Vec<TracingBBlock>) -> SWTraceIterator {
-        return SWTraceIterator {
+        SWTraceIterator {
             bbs: bbs.into_iter(),
-        };
+        }
     }
 }
 

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::len_without_is_empty)]
-#![allow(clippy::new_without_default)]
 
 //! Note that LLVM currently only supports stackmaps for 64 bit architectures. Once they support
 //! others we will need to either make this parser more dynamic or create a new one for each

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::len_without_is_empty)]
-
 //! Note that LLVM currently only supports stackmaps for 64 bit architectures. Once they support
 //! others we will need to either make this parser more dynamic or create a new one for each
 //! architecture.
@@ -50,6 +48,10 @@ pub struct LiveVar {
 impl LiveVar {
     pub fn len(&self) -> usize {
         self.locs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.locs.is_empty()
     }
 
     pub fn get(&self, idx: usize) -> Option<&Location> {


### PR DESCRIPTION
This PR does three main things:

1. An audit for no-longer-needed Clippy hints.
2. Fix Clippy warnings, many of which have crept into the code since the last Clippy PR 10 days (!) ago https://github.com/ykjit/yk/pull/1111.
3. Experiment with a way of stopping so many Clippy things slipping into the code.

The problem with (3) is that the people who do (2) are mostly not the people introducing things that need (3). In other words, Clippy isn't helping all of us equally, and some folk are introducing the same easily-spotted-by-Clippy issues repeatedly.

https://github.com/ykjit/yk/commit/5212b9bab59b0baeb7c0a5c9e90eba80c8a70daa thus *enforces* Clippy from now on: it uses [cargo-diff-tools](https://github.com/fpoli/cargo-diff-tools/) to raise an error when a PR introduces a change which triggers a Clippy hint. Note that this is slightly clever: if Clippy changes (which it does, and often!) this will suppress warnings on code not changed by a PR. So it will encourage us not to merge code that obviously violates Clippy.

Does this commit have the potential to be annoying? Definitely! Maybe too annoying? Possibly. If it is too annoying, we can revert this commit later. But I think it's worth trying: I find that perhaps 80% of Clippy lints actively improve code; 10% are neutral; and 10% are wrong. We can always suppress that latter category with `allow(...)` if we need to.