### PR TITLE
Clippy now wants to know all the `cfg` flags we've added.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -106,14 +106,6 @@ for tracer in ${TRACERS}; do
 
     # Error if Clippy detects any warnings introduced in lines changed in this PR.
     cargo-clippy-diff origin/master -- --all-features -- -D warnings
-
-    # There are some feature-gated testing/debugging switches which slow the JIT
-    # down a bit. Check that if we build the system without tests, those features
-    # are not enabled.
-    cargo -Z unstable-options build --build-plan -p ykcapi | \
-      awk '/yk_testing/ { ec=1 } END {exit ec}'
-    cargo -Z unstable-options build --build-plan -p ykrt | \
-      awk '/yk_testing/ { ec=1 } /yk_jitstate_debug/ { ec=1 } END {exit ec}'
 done
 
 # Run the tests multiple times on hwt to try and catch non-deterministic
@@ -188,10 +180,6 @@ fi
 
 for tracer in $TRACERS; do
     export YKB_TRACER="${tracer}"
-    cargo -Z unstable-options build --release --build-plan -p ykcapi | \
-      awk '/yk_testing/ { ec=1 } /yk_jitstate_debug/ { ec=1 } END {exit ec}'
-
-    cargo build --release -p ykcapi
     echo "===> Running ${tracer} tests"
     RUST_TEST_SHUFFLE=1 cargo test --release
     YKD_NEW_CODEGEN=1 RUST_TEST_SHUFFLE=1 cargo test --release

--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -34,11 +34,14 @@ fn main() {
         if feature_check("linux_perf.c", "linux_perf") {
             c_build.file("src/perf/collect.c");
             println!("cargo:rustc-cfg=linux_perf");
+            println!("cargo::rustc-check-cfg=cfg(linux_perf)");
 
             #[cfg(target_arch = "x86_64")]
             {
                 println!("cargo:rustc-cfg=ykpt");
+                println!("cargo::rustc-check-cfg=cfg(ykpt)");
                 println!("cargo:rustc-cfg=pt");
+                println!("cargo::rustc-check-cfg=cfg(pt)");
             }
         }
     }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -8,6 +8,9 @@ pub fn main() {
     // Expose the cargo profile to run.rs so that it can set the right link flags.
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=cargo_profile=\"{}\"", profile);
+        println!(
+            r#"cargo::rustc-check-cfg=cfg(cargo_profile, values("debug", "release", "release-with-debug"))"#
+        );
     }
 
     ykbuild::apply_llvm_ld_library_path();

--- a/ykcapi/build.rs
+++ b/ykcapi/build.rs
@@ -6,6 +6,8 @@ pub fn main() {
     // FIXME: This is a temporary hack because LLVM has problems if the main thread exits before
     // compilation threads have finished.
     println!("cargo:rustc-cfg=yk_llvm_sync_hack");
+    println!("cargo::rustc-check-cfg=cfg(yk_llvm_sync_hack)");
+
     println!("cargo:rerun-if-env-changed=YKB_TRACER");
     match env::var("YKB_TRACER") {
         Ok(ref tracer) if tracer == "swt" => println!("cargo:rustc-cfg=tracer_swt"),

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -5,11 +5,17 @@ pub fn main() {
     println!("cargo:rerun-if-env-changed=YKB_TRACER");
     // Always compile in the LLVM JIT compiler.
     println!("cargo:rustc-cfg=jitc_llvm");
+    println!("cargo::rustc-check-cfg=cfg(jitc_llvm)");
     // Always compile in our bespoke JIT compiler.
     println!("cargo:rustc-cfg=jitc_yk");
+    println!("cargo::rustc-check-cfg=cfg(jitc_yk)");
     // FIXME: This is a temporary hack because LLVM has problems if the main thread exits before
     // compilation threads have finished.
     println!("cargo:rustc-cfg=yk_llvm_sync_hack");
+    println!("cargo::rustc-check-cfg=cfg(yk_llvm_sync_hack)");
+
+    println!("cargo::rustc-check-cfg=cfg(tracer_hwt)");
+    println!("cargo::rustc-check-cfg=cfg(tracer_swt)");
     match env::var("YKB_TRACER") {
         Ok(ref tracer) if tracer == "swt" => println!("cargo:rustc-cfg=tracer_swt"),
         Ok(ref tracer) if tracer == "hwt" => println!("cargo:rustc-cfg=tracer_hwt"),


### PR DESCRIPTION
Without specifying these -- and, where they have values, their values -- Clippy now generates warnings. Unfortunately, adding these in means that one old Buildbot check no longer works (it always fails because "yk_testing" is now always part of Cargo's output). So we have to forego those.