### PR TITLE
Dockerfile speedups

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,20 +1,19 @@
 FROM debian:latest
+WORKDIR /ci
+RUN apt-get update && \
+  apt-get -y install clang-15 make curl procps file git cmake python3 \
+    libtinfo-dev libzip-dev mold ninja-build && \
+  update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 999 && \
+  update-alternatives --set cc /usr/bin/clang-15 && \
+  update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 999 && \
+  update-alternatives --set c++ /usr/bin/clang++-15 && \
+  update-alternatives --install /usr/bin/ld ld /usr/bin/mold 999 && \
+  update-alternatives --set ld /usr/bin/mold && \
+  ln -sf /usr/bin/clang-15 /usr/bin/clang && \
+  ln -sf /usr/bin/clang++-15 /usr/bin/clang++
 ARG CI_UID
+RUN useradd -m -u ${CI_UID} ci && chown ${CI_UID}:${CI_UID} .
 ARG CI_RUNNER
 ENV CI_RUNNER=${CI_RUNNER}
-RUN useradd -m -u ${CI_UID} ci
-RUN apt-get update && \
-apt-get -y install clang-15 make curl procps file git cmake python3 \
-    libtinfo-dev libzip-dev mold ninja-build
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 999
-RUN update-alternatives --set cc /usr/bin/clang-15
-RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 999
-RUN update-alternatives --set c++ /usr/bin/clang++-15
-RUN update-alternatives --install /usr/bin/ld ld /usr/bin/mold 999
-RUN update-alternatives --set ld /usr/bin/mold
-RUN ln -sf /usr/bin/clang-15 /usr/bin/clang
-RUN ln -sf /usr/bin/clang++-15 /usr/bin/clang++
-WORKDIR /ci
-RUN chown ${CI_UID}:${CI_UID} .
 COPY --chown=${CI_UID}:${CI_UID} . .
 CMD sh -x .buildbot.sh

--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,6 +1,9 @@
 FROM debian:latest
 WORKDIR /ci
-RUN apt-get update && \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+  rm -f /etc/apt/apt.conf.d/docker-clean && \
+  apt-get update && \
   apt-get -y install clang-15 make curl procps file git cmake python3 \
     libtinfo-dev libzip-dev mold ninja-build && \
   update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 999 && \


### PR DESCRIPTION
This PR uses insights from https://www.marcobehler.com/guides/docker-images and https://stackoverflow.com/a/72851168 to speed up using Docker. Between the two commits in this PR, tryci can go from taking ~75s to starting to about 15s. I suspect this will also speedup our use with buildbot.