### PR TITLE
Implement PtrToInt.

### DIFF
--- a/tests/c/ptrtoint.newcg.c
+++ b/tests/c/ptrtoint.newcg.c
@@ -1,0 +1,55 @@
+// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// Run-time:
+//   env-var: YKD_LOG_IR=-:jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG_JITSTATE=-
+//   stderr:
+//     jitstate: start-tracing
+//     ptr: {{ptr}}
+//     jitstate: stop-tracing
+//     --- Begin jit-pre-opt ---
+//     ...
+//     %{{1}}: i64 = ZeroExtend %{{2}}, i64
+//     ...
+//     --- End jit-pre-opt ---
+//     ptr: {{ptr}}
+//     jitstate: enter-jit-code
+//     ptr: {{ptr}}
+//     ptr: {{ptr}}
+//     jitstate: deoptimise
+//     exit
+
+// Check that basic trace compilation works.
+
+// FIXME: Get this test all the way through the new codegen pipeline!
+//
+// Currently it succeeds even though it crashes on deopt. This is so
+// that we can incrementally implement the new codegen and have CI merge our
+// incomplete work.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    long ptr = (long)&loc;
+    fprintf(stderr, "ptr: %ld\n", ptr);
+    i--;
+  }
+  fprintf(stderr, "exit\n");
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/ir_lowering/unsupported_variants.ll
+++ b/tests/ir_lowering/unsupported_variants.ll
@@ -24,6 +24,10 @@
 ;         unimplemented <<  %{{21}} = call ghccc i32 @f(i32 5)>>
 ;         unimplemented <<  %{{22}} = call i32 @f(i32 5) [ "kcfi"(i32 1234) ]>>
 ;         unimplemented <<  %{{23}} = call addrspace(6) ptr @p()>>
+;         br bb4
+;      bb4:
+;         unimplemented <<  %{{25}} = ptrtoint ptr %{{ptr}} to i8>>
+;         unimplemented <<  %{{26}} = ptrtoint <8 x ptr> %{{ptrs}} to <8 x i8>>>
 ;         ret
 ;     }
 ;     ...
@@ -86,5 +90,9 @@ calls:
   %14 = call addrspace(6) ptr @p()
   ; stackmap required (but irrelevant for the test) for all of the above calls.
   call void (i64, i32, ...) @llvm.experimental.stackmap(i64 7, i32 0);
+  br label %casts
+casts:
+  %15 = ptrtoint ptr %ptr to i8
+  %16 = ptrtoint <8 x ptr> %ptrs to <8 x i8>
   ret void
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -750,10 +750,12 @@ impl<'a> X64CodeGen<'a> {
         let to_type = self.m.type_(i.dest_ty_idx());
         let to_size = to_type.byte_size().unwrap();
 
-        // You can only zero-extend a smaller integer to a larger integer.
         debug_assert!(matches!(to_type, jit_ir::Ty::Integer(_)));
-        debug_assert!(matches!(from_type, jit_ir::Ty::Integer(_)));
-        debug_assert!(from_size < to_size);
+        debug_assert!(
+            matches!(from_type, jit_ir::Ty::Integer(_)) || matches!(from_type, jit_ir::Ty::Ptr)
+        );
+        // You can only zero-extend a smaller integer to a larger integer.
+        debug_assert!(from_size <= to_size);
 
         // FIXME: assumes the input and output fit in a register.
         self.load_operand(WR0, &from_val);


### PR DESCRIPTION
Since we cast them to zeroextend instructions, we only have to adjust some debug_asserts to make this work.

Requires: https://github.com/ykjit/ykllvm/pull/158