### PR TITLE
Test unsupported call instructions.

### DIFF
--- a/tests/ir_lowering/unsupported_variants.ll
+++ b/tests/ir_lowering/unsupported_variants.ll
@@ -15,14 +15,38 @@
 ;         unimplemented <<  %{{13}} = fadd nnan float %{{3}}, %{{3}}>>
 ;         unimplemented <<  %{{14}} = udiv exact i32 %{{2}}, 1>>
 ;         unimplemented <<  %{{15}} = add <4 x i32> %{{44}}, %{{44}}>>
+;         br bb3
+;      bb3:
+;         unimplemented <<  %{{17}} = call i32 @f(i32 swiftself 5)>>
+;         unimplemented <<  %{{18}} = call inreg i32 @f(i32 5)>>
+;         unimplemented <<  %{{19}} = call i32 @f(i32 5) #{{0}}>>
+;         unimplemented <<  %{{20}} = call nnan float @g()>>
+;         unimplemented <<  %{{21}} = call ghccc i32 @f(i32 5)>>
+;         unimplemented <<  %{{22}} = call i32 @f(i32 5) [ "kcfi"(i32 1234) ]>>
+;         unimplemented <<  %{{23}} = call addrspace(6) ptr @p()>>
 ;         ret
 ;     }
+;     ...
 
 ; This test ensures that as-yet unsupported variants of LLVM instructions are
 ; serialised as an unsupported instruction in the AOT IR. This prevents the JIT
 ; from silently miscompiling things we haven't yet thought about.
 
 @arr = global [4 x i8] zeroinitializer
+
+define i32 @f(i32 %num) {
+    ret i32 5
+}
+
+define float @g() {
+    ret float 5.5
+}
+
+define ptr @p() addrspace(6) {
+    ret ptr null
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...);
 
 define void @main(ptr %ptr, <8 x ptr> %ptrs, i32 %num, float %flt, <4 x i32> %vecnums) {
 geps:
@@ -40,5 +64,27 @@ binops:
   %5 = fadd nnan float %flt, %flt
   %6 = udiv exact i32 %num, 1
   %7 = add <4 x i32> %vecnums, %vecnums
+  br label %calls
+calls:
+  ; FIXME: we are unable to test `musttail` because a tail call must be
+  ; succeeded by either a `ret` or a `bitcast` and then a `ret`. But the JIT
+  ; requires a stackmap after a call...
+  ;
+  ; param attrs
+  %8 = call i32 @f(i32 swiftself 5)
+  ; ret attrs
+  %9 = call inreg i32 @f(i32 5)
+  ; func attrs
+  %10 = call i32 @f(i32 5) alignstack(8)
+  ; fast math flags
+  %11 = call nnan float @g()
+  ; Non-C calling conventions.
+  %12 = call ghccc i32 @f(i32 5)
+  ; operand bundles
+  %13 = call i32 @f(i32 5) ["kcfi"(i32 1234)]
+  ; non-zero address spaces
+  %14 = call addrspace(6) ptr @p()
+  ; stackmap required (but irrelevant for the test) for all of the above calls.
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 7, i32 0);
   ret void
 }


### PR DESCRIPTION
Requires a ykllvm change: https://github.com/ykjit/ykllvm/pull/159