### PR TITLE
Deserialise unimplemented constants.

### DIFF
--- a/tests/ir_lowering/struct.ll
+++ b/tests/ir_lowering/struct.ll
@@ -1,9 +1,9 @@
 ; Dump:
 ;   stdout:
 ;     ...
-;     func main() {
+;     func main($arg0: {0: i32, 64: i64}) {
 ;       bb0:
-;         $0_0: {0: i32, 64: i64} = insertvalue const_struct, 100i32
+;         $0_0: {0: i32, 64: i64} = insertvalue $arg0, 100i32
 ;         ret
 ;     }
 
@@ -11,8 +11,8 @@
 
 %s = type { i32, i64 }
 
-define void @main() {
+define void @main(%s %val) {
 entry:
-  %0 = insertvalue %s zeroinitializer, i32 100, 0
+  %0 = insertvalue %s %val, i32 100, 0
   ret void
 }

--- a/tests/ir_lowering/unsupported_variants.ll
+++ b/tests/ir_lowering/unsupported_variants.ll
@@ -37,8 +37,6 @@
 ; serialised as an unsupported instruction in the AOT IR. This prevents the JIT
 ; from silently miscompiling things we haven't yet thought about.
 
-@arr = global [4 x i8] zeroinitializer
-
 define i32 @f(i32 %num) {
     ret i32 5
 }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -344,6 +344,7 @@ impl<'a> TraceBuilder<'a> {
         &mut self,
         aot_const: &aot_ir::Const,
     ) -> Result<jit_ir::Const, CompilationError> {
+        let aot_const = aot_const.unwrap_val();
         let jit_ty_idx = self.handle_type(self.aot_mod.type_(aot_const.ty_idx()))?;
         Ok(jit_ir::Const::new(jit_ty_idx, Vec::from(aot_const.bytes())))
     }
@@ -461,7 +462,7 @@ impl<'a> TraceBuilder<'a> {
                 panic!();
             };
             assert!(ity.num_bits() == u64::BITS);
-            let id = u64::from_ne_bytes(c.bytes()[0..8].try_into().unwrap());
+            let id = u64::from_ne_bytes(c.unwrap_val().bytes()[0..8].try_into().unwrap());
             smids.push(id);
 
             // Collect live variables.


### PR DESCRIPTION
Requires a ykllvm change: https://github.com/ykjit/ykllvm/pull/164

Before, we serialised unimplemented LLVM constants as a zero-sized Yk constants.

This turned out to be a big mistake, as you don't find out there's a problem until the constant is used and you then have to go on a wild goose chase to find out what's wrong.

This change introduces an explicit "unimplemented constant", which crashes when you ask of it: "what's your type?" or "can I have your bytes?". The panic message then tells you what's up right away.

This changes a yklua `db.lua` crash from:

```
thread '<unnamed>' panicked at ykrt/src/compile/jitc_yk/jit_ir.rs:880:17:
assertion `left == right` failed
  left: 0
 right: 8
```

into:

```
unimplemented const: ptr null
```

To make this happen, I had to make the existing `struct Const` into an `enum Const` containing an `Unimplemented` variant.

I had hoped to express an unimplemented constant at the operand level (serialising an unimplemented *operand*) but this isn't easy. Because a constant index and the constant bytes are serialised at different times, you don't know a constant is unimplemented until after you've already encoded it as an instruction operand. So the "unimplementedness" has to be in `Const` somewhere -- that's what I've done here.