### PR TITLE
Add a basic JIT IR parser.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -42,6 +42,9 @@ default-features = false
 features = ["read_core", "elf"]
 
 [build-dependencies]
+cfgrammar = "0.13"
+lrlex = "0.13"
+lrpar = "0.13"
 regex = "1.9"
 ykbuild = { path = "../ykbuild" }
 
@@ -55,5 +58,8 @@ ykd = ["yktracec/yk_testing"]
 yk_testing = ["yktracec/yk_testing"]
 
 [dev-dependencies]
+cfgrammar = "0.13"
 fm = "0.3.0"
+lrlex = "0.13"
+lrpar = "0.13"
 regex = { version = "1.9", features = ["std"] }

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -1,3 +1,6 @@
+use cfgrammar::yacc::YaccKind;
+use lrlex::{CTLexerBuilder, DefaultLexerTypes};
+
 use std::env;
 
 pub fn main() {
@@ -23,4 +26,19 @@ pub fn main() {
         Ok(x) => panic!("Unknown tracer {x}"),
         Err(_) => panic!("Invalid value for YKB_TRACER"),
     }
+
+    // We need to explicitly tell Cargo to track these files otherwise it won't rebuild when they
+    // change.
+    println!("cargo::rerun-if-changed=src/compile/jitc_yk/jit_ir.y");
+    println!("cargo::rerun-if-changed=src/compile/jitc_yk/jit_ir.l");
+    CTLexerBuilder::<DefaultLexerTypes<u8>>::new_with_lexemet()
+        .lrpar_config(|ctp| {
+            ctp.yacckind(YaccKind::Grmtools)
+                .grammar_in_src_dir("compile/jitc_yk/jit_ir.y")
+                .unwrap()
+        })
+        .lexer_in_src_dir("compile/jitc_yk/jit_ir.l")
+        .unwrap()
+        .build()
+        .unwrap();
 }

--- a/ykrt/src/compile/jitc_yk/jit_ir.l
+++ b/ykrt/src/compile/jitc_yk/jit_ir.l
@@ -1,0 +1,15 @@
+%%
+@[a-zA-Z_.]+ "GLOBAL"
+%[0-9]+ "LOCAL_OPERAND"
+i[0-9]+ "INT_TYPE"
+[0-9]+ "INT"
+load_ti "LOAD_TI"
+test_use "TEST_USE"
+add "ADD"
+[a-zA_Z_]+: "LABEL"
+[a-zA_Z_]+ "ID"
+: ":"
+, ","
+= "="
+;.*?$ ;
+[\t \n\r]+ ;

--- a/ykrt/src/compile/jitc_yk/jit_ir.y
+++ b/ykrt/src/compile/jitc_yk/jit_ir.y
@@ -1,0 +1,62 @@
+%start Module
+
+%%
+
+Module -> Result<(Vec<()>, Vec<ASTBBlock>), Box<dyn Error>>:
+    Globals BBlocks {
+      Ok(($1?, $2?))
+    }
+  ;
+
+Globals -> Result<Vec<()>, Box<dyn Error>>:
+    "GLOBAL" Globals { todo!() }
+  | { Ok(Vec::new()) }
+  ;
+
+BBlocks -> Result<Vec<ASTBBlock>, Box<dyn Error>>:
+    BBlock BBlocks { flatten($1, $2) }
+  | { Ok(Vec::new()) }
+  ;
+
+BBlock -> Result<ASTBBlock, Box<dyn Error>>:
+    "LABEL" Insts { Ok(ASTBBlock{ label: $1?.span(), insts: $2?}) }
+  ;
+
+Insts -> Result<Vec<ASTInst>, Box<dyn Error>>:
+    Inst Insts { flatten($1, $2) }
+  | { Ok(Vec::new()) }
+  ;
+
+Inst -> Result<ASTInst, Box<dyn Error>>:
+    "LOCAL_OPERAND" ":" Type "=" "LOAD_TI" "INT" "," Type  {
+      Ok(ASTInst::LoadTraceInput{type_: $3?, off: $6?.span()})
+    }
+  | "LOCAL_OPERAND" ":" Type "=" "ADD" Operand "," Operand  {
+      Ok(ASTInst::Add{type_: $3?, lhs: $6?, rhs: $8?})
+    }
+  | "TEST_USE" Operand { Ok(ASTInst::TestUse($2?)) }
+  ;
+
+Operand -> Result<ASTOperand, Box<dyn Error>>:
+    "LOCAL_OPERAND" { Ok(ASTOperand::Local($1?.span())) }
+  ;
+
+Type -> Result<ASTType, Box<dyn Error>>:
+    "INT_TYPE" { Ok(ASTType::Int($1?.span())) }
+  ;
+
+%%
+
+use crate::compile::jitc_yk::jit_ir_parser::*;
+use std::error::Error;
+
+fn flatten<T>(lhs: Result<T, Box<dyn Error>>, rhs: Result<Vec<T>, Box<dyn Error>>)
+  -> Result<Vec<T>, Box<dyn Error>>
+{
+    let lhs = lhs?;
+    let mut rhs = rhs?;
+    let mut out = Vec::with_capacity(rhs.len() + 1);
+    out.push(lhs);
+    out.append(&mut rhs);
+    Ok(out)
+}

--- a/ykrt/src/compile/jitc_yk/jit_ir_parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir_parser.rs
@@ -1,0 +1,156 @@
+//! A basic parser for JIT IR.
+//!
+//! This module -- which is only intended to be compiled-in in `cfg(test)` -- adds a `from_str`
+//! method to [Module] which takes in JIT IR as a string, parses it, and produces a [Module]. This
+//! makes it possible to write JIT IR tests using JIT IR concrete syntax.
+
+use super::jit_ir::{
+    AddInst, InstIdx, IntegerTy, LoadTraceInputInst, Module, Operand, TestUseInst, Ty, TyIdx,
+};
+use lrlex::{lrlex_mod, DefaultLexerTypes, LRNonStreamingLexer};
+use lrpar::{lrpar_mod, NonStreamingLexer, Span};
+use std::error::Error;
+
+lrlex_mod!("compile/jitc_yk/jit_ir.l");
+lrpar_mod!("compile/jitc_yk/jit_ir.y");
+
+type StorageT = u8;
+
+impl Module {
+    pub(crate) fn from_str(s: &str) -> Self {
+        // Get the `LexerDef` for the `calc` language.
+        let lexerdef = jit_ir_l::lexerdef();
+        let lexer = lexerdef.lexer(s);
+        // Pass the lexer to the parser and lex and parse the input.
+        let (res, errs) = jit_ir_y::parse(&lexer);
+        if !errs.is_empty() {
+            for e in errs {
+                eprintln!("{}", e.pp(&lexer, &jit_ir_y::token_epp));
+            }
+            panic!("Could not parse input");
+        }
+        match res {
+            Some(Ok((globals, bblocks))) => process(lexer, globals, bblocks).unwrap(),
+            _ => panic!("Could not produce JIT Module."),
+        }
+    }
+}
+
+fn process(
+    lexer: LRNonStreamingLexer<DefaultLexerTypes<StorageT>>,
+    _globals: Vec<()>,
+    bblocks: Vec<ASTBBlock>,
+) -> Result<Module, Box<dyn Error>> {
+    let mut m = Module::new_testing();
+    for bblock in bblocks {
+        for inst in bblock.insts {
+            match inst {
+                ASTInst::Add { type_: _, lhs, rhs } => {
+                    let inst =
+                        AddInst::new(process_operand(&lexer, lhs)?, process_operand(&lexer, rhs)?);
+                    m.push(inst.into()).unwrap();
+                }
+                ASTInst::LoadTraceInput { type_, off } => {
+                    let off = lexer
+                        .span_str(off)
+                        .parse::<u32>()
+                        .map_err(|e| error_at_span(&lexer, off, &e.to_string()))?;
+                    let inst = LoadTraceInputInst::new(off, process_type(&lexer, &mut m, type_)?);
+                    m.push(inst.into()).unwrap();
+                }
+                ASTInst::TestUse(op) => {
+                    let inst = TestUseInst::new(process_operand(&lexer, op)?);
+                    m.push(inst.into()).unwrap();
+                }
+            }
+        }
+    }
+    Ok(m)
+}
+
+fn process_operand(
+    lexer: &LRNonStreamingLexer<DefaultLexerTypes<StorageT>>,
+    op: ASTOperand,
+) -> Result<Operand, Box<dyn Error>> {
+    match op {
+        ASTOperand::Local(span) => {
+            let idx = lexer.span_str(span)[1..]
+                .parse::<usize>()
+                .map_err(|e| error_at_span(lexer, span, &e.to_string()))?;
+            Ok(Operand::Local(
+                InstIdx::new(idx).map_err(|e| error_at_span(lexer, span, &e.to_string()))?,
+            ))
+        }
+    }
+}
+
+fn process_type(
+    lexer: &LRNonStreamingLexer<DefaultLexerTypes<StorageT>>,
+    m: &mut Module,
+    type_: ASTType,
+) -> Result<TyIdx, Box<dyn Error>> {
+    match type_ {
+        ASTType::Int(span) => {
+            let width = lexer.span_str(span)[1..]
+                .parse::<u32>()
+                .map_err(|e| error_at_span(lexer, span, &e.to_string()))?;
+            let ty = IntegerTy::new(width);
+            m.insert_ty(Ty::Integer(ty))
+                .map_err(|e| error_at_span(lexer, span, &e.to_string()))
+        }
+    }
+}
+
+/// Return an error message pinpointing `span` as the culprit.
+fn error_at_span(
+    lexer: &LRNonStreamingLexer<DefaultLexerTypes<StorageT>>,
+    span: Span,
+    msg: &str,
+) -> Box<dyn Error> {
+    let ((line_off, col), _) = lexer.line_col(span);
+    let code = lexer
+        .span_lines_str(span)
+        .split('\n')
+        .next()
+        .unwrap()
+        .trim();
+    Box::from(format!(
+        "Line {}, column {}:\n  {}\n{}",
+        line_off,
+        col,
+        code.trim(),
+        msg
+    ))
+}
+
+#[derive(Debug)]
+struct ASTBBlock {
+    #[allow(dead_code)]
+    label: Span,
+    insts: Vec<ASTInst>,
+}
+
+#[derive(Debug)]
+enum ASTInst {
+    Add {
+        #[allow(dead_code)]
+        type_: ASTType,
+        lhs: ASTOperand,
+        rhs: ASTOperand,
+    },
+    LoadTraceInput {
+        type_: ASTType,
+        off: Span,
+    },
+    TestUse(ASTOperand),
+}
+
+#[derive(Debug)]
+enum ASTOperand {
+    Local(Span),
+}
+
+#[derive(Debug)]
+enum ASTType {
+    Int(Span),
+}

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -22,6 +22,8 @@ use ykaddr::addr::symbol_to_ptr;
 pub mod aot_ir;
 mod codegen;
 pub mod jit_ir;
+#[cfg(test)]
+mod jit_ir_parser;
 mod opt;
 mod trace_builder;
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -38,6 +38,17 @@ pub(crate) enum CompilationError {
     ResourceExhausted(Box<dyn Error>),
 }
 
+impl fmt::Display for CompilationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompilationError::General(s) => write!(f, "General error: {s}"),
+            CompilationError::InternalError(s) => write!(f, "Internal error: {s}"),
+            CompilationError::LimitExceeded(s) => write!(f, "Limit exceeded: {s}"),
+            CompilationError::ResourceExhausted(e) => write!(f, "Resource exhausted: {e:}"),
+        }
+    }
+}
+
 /// The trait that every JIT compiler backend must implement.
 pub(crate) trait Compiler: Send + Sync {
     /// Compile a mapped trace into machine code.


### PR DESCRIPTION
This uses grmtools to parse pretty-printed JIT IR concrete syntax back into JIT IR. The parser is woefully incomplete, only handling enough for the toy optimisation in lvn.rs, and not dealing with anything clever with local operand numbers and so on.

However, this is already enough to prove a useful point: we can now turn the horror that was the (sole) test in lvn.rs to:

```
fm_match(
    "
  entry:
    %0: i16 = load_ti 0, i16
    %1: i16 = load_ti 16, i16
    %2: i16 = add %0, %1
    %3: i16 = add %0, %1
    %4: i16 = add %0, %3
    test_use %3
    test_use %4
",
    |m| lvn(m).unwrap(),
    "
  ...
  entry:
    %0: i16 = load_ti 0, i16
    %1: i16 = load_ti 16, i16
    %2: i16 = add %0, %1
    %3: i16 = add %0, %2
    test_use %2
    test_use %3
",
);
```

Much more will need to be done on this before it can be used elsewhere, but this feels like the minimum useful to be worthy of considered for merging.