### PR TITLE
Reduce load_ti redundancy

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -1228,7 +1228,7 @@ mod tests {
                 .unwrap();
             let patt_lines = "
                 ...
-                ; %0: i8 = load_ti 0, i8
+                ; %0: i8 = load_ti 0
                 ... movzx r12, byte ptr [rdi]
                 ... mov [rbp-0x01], r12b
                 ...
@@ -1246,7 +1246,7 @@ mod tests {
                 .unwrap();
             let patt_lines = "
                 ...
-                ; %0: i16 = load_ti 32, i16
+                ; %0: i16 = load_ti 32
                 ... movzx r12d, word ptr [rdi+0x20]
                 ... mov [rbp-0x02], r12w
                 ...
@@ -1271,19 +1271,19 @@ mod tests {
                 .unwrap();
             let patt_lines = "
                 ...
-                ; %0: i8 = load_ti 0, i8
+                ; %0: i8 = load_ti 0
                 ... movzx r12, byte ptr [rdi]
                 ... mov [rbp-0x01], r12b
-                ; %1: i8 = load_ti 1, i8
+                ; %1: i8 = load_ti 1
                 ... movzx r12, byte ptr [rdi+0x01]
                 ... mov [rbp-0x02], r12b
-                ; %2: i8 = load_ti 2, i8
+                ; %2: i8 = load_ti 2
                 ... movzx r12, byte ptr [rdi+0x02]
                 ... mov [rbp-0x03], r12b
-                ; %3: i8 = load_ti 3, i8
+                ; %3: i8 = load_ti 3
                 ... movzx r12, byte ptr [rdi+0x03]
                 ... mov [rbp-0x04], r12b
-                ; %4: ptr = load_ti 8, ptr
+                ; %4: ptr = load_ti 8
                 ... mov r12, [rdi+0x08]
                 ... mov [rbp-0x10], r12
                 ...
@@ -1769,7 +1769,7 @@ mod tests {
                 .unwrap();
             let patt_lines = "
                 ...
-                ; %0: i8 = load_ti 0, i8
+                ; %0: i8 = load_ti 0
                 ...
                 ; tloop_start:
                 ; %2: i8 = add %0, %0

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -1140,7 +1140,7 @@ impl fmt::Display for DisplayableInst<'_> {
                 if x.expect { "true" } else { "false " }
             ),
             Inst::LoadTraceInput(x) => {
-                write!(f, "load_ti {}, {}", x.off(), self.m.type_(x.ty_idx()))
+                write!(f, "load_ti {}", x.off())
             }
             Inst::TraceLoopStart => {
                 // Just marks a location, so we format it to look like a label.
@@ -2080,9 +2080,9 @@ mod tests {
             "@some_thread_local    ; thread local",
             "",
             "entry:",
-            "    %0: i8 = load_ti 0, i8",
-            "    %1: i8 = load_ti 8, i8",
-            "    %2: i8 = load_ti 16, i8",
+            "    %0: i8 = load_ti 0",
+            "    %1: i8 = load_ti 8",
+            "    %2: i8 = load_ti 16",
         ]
         .join("\n");
         assert_eq!(m.to_string(), expect);

--- a/ykrt/src/compile/jitc_yk/jit_ir.y
+++ b/ykrt/src/compile/jitc_yk/jit_ir.y
@@ -28,7 +28,7 @@ Insts -> Result<Vec<ASTInst>, Box<dyn Error>>:
   ;
 
 Inst -> Result<ASTInst, Box<dyn Error>>:
-    "LOCAL_OPERAND" ":" Type "=" "LOAD_TI" "INT" "," Type  {
+    "LOCAL_OPERAND" ":" Type "=" "LOAD_TI" "INT" {
       Ok(ASTInst::LoadTraceInput{type_: $3?, off: $6?.span()})
     }
   | "LOCAL_OPERAND" ":" Type "=" "ADD" Operand "," Operand  {

--- a/ykrt/src/compile/jitc_yk/opt/lvn.rs
+++ b/ykrt/src/compile/jitc_yk/opt/lvn.rs
@@ -96,8 +96,8 @@ mod tests {
         fm_match(
             "
           entry:
-            %0: i16 = load_ti 0, i16
-            %1: i16 = load_ti 16, i16
+            %0: i16 = load_ti 0
+            %1: i16 = load_ti 16
             %2: i16 = add %0, %1
             %3: i16 = add %0, %1
             %4: i16 = add %0, %3
@@ -108,8 +108,8 @@ mod tests {
             "
           ...
           entry:
-            %0: i16 = load_ti 0, i16
-            %1: i16 = load_ti 16, i16
+            %0: i16 = load_ti 0
+            %1: i16 = load_ti 16
             %2: i16 = add %0, %1
             %3: i16 = add %0, %2
             test_use %2


### PR DESCRIPTION
This is always implied by `%x: T = load_ti y` (in other words all this commit does is remove the second `T`, and its preceding comma, in `%x: T = load_ti y, T`).