### PR TITLE
Handle constant pointers in AOT IR.

### DIFF
--- a/tests/ir_lowering/null_ptr.ll
+++ b/tests/ir_lowering/null_ptr.ll
@@ -1,0 +1,13 @@
+; Dump:
+;   stdout:
+;     ...
+;     func main() -> ptr {
+;       bb0:
+;         ret 0x0
+;     }
+
+; Check null pointer constants lower OK.
+
+define ptr @main() {
+  ret ptr null
+}

--- a/ykrt/src/compile/jitc_yk/jit_ir.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir.rs
@@ -2040,17 +2040,6 @@ mod tests {
     }
 
     #[test]
-    fn stringify_const_ptr2() {
-        let m = Module::new_testing();
-        let ptr_val = stringify_const_ptr2 as *const u8 as usize;
-        let cp = Const {
-            ty_idx: m.ptr_ty_idx(),
-            bytes: ptr_val.to_ne_bytes().to_vec(),
-        };
-        assert_eq!(format!("{}", cp.display(&m)), format!("{:#x}", ptr_val));
-    }
-
-    #[test]
     fn stringify_const_ptr() {
         let m = Module::new_testing();
         // Build a constant pointer with higher valued bytes towards the most-significant byte.
@@ -2072,6 +2061,17 @@ mod tests {
             format!("{}", cp.display(&m)),
             format!("{:#x}", expect_usize)
         );
+    }
+
+    #[test]
+    fn stringify_const_ptr2() {
+        let m = Module::new_testing();
+        let ptr_val = stringify_const_ptr2 as *const u8 as usize;
+        let cp = Const {
+            ty_idx: m.ptr_ty_idx(),
+            bytes: ptr_val.to_ne_bytes().to_vec(),
+        };
+        assert_eq!(format!("{}", cp.display(&m)), format!("{:#x}", ptr_val));
     }
 
     #[test]


### PR DESCRIPTION
Requires https://github.com/ykjit/ykllvm/pull/166.

Fixes the db.lua issue where we choke on an unimplemented constant null pointer.