### PR TITLE
To `assert_ir_transform_eq`

### DIFF
--- a/ykrt/src/compile/jitc_yk/opt/lvn.rs
+++ b/ykrt/src/compile/jitc_yk/opt/lvn.rs
@@ -77,23 +77,10 @@ pub(super) fn lvn(mut m: Module) -> Result<Module, CompilationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fm::FMBuilder;
-
-    fn fm_match<F>(before: &str, f: F, after: &str)
-    where
-        F: FnOnce(Module) -> Module,
-    {
-        let m = Module::from_str(before);
-        let m = f(m);
-        let fmm = FMBuilder::new(after).unwrap().build().unwrap();
-        if let Err(e) = fmm.matches(&m.to_string()) {
-            panic!("{e}");
-        }
-    }
 
     #[test]
     fn opt_add() {
-        fm_match(
+        Module::assert_ir_transform_eq(
             "
           entry:
             %0: i16 = load_ti 0


### PR DESCRIPTION
This PR:

1. Makes it easier for different parts of the JIT compiler to utilise the "check how transformations change the IR with fm tests" (https://github.com/ykjit/yk/commit/a6d052533d83a6380347651f1f5c569d53b235ad).
2. Makes use of our "standard" fm features in such tests (https://github.com/ykjit/yk/commit/12c64bef3fda317b7f4fc685122f157fa519ebef).