### PR TITLE
Let fm do the hard work when pattern matching fails.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -1148,10 +1148,7 @@ mod tests {
 
         match fmm.matches(&dis.to_lowercase()) {
             Ok(()) => (),
-            Err(e) => panic!(
-                "\n!!! Emitted code didn't match !!!\n\n{}\nFull asm:\n{}\n",
-                e, dis
-            ),
+            Err(e) => panic!("{e}"),
         }
     }
 


### PR DESCRIPTION
I think this code predates https://github.com/softdevteam/fm/pull/39 in fm: fm now prints out the disassembly code, and then where the literal and pattern didn't match. So by printing out the assembly twice (as well as the shouty "!!!") we're just making it harder to work out what the problem was.