### PR TITLE
Be explicit about integer truncation.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -706,6 +706,11 @@ pub(crate) enum Inst {
         default_dest: BBlockIdx,
         #[deku(temp)]
         num_cases: usize,
+        /// The values for each switch block. FIXME: These are currently cast by ykllvm to a `u64`
+        /// no matter what the original type was: in other words, these should be interpreted as
+        /// bit patterns consuming 64-bits, not integer types of `u64`. Currently ykllvm prevents
+        /// types bigger than 64 bits being serialised, but the original integer type may require
+        /// fewer than 64-bits.
         #[deku(count = "num_cases")]
         case_values: Vec<u64>,
         #[deku(count = "num_cases")]

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -699,7 +699,8 @@ impl<'a> TraceBuilder<'a> {
         let mut jit_ptr = self.handle_operand(ptr)?;
         if const_off != 0 {
             let co_ty = jit_ir::IntegerTy::new(32);
-            let co_const = co_ty.make_constant(&mut self.jit_mod, const_off)?;
+            let co_const =
+                co_ty.make_constant(&mut self.jit_mod, i32::try_from(const_off).unwrap())?;
             let co_opnd = jit_ir::Operand::Const(self.jit_mod.insert_const(co_const)?);
             jit_ptr = self
                 .jit_mod
@@ -798,9 +799,21 @@ impl<'a> TraceBuilder<'a> {
                 let bb = case_dests[cidx];
 
                 // Build the constant value to guard.
-                let jit_const = jit_int_type
-                    .to_owned()
-                    .make_constant(&mut self.jit_mod, val)?;
+                let jit_const = match jit_int_type.num_bits() {
+                    8 => jit_int_type
+                        .to_owned()
+                        .make_constant(&mut self.jit_mod, u8::try_from(val).unwrap())?,
+                    16 => jit_int_type
+                        .to_owned()
+                        .make_constant(&mut self.jit_mod, u16::try_from(val).unwrap())?,
+                    32 => jit_int_type
+                        .to_owned()
+                        .make_constant(&mut self.jit_mod, u32::try_from(val).unwrap())?,
+                    64 => jit_int_type
+                        .to_owned()
+                        .make_constant(&mut self.jit_mod, val)?,
+                    _ => unreachable!(),
+                };
                 let jit_const_opnd = jit_ir::Operand::Const(self.jit_mod.insert_const(jit_const)?);
 
                 // Perform the comparison.
@@ -831,9 +844,21 @@ impl<'a> TraceBuilder<'a> {
                 let mut cmps_opnds = Vec::new();
                 for cv in case_values {
                     // Build a constant of the case value.
-                    let jit_const = jit_int_type
-                        .to_owned()
-                        .make_constant(&mut self.jit_mod, *cv)?;
+                    let jit_const = match jit_int_type.num_bits() {
+                        8 => jit_int_type
+                            .to_owned()
+                            .make_constant(&mut self.jit_mod, u8::try_from(*cv).unwrap())?,
+                        16 => jit_int_type
+                            .to_owned()
+                            .make_constant(&mut self.jit_mod, u16::try_from(*cv).unwrap())?,
+                        32 => jit_int_type
+                            .to_owned()
+                            .make_constant(&mut self.jit_mod, u32::try_from(*cv).unwrap())?,
+                        64 => jit_int_type
+                            .to_owned()
+                            .make_constant(&mut self.jit_mod, *cv)?,
+                        _ => unreachable!(),
+                    };
                     let jit_const_opnd =
                         jit_ir::Operand::Const(self.jit_mod.insert_const(jit_const)?);
 


### PR DESCRIPTION
This commit stops `jit_ir::IntegerTy::make_constant` truncating integer values. Currently this function is as dangerous as Rust's `as`, but hides behind an innocuous function name and a doc string which I at least managed to misread multiple times:

> The byte size of `T` must be at least as big as `self.byte_size()`. If the byte size of `T`
> is larger, `val` will be truncated to `self.byte_size()` bytes.

Both sentences are congruous with the code, but I read them many, many times before realising what they meant. In particular, I assumed the first sentence meant to say "less than or equal", and then I assumed that the second sentence was probably incorrect. Clearly I was wrong in both cases!

This commit makes `make_constant` neither extend or truncate: you now have to pass it in the *correctly sized* Rust integer type or else it will (at least in debug mode) panic. This is, inevitably, more annoying to use, but it now places the burden on the caller of `make_constant` to do truncation/extension at their end, rather than having `make_constant` do it silently.