### PR TITLE
Add an explicit well-formedness check for the JIT IR

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1643,6 +1643,12 @@ impl PtrAddInst {
     }
 }
 
+pub(crate) trait BinOp {
+    fn lhs(&self) -> Operand;
+    fn rhs(&self) -> Operand;
+    fn ty_idx(&self, m: &Module) -> TyIdx;
+}
+
 macro_rules! bin_op {
     ($discrim :ident, $struct: ident, $disp: literal) => {
         #[derive(Clone, Debug, PartialEq)]
@@ -1662,18 +1668,19 @@ macro_rules! bin_op {
                     rhs: PackedOperand::new(&rhs),
                 }
             }
+        }
 
-            pub(crate) fn lhs(&self) -> Operand {
+        impl BinOp for $struct {
+            fn lhs(&self) -> Operand {
                 self.lhs.unpack()
             }
 
-            pub(crate) fn rhs(&self) -> Operand {
+            fn rhs(&self) -> Operand {
                 self.rhs.unpack()
             }
 
             /// Returns the type index of the operands being added.
-            pub(crate) fn ty_idx(&self, m: &Module) -> TyIdx {
-                debug_assert_eq!(self.lhs.unpack().ty_idx(m), self.rhs.unpack().ty_idx(m));
+            fn ty_idx(&self, m: &Module) -> TyIdx {
                 self.lhs.unpack().ty_idx(m)
             }
         }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -672,8 +672,8 @@ index_16bit!(InstIdx);
 /// A function's type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct FuncTy {
-    /// Ty indices for the function's formal arguments.
-    arg_ty_idxs: Vec<TyIdx>,
+    /// Ty indices for the function's parameters.
+    param_ty_idxs: Vec<TyIdx>,
     /// Ty index of the function's return type.
     ret_ty_idx: TyIdx,
     /// Is the function vararg?
@@ -681,17 +681,18 @@ pub(crate) struct FuncTy {
 }
 
 impl FuncTy {
-    pub(crate) fn new(arg_ty_idxs: Vec<TyIdx>, ret_ty_idx: TyIdx, is_vararg: bool) -> Self {
+    pub(crate) fn new(param_ty_idxs: Vec<TyIdx>, ret_ty_idx: TyIdx, is_vararg: bool) -> Self {
         Self {
-            arg_ty_idxs,
+            param_ty_idxs,
             ret_ty_idx,
             is_vararg,
         }
     }
 
-    /// Return the number of arguments the function accepts (not including varargs arguments).
-    pub(crate) fn num_args(&self) -> usize {
-        self.arg_ty_idxs.len()
+    /// Return the number of paramaters the function accepts (not including varargs).
+    #[cfg(test)]
+    pub(crate) fn num_params(&self) -> usize {
+        self.param_ty_idxs.len()
     }
 
     /// Returns the type index of the argument at the specified index.
@@ -699,8 +700,15 @@ impl FuncTy {
     /// # Panics
     ///
     /// Panics if the index is out of bounds.
-    pub(crate) fn arg_type<'a>(&self, m: &'a Module, idx: usize) -> &'a Ty {
-        m.type_(self.arg_ty_idxs[idx])
+    #[cfg(test)]
+    pub(crate) fn param_ty<'a>(&self, m: &'a Module, idx: usize) -> &'a Ty {
+        m.type_(self.param_ty_idxs[idx])
+    }
+
+    /// Return a slice of this function's non-varargs parameters.
+    #[cfg(test)]
+    pub(crate) fn param_tys(&self) -> &[TyIdx] {
+        &self.param_ty_idxs
     }
 
     /// Returns whether the function type has vararg arguments.
@@ -716,12 +724,6 @@ impl FuncTy {
     /// Returns the type index of the return value.
     pub(crate) fn ret_ty_idx(&self) -> TyIdx {
         self.ret_ty_idx
-    }
-
-    /// Return a slice of this function's non-varargs parameters.
-    #[cfg(test)]
-    pub(crate) fn param_tys(&self) -> &[TyIdx] {
-        &self.arg_ty_idxs
     }
 }
 
@@ -775,7 +777,7 @@ impl fmt::Display for DisplayableTy<'_> {
             Ty::Ptr => write!(f, "ptr"),
             Ty::Func(x) => {
                 let mut args = x
-                    .arg_ty_idxs
+                    .param_ty_idxs
                     .iter()
                     .map(|x| self.m.type_(*x).display(self.m).to_string())
                     .collect::<Vec<_>>();

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -695,16 +695,6 @@ impl FuncTy {
         self.param_ty_idxs.len()
     }
 
-    /// Returns the type index of the argument at the specified index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the index is out of bounds.
-    #[cfg(test)]
-    pub(crate) fn param_ty<'a>(&self, m: &'a Module, idx: usize) -> &'a Ty {
-        m.type_(self.param_ty_idxs[idx])
-    }
-
     /// Return a slice of this function's non-varargs parameters.
     #[cfg(test)]
     pub(crate) fn param_tys(&self) -> &[TyIdx] {

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -50,6 +50,7 @@ impl Module {
                     inst_idx_map: HashMap::new(),
                 };
                 p.process(func_decls, globals, bblocks).unwrap();
+                m.assert_well_formed();
                 m
             }
             _ => panic!("Could not produce JIT Module."),
@@ -527,7 +528,7 @@ mod tests {
               guard %4, true
               call @f1()
               %5: i8 = load_ti 1
-              %6: i32 = call @f2(%1)
+              %6: i32 = call @f2(%5)
               %7: i32 = load_ti 2
               %8: i64 = call @f3(%5, %7, %0)
               call @f4(%0, %1)

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -1,0 +1,168 @@
+//! This module adds some basic well-formedness checks to the JIT IR. These are intended both to
+//! help debugging incorrectly formed IR and to provide guarantees about what IR different stages
+//! of the compiler can expect.
+//!
+//! Specifically, after calling [Module::assert_well_formed] one can safely assume:
+//!
+//!   * [super::DirectCallInst]s pass the correct number of arguments to a [super::FuncTy] and each
+//!   of those arguments has the correct [super::Ty].
+//!   * Binary operations' left and right hand side operands have the same [Ty]s.
+
+use super::{BinOp, Inst, InstIdx, Module, Ty};
+
+impl Module {
+    pub(crate) fn assert_well_formed(&self) {
+        for (i, inst) in self.insts.iter().enumerate() {
+            match inst {
+                Inst::Call(x) => {
+                    // Check number of parameters/arguments.
+                    let fdecl = self.func_decl(x.target());
+                    let Ty::Func(fty) = self.type_(fdecl.ty_idx()) else {
+                        panic!()
+                    };
+                    if x.num_args() < fty.num_args() {
+                        panic!(
+                            "Instruction at position {i} passing too few arguments:\n  {}",
+                            inst.display(InstIdx::new(i).unwrap(), self)
+                        );
+                    }
+                    if x.num_args() > fty.num_args() && !fty.is_vararg() {
+                        panic!(
+                            "Instruction at position {i} passing too many arguments:\n  {}",
+                            inst.display(InstIdx::new(i).unwrap(), self)
+                        );
+                    }
+
+                    // Check parameter/argument types.
+                    for (j, (par_ty, arg_ty)) in fty
+                        .param_tys()
+                        .iter()
+                        .zip(x.iter_args_idx().map(|x| self.arg(x).ty_idx(self)))
+                        .enumerate()
+                    {
+                        if *par_ty != arg_ty {
+                            panic!("Instruction at position {i} passing argument {j} of wrong type ({}, but should be {})\n  {}",
+                                self.type_(arg_ty).display(self),
+                                self.type_(*par_ty).display(self),
+                                inst.display(InstIdx::new(i).unwrap(), self));
+                        }
+                    }
+                }
+                Inst::Add(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::Sub(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::Mul(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::Or(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::And(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::Xor(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::Shl(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::AShr(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::FAdd(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::FDiv(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::FMul(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::FRem(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::FSub(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::LShr(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::SDiv(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::SRem(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::UDiv(x) => self.assert_well_formed_bin_op(i, x),
+                Inst::URem(x) => self.assert_well_formed_bin_op(i, x),
+                _ => (),
+            }
+        }
+    }
+
+    fn assert_well_formed_bin_op<T: BinOp>(&self, inst_idx: usize, x: &T) {
+        if x.lhs().ty_idx(self) != x.rhs().ty_idx(self) {
+            let inst_idx = InstIdx::new(inst_idx).unwrap();
+            panic!(
+                "Instruction at position {} has different types on lhs and rhs\n  {}",
+                usize::from(inst_idx),
+                self.inst(inst_idx).display(inst_idx, self)
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Module;
+
+    #[should_panic(expected = "Instruction at position 0 passing too few arguments")]
+    #[test]
+    fn too_few_args() {
+        Module::from_str(
+            "
+              func_decl f(i32)
+              entry:
+                call @f()
+            ",
+        );
+    }
+
+    #[should_panic(expected = "Instruction at position 0 passing too few arguments")]
+    #[test]
+    fn too_few_args2() {
+        Module::from_str(
+            "
+              func_decl f(i32, ...)
+              entry:
+                call @f()
+            ",
+        );
+    }
+
+    #[should_panic(expected = "Instruction at position 1 passing too many arguments")]
+    #[test]
+    fn too_many_args() {
+        Module::from_str(
+            "
+              func_decl f()
+              entry:
+                %0: i8 = load_ti 0
+                call @f(%0)
+            ",
+        );
+    }
+
+    #[test]
+    fn var_args() {
+        Module::from_str(
+            "
+              func_decl f(...)
+              entry:
+                %0: i8 = load_ti 0
+                call @f(%0)
+            ",
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[should_panic(
+        expected = "Instruction at position 1 passing argument 0 of wrong type (i8, but should be i32)"
+    )]
+    #[test]
+    fn cg_call_bad_arg_type() {
+        Module::from_str(
+            "
+              func_decl f(i32) -> i32
+              entry:
+                %0: i8 = load_ti 0
+                %1: i32 = call @f(%0)
+            ",
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Instruction at position 2 has different types on lhs and rhs")]
+    #[test]
+    fn cg_add_wrong_types() {
+        Module::from_str(
+            "
+              entry:
+                %0: i64 = load_ti 0
+                %1: i32 = load_ti 1
+                %2: i32 = add %0, %1
+            ",
+        );
+    }
+}

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -20,13 +20,13 @@ impl Module {
                     let Ty::Func(fty) = self.type_(fdecl.ty_idx()) else {
                         panic!()
                     };
-                    if x.num_args() < fty.num_args() {
+                    if x.num_args() < fty.num_params() {
                         panic!(
                             "Instruction at position {i} passing too few arguments:\n  {}",
                             inst.display(InstIdx::new(i).unwrap(), self)
                         );
                     }
-                    if x.num_args() > fty.num_args() && !fty.is_vararg() {
+                    if x.num_args() > fty.num_params() && !fty.is_vararg() {
                         panic!(
                             "Instruction at position {i} passing too many arguments:\n  {}",
                             inst.display(InstIdx::new(i).unwrap(), self)

--- a/ykrt/src/compile/jitc_yk/opt/lvn.rs
+++ b/ykrt/src/compile/jitc_yk/opt/lvn.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use crate::compile::jitc_yk::jit_ir::BlackBoxInst;
 use crate::compile::{
-    jitc_yk::jit_ir::{AddInst, Inst, InstIdx, Module, Operand},
+    jitc_yk::jit_ir::{AddInst, BinOp, Inst, InstIdx, Module, Operand},
     CompilationError,
 };
 use typed_index_collections::TiVec;


### PR DESCRIPTION
This PR adds an explicit well-formedness check for the JIT IR. This is currently always called when `Module::from_str` is used, but can be called elsewhere if desired. It takes the basic checks from the x86 backend and expands and generalises them. It's useful enough that it caught one error in JIT IR input (in a parser test), which is encouraging (I'm ignoring the worrying part that I didn't spot this earlier!).

As part of this, I thoroughly confused myself with call arguments and function parameters, so I have snuck in a commit to use the standard naming of these things (https://github.com/ykjit/yk/commit/41dfca912978959b61ba59f322a8943ab36fd707) which might help me next time I have to wrap my head around this stuff.