### PR TITLE
Contract binary operations into `BinOpInst`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -5,11 +5,11 @@
 //! makes it possible to write JIT IR tests using JIT IR concrete syntax.
 
 use super::super::{
-    aot_ir::Predicate,
+    aot_ir::{BinOp, Predicate},
     jit_ir::{
-        AddInst, BlackBoxInst, DirectCallInst, FuncDecl, FuncTy, GuardInfo, GuardInst, IcmpInst,
+        BinOpInst, BlackBoxInst, DirectCallInst, FuncDecl, FuncTy, GuardInfo, GuardInst, IcmpInst,
         Inst, InstIdx, IntegerTy, LoadInst, LoadTraceInputInst, Module, Operand, PtrAddInst,
-        SRemInst, StoreInst, TruncInst, Ty, TyIdx,
+        StoreInst, TruncInst, Ty, TyIdx,
     },
 };
 use fm::FMBuilder;
@@ -130,8 +130,11 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                         lhs,
                         rhs,
                     } => {
-                        let inst =
-                            AddInst::new(self.process_operand(lhs)?, self.process_operand(rhs)?);
+                        let inst = BinOpInst::new(
+                            self.process_operand(lhs)?,
+                            BinOp::Add,
+                            self.process_operand(rhs)?,
+                        );
                         self.add_assign(self.m.len(), assign)?;
                         self.m.push(inst.into()).unwrap();
                     }
@@ -205,8 +208,11 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                         lhs,
                         rhs,
                     } => {
-                        let inst =
-                            SRemInst::new(self.process_operand(lhs)?, self.process_operand(rhs)?);
+                        let inst = BinOpInst::new(
+                            self.process_operand(lhs)?,
+                            BinOp::SRem,
+                            self.process_operand(rhs)?,
+                        );
                         self.add_assign(self.m.len(), assign)?;
                         self.m.push(inst.into()).unwrap();
                     }
@@ -478,10 +484,10 @@ mod tests {
             .push_and_make_operand(LoadTraceInputInst::new(16, i16_ty_idx).into())
             .unwrap();
         let op3 = m
-            .push_and_make_operand(AddInst::new(op1.clone(), op2.clone()).into())
+            .push_and_make_operand(BinOpInst::new(op1.clone(), BinOp::Add, op2.clone()).into())
             .unwrap();
         let op4 = m
-            .push_and_make_operand(AddInst::new(op1.clone(), op3.clone()).into())
+            .push_and_make_operand(BinOpInst::new(op1.clone(), BinOp::Add, op3.clone()).into())
             .unwrap();
         m.push(BlackBoxInst::new(op3).into()).unwrap();
         m.push(BlackBoxInst::new(op4).into()).unwrap();

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -8,12 +8,22 @@
 //!   of those arguments has the correct [super::Ty].
 //!   * Binary operations' left and right hand side operands have the same [Ty]s.
 
-use super::{BinOp, Inst, InstIdx, Module, Ty};
+use super::{Inst, InstIdx, Module, Ty};
 
 impl Module {
     pub(crate) fn assert_well_formed(&self) {
         for (i, inst) in self.insts.iter().enumerate() {
             match inst {
+                Inst::BinOp(x) => {
+                    if x.lhs().ty_idx(self) != x.rhs().ty_idx(self) {
+                        let inst_idx = InstIdx::new(i).unwrap();
+                        panic!(
+                            "Instruction at position {} has different types on lhs and rhs\n  {}",
+                            usize::from(inst_idx),
+                            self.inst(inst_idx).display(inst_idx, self)
+                        );
+                    }
+                }
                 Inst::Call(x) => {
                     // Check number of parameters/arguments.
                     let fdecl = self.func_decl(x.target());
@@ -48,37 +58,8 @@ impl Module {
                         }
                     }
                 }
-                Inst::Add(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::Sub(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::Mul(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::Or(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::And(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::Xor(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::Shl(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::AShr(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::FAdd(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::FDiv(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::FMul(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::FRem(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::FSub(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::LShr(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::SDiv(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::SRem(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::UDiv(x) => self.assert_well_formed_bin_op(i, x),
-                Inst::URem(x) => self.assert_well_formed_bin_op(i, x),
                 _ => (),
             }
-        }
-    }
-
-    fn assert_well_formed_bin_op<T: BinOp>(&self, inst_idx: usize, x: &T) {
-        if x.lhs().ty_idx(self) != x.rhs().ty_idx(self) {
-            let inst_idx = InstIdx::new(inst_idx).unwrap();
-            panic!(
-                "Instruction at position {} has different types on lhs and rhs\n  {}",
-                usize::from(inst_idx),
-                self.inst(inst_idx).display(inst_idx, self)
-            );
         }
     }
 }


### PR DESCRIPTION
In 76871215b37281b24712364a27d5c89f0f71a017 I expanded all the binary operations into individual instructions. This seemed a good idea at the time, but subsequent experience has shown that doing so doesn't play well with Rust's pattern matching, and that it causes us to duplicate code or do other dances (see 38d355fce9f0f282f25e59ae5782f17a3ddb4ea3 in particular).

This commit is a sort-of manual reversion of
76871215b37281b24712364a27d5c89f0f71a017 -- far too much has changed since then for an automatic reversion to be possible. In some ways this commit is the minimum necessary changes, but reasonable people could definitely differ on what "minimum" in this case might be. For example, in the x86 codegen, squeezing things down into a single function makes much more sense from several perspectives, but one might say it's not minimal. Still, overall, this commit noticeably reduces the quantity of code while not breaking behaviour.