### PR TITLE
Use "lhs/rhs" in `ICmp` to match `BinOp`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -724,28 +724,28 @@ impl<'a> X64CodeGen<'a> {
     }
 
     fn cg_icmp(&mut self, inst_idx: InstIdx, inst: &jit_ir::IcmpInst) {
-        let (left, pred, right) = (inst.left(), inst.predicate(), inst.right());
+        let (lhs, pred, rhs) = (inst.lhs(), inst.predicate(), inst.rhs());
 
         // FIXME: We should be checking type equality here, but since constants currently don't
         // have a type, checking their size is close enough. This won't be correct for struct
         // types, but this function can't deal with those anyway at the moment.
         debug_assert_eq!(
-            left.byte_size(self.m),
-            right.byte_size(self.m),
+            lhs.byte_size(self.m),
+            rhs.byte_size(self.m),
             "icmp of differing types"
         );
         debug_assert!(
-            matches!(self.m.type_(left.ty_idx(self.m)), jit_ir::Ty::Integer(_))
-                || matches!(self.m.type_(left.ty_idx(self.m)), jit_ir::Ty::Ptr),
+            matches!(self.m.type_(lhs.ty_idx(self.m)), jit_ir::Ty::Integer(_))
+                || matches!(self.m.type_(lhs.ty_idx(self.m)), jit_ir::Ty::Ptr),
             "icmp of nonsense types"
         );
 
         // FIXME: assumes values fit in a registers
-        self.load_operand(WR0, &left);
-        self.load_operand(WR1, &right);
+        self.load_operand(WR0, &lhs);
+        self.load_operand(WR1, &rhs);
 
         // Perform the comparison.
-        match left.byte_size(self.m) {
+        match rhs.byte_size(self.m) {
             8 => dynasm!(self.asm; cmp Rq(WR0.code()), Rq(WR1.code())),
             4 => dynasm!(self.asm; cmp Rd(WR0.code()), Rd(WR1.code())),
             2 => dynasm!(self.asm; cmp Rw(WR0.code()), Rw(WR1.code())),

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1177,8 +1177,8 @@ impl fmt::Display for DisplayableInst<'_> {
                 f,
                 "{} {}, {}",
                 x.pred,
-                x.left().display(self.m),
-                x.right().display(self.m)
+                x.lhs().display(self.m),
+                x.rhs().display(self.m)
             ),
             Inst::Guard(x) => write!(
                 f,
@@ -1738,32 +1738,32 @@ bin_op!(URem, URemInst, "URem");
 ///
 #[derive(Clone, Debug, PartialEq)]
 pub struct IcmpInst {
-    left: PackedOperand,
+    lhs: PackedOperand,
     pred: Predicate,
-    right: PackedOperand,
+    rhs: PackedOperand,
 }
 
 impl IcmpInst {
-    pub(crate) fn new(op1: Operand, pred: Predicate, op2: Operand) -> Self {
+    pub(crate) fn new(lhs: Operand, pred: Predicate, rhs: Operand) -> Self {
         Self {
-            left: PackedOperand::new(&op1),
+            lhs: PackedOperand::new(&lhs),
             pred,
-            right: PackedOperand::new(&op2),
+            rhs: PackedOperand::new(&rhs),
         }
     }
 
     /// Returns the left-hand-side of the comparison.
     ///
     /// E.g. in `x <= y`, it's `x`.
-    pub(crate) fn left(&self) -> Operand {
-        self.left.unpack()
+    pub(crate) fn lhs(&self) -> Operand {
+        self.lhs.unpack()
     }
 
     /// Returns the right-hand-side of the comparison.
     ///
     /// E.g. in `x <= y`, it's `y`.
-    pub(crate) fn right(&self) -> Operand {
-        self.right.unpack()
+    pub(crate) fn rhs(&self) -> Operand {
+        self.rhs.unpack()
     }
 
     /// Returns the predicate of the comparison.


### PR DESCRIPTION
We could have chosen "left" and "right" but my sense is that "lhs" and "rhs" are the more common terminology, so we might as well standardise on that.