### PR TITLE
Allow the x86 backend to know that it's dealing with well-formed IR

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -88,6 +88,8 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
         m: &'a jit_ir::Module,
         ra: Box<dyn RegisterAllocator>,
     ) -> Result<Box<X64CodeGen<'a>>, CompilationError> {
+        #[cfg(debug_assertions)]
+        m.assert_well_formed();
         let asm = dynasmrt::x64::Assembler::new()
             .map_err(|e| CompilationError::ResourceExhausted(Box::new(e)))?;
         Ok(Box::new(Self {
@@ -600,12 +602,6 @@ impl<'a> X64CodeGen<'a> {
 
     fn cg_icmp(&mut self, inst_idx: InstIdx, inst: &jit_ir::IcmpInst) {
         let (lhs, pred, rhs) = (inst.lhs(), inst.predicate(), inst.rhs());
-
-        debug_assert!(
-            matches!(self.m.type_(lhs.ty_idx(self.m)), jit_ir::Ty::Integer(_))
-                || matches!(self.m.type_(lhs.ty_idx(self.m)), jit_ir::Ty::Ptr),
-            "icmp of nonsense types"
-        );
 
         // FIXME: assumes values fit in a registers
         self.load_operand(WR0, &lhs);

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -601,14 +601,6 @@ impl<'a> X64CodeGen<'a> {
     fn cg_icmp(&mut self, inst_idx: InstIdx, inst: &jit_ir::IcmpInst) {
         let (lhs, pred, rhs) = (inst.lhs(), inst.predicate(), inst.rhs());
 
-        // FIXME: We should be checking type equality here, but since constants currently don't
-        // have a type, checking their size is close enough. This won't be correct for struct
-        // types, but this function can't deal with those anyway at the moment.
-        debug_assert_eq!(
-            lhs.byte_size(self.m),
-            rhs.byte_size(self.m),
-            "icmp of differing types"
-        );
         debug_assert!(
             matches!(self.m.type_(lhs.ty_idx(self.m)), jit_ir::Ty::Integer(_))
                 || matches!(self.m.type_(lhs.ty_idx(self.m)), jit_ir::Ty::Ptr),

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -24,7 +24,7 @@
 
 #[cfg(test)]
 mod parser;
-#[cfg(test)]
+#[cfg(any(debug_assertions, test))]
 mod well_formed;
 
 use super::aot_ir;
@@ -690,13 +690,13 @@ impl FuncTy {
     }
 
     /// Return the number of paramaters the function accepts (not including varargs).
-    #[cfg(test)]
+    #[cfg(any(debug_assertions, test))]
     pub(crate) fn num_params(&self) -> usize {
         self.param_ty_idxs.len()
     }
 
     /// Return a slice of this function's non-varargs parameters.
-    #[cfg(test)]
+    #[cfg(any(debug_assertions, test))]
     pub(crate) fn param_tys(&self) -> &[TyIdx] {
         &self.param_ty_idxs
     }
@@ -1516,7 +1516,7 @@ impl DirectCallInst {
     }
 
     /// Return an iterator for each of this direct call instruction's [ArgsIdx].
-    #[cfg(test)]
+    #[cfg(any(debug_assertions, test))]
     pub(crate) fn iter_args_idx(&self) -> impl Iterator<Item = ArgsIdx> {
         (usize::from(self.args_idx)..usize::from(self.args_idx) + usize::from(self.num_args))
             .map(|x| ArgsIdx::new(x).unwrap())

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -5,7 +5,7 @@
 //! Specifically, after calling [Module::assert_well_formed] one can safely assume:
 //!
 //!   * [super::DirectCallInst]s pass the correct number of arguments to a [super::FuncTy] and each
-//!   of those arguments has the correct [super::Ty].
+//!     of those arguments has the correct [super::Ty].
 //!   * [super::BinOpInst]s left and right hand side operands have the same [Ty]s.
 //!   * [super::ICmpInst]s left and right hand side operands have the same [Ty]s.
 


### PR DESCRIPTION
In debug mode, this PR has the x86 backend always check that it's got well-formed IR as input.