### PR TITLE
Turn lexing errors into parsing errors in the JIT IR parser.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.l
+++ b/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.l
@@ -32,3 +32,4 @@ trunc "TRUNC"
 ;.*?$ ;
 @ "@"
 [\t \n\r]+ ;
+. "UNMATCHED"

--- a/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
+++ b/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
@@ -1,4 +1,5 @@
 %start Module
+%expect-unused Unmatched "UNMATCHED"
 
 %%
 
@@ -110,6 +111,10 @@ CallArgs -> Result<Vec<ASTOperand>, Box<dyn Error>>:
     CallArgs "," Operand { flattenr($1, $3) }
   | Operand { Ok(vec![$1?]) }
   | { Ok(Vec::new()) }
+  ;
+
+Unmatched -> ():
+    "UNMATCHED" { }
   ;
 
 %%


### PR DESCRIPTION
Previously lexing error caused the unhelpful message "Lexing error". This commit makes such errors normal parsing errors that suggest repairs and give nice line and column numbers.