### PR TITLE
Move JIT IR constants from "bag of bytes" to usable Rust types.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -7,7 +7,7 @@
 use super::super::{
     aot_ir::{BinOp, Predicate},
     jit_ir::{
-        BinOpInst, BlackBoxInst, DirectCallInst, DynPtrAddInst, FuncDecl, FuncTy, GuardInfo,
+        BinOpInst, BlackBoxInst, Const, DirectCallInst, DynPtrAddInst, FuncDecl, FuncTy, GuardInfo,
         GuardInst, IcmpInst, Inst, InstIdx, IntegerTy, LoadInst, LoadTraceInputInst, Module,
         Operand, PtrAddInst, SExtInst, StoreInst, TruncInst, Ty, TyIdx,
     },
@@ -307,15 +307,12 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                 let width = type_
                     .parse::<u32>()
                     .map_err(|e| self.error_at_span(span, &e.to_string()))?;
-                let type_ = IntegerTy::new(width);
                 let const_ = match width {
                     32 => {
                         let val = val
                             .parse::<i32>()
                             .map_err(|e| self.error_at_span(span, &e.to_string()))?;
-                        type_
-                            .make_constant(self.m, val)
-                            .map_err(|e| self.error_at_span(span, &e.to_string()))?
+                        Const::I32(val)
                     }
                     x => todo!("{x}"),
                 };


### PR DESCRIPTION
The "bag of bytes" approach has 3 problems:

  1. It's impractical to work. I tried writing a JIT analysis and the query "is this `Const` an integer 1" requires writing platform specific code. That's what triggered me to write this commit.

  2. All constants have a fixed size know at AOT: making the JIT treat them as variable sized things is unnecessary.

  3. The "struct pointing to a vec" thing is memory inefficient.

This commit thus moves `Const` from a "struct pointing to a vector" (which also isn't very efficient!) to an `enum`:

```rust
pub(crate) enum Const {
    I8(i8),
    I16(i16),
    I32(i32),
    I64(i64),
    Ptr(*const ()),
 }
```

This is more memory efficient than the previous representation and easier to work with: see e.g. the changes to `load_const` in trace_builder.

As noted in (2) above, it's not necessary for the AOT IR to consider these things variable sized, but this commit only deals with the JIT IR case. It would make sense to ram this change back through the AOT IR and ykllvm (i.e. removing the "bag of bytes" approach there and moving to a similar constant-sized enum, which would save some of the byte-vec dance that we have at JIT time), but from my perspective, I only care about users of the JIT IR, so it's not relevant for this commit.

Note that I had to delete the original `stringify_const_ptr` test because I couldn't work out how to make it platform independent (alas, Rust's integer types are an issue here), and the rest of the test is of a simple property that `stringify_const_ptr2` was adequately testing anyway.