### PR TITLE
GDB support for JITted code.

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -5,7 +5,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
   rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
   apt-get -y install clang-15 make curl procps file git cmake python3 \
-    libtinfo-dev libzip-dev mold ninja-build && \
+    libtinfo-dev libzip-dev mold ninja-build gdb && \
   update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 999 && \
   update-alternatives --set cc /usr/bin/clang-15 && \
   update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 999 && \

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -1,7 +1,11 @@
 use cfgrammar::yacc::YaccKind;
 use lrlex::{CTLexerBuilder, DefaultLexerTypes};
 
-use std::env;
+use {
+    std::env,
+    std::io::{self, Write},
+    std::process::{exit, Command},
+};
 
 pub fn main() {
     ykbuild::apply_llvm_ld_library_path();
@@ -41,4 +45,15 @@ pub fn main() {
         .unwrap()
         .build()
         .unwrap();
+
+    // Build the gdb plugin.
+    env::set_current_dir("yk_gdb_plugin").unwrap();
+    let out = Command::new("make").output().unwrap();
+    if !out.status.success() {
+        io::stderr().write_all(&out.stdout).unwrap();
+        io::stderr().write_all(&out.stderr).unwrap();
+        exit(1);
+    }
+    env::set_current_dir("..").unwrap();
+    println!("cargo::rerun-if-changed=yk_gdb_plugin/yk_gdb_plugin.c");
 }

--- a/ykrt/src/compile/jitc_yk/gdb.rs
+++ b/ykrt/src/compile/jitc_yk/gdb.rs
@@ -1,0 +1,275 @@
+//! This implements support for the GDB JIT Compilation Interface described here:
+//! https://sourceware.org/gdb/onlinedocs/gdb/JIT-Interface.html
+//!
+//! This allows gdb to recognise our JITted code, so that we can have higher-level information
+//! (than just raw asm) displayed when debugging traces.
+
+use super::CompilationError;
+use deku::prelude::*;
+use indexmap::IndexMap;
+use std::{
+    ffi::{c_char, c_int, CString},
+    io::Write,
+    ptr,
+    sync::Mutex,
+};
+use tempfile::NamedTempFile;
+
+const TRACE_SYM_PREFIX: &str = "__yk_compiled_trace";
+
+/// JITted code actions.
+///
+/// This is a mirror of `jit_actions_t` from <jit-reader.h>.
+#[allow(dead_code, clippy::enum_variant_names)]
+#[repr(u32)]
+pub enum JitActionsT {
+    JitNoAction = 0u32,
+    JitRegisterFn = 1u32,
+    JitUnregisterFn = 2u32,
+}
+
+/// An entry in gdb's linked list of JITted code objects.
+///
+/// This is a mirror of `struct jit_code_entry` from <jit-reader.h>.
+#[repr(C)]
+#[derive(Debug)]
+pub struct JitCodeEntry {
+    next_entry: *mut Self,
+    prev_entry: *mut Self,
+    symfile_addr: *const c_char,
+    symfile_size: u64,
+}
+
+impl Drop for JitCodeEntry {
+    fn drop(&mut self) {
+        JIT_DESCRIPTOR_ACCESSOR.with_mut(|desc| {
+            let prev: *mut Self = self.prev_entry;
+            let next: *mut Self = self.next_entry;
+
+            // Take the entry out of gdb's linked list.
+            //
+            // If there's a previous entry, update its "next" link.
+            if !prev.is_null() {
+                unsafe { ptr::write(ptr::addr_of_mut!((*prev).next_entry), next) };
+            } else {
+                // The entry being deleted is the head of the list. Update the head pointer.
+                unsafe { (*desc).first_entry = next };
+            }
+            // If there's a "next" entry, update its "prev" link.
+            if !next.is_null() {
+                unsafe { ptr::write(ptr::addr_of_mut!((*next).prev_entry), prev) };
+            }
+        });
+    }
+}
+
+/// The top-level data structure for talking to gdb.
+///
+/// This is a mirror of `struct jit_descriptor` from <jit-reader.h>.
+#[repr(C)]
+pub struct JitDescriptor {
+    version: u32,
+    action_flag: u32,
+    relevant_entry: *mut JitCodeEntry,
+    first_entry: *mut JitCodeEntry,
+}
+
+/// An instance of [JitDescriptor] with a special symbol name that gdb recognises specially.
+///
+/// Only [JitDescriptorAccessor] should directly access this.
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+pub static mut __jit_debug_descriptor: JitDescriptor = JitDescriptor {
+    version: 1,
+    action_flag: 0,
+    relevant_entry: ptr::null_mut(),
+    first_entry: ptr::null_mut(),
+};
+
+/// Due to the way the gdb JIT API works, we are unable to have Rust handle the synchronisation of
+/// `__jit_debug_descriptor` for us.
+unsafe impl Send for JitDescriptor {}
+unsafe impl Sync for JitDescriptor {}
+unsafe impl Send for JitCodeEntry {}
+unsafe impl Sync for JitCodeEntry {}
+
+/// Wraps `__jit_debug_descriptor`, ensuring that accesses are synchronised.
+struct JitDescriptorAccessor {
+    mtx: Mutex<()>,
+}
+
+impl JitDescriptorAccessor {
+    fn with_mut<F>(&self, mut f: F)
+    where
+        F: FnMut(*mut JitDescriptor),
+    {
+        let lock = self.mtx.lock().unwrap();
+        unsafe { f(ptr::addr_of_mut!(__jit_debug_descriptor)) };
+        drop(lock);
+    }
+}
+
+static JIT_DESCRIPTOR_ACCESSOR: JitDescriptorAccessor = JitDescriptorAccessor {
+    mtx: Mutex::new(()),
+};
+
+/// The JITted code registration hook.
+///
+/// GDB regognises calls to this function to detect when JITted code is being loaded.
+#[inline(never)]
+#[no_mangle]
+pub extern "C" fn __jit_debug_register_code() {}
+
+/// Describes the mapping from a line in the source file to a virtual address.
+#[derive(Debug)]
+#[deku_derive(DekuWrite)]
+struct LineInfo {
+    vaddr: usize,
+    line_num: c_int,
+}
+
+/// Our custom gdb "symbol file".
+///
+/// Instances of this get serialised for gdb to read. Note that gdb runs in a separate address
+/// space, so we can't put pointers from this address space in here and expect them to be
+/// dereferencable.
+#[derive(Debug)]
+#[deku_derive(DekuWrite)]
+struct YkSymFile {
+    sym_name: CString,
+    jitted_code_vaddr: usize,
+    jitted_code_size: usize,
+    src_path: std::ffi::CString,
+    num_lineinfos: c_int,
+    #[deku(count = "num_lineinfos")]
+    lineinfos: Vec<LineInfo>,
+}
+
+/// The gdb context for a trace.
+///
+/// This contains resources that need to be kept-alive for the trace to be safely debuggable.
+#[derive(Debug)]
+pub(crate) struct GdbCtx {
+    /// The file containing the "source code" that we show in gdb.
+    #[allow(dead_code)]
+    src_file: tempfile::NamedTempFile,
+    /// The entry into gdb's linked list.
+    ///
+    /// This is a ptr to a Rust `Box` that must be reconstituted to be freed.
+    #[allow(dead_code)]
+    jit_code_entry: *mut JitCodeEntry,
+    /// The serialised payload of the symbol file.
+    #[allow(dead_code)]
+    payload: Vec<u8>,
+}
+
+unsafe impl Send for GdbCtx {}
+unsafe impl Sync for GdbCtx {}
+
+impl Drop for GdbCtx {
+    fn drop(&mut self) {
+        drop(unsafe { Box::from_raw(self.jit_code_entry) });
+    }
+}
+
+/// Inform gdb of newly-compiled JITted code.
+pub(crate) fn register_jitted_code(
+    id: u64,
+    jitted_code: *const u8,
+    jitted_code_size: usize,
+    comments: &IndexMap<usize, Vec<String>>,
+) -> Result<GdbCtx, CompilationError> {
+    // Write the comment lines out to a "source code file" that we want gdb to show lines from. As
+    // we do this, we also build a mapping from virtual addresses to line numbers.
+    let mut src_file = NamedTempFile::new()
+        .map_err(|_| CompilationError::InternalError("failed to create gdb src_file".into()))?;
+    let mut lineinfos = Vec::new();
+    let mut line_num = 1;
+    let code_vaddr = jitted_code as usize;
+    for (off, lines) in comments {
+        lineinfos.push(LineInfo {
+            line_num,
+            vaddr: code_vaddr + off,
+        });
+        for line in lines {
+            writeln!(src_file, "{}", line).map_err(|_| {
+                CompilationError::InternalError("failed to write into gdb src_file".into())
+            })?;
+            line_num += 1;
+        }
+    }
+    // Ensure the source file is fully-written before gdb can read it.
+    src_file
+        .flush()
+        .map_err(|_| CompilationError::InternalError("failed to flush gdb src_file".into()))?;
+
+    // Build the symbol file we are going to give to gdb.
+    //
+    // unwrap safe: string cannot contain internal zero bytes.
+    let sym_name = CString::new(format!("{}{}", TRACE_SYM_PREFIX, id)).unwrap();
+    // unwrap safe: path is valid UTF-8 and  cannot contain internal zero bytes.
+    let src_path = CString::new(src_file.path().to_str().unwrap()).unwrap();
+    // Support for more lineinfos could be added if required.
+    let num_lineinfos = c_int::try_from(lineinfos.len())
+        .map_err(|_| CompilationError::LimitExceeded("too many gdb lineinfos".into()))?;
+    let sym_file = Box::new(YkSymFile {
+        sym_name,
+        jitted_code_vaddr: jitted_code as usize, // cast safe: ptr and usize the same size.
+        jitted_code_size,
+        src_path,
+        num_lineinfos,
+        lineinfos,
+    });
+
+    // And serialise it for gdb to read.
+    //
+    // The serialised payload is conceptually an owned copy, so it's ok to let the original drop.
+    let payload = sym_file
+        .to_bytes()
+        .map_err(|_| CompilationError::InternalError("failed to serialise gdb payload".into()))?;
+
+    // Create and insert the new entry into gdb's JITted code linked list.
+    let mut jit_code_entry = None;
+    JIT_DESCRIPTOR_ACCESSOR.with_mut(|desc| {
+        // Cache the current head of the linked list.
+        let old_first = unsafe { (*desc).first_entry };
+
+        // Make a new linked list node.
+        let new_ent = Box::new(JitCodeEntry {
+            next_entry: old_first,
+            prev_entry: ptr::null_mut(),
+            symfile_addr: payload.as_ptr() as *const i8,
+            // unwrap so unlikely to fail, it's not worth considering.
+            symfile_size: u64::try_from(payload.len()).unwrap(),
+        });
+        let new_ent_ptr = Box::into_raw(new_ent);
+
+        // Insert the new entry at the head position of gdb's linked list.
+        //
+        // If the linked list is non-empty, set the current head node's previous pointer to the entry
+        // we are about to prepend.
+        if !old_first.is_null() {
+            unsafe { ptr::write(ptr::addr_of_mut!((*old_first).prev_entry), new_ent_ptr) };
+        }
+        // Update the head pointer.
+        unsafe { __jit_debug_descriptor.first_entry = new_ent_ptr };
+
+        // Inform gdb that new JITted code has arrived.
+        unsafe { ptr::write(ptr::addr_of_mut!((*desc).relevant_entry), new_ent_ptr) };
+        unsafe {
+            ptr::write(
+                ptr::addr_of_mut!((*desc).action_flag),
+                JitActionsT::JitRegisterFn as u32,
+            )
+        };
+        __jit_debug_register_code();
+
+        jit_code_entry = Some(new_ent_ptr);
+    });
+
+    Ok(GdbCtx {
+        src_file,
+        jit_code_entry: jit_code_entry.unwrap(), // unwrap cannot fail. Populated by closure above.
+        payload,
+    })
+}

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -52,9 +52,9 @@ pub(crate) use super::aot_ir::{BinOp, Predicate};
 /// - you may NOT remove an instruction.
 #[derive(Debug)]
 pub(crate) struct Module {
-    /// The ID of this compiled trace. In `cfg(test)` this value is meaningless: in
-    /// `cfg(not(test))` the ID is obtained from [MT::next_compiled_trace_id()] and can be used to
-    /// semi-uniquely distinguish traces (see [MT::compiled_trace_id] for more details).
+    /// The ID of the compiled trace.
+    ///
+    /// See the [Self::ctr_id] method for details.
     ctr_id: u64,
     /// The IR trace as a linear sequence of instructions.
     insts: TiVec<InstIdx, Inst>,
@@ -104,6 +104,16 @@ impl Module {
     /// Create a new [Module].
     pub(crate) fn new(ctr_id: u64, global_decls_len: usize) -> Result<Self, CompilationError> {
         Self::new_internal(ctr_id, global_decls_len)
+    }
+
+    /// Returns the ID of the module.
+    ///
+    /// In `cfg(test)` the ID is meaningless: in `cfg(not(test))` the ID is obtained from
+    /// [crate::mt::MT::next_compiled_trace_id] and can be used to semi-uniquely distinguish traces
+    /// (see [crate::mt::MT::compiled_trace_id] for more details).
+    #[cfg(any(debug_assertions, test))]
+    pub(crate) fn ctr_id(&self) -> u64 {
+        self.ctr_id
     }
 
     #[cfg(test)]

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -21,6 +21,8 @@ use ykaddr::addr::symbol_to_ptr;
 
 pub mod aot_ir;
 mod codegen;
+#[cfg(any(debug_assertions, test))]
+mod gdb;
 pub mod jit_ir;
 mod opt;
 mod trace_builder;

--- a/ykrt/yk_gdb_plugin/Makefile
+++ b/ykrt/yk_gdb_plugin/Makefile
@@ -1,0 +1,9 @@
+CPPFLAGS=-I/usr/include/gdb
+CFLAGS=-fPIC -g -Wextra -Wpedantic
+
+../../target/yk_gdb_plugin.so: yk_gdb_plugin.c
+	${CC} ${CFLAGS} ${CPPFLAGS} -shared $< -o $@
+
+.PHONY: clean
+clean:
+	-rm ../../target/yk_gdb_plugin.so

--- a/ykrt/yk_gdb_plugin/yk_gdb_plugin.c
+++ b/ykrt/yk_gdb_plugin/yk_gdb_plugin.c
@@ -1,0 +1,137 @@
+// A gdb plugin for debugging Yk JITted traces.
+//
+// To use this, put in your ~/.gdbinit:
+//   jit-reader-load /path/to/yk/target/yk_gdb_plugin.so
+
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <gdb/jit-reader.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// gdb requires JIT plugins to be GPL licensed.
+//
+// Without this declaration the plugin will build, but refuse to load.
+//
+// As such, this individual C file is licensed under the GPL license.
+GDB_DECLARE_GPL_COMPATIBLE_READER
+
+enum gdb_status read_debug_info_cb(struct gdb_reader_funcs *self,
+                                   struct gdb_symbol_callbacks *cb,
+                                   void *memory, long memory_sz) {
+  (void)self;
+  (void)memory_sz;
+  (void)cb;
+
+  // Treat the payload as a byte array.
+  char *payload = memory;
+
+  // Start deserialising the payload.
+  //
+  // To avoid pointer aliasing issues, we memcpy anything that isn't
+  // `char *`-typed (instead of creating aliased pointers).
+  //
+  // Read the symbol name.
+  char *sym_name = payload;
+  payload += strlen(sym_name) + 1; // +1 for null terminator.
+
+  // Read out the jitted code virtual address.
+  unsigned char *jitted_code_vaddr;
+  memcpy(&jitted_code_vaddr, payload, sizeof(jitted_code_vaddr));
+  payload += sizeof(jitted_code_vaddr);
+
+  // Read out the jitted code size.
+  size_t jitted_code_size;
+  memcpy(&jitted_code_size, payload, sizeof(jitted_code_size));
+  payload += sizeof(jitted_code_size);
+
+  // Next is the source file path (as a null-terminated string).
+  char *src_path = payload;
+  payload += strlen(src_path) + 1; // +1 for null terminator.
+
+  // Tell gdb about where the code lives and where the "source code" is.
+  struct gdb_object *obj = cb->object_open(cb);
+  struct gdb_symtab *symtab = cb->symtab_open(cb, obj, src_path);
+
+  // Tell gdb the extent of the JITted code.
+  //
+  // FIXME: why can't we break on the symbol name we tell gdb here?
+  //
+  // NOTE: this returns a `struct gdb_block`. At the time of writing there's a
+  // comment next to `gdb_block_open()` in <jit-reader.h> that says the return
+  // value is unused, but must not be freed by the caller.
+  unsigned char *jitted_code_end_vaddr = jitted_code_vaddr + jitted_code_size;
+  assert(sizeof(GDB_CORE_ADDR) == sizeof(uintptr_t));
+  cb->block_open(cb, symtab, NULL, (GDB_CORE_ADDR)jitted_code_vaddr,
+                 (GDB_CORE_ADDR)jitted_code_end_vaddr, sym_name);
+
+  // Read out the number of lineinfo pairs to expect.
+  int num_lineinfos;
+  memcpy(&num_lineinfos, payload, sizeof(num_lineinfos));
+  payload += sizeof(num_lineinfos);
+
+  // Read out the lineinfo records.
+  //
+  // Note that for gdb to reliably use the lineinfo, it appears the records
+  // need to be ordered by line number, ascending.
+  struct gdb_line_mapping *l_infos =
+      calloc(num_lineinfos, sizeof(struct gdb_line_mapping));
+  for (int i = 0; i < num_lineinfos; i++) {
+    // Read out the virtual address.
+    memcpy(&(l_infos[i].pc), payload, sizeof(l_infos[i].pc));
+    payload += sizeof(l_infos[i].pc);
+
+    // Read out the line number.
+    memcpy(&(l_infos[i].line), payload, sizeof(l_infos[i].line));
+    payload += sizeof(l_infos[i].line);
+  }
+
+  // Tell gdb about the lineinfo.
+  cb->line_mapping_add(cb, symtab, num_lineinfos, l_infos);
+
+  free(l_infos);
+
+  // Tells gdb that no more blocks will be added to this symtab.
+  cb->symtab_close(cb, symtab);
+  // Commit everything to gdb's internal data structures.
+  cb->object_close(cb, obj);
+
+  return GDB_SUCCESS;
+}
+
+// Required by the plugin API, but unused by us.
+void destory_reader_cb(struct gdb_reader_funcs *self) { (void)self; }
+
+// Required by the plugin API, but unused by us.
+enum gdb_status unwind_frame_cb(struct gdb_reader_funcs *self,
+                                struct gdb_unwind_callbacks *cb) {
+  (void)self;
+  (void)cb;
+  return GDB_FAIL;
+}
+
+// Required by the plugin API, but unused by us.
+struct gdb_frame_id get_frame_id_cb(struct gdb_reader_funcs *self,
+                                    struct gdb_unwind_callbacks *c) {
+  (void)self;
+  (void)c;
+  struct gdb_frame_id ret = {0, 0};
+  return ret;
+}
+
+struct gdb_reader_funcs reader_funcs = {
+    .reader_version = GDB_READER_INTERFACE_VERSION,
+    .priv_data = NULL,
+    .read = read_debug_info_cb,
+    .unwind = unwind_frame_cb,
+    .get_frame_id = get_frame_id_cb,
+    .destroy = destory_reader_cb,
+};
+
+struct gdb_reader_funcs *gdb_init_reader(void) {
+  printf("Yk JIT support loaded.\n");
+  return &reader_funcs;
+}


### PR DESCRIPTION
As requested, a work-in-progress (but working) branch to give us GDB support for our JITted code.

Unfinished:
 - C code is messy, needs tidy up.
 - Rust code has no error propagation.
 - GDB plugin not yet hooked into cargo build.
 - Can't break on jitted code symbols for some reason.

The (sparse) documentaton for the GDB JIT interface is here: https://sourceware.org/gdb/current/onlinedocs/gdb.html/JIT-Interface.html

In short, GDB defines and API and ABI for notifying it that new code is appearing. It's bother clever and scary. You define a global variable (I know, I know) with a special name that gdb reads when you call __jit_debug_register_code(). We have no control over the type or scope of this global: gdb expects it a certain way, and we have to play ball.

The docs also say you must synchronise modifications to the internals of the global if you are multi-threaded, which we are. Since we can't wrap the variable in a Rust mutex, we have to use an "out-of-band" mutex and very carefully ensure it stays locked while mutations can still occur.

All tests passing.