### PR TITLE
Translate phi nodes to the local variable, not an intermediate variable.

### DIFF
--- a/tests/c/phi1.newcg.c
+++ b/tests/c/phi1.newcg.c
@@ -9,12 +9,12 @@
 //     jitstate: stop-tracing
 //     --- Begin aot ---
 //     ...
-//     %{{14_0}}: i32 = phi bb{{bb13}} -> 2i32, bb{{bb12}} -> 1i32
+//     %{{_}}: i32 = phi bb{{_}} -> 2i32, bb{{_}} -> 1i32
 //     ...
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{15}}: i32 = 1i32
+//     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, 1i32)
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=1

--- a/tests/c/phi2.newcg.c
+++ b/tests/c/phi2.newcg.c
@@ -5,22 +5,28 @@
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     jitstate: start-tracing
-//     i=4, val=2
+//     i=4, val=6
 //     jitstate: stop-tracing
 //     --- Begin aot ---
 //     ...
-//     %{{14_0}}: i32 = phi bb{{bb13}} -> 2i32, bb{{bb12}} -> 1i32
+//     %{{23_0}}: i32 = phi bb{{bb22}} -> 100i32, bb{{bb21}} -> 6i32
+//     ...
+//     %{{24_0}}: i32 = phi bb{{bb23}} -> %{{23_0}}, bb{{bb19}} -> 3i32
+//     ...
+//     %{{25_0}}: i32 = phi bb{{bb24}} -> %{{24_0}}, bb{{bb17}} -> 2i32
+//     ...
+//     %{{26_0}}: i32 = phi bb{{bb25}} -> %{{25_0}}, bb{{bb15}} -> 1i32
 //     ...
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{15}}: i32 = 2i32
+//     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, 6i32)
 //     ...
 //     --- End jit-pre-opt ---
-//     i=3, val=2
+//     i=3, val=6
 //     jitstate: enter-jit-code
-//     i=2, val=2
-//     i=1, val=2
+//     i=2, val=6
+//     i=1, val=6
 //     jitstate: deoptimise
 
 // Check that PHI nodes JIT properly.
@@ -40,7 +46,7 @@ int main(int argc, char **argv) {
   YkLocation loc = yk_location_new();
 
   int val = 0;
-  int cond = -1;
+  int cond = -3;
   int i = 4;
   NOOPT_VAL(loc);
   NOOPT_VAL(val);
@@ -53,8 +59,14 @@ int main(int argc, char **argv) {
     NOOPT_VAL(cond);
     if (cond > 0) {
       val = 1;
-    } else {
+    } else if (cond == -1) {
       val = 2;
+    } else if (cond == -2) {
+      val = 3;
+    } else if (cond == -3) {
+      val = 6;
+    } else {
+      val = 100;
     }
     fprintf(stderr, "i=%d, val=%d\n", i, val);
     i--;

--- a/tests/c/phi3.newcg.c
+++ b/tests/c/phi3.newcg.c
@@ -5,28 +5,35 @@
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     jitstate: start-tracing
-//     i=4, val=6
+//     i=4, val=3
 //     jitstate: stop-tracing
 //     --- Begin aot ---
-//     ...
-//     %{{23_0}}: i32 = phi bb{{bb22}} -> 100i32, bb{{bb21}} -> 6i32
-//     ...
-//     %{{24_0}}: i32 = phi bb{{bb23}} -> %{{23_0}}, bb{{bb19}} -> 3i32
-//     ...
-//     %{{25_0}}: i32 = phi bb{{bb24}} -> %{{24_0}}, bb{{bb17}} -> 2i32
-//     ...
-//     %{{26_0}}: i32 = phi bb{{bb25}} -> %{{25_0}}, bb{{bb15}} -> 1i32
+//     ..~
+//     bb{{_}}:
+//       ...ptr_add...
+//       store...
+//       %{{13_2}}: i32 = call f() ...
+//     ..~
+//     bb{{_}}:
+//       ...ptr_add...
+//       store...
+//       %{{15_2}}: i32 = call g() ...
+//     ..~
+//     bb{{_}}:
+//       %{{_}}: i32 = phi bb{{_}} -> %{{15_2}}, bb{{_}} -> %{{13_2}}
 //     ...
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{15}}: i32 = 6i32
+//     %{{19}}: i32 = call @f()
+//     ...
+//     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, %{{19}})
 //     ...
 //     --- End jit-pre-opt ---
-//     i=3, val=6
+//     i=3, val=3
 //     jitstate: enter-jit-code
-//     i=2, val=6
-//     i=1, val=6
+//     i=2, val=3
+//     i=1, val=3
 //     jitstate: deoptimise
 
 // Check that PHI nodes JIT properly.
@@ -40,33 +47,28 @@ bool test_compiled_event(YkCStats stats) {
   return stats.traces_compiled_ok == 1;
 }
 
+__attribute__((yk_outline)) int f() { return 3; }
+
+__attribute__((yk_outline)) int g() { return 4; }
+
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
-  int val = 0;
-  int cond = -3;
   int i = 4;
   NOOPT_VAL(loc);
-  NOOPT_VAL(val);
   NOOPT_VAL(i);
   while (i > 0) {
     yk_mt_control_point(mt, &loc);
     if (i == 3) {
       __ykstats_wait_until(mt, test_compiled_event);
     }
-    NOOPT_VAL(cond);
-    if (cond > 0) {
-      val = 1;
-    } else if (cond == -1) {
-      val = 2;
-    } else if (cond == -2) {
-      val = 3;
-    } else if (cond == -3) {
-      val = 6;
+    int val;
+    if (i > 0) {
+      val = f();
     } else {
-      val = 100;
+      val = g();
     }
     fprintf(stderr, "i=%d, val=%d\n", i, val);
     i--;

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -895,8 +895,14 @@ impl<'a> TraceBuilder<'a> {
     ) -> Result<(), CompilationError> {
         // If the IR is well-formed the indexing and unwrap() here will not fail.
         let chosen_val = &incoming_vals[incoming_bbs.iter().position(|bb| bb == prev_bb).unwrap()];
-        let assign = jit_ir::AssignInst::new(&self.handle_operand(chosen_val)?);
-        self.copy_inst(assign.into(), bid, aot_inst_idx)
+        let aot_iit = aot_ir::InstID::new(
+            bid.func_idx(),
+            bid.bb_idx(),
+            aot_ir::InstIdx::new(aot_inst_idx),
+        );
+        let op = self.handle_operand(chosen_val)?;
+        self.local_map.insert(aot_iit, op);
+        Ok(())
     }
 
     fn u64_to_const(


### PR DESCRIPTION
Previously a phi node would be converted to an assignment. So, roughly:

```
%2 = phi %0, %1
print %2
```

would, if the `%1` case was taken, be translated to:

```
%2 = %1
print %2
```

but there's no need for the assignment: we can reference the local variable as often as we want.

This commit thus maps a phi node to its local variable without an intermediate assignment. In our running example we thus translate the code directly into:

```
print %1
```

I've also beefed up the phi-node tests considerably, including checking that they work for values returned from functions (which require intermediate variables, though in a different sense to the rest of this commit), and strengthening the text output we actually check for.