### PR TITLE
Skip duplicate control point blocks.

### DIFF
--- a/tests/c/simple_interp_loop2.newcg.c
+++ b/tests/c/simple_interp_loop2.newcg.c
@@ -1,6 +1,7 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     jitstate: start-tracing
@@ -9,6 +10,21 @@
 //     pc=2, mem=4
 //     pc=3, mem=3
 //     jitstate: stop-tracing
+//     --- Begin jit-pre-opt ---
+//     ..~
+//     guard %{{_}}, true
+//     %{{_}}: ptr = load %{{8}}
+//     %{{48}}: ptr = load %{{4}}
+//     %{{49}}: i32 = load %{{3}}
+//     %{{50}}: i64 = sext %{{49}}, i64
+//     %{{51}}: ptr = dyn_ptr_add %{{48}}, %{{50}}, 8
+//     %{{_}}: ptr = load %{{51}}
+//     %{{54}}: ptr = ptr_add %{{9}}, 48
+//     %{{56}}: ptr = lookup_global @shadowstack_0
+//     *%{{56}} = %{{54}}
+//     %{{_}}: ptr = lookup_global @shadowstack_0
+//     ...
+//     --- End jit-pre-opt ---
 //     pc=0, mem=3
 //     pc=1, mem=3
 //     pc=2, mem=3


### PR DESCRIPTION
When processing a trace generated by the hardware tracer, trace_builder will encounter two control point blocks. We must only process one of them. The simplest way to do this that is compatible with the software tracer is to start outlining after processing the first block by setting the outlining target to the blocks successor.