### PR TITLE
Document `jit-asm` logging.

### DIFF
--- a/docs/src/dev/understanding_traces.md
+++ b/docs/src/dev/understanding_traces.md
@@ -18,7 +18,10 @@ The following stages are supported:
  - `aot`: the entire AOT IR for the interpreter.
  - `jit-pre-opt`: the JIT IR trace before optimisation.
  - `jit-post-opt`: the JIT IR trace after optimisation.
+ - `jit-asm`: the assembler code of the compiled JIT IR trace.
 
+Note that `jit-asm` is currently only available for debug builds and in unit
+tests.
 
 #### `YKD_TRACE_DEBUGINFO`
 


### PR DESCRIPTION
The reason jit-asm isn't always available is because we display "comment lines" in the asm log that are stored up in a hashmap. These comment lines show where you are in the assembler code and are needed to make lang testing and debugging humanly possible.

But later we could choose to allow `jit-asm` in release builds, but just not show the comment lines, for example.