### PR TITLE
Abort traces instead of panicking.

### DIFF
--- a/tests/c/setlongjmp.newcg.c
+++ b/tests/c/setlongjmp.newcg.c
@@ -1,0 +1,61 @@
+// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// Run-time:
+//   env-var: YKD_LOG_IR=-:jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG_JITSTATE=-
+//   stderr:
+//     jitstate: start-tracing
+//     we jumped
+//     jitstate: stop-tracing
+//     jitstate: trace-compilation-aborted: Long jump encountered.
+//     ...
+
+// Tests that we can deal with setjmp/longjmp.
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+jmp_buf buf;
+
+void ljmp() {
+  int r = 0;
+  for (int i = 0; i < 10; i++) {
+    r += 1;
+  }
+  longjmp(buf, r);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  int r = setjmp(buf);
+  if (r == 10) {
+    fprintf(stderr, "we jumped\n");
+  }
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    if (r != 10) {
+      ljmp();
+    }
+    fprintf(stderr, "i=%d\n", i);
+    res += 2;
+    i--;
+  }
+  printf("exit");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -5,7 +5,7 @@
 use super::aot_ir::{self, BBlockId, BinOp, FuncIdx, Module};
 use super::jit_ir;
 use crate::compile::CompilationError;
-use crate::trace::{AOTTraceIterator, TraceAction};
+use crate::trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction};
 use std::{collections::HashMap, ffi::CString};
 
 /// The argument index of the trace inputs struct in the trace function.
@@ -1076,7 +1076,14 @@ impl<'a> TraceBuilder<'a> {
                         }
                     }
                 }
-                Err(_) => todo!(),
+                Err(e) => match e {
+                    AOTTraceIteratorError::TraceTooLong => {
+                        return Err(CompilationError::LimitExceeded("Trace too long.".into()));
+                    }
+                    AOTTraceIteratorError::LongJmpEncountered => {
+                        return Err(CompilationError::General("Long jump encountered.".into()));
+                    }
+                },
             }
         }
         Ok(self.jit_mod)


### PR DESCRIPTION
When traces get too long or a longjmp is detected, we want to abort the trace instead of crashing the interpreter.