### PR TITLE
Implement support for 1-bit constant integers.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -841,6 +841,7 @@ impl<'a> X64CodeGen<'a> {
     /// Load a constant into the specified register.
     fn load_const(&mut self, reg: Rq, cidx: jit_ir::ConstIdx) {
         match self.m.const_(cidx) {
+            jit_ir::Const::I1(x) => dynasm!(self.asm; mov Rq(reg.code()), i32::from(*x)),
             jit_ir::Const::I8(x) => dynasm!(self.asm; mov Rq(reg.code()), i32::from(*x)),
             jit_ir::Const::I16(x) => dynasm!(self.asm; mov Rw(reg.code()), WORD *x),
             jit_ir::Const::I32(x) => dynasm!(self.asm; mov Rq(reg.code()), DWORD *x),

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -365,6 +365,10 @@ impl<'a> TraceBuilder<'a> {
         let bytes = aot_const.bytes();
         match self.aot_mod.type_(aot_const.ty_idx()) {
             aot_ir::Ty::Integer(aot_ty) => match aot_ty.num_bits() {
+                1 => {
+                    debug_assert_eq!(bytes.len(), 1);
+                    Ok(jit_ir::Const::I1(bytes[0] != 0))
+                }
                 8 => {
                     debug_assert_eq!(bytes.len(), 1);
                     Ok(jit_ir::Const::I8(i8::from_ne_bytes([bytes[0]])))
@@ -386,7 +390,7 @@ impl<'a> TraceBuilder<'a> {
                         bytes[7],
                     ])))
                 }
-                _ => unreachable!(),
+                _ => unreachable!("{}", aot_ty.num_bits()),
             },
             aot_ir::Ty::Ptr => {
                 let val: usize;


### PR DESCRIPTION
Needed for events.lua.

This is hard to test since we don't have an AOT IR parser yet.

I've been unable to get clang to emit a 1-bit constant integer, but I have a cvise running now to try and find a C test at least.

In the interest of moving onwards, do we want to merge this now, and a test can be added later if we manage to reduce one?