### PR TITLE
Move to one `Const::Int` type.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -1255,7 +1255,7 @@ pub(crate) fn const_int_bytes_to_string(num_bits: u32, bytes: &[u8]) -> String {
 #[deku_derive(DekuRead)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct IntegerTy {
-    num_bits: u32,
+    pub(crate) num_bits: u32,
 }
 
 impl IntegerTy {

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -8,8 +8,9 @@
 //!     of those arguments has the correct [super::Ty].
 //!   * [super::BinOpInst]s left and right hand side operands have the same [Ty]s.
 //!   * [super::ICmpInst]s left and right hand side operands have the same [Ty]s.
+//!   * [Const::Int]s cannot use more bits than the corresponding [Ty::Integer] type.
 
-use super::{Inst, InstIdx, Module, Ty};
+use super::{Const, Inst, InstIdx, Module, Ty};
 
 impl Module {
     pub(crate) fn assert_well_formed(&self) {
@@ -82,6 +83,17 @@ impl Module {
                     }
                 }
                 _ => (),
+            }
+        }
+
+        for x in self.consts.iter() {
+            if let Const::Int(ty_idx, val) = x {
+                let Ty::Integer(width) = self.type_(*ty_idx) else {
+                    panic!()
+                };
+                if *width < 64 && *val > (1 << *width) - 1 {
+                    panic!("Constant {val} exceeds the bit width {width} of the corresponding integer type");
+                }
             }
         }
     }
@@ -191,6 +203,20 @@ mod tests {
               entry:
                 %0: i8 = load_ti 0
                 %1: i8 = sext %0
+            ",
+        );
+    }
+
+    #[should_panic(
+        expected = "Constant 256 exceeds the bit width 8 of the corresponding integer type"
+    )]
+    #[test]
+    fn int_exceeds_width() {
+        Module::from_str(
+            "
+              entry:
+                %0: i8 = load_ti 0
+                %1: i8 = add %0, 256i8
             ",
         );
     }

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -17,11 +17,11 @@ pub(super) fn simple(mut m: Module) -> Result<Module, CompilationError> {
             Inst::BinOp(x) if x.binop() == BinOp::Mul => {
                 if let (Operand::Local(_), Operand::Const(c_idx)) = (x.lhs(), x.rhs()) {
                     let old_const = m.const_(c_idx);
-                    if let Some(y) = old_const.int_to_i64() {
+                    if let Some(y) = old_const.int_to_u64() {
                         if y % 2 == 0 {
-                            let shl = i64::from(y.ilog2());
+                            let shl = u64::from(y.ilog2());
                             let new_const =
-                                Operand::Const(m.insert_const(old_const.i64_to_int(shl))?);
+                                Operand::Const(m.insert_const(old_const.u64_to_int(shl))?);
                             let new_inst = BinOpInst::new(x.lhs(), BinOp::Shl, new_const).into();
                             m.replace(inst_i, new_inst);
                         }


### PR DESCRIPTION
This moves us from multiple `Const::Int{8,16,...}` types to just `Const::Int(ty_idx, val)`. This is easier to use and more closely models what other IRs (e.g. LLVM and Cranelift) do: in essence, integers up to (and including) 64 bits are easy to handle. Bigger sized ints are still something we don't deal with: they'll probably become a `Const::ArbInt` type one day.

A downside to this change is that one now express nonsense integers (e.g. an "8 bit" integer with 9 bits set). The well_formedness check catches those.