### PR TITLE
Tidy up `insts` in `Module`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -111,8 +111,9 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
     fn codegen(mut self: Box<Self>) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         let alloc_off = self.emit_prologue();
 
-        for (idx, inst) in self.m.insts().iter_enumerated() {
-            self.cg_inst(idx, inst)?;
+        let mut inst_iter = self.m.iter_inst_idxs();
+        while let Some(idx) = inst_iter.next(self.m) {
+            self.cg_inst(idx, self.m.inst(idx))?;
         }
 
         // Loop the JITted code if the `tloop_start` label is present.

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -34,7 +34,7 @@ use std::{
     ffi::{c_void, CString},
     fmt, mem,
 };
-use typed_index_collections::{TiSlice, TiVec};
+use typed_index_collections::TiVec;
 #[cfg(not(test))]
 use ykaddr::addr::symbol_to_ptr;
 
@@ -239,11 +239,6 @@ impl Module {
     /// Returns the number of [Inst]s in the [Module].
     pub(crate) fn len(&self) -> usize {
         self.insts.len()
-    }
-
-    /// Return a slice of this module's instructions.
-    pub(crate) fn insts(&self) -> &TiSlice<InstIdx, Inst> {
-        &self.insts
     }
 
     /// Push a slice of arguments into the args pool.

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -230,15 +230,19 @@ impl Module {
     ) -> Result<Operand, CompilationError> {
         // Assert that `inst` defines a local var.
         debug_assert!(inst.def_type(self).is_some());
-        InstIdx::new(self.len()).map(|x| {
+        InstIdx::new(self.insts.len()).map(|x| {
             self.insts.push(inst);
             Operand::Local(x)
         })
     }
 
-    /// Returns the number of [Inst]s in the [Module].
-    pub(crate) fn len(&self) -> usize {
-        self.insts.len()
+    /// Returns the [InstIdx] of the last instruction in this module.
+    ///
+    /// # Panics
+    ///
+    /// If this module has no instructions.
+    pub(crate) fn last_inst_idx(&self) -> InstIdx {
+        InstIdx::new(self.insts.len().checked_sub(1).unwrap()).unwrap()
     }
 
     /// Push a slice of arguments into the args pool.

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -312,7 +312,7 @@ impl<'a> TraceBuilder<'a> {
     }
 
     /// Link the AOT IR to the last instruction pushed into the JIT IR.
-    fn link_iid_to_last_instr(&mut self, bid: &aot_ir::BBlockId, aot_inst_idx: usize) {
+    fn link_iid_to_last_inst(&mut self, bid: &aot_ir::BBlockId, aot_inst_idx: usize) {
         let aot_iid = aot_ir::InstID::new(
             bid.func_idx(),
             bid.bb_idx(),
@@ -335,7 +335,7 @@ impl<'a> TraceBuilder<'a> {
         if jit_inst.def_type(&self.jit_mod).is_some() {
             // If the AOT instruction defines a new value, then add it to the local map.
             self.jit_mod.push(jit_inst)?;
-            self.link_iid_to_last_instr(bid, aot_inst_idx);
+            self.link_iid_to_last_inst(bid, aot_inst_idx);
         } else {
             self.jit_mod.push(jit_inst)?;
         }
@@ -779,7 +779,7 @@ impl<'a> TraceBuilder<'a> {
                 jit_ir::DynPtrAddInst::new(jit_ptr, num_elems, elem_size).into(),
             )?;
         }
-        self.link_iid_to_last_instr(bid, aot_inst_idx);
+        self.link_iid_to_last_inst(bid, aot_inst_idx);
         Ok(())
     }
 


### PR DESCRIPTION
This PR stops some implementation details about `Module::insts` leaking out unnecessarily.