### PR TITLE
Optimise multiply chains

### DIFF
--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -45,7 +45,7 @@ fn opt_mul(
                 } else if y == 1 {
                     // Replace `x * 1` with `x`.
                     m.replace(inst_i, Inst::ProxyInst(mul_inst));
-                } else if y % 2 == 0 {
+                } else if y & (y - 1) == 0 {
                     // Replace `x * y` with `x << ...`.
                     let shl = u64::from(y.ilog2());
                     let new_const = Operand::Const(m.insert_const(old_const.u64_to_int(shl))?);
@@ -207,10 +207,7 @@ mod tests {
             %2: i64 = mul %0, 4i64
             %3: i64 = mul %0, 4611686018427387904i64
             %4: i64 = mul %0, 9223372036854775807i64
-            black_box %1
-            black_box %2
-            black_box %3
-            black_box %4
+            %5: i64 = mul %0, 12i64
         ",
             |m| simple(m).unwrap(),
             "
@@ -221,10 +218,7 @@ mod tests {
             %2: i64 = shl %0, 2i64
             %3: i64 = shl %0, 62i64
             %4: i64 = mul %0, 9223372036854775807i64
-            black_box %1
-            black_box %2
-            black_box %3
-            black_box %4
+            %5: i64 = mul %0, 12i64
         ",
         );
     }


### PR DESCRIPTION
The main part of this commit is https://github.com/ykjit/yk/commit/0145e7ba45913a694052c9d4731b764a2e8be5fa, which allows us to optimise chains of multiplications of constants, but first of all I had to fix a "what was I thinking?" bug (https://github.com/ykjit/yk/commit/4209c61cb914eb83aaadc70dee9011328d2a1192).