### PR TITLE
Introduce a `YKD_OPT` environment variable to turn on the trace optimiser

### DIFF
--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -1,5 +1,20 @@
 # Debugging
 
+## Trace optimisation
+
+Trace optimisation can make it difficult to understand why a yk interpreter has
+behaved in the way it does. It is worth trying to run your code with the
+optimiser turned off/down. You can do this with the `YKD_OPT` environment
+variable, which takes the following values:
+
+  * 1, 2, 3: increasing levels of optimisation. [Currently these all have the
+    same effect, but in the future this might change.]
+  * 0: turn the optimiser off.
+
+**NOTE**: Currently the trace optimiser is not enabled by default. This will
+change in the near future.
+
+
 ## Debugging JITted code
 
 Often you will find the need to inspect JITted code with a debugger. If the

--- a/tests/c/arithmetic.newcg.c
+++ b/tests/c/arithmetic.newcg.c
@@ -1,6 +1,6 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
-//   env-var: YKD_LOG_IR=-:jit-pre-opt
+//   env-var: YKD_LOG_IR=-:jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_JITSTATE=-
 //   stderr:

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -14,9 +14,13 @@ use crate::{
     mt::{SideTraceInfo, MT},
     trace::AOTTraceIterator,
 };
-
 use parking_lot::Mutex;
-use std::{error::Error, slice, sync::Arc};
+use std::{
+    env,
+    error::Error,
+    slice,
+    sync::{Arc, LazyLock},
+};
 use ykaddr::addr::symbol_to_ptr;
 
 pub mod aot_ir;
@@ -26,6 +30,15 @@ mod gdb;
 pub mod jit_ir;
 mod opt;
 mod trace_builder;
+
+/// Should we turn trace optimisations on or off? Currently defaults to "off".
+static YKD_OPT: LazyLock<bool> = LazyLock::new(|| {
+    let x = env::var("YKD_OPT");
+    match x.as_ref().map(|x| x.as_str()) {
+        Ok("1" | "2" | "3") => true,
+        Ok(_) | Err(_) => false,
+    }
+});
 
 pub(crate) struct JITCYk;
 
@@ -66,7 +79,8 @@ impl Compiler for JITCYk {
             log_ir(&format!("--- Begin aot ---\n{}\n--- End aot ---", aot_mod));
         }
 
-        let jit_mod = trace_builder::build(mt.next_compiled_trace_id(), &aot_mod, aottrace_iter.0)?;
+        let mut jit_mod =
+            trace_builder::build(mt.next_compiled_trace_id(), &aot_mod, aottrace_iter.0)?;
 
         if should_log_ir(IRPhase::PreOpt) {
             log_ir(&format!(
@@ -74,13 +88,14 @@ impl Compiler for JITCYk {
             ));
         }
 
-        // FIXME: This should be enabled when optimisations can cope with all the inputs we see.
-        // let jit_mod = opt::opt(jit_mod)?;
-        // if should_log_ir(IRPhase::PostOpt) {
-        //     log_ir(&format!(
-        //         "--- Begin jit-post-opt ---\n{jit_mod}\n--- End jit-pre-opt ---",
-        //     ));
-        // }
+        if *YKD_OPT {
+            jit_mod = opt::opt(jit_mod)?;
+            if should_log_ir(IRPhase::PostOpt) {
+                log_ir(&format!(
+                    "--- Begin jit-post-opt ---\n{jit_mod}\n--- End jit-post-opt ---",
+                ));
+            }
+        }
 
         let cg = Box::new(Self::default_codegen(&jit_mod)?);
         let ct = cg.codegen()?;


### PR DESCRIPTION
This currently defaults to "0" (i.e. off), but that will change when we gain more confidence in the optimiser.