### PR TITLE
Enable deoptimisation of inlined constants.

### DIFF
--- a/tests/c/safepoint_const.newcg.c
+++ b/tests/c/safepoint_const.newcg.c
@@ -1,0 +1,53 @@
+// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// Run-time:
+//   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG_JITSTATE=-
+
+// Check that basic trace compilation works.
+
+// FIXME: Get this test all the way through the new codegen pipeline!
+//
+// Currently it succeeds even though it crashes on deopt. This is so
+// that we can incrementally implement the new codegen and have CI merge our
+// incomplete work.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+__attribute__((noinline)) int f(int x, int i) {
+  int y;
+  if (i == 1) {
+    y = 10;
+  } else {
+    y = 20;
+  }
+  // Force deoptimisation of a constant.
+  fprintf(stderr, "%d %d %d\n", x, y, i);
+  return y;
+}
+
+__attribute__((noinline)) int g(int x, int i) { return f(x, i); }
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, ">%d\n", g(4, i));
+    i--;
+  }
+  fprintf(stderr, "exit\n");
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
@@ -31,6 +31,7 @@ pub(crate) enum LocalAlloc {
     ///
     /// FIXME: unimplemented.
     Register,
+    ConstInt(u64),
 }
 
 impl LocalAlloc {

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
@@ -114,6 +114,7 @@ pub(crate) extern "C" fn __yk_deopt(
                     }
                 }
                 LocalAlloc::Register => todo!(),
+                LocalAlloc::ConstInt(c) => c,
             };
             varidx += 1;
 

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -19,7 +19,10 @@ use super::{
 };
 #[cfg(any(debug_assertions, test))]
 use crate::compile::jitc_yk::gdb::GdbCtx;
-use crate::compile::{jitc_yk::jit_ir::IndirectCallIdx, CompiledTrace};
+use crate::compile::{
+    jitc_yk::jit_ir::{Const, IndirectCallIdx},
+    CompiledTrace,
+};
 use dynasmrt::{
     components::StaticLabel, dynasm, x64::Rq, AssemblyOffset, DynasmApi, DynasmError,
     DynasmLabelApi, ExecutableBuffer, Register,
@@ -817,7 +820,20 @@ impl<'a> X64CodeGen<'a> {
         let mut locs: Vec<LocalAlloc> = Vec::new();
         let gi = inst.guard_info(self.m);
         for lidx in gi.lives() {
-            locs.push(*self.ra.allocation(*lidx));
+            match self.m.inst(*lidx) {
+                jit_ir::Inst::ProxyConst(c) => {
+                    // The live variable is a constant (e.g. this can happen during inlining), so
+                    // it doesn't have an allocation. We can just push the actual value instead
+                    // which will be written as is during deoptimisation.
+                    match self.m.const_(*c) {
+                        Const::Int(_, c) => locs.push(LocalAlloc::ConstInt(*c)),
+                        _ => todo!(),
+                    };
+                }
+                _ => {
+                    locs.push(*self.ra.allocation(*lidx));
+                }
+            }
         }
 
         // FIXME: Move `frames` instead of copying them (requires JIT module to be consumable).
@@ -858,7 +874,15 @@ impl<'a> X64CodeGen<'a> {
 
     /// Load a local variable out of its stack slot into the specified register.
     fn load_local(&mut self, reg: Rq, local: InstIdx) {
-        match self.ra.allocation(local) {
+        let alloc = match self.m.inst(local) {
+            jit_ir::Inst::ProxyConst(c) => match self.m.const_(*c) {
+                Const::Int(_, c) => &LocalAlloc::ConstInt(*c),
+                _ => todo!(),
+            },
+            jit_ir::Inst::ProxyInst(_) => todo!(),
+            _ => self.ra.allocation(local),
+        };
+        match alloc {
             LocalAlloc::Stack { frame_off, size: _ } => {
                 match i32::try_from(*frame_off) {
                     Ok(foff) => {
@@ -876,6 +900,11 @@ impl<'a> X64CodeGen<'a> {
                 }
             }
             LocalAlloc::Register => todo!(),
+            LocalAlloc::ConstInt(c) => {
+                // FIXME: Adjust for different constant sizes. Requires storing the size in the
+                // variant.
+                dynasm!(self.asm; mov Rq(reg.code()), QWORD *c as i64);
+            }
         }
     }
 
@@ -915,6 +944,7 @@ impl<'a> X64CodeGen<'a> {
                 Err(_) => todo!("{}", size),
             },
             LocalAlloc::Register => todo!(),
+            LocalAlloc::ConstInt(_) => todo!(),
         }
     }
 
@@ -1697,6 +1727,26 @@ mod tests {
                 ... movzx r13, byte ptr [rbp-0x02]
                 ... div r13b
                 ... mov [rbp-0x03], al
+                ...
+            ",
+            );
+        }
+
+        #[test]
+        fn cg_proxyconst() {
+            test_with_spillalloc(
+                "
+              entry:
+                %0: i8 = load_ti 0
+                %1: i8 = 1i8
+                %2: i8 = add %0, %1
+            ",
+                "
+                ...
+                ; %2: i8 = add %0, 1i8
+                ... movzx r12, byte ptr [rbp-0x01]
+                ... mov r13, 0x01
+                ... add r12b, r13b
                 ...
             ",
             );

--- a/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
+++ b/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
@@ -104,6 +104,9 @@ Inst -> Result<ASTInst, Box<dyn Error>>:
   | "LOCAL_OPERAND" ":" Type "=" Operand "?" Operand ":" Operand {
       Ok(ASTInst::Select{assign: $1?.span(), cond: $5?, trueval: $7?, falseval: $9? })
     }
+  | "LOCAL_OPERAND" ":" Type "=" Operand {
+      Ok(ASTInst::Proxy{assign: $1?.span(), val: $5? })
+    }
   | "TLOOP_START" { Ok(ASTInst::TraceLoopStart) }
   ;
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -907,7 +907,15 @@ pub(crate) struct DisplayableOperand<'a> {
 impl fmt::Display for DisplayableOperand<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.operand {
-            Operand::Local(idx) => write!(f, "%{}", idx.to_u16()),
+            Operand::Local(idx) => match self.m.inst(*idx) {
+                Inst::ProxyConst(c) => {
+                    write!(f, "{}", self.m.const_(*c).display(self.m))
+                }
+                Inst::ProxyInst(idx) => {
+                    write!(f, "%{}", idx.to_u16())
+                }
+                _ => write!(f, "%{}", idx.to_u16()),
+            },
             Operand::Const(idx) => write!(f, "{}", self.m.const_(*idx).display(self.m)),
         }
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -275,6 +275,14 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                         );
                         self.push_assign(inst.into(), assign)?;
                     }
+                    ASTInst::Proxy { assign, val } => {
+                        let op = self.process_operand(val)?;
+                        let inst = match op {
+                            Operand::Local(_) => todo!(),
+                            Operand::Const(cidx) => Inst::ProxyConst(cidx),
+                        };
+                        self.push_assign(inst.into(), assign)?;
+                    }
                 }
             }
         }
@@ -521,6 +529,10 @@ enum ASTInst {
         cond: ASTOperand,
         trueval: ASTOperand,
         falseval: ASTOperand,
+    },
+    Proxy {
+        assign: Span,
+        val: ASTOperand,
     },
 }
 


### PR DESCRIPTION
I'm raising this as a DRAFT, as I'm not quite sold on the design yet and would like to have some additional eyes on this. There's two main issues:
1) We need to introduce a `LocalAlloc::Const`, which doesn't make much sense conceptually.
2) We currently don't adjust for the size of the constant (this can be easily fixed by adding the size to the enum variant)

---

Due to function inlining (and later other optimisations) it can happen that a variable in AOT becomes a constant in the JIT. Currently, neither the trace builder nor deoptimisation can handle such cases, which this commit fixes, by inserting a `ProxyConst` instruction and reference this instead of the direct constant.