### PR TITLE
Update `YKD_LOG_IR` documentation to reflect reality.

### DIFF
--- a/docs/src/dev/understanding_traces.md
+++ b/docs/src/dev/understanding_traces.md
@@ -10,18 +10,18 @@ to make them a bit easier to understand.
 
 ### `YKD_LOG_IR`
 
-`YKD_LOG_IR` accepts a comma-separated list of JIT pipeline stages at which
-to print IR to stderr.
+`YKD_LOG_IR=<path>:<irstage_1>[,...,<irstage_n>]` logs IR from different stages
+to `path`. The special value `-` (i.e. a single dash) can be used for `<path>`
+to indicate stderr.
 
-The following stages are supported:
+The following `ir_stage`s are supported:
 
  - `aot`: the entire AOT IR for the interpreter.
  - `jit-pre-opt`: the JIT IR trace before optimisation.
  - `jit-post-opt`: the JIT IR trace after optimisation.
- - `jit-asm`: the assembler code of the compiled JIT IR trace.
+ - `jit-asm`: the assembler code of the compiled JIT IR trace. Note this stage
+   is only available for debug builds and unit tests.
 
-Note that `jit-asm` is currently only available for debug builds and in unit
-tests.
 
 #### `YKD_TRACE_DEBUGINFO`
 

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -61,7 +61,9 @@ mod internals {
                     }
                     Some((p.to_string(), log_phases))
                 }
-                _ => panic!("YKD_LOG_IR must be of the format '<path|->:stage_1,...,stage_n'"),
+                _ => panic!(
+                    "YKD_LOG_IR must be of the format '<path>:<irstage_1>[,...,<irstage_n>]'"
+                ),
             }
         } else {
             None


### PR DESCRIPTION
The docs previously failed to mention that you *have* to specify a path (or `-`) for `YKD_LOG_IR`. This commit minimally-ish updates the docs and makes the error the code throws consistent with the docs.