### PR TITLE
Minimally allow `cargo check` to work on non-Linux.

### DIFF
--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -1,36 +1,45 @@
-use rerun_except::rerun_except;
-use std::env;
-use std::path::PathBuf;
-use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
+#[cfg(not(target_os = "linux"))]
+mod inner {
+    use rerun_except::rerun_except;
 
-const FEATURE_CHECKS_PATH: &str = "feature_checks";
-
-/// Simple feature check, returning `true` if we have the feature.
-///
-/// The checks themselves are in files under `FEATURE_CHECKS_PATH`.
-fn feature_check(filename: &str, output_file: &str) -> bool {
-    let mut path = PathBuf::new();
-    path.push(FEATURE_CHECKS_PATH);
-    path.push(filename);
-
-    let mut check_build = cc::Build::new();
-    check_build.file(path).try_compile(output_file).is_ok()
+    pub(super) fn main() {
+        rerun_except(&["README.md"]).unwrap();
+    }
 }
 
-fn main() {
-    rerun_except(&["README.md"]).unwrap();
+#[cfg(target_os = "linux")]
+mod inner {
+    use rerun_except::rerun_except;
+    use std::env;
+    use std::path::PathBuf;
+    use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
 
-    let mut c_build = cc::Build::new();
+    const FEATURE_CHECKS_PATH: &str = "feature_checks";
 
-    // Generate a `compile_commands.json` database for clangd.
-    let ccg = CompletionWrapper::new(ykllvm_bin("clang"), "hwtracer");
-    for (k, v) in ccg.build_env() {
-        env::set_var(k, v);
+    /// Simple feature check, returning `true` if we have the feature.
+    ///
+    /// The checks themselves are in files under `FEATURE_CHECKS_PATH`.
+    fn feature_check(filename: &str, output_file: &str) -> bool {
+        let mut path = PathBuf::new();
+        path.push(FEATURE_CHECKS_PATH);
+        path.push(filename);
+
+        let mut check_build = cc::Build::new();
+        check_build.file(path).try_compile(output_file).is_ok()
     }
-    c_build.compiler(ccg.wrapper_path());
 
-    #[cfg(target_os = "linux")]
-    {
+    pub(super) fn main() {
+        rerun_except(&["README.md"]).unwrap();
+
+        let mut c_build = cc::Build::new();
+
+        // Generate a `compile_commands.json` database for clangd.
+        let ccg = CompletionWrapper::new(ykllvm_bin("clang"), "hwtracer");
+        for (k, v) in ccg.build_env() {
+            env::set_var(k, v);
+        }
+        c_build.compiler(ccg.wrapper_path());
+
         if feature_check("linux_perf.c", "linux_perf") {
             c_build.file("src/perf/collect.c");
             println!("cargo:rustc-cfg=linux_perf");
@@ -44,8 +53,12 @@ fn main() {
                 println!("cargo::rustc-check-cfg=cfg(pt)");
             }
         }
-    }
 
-    c_build.compile("hwtracer_c");
-    ccg.generate();
+        c_build.compile("hwtracer_c");
+        ccg.generate();
+    }
+}
+
+fn main() {
+    inner::main();
 }

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::upper_case_acronyms)]

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -1,3 +1,5 @@
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+
 //! Testing and benchmarking bits for hwtracer's ykpt decoder.
 //!
 //! Why is this so convoluted? Read on...

--- a/ykbuild/src/lib.rs
+++ b/ykbuild/src/lib.rs
@@ -63,5 +63,9 @@ pub fn apply_llvm_ld_library_path() {
         .unwrap()
         .stdout;
     let lib_dir = std::str::from_utf8(&lib_dir).unwrap();
-    println!("cargo:rustc-env=LD_LIBRARY_PATH={}", lib_dir);
+    let ldp = match env::var("LD_LIBRARY_PATH") {
+        Ok(x) => format!("{lib_dir}:{x})"),
+        Err(_) => lib_dir.to_owned(),
+    };
+    println!("cargo:rustc-env=LD_LIBRARY_PATH={ldp}");
 }

--- a/ykcapi/build.rs
+++ b/ykcapi/build.rs
@@ -12,7 +12,10 @@ pub fn main() {
     match env::var("YKB_TRACER") {
         Ok(ref tracer) if tracer == "swt" => println!("cargo:rustc-cfg=tracer_swt"),
         Ok(ref tracer) if tracer == "hwt" => println!("cargo:rustc-cfg=tracer_hwt"),
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
         Err(env::VarError::NotPresent) => println!("cargo:rustc-cfg=tracer_hwt"),
+        #[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
+        Err(env::VarError::NotPresent) => println!("cargo:rustc-cfg=tracer_swt"),
         Ok(x) => panic!("Unknown tracer {x}"),
         Err(_) => panic!("Invalid value for YKB_TRACER"),
     }

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0 OR MIT"
 byteorder = "1.4.3"
 deku = { version = "0.16.0", features = ["std"] }
 dynasmrt = "2.0.0"
-hwtracer = { path = "../hwtracer" }
 indexmap = "2.2.6"
 libc = "0.2.148"
 memmap2 = "0.9"
@@ -27,6 +26,9 @@ ykaddr = { path = "../ykaddr" }
 yksmp = { path = "../yksmp" }
 yktracec = { path = "../yktracec" }
 zydis = "4.1.0"
+
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
+hwtracer = { path = "../hwtracer" }
 
 [dependencies.llvm-sys]
 # note: using a git version to get llvm linkage features in llvm-sys (not in a

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -25,8 +25,10 @@ pub fn main() {
     println!("cargo::rustc-check-cfg=cfg(tracer_swt)");
     match env::var("YKB_TRACER") {
         Ok(ref tracer) if tracer == "swt" => println!("cargo:rustc-cfg=tracer_swt"),
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
         Ok(ref tracer) if tracer == "hwt" => println!("cargo:rustc-cfg=tracer_hwt"),
-        Err(env::VarError::NotPresent) => println!("cargo:rustc-cfg=tracer_hwt"),
+        #[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
+        Err(env::VarError::NotPresent) => println!("cargo:rustc-cfg=tracer_swt"),
         Ok(x) => panic!("Unknown tracer {x}"),
         Err(_) => panic!("Invalid value for YKB_TRACER"),
     }
@@ -48,7 +50,7 @@ pub fn main() {
 
     // Build the gdb plugin.
     env::set_current_dir("yk_gdb_plugin").unwrap();
-    let out = Command::new("make").output().unwrap();
+    let out = Command::new("gmake").output().unwrap();
     if !out.status.success() {
         io::stderr().write_all(&out.stdout).unwrap();
         io::stderr().write_all(&out.stderr).unwrap();

--- a/ykrt/yk_gdb_plugin/Makefile
+++ b/ykrt/yk_gdb_plugin/Makefile
@@ -1,4 +1,4 @@
-CPPFLAGS=-I/usr/include/gdb
+CPPFLAGS=-I/usr/include/ -I/usr/local/include/
 CFLAGS=-fPIC -g -Wextra -Wpedantic
 
 ../../target/yk_gdb_plugin.so: yk_gdb_plugin.c

--- a/yktracec/src/stackmap_oll_plugin.cc
+++ b/yktracec/src/stackmap_oll_plugin.cc
@@ -2,7 +2,7 @@
 
 #include "stackmap_oll_plugin.h"
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__OpenBSD__)
 const char *SMSectionName = ".llvm_stackmaps";
 #else
 #error unknown stackmap section name for this platform


### PR DESCRIPTION
Although yk can only run on Linux at the moment, `cargo check` fails on non-Linux, which means that rust-analyzer fails. Having got sufficiently fed up with not having any LSP help, I finally got around to working out the minimal (hopefully) changes necessary for `cargo check` to succeed on OpenBSD (but `cargo test` doesn't work, and I'm not worried about that for now).

Most of these changes are probably good things full stop -- it makes clearer that `hwt` can only work on x86_64/Linux, for example. One annoying thing is that Cargo workspaces can't be conditionally compiled, so `hwtracer` must always be compilable. It's easy to make its `lib.rs` not compile anything useful, but harder for `build.rs`. To add insult to injury `build::main` must always be a top-level function. I've therefore resorted to a slightly evil "inner mod" trick for `hwtracer/build.rs`

Still, overall, these changes aren't too intrusive, and they will probably help us when eventually we want to get yk actually working on non-Linux.