### PR TITLE
Split `InstIdx` iteration into two.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -114,8 +114,7 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
     fn codegen(mut self: Box<Self>) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         let alloc_off = self.emit_prologue();
 
-        let mut inst_iter = self.m.iter_inst_idxs();
-        while let Some(idx) = inst_iter.next(self.m) {
+        for idx in self.m.iter_skipping_inst_idxs() {
             self.cg_inst(idx, self.m.inst(idx))?;
         }
 
@@ -199,7 +198,7 @@ impl<'a> X64CodeGen<'a> {
             #[cfg(test)]
             jit_ir::Inst::BlackBox(_) => unreachable!(),
             jit_ir::Inst::ProxyConst(_) | jit_ir::Inst::ProxyInst(_) | jit_ir::Inst::Tombstone => {
-                unreachable!()
+                unreachable!();
             }
 
             jit_ir::Inst::BinOp(i) => self.cg_binop(inst_idx, i),

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -12,8 +12,7 @@ use crate::compile::{
 };
 
 pub(super) fn simple(mut m: Module) -> Result<Module, CompilationError> {
-    let mut inst_iter = m.iter_inst_idxs();
-    while let Some(inst_i) = inst_iter.next(&m) {
+    for inst_i in m.iter_inst_idxs() {
         let inst = m.inst(inst_i).clone();
         match inst {
             Inst::BinOp(BinOpInst {


### PR DESCRIPTION
While doing work elsewhere, I realised that we need to iterate over instructions in two ways:

  1. Only iterate over "instructions that do something" (i.e. hide `Proxy*` and `Tombstone`).
  2. Iterate over all instructions (including `Proxy*` and `Tombstone`).

However, our existing `iter_inst_idx` only did (1) -- and it's easy to misread it and assume it will do (2).

This commit makes `iter_inst_idx` do (2), with `iter_skipping_inst_idx` do (1). I did consider getting rid of the latter, but that just forces more knowledge of `Proxy*` and `Tombstone` around the system in a way that doesn't seem very helpf way that doesn't seem very helpful.