### PR TITLE
Fix tracer selection logic.

### DIFF
--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -27,6 +27,8 @@ pub fn main() {
         Ok(ref tracer) if tracer == "swt" => println!("cargo:rustc-cfg=tracer_swt"),
         #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
         Ok(ref tracer) if tracer == "hwt" => println!("cargo:rustc-cfg=tracer_hwt"),
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        Err(env::VarError::NotPresent) => println!("cargo:rustc-cfg=tracer_hwt"),
         #[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
         Err(env::VarError::NotPresent) => println!("cargo:rustc-cfg=tracer_swt"),
         Ok(x) => panic!("Unknown tracer {x}"),


### PR DESCRIPTION
As discussed offline:

> On x86_64 linux we should currently default to hwt, but otherwise we
> should default to swt.

Fixes a build crash on x86/linux when YKB_TRACER is unset.