### PR TITLE
More consistent `idx` naming

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -517,8 +517,8 @@ pub(crate) struct DisplayableOperand<'a> {
 impl fmt::Display for DisplayableOperand<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.operand {
-            Operand::Const(const_idx) => {
-                write!(f, "{}", self.m.consts[*const_idx].display(self.m))
+            Operand::Const(cidx) => {
+                write!(f, "{}", self.m.consts[*cidx].display(self.m))
             }
             Operand::LocalVariable(iid) => {
                 write!(f, "%{}_{}", usize::from(iid.bb_idx), usize::from(iid.iidx))

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -349,15 +349,15 @@ pub(crate) struct InstID {
     /// The index of the parent function.
     func_idx: FuncIdx,
     bb_idx: BBlockIdx,
-    inst_idx: InstIdx,
+    iidx: InstIdx,
 }
 
 impl InstID {
-    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBlockIdx, inst_idx: InstIdx) -> Self {
+    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBlockIdx, iidx: InstIdx) -> Self {
         Self {
             func_idx,
             bb_idx,
-            inst_idx,
+            iidx,
         }
     }
 }
@@ -474,7 +474,7 @@ impl Operand {
         let Self::LocalVariable(iid) = self else {
             panic!()
         };
-        &aotmod.funcs[iid.func_idx].bblocks[iid.bb_idx].insts[iid.inst_idx]
+        &aotmod.funcs[iid.func_idx].bblocks[iid.bb_idx].insts[iid.iidx]
     }
 
     /// Returns the [Ty] of the operand.
@@ -521,12 +521,7 @@ impl fmt::Display for DisplayableOperand<'_> {
                 write!(f, "{}", self.m.consts[*const_idx].display(self.m))
             }
             Operand::LocalVariable(iid) => {
-                write!(
-                    f,
-                    "%{}_{}",
-                    usize::from(iid.bb_idx),
-                    usize::from(iid.inst_idx)
-                )
+                write!(f, "%{}_{}", usize::from(iid.bb_idx), usize::from(iid.iidx))
             }
             Operand::Global(gidx) => write!(f, "@{}", self.m.global_decls[*gidx].name()),
             Operand::Func(fidx) => write!(f, "{}", self.m.funcs[*fidx].name()),
@@ -762,9 +757,9 @@ impl Inst {
     fn local_name(&self, m: &Module) -> String {
         for f in m.funcs.iter() {
             for (bb_idx, bb) in f.bblocks.iter().enumerate() {
-                for (inst_idx, inst) in bb.insts.iter().enumerate() {
+                for (iidx, inst) in bb.insts.iter().enumerate() {
                     if std::ptr::addr_eq(inst, self) {
-                        return format!("%{}_{}", bb_idx, inst_idx);
+                        return format!("%{}_{}", bb_idx, iidx);
                     }
                 }
             }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -265,7 +265,7 @@ index!(ConstIdx);
 pub(crate) struct GlobalDeclIdx(usize);
 index!(GlobalDeclIdx);
 
-/// An index into [FuncTy::arg_ty_idxs].
+/// An index into [FuncTy::arg_tyidxs].
 /// ^ FIXME: no it's not! But it should be!
 #[deku_derive(DekuRead)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -489,7 +489,7 @@ impl Operand {
                 let Ty::Func(ft) = m.type_(m.func(*func_idx).tyidx) else {
                     panic!()
                 };
-                m.type_(ft.arg_ty_idxs()[usize::from(*arg_idx)])
+                m.type_(ft.arg_tyidxs()[usize::from(*arg_idx)])
             }
             _ => todo!(),
         }
@@ -1185,7 +1185,7 @@ impl fmt::Display for DisplayableFunc<'_> {
                 f,
                 "func {}({}",
                 self.func_.name,
-                fty.arg_ty_idxs
+                fty.arg_tyidxs
                     .iter()
                     .enumerate()
                     .map(|(i, t)| format!("%arg{}: {}", i, self.m.types[*t].display(self.m)))
@@ -1301,7 +1301,7 @@ pub(crate) struct FuncTy {
     num_args: usize,
     /// Ty indices for the function's formal arguments.
     #[deku(count = "num_args")]
-    arg_ty_idxs: Vec<TyIdx>,
+    arg_tyidxs: Vec<TyIdx>,
     /// Ty index of the function's return type.
     ret_ty: TyIdx,
     /// Is the function vararg?
@@ -1310,16 +1310,16 @@ pub(crate) struct FuncTy {
 
 impl FuncTy {
     #[cfg(test)]
-    fn new(arg_ty_idxs: Vec<TyIdx>, ret_tyidx: TyIdx, is_vararg: bool) -> Self {
+    fn new(arg_tyidxs: Vec<TyIdx>, ret_tyidx: TyIdx, is_vararg: bool) -> Self {
         Self {
-            arg_ty_idxs,
+            arg_tyidxs,
             ret_ty: ret_tyidx,
             is_vararg,
         }
     }
 
-    pub(crate) fn arg_ty_idxs(&self) -> &[TyIdx] {
-        &self.arg_ty_idxs
+    pub(crate) fn arg_tyidxs(&self) -> &[TyIdx] {
+        &self.arg_tyidxs
     }
 
     pub(crate) fn ret_ty(&self) -> TyIdx {
@@ -1344,7 +1344,7 @@ impl fmt::Display for DisplayableFuncTy<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut args = self
             .func_type
-            .arg_ty_idxs
+            .arg_tyidxs
             .iter()
             .map(|t| self.m.types[*t].display(self.m).to_string())
             .collect::<Vec<_>>();
@@ -1368,7 +1368,7 @@ pub(crate) struct StructTy {
     num_fields: usize,
     /// The types of the fields.
     #[deku(count = "num_fields")]
-    field_ty_idxs: Vec<TyIdx>,
+    field_tyidxs: Vec<TyIdx>,
     /// The bit offsets of the fields (taking into account any required padding for alignment).
     #[deku(count = "num_fields")]
     field_bit_offs: Vec<usize>,
@@ -1381,7 +1381,7 @@ impl StructTy {
     ///
     /// Panics if the index is out of bounds.
     pub(crate) fn field_tyidx(&self, idx: usize) -> TyIdx {
-        self.field_ty_idxs[idx]
+        self.field_tyidxs[idx]
     }
 
     /// Returns the byte offset of the specified field index.
@@ -1399,7 +1399,7 @@ impl StructTy {
 
     /// Returns the number of fields in the struct.
     pub(crate) fn num_fields(&self) -> usize {
-        self.field_ty_idxs.len()
+        self.field_tyidxs.len()
     }
 
     pub(crate) fn display<'a>(&'a self, m: &'a Module) -> DisplayableStructTy<'a> {
@@ -1421,7 +1421,7 @@ impl Display for DisplayableStructTy<'_> {
             f,
             "{{{}}}",
             self.struct_type
-                .field_ty_idxs
+                .field_tyidxs
                 .iter()
                 .enumerate()
                 .map(|(i, ti)| format!(

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -108,7 +108,7 @@ impl Module {
 
     /// Return the block uniquely identified (in this module) by the specified [BBlockId].
     pub(crate) fn bblock(&self, bid: &BBlockId) -> &BBlock {
-        self.funcs[bid.funcidx].bblock(bid.bb_idx)
+        self.funcs[bid.funcidx].bblock(bid.bbidx)
     }
 
     pub(crate) fn const_type(&self, c: &Const) -> &Ty {
@@ -348,15 +348,15 @@ impl Display for BinOp {
 pub(crate) struct InstID {
     /// The index of the parent function.
     funcidx: FuncIdx,
-    bb_idx: BBlockIdx,
+    bbidx: BBlockIdx,
     iidx: InstIdx,
 }
 
 impl InstID {
-    pub(crate) fn new(funcidx: FuncIdx, bb_idx: BBlockIdx, iidx: InstIdx) -> Self {
+    pub(crate) fn new(funcidx: FuncIdx, bbidx: BBlockIdx, iidx: InstIdx) -> Self {
         Self {
             funcidx,
-            bb_idx,
+            bbidx,
             iidx,
         }
     }
@@ -366,24 +366,24 @@ impl InstID {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct BBlockId {
     funcidx: FuncIdx,
-    bb_idx: BBlockIdx,
+    bbidx: BBlockIdx,
 }
 
 impl BBlockId {
-    pub(crate) fn new(funcidx: FuncIdx, bb_idx: BBlockIdx) -> Self {
-        Self { funcidx, bb_idx }
+    pub(crate) fn new(funcidx: FuncIdx, bbidx: BBlockIdx) -> Self {
+        Self { funcidx, bbidx }
     }
 
     pub(crate) fn funcidx(&self) -> FuncIdx {
         self.funcidx
     }
 
-    pub(crate) fn bb_idx(&self) -> BBlockIdx {
-        self.bb_idx
+    pub(crate) fn bbidx(&self) -> BBlockIdx {
+        self.bbidx
     }
 
     pub(crate) fn is_entry(&self) -> bool {
-        self.bb_idx == BBlockIdx(0)
+        self.bbidx == BBlockIdx(0)
     }
 }
 
@@ -474,7 +474,7 @@ impl Operand {
         let Self::LocalVariable(iid) = self else {
             panic!()
         };
-        &aotmod.funcs[iid.funcidx].bblocks[iid.bb_idx].insts[iid.iidx]
+        &aotmod.funcs[iid.funcidx].bblocks[iid.bbidx].insts[iid.iidx]
     }
 
     /// Returns the [Ty] of the operand.
@@ -521,7 +521,7 @@ impl fmt::Display for DisplayableOperand<'_> {
                 write!(f, "{}", self.m.consts[*cidx].display(self.m))
             }
             Operand::LocalVariable(iid) => {
-                write!(f, "%{}_{}", usize::from(iid.bb_idx), usize::from(iid.iidx))
+                write!(f, "%{}_{}", usize::from(iid.bbidx), usize::from(iid.iidx))
             }
             Operand::Global(gidx) => write!(f, "@{}", self.m.global_decls[*gidx].name()),
             Operand::Func(fidx) => write!(f, "{}", self.m.funcs[*fidx].name()),
@@ -756,10 +756,10 @@ impl Inst {
     /// FIXME: This is very slow and could be optimised.
     fn local_name(&self, m: &Module) -> String {
         for f in m.funcs.iter() {
-            for (bb_idx, bb) in f.bblocks.iter().enumerate() {
+            for (bbidx, bb) in f.bblocks.iter().enumerate() {
                 for (iidx, inst) in bb.insts.iter().enumerate() {
                     if std::ptr::addr_eq(inst, self) {
-                        return format!("%{}_{}", bb_idx, iidx);
+                        return format!("%{}_{}", bbidx, iidx);
                     }
                 }
             }
@@ -1153,8 +1153,8 @@ impl Func {
     /// # Panics
     ///
     /// Panics if the index is out of range.
-    pub(crate) fn bblock(&self, bb_idx: BBlockIdx) -> &BBlock {
-        &self.bblocks[bb_idx]
+    pub(crate) fn bblock(&self, bbidx: BBlockIdx) -> &BBlock {
+        &self.bblocks[bbidx]
     }
 
     /// Return the name of the function.

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -461,7 +461,7 @@ pub(crate) enum Operand {
     #[deku(id = "3")]
     Func(FuncIdx),
     #[deku(id = "4")]
-    Arg { func_idx: FuncIdx, arg_idx: ArgIdx },
+    Arg { func_idx: FuncIdx, argidx: ArgIdx },
 }
 
 impl Operand {
@@ -485,11 +485,11 @@ impl Operand {
                 self.to_inst(m).def_type(m).unwrap()
             }
             Self::Const(cidx) => m.type_(m.const_(*cidx).unwrap_val().tyidx()),
-            Self::Arg { func_idx, arg_idx } => {
+            Self::Arg { func_idx, argidx } => {
                 let Ty::Func(ft) = m.type_(m.func(*func_idx).tyidx) else {
                     panic!()
                 };
-                m.type_(ft.arg_tyidxs()[usize::from(*arg_idx)])
+                m.type_(ft.arg_tyidxs()[usize::from(*argidx)])
             }
             _ => todo!(),
         }
@@ -525,7 +525,7 @@ impl fmt::Display for DisplayableOperand<'_> {
             }
             Operand::Global(gidx) => write!(f, "@{}", self.m.global_decls[*gidx].name()),
             Operand::Func(fidx) => write!(f, "{}", self.m.funcs[*fidx].name()),
-            Operand::Arg { arg_idx, .. } => write!(f, "%arg{}", usize::from(*arg_idx)),
+            Operand::Arg { argidx, .. } => write!(f, "%arg{}", usize::from(*argidx)),
         }
     }
 }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -92,7 +92,7 @@ impl Module {
     /// # Panics
     ///
     /// Panics if no function exists with that name.
-    pub(crate) fn func_idx(&self, find_func: &str) -> FuncIdx {
+    pub(crate) fn funcidx(&self, find_func: &str) -> FuncIdx {
         // OPT: create a cache in the Module.
         self.funcs
             .iter()
@@ -108,7 +108,7 @@ impl Module {
 
     /// Return the block uniquely identified (in this module) by the specified [BBlockId].
     pub(crate) fn bblock(&self, bid: &BBlockId) -> &BBlock {
-        self.funcs[bid.func_idx].bblock(bid.bb_idx)
+        self.funcs[bid.funcidx].bblock(bid.bb_idx)
     }
 
     pub(crate) fn const_type(&self, c: &Const) -> &Ty {
@@ -347,15 +347,15 @@ impl Display for BinOp {
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub(crate) struct InstID {
     /// The index of the parent function.
-    func_idx: FuncIdx,
+    funcidx: FuncIdx,
     bb_idx: BBlockIdx,
     iidx: InstIdx,
 }
 
 impl InstID {
-    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBlockIdx, iidx: InstIdx) -> Self {
+    pub(crate) fn new(funcidx: FuncIdx, bb_idx: BBlockIdx, iidx: InstIdx) -> Self {
         Self {
-            func_idx,
+            funcidx,
             bb_idx,
             iidx,
         }
@@ -365,17 +365,17 @@ impl InstID {
 /// Uniquely identifies a basic block within a [Module].
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct BBlockId {
-    func_idx: FuncIdx,
+    funcidx: FuncIdx,
     bb_idx: BBlockIdx,
 }
 
 impl BBlockId {
-    pub(crate) fn new(func_idx: FuncIdx, bb_idx: BBlockIdx) -> Self {
-        Self { func_idx, bb_idx }
+    pub(crate) fn new(funcidx: FuncIdx, bb_idx: BBlockIdx) -> Self {
+        Self { funcidx, bb_idx }
     }
 
-    pub(crate) fn func_idx(&self) -> FuncIdx {
-        self.func_idx
+    pub(crate) fn funcidx(&self) -> FuncIdx {
+        self.funcidx
     }
 
     pub(crate) fn bb_idx(&self) -> BBlockIdx {
@@ -461,7 +461,7 @@ pub(crate) enum Operand {
     #[deku(id = "3")]
     Func(FuncIdx),
     #[deku(id = "4")]
-    Arg { func_idx: FuncIdx, argidx: ArgIdx },
+    Arg { funcidx: FuncIdx, argidx: ArgIdx },
 }
 
 impl Operand {
@@ -474,7 +474,7 @@ impl Operand {
         let Self::LocalVariable(iid) = self else {
             panic!()
         };
-        &aotmod.funcs[iid.func_idx].bblocks[iid.bb_idx].insts[iid.iidx]
+        &aotmod.funcs[iid.funcidx].bblocks[iid.bb_idx].insts[iid.iidx]
     }
 
     /// Returns the [Ty] of the operand.
@@ -485,8 +485,8 @@ impl Operand {
                 self.to_inst(m).def_type(m).unwrap()
             }
             Self::Const(cidx) => m.type_(m.const_(*cidx).unwrap_val().tyidx()),
-            Self::Arg { func_idx, argidx } => {
-                let Ty::Func(ft) = m.type_(m.func(*func_idx).tyidx) else {
+            Self::Arg { funcidx, argidx } => {
+                let Ty::Func(ft) = m.type_(m.func(*funcidx).tyidx) else {
                     panic!()
                 };
                 m.type_(ft.arg_tyidxs()[usize::from(*argidx)])

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -636,7 +636,7 @@ impl<'a> X64CodeGen<'a> {
     ) -> Result<(), CompilationError> {
         let inst = self.m.indirect_call(*indirect_call_idx);
         self.load_operand(WR0, &inst.target(self.m));
-        let jit_ir::Ty::Func(fty) = self.m.type_(inst.fty_idx()) else {
+        let jit_ir::Ty::Func(fty) = self.m.type_(inst.ftyidx()) else {
             panic!()
         };
         let args = (0..(inst.num_args()))
@@ -699,10 +699,10 @@ impl<'a> X64CodeGen<'a> {
 
     fn cg_sext(&mut self, iidx: InstIdx, i: &jit_ir::SExtInst) {
         let src_val = i.val(self.m);
-        let src_type = self.m.type_(src_val.ty_idx(self.m));
+        let src_type = self.m.type_(src_val.tyidx(self.m));
         let src_size = src_type.byte_size().unwrap();
 
-        let dest_type = self.m.type_(i.dest_ty_idx());
+        let dest_type = self.m.type_(i.dest_tyidx());
         let dest_size = dest_type.byte_size().unwrap();
 
         // FIXME: assumes the input and output fit in a register.
@@ -720,10 +720,10 @@ impl<'a> X64CodeGen<'a> {
 
     fn cg_zeroextend(&mut self, iidx: InstIdx, i: &jit_ir::ZeroExtendInst) {
         let from_val = i.val(self.m);
-        let from_type = self.m.type_(from_val.ty_idx(self.m));
+        let from_type = self.m.type_(from_val.tyidx(self.m));
         let from_size = from_type.byte_size().unwrap();
 
-        let to_type = self.m.type_(i.dest_ty_idx());
+        let to_type = self.m.type_(i.dest_tyidx());
         let to_size = to_type.byte_size().unwrap();
 
         debug_assert!(matches!(to_type, jit_ir::Ty::Integer(_)));
@@ -745,10 +745,10 @@ impl<'a> X64CodeGen<'a> {
 
     fn cg_trunc(&mut self, iidx: InstIdx, i: &jit_ir::TruncInst) {
         let from_val = i.val(self.m);
-        let from_type = self.m.type_(from_val.ty_idx(self.m));
+        let from_type = self.m.type_(from_val.tyidx(self.m));
         let from_size = from_type.byte_size().unwrap();
 
-        let to_type = self.m.type_(i.dest_ty_idx());
+        let to_type = self.m.type_(i.dest_tyidx());
         let to_size = to_type.byte_size().unwrap();
 
         debug_assert!(matches!(to_type, jit_ir::Ty::Integer(_)));
@@ -884,8 +884,8 @@ impl<'a> X64CodeGen<'a> {
     /// Load a constant into the specified register.
     fn load_const(&mut self, reg: Rq, cidx: jit_ir::ConstIdx) {
         match self.m.const_(cidx) {
-            jit_ir::Const::Int(ty_idx, x) => {
-                let jit_ir::Ty::Integer(width) = self.m.type_(*ty_idx) else {
+            jit_ir::Const::Int(tyidx, x) => {
+                let jit_ir::Ty::Integer(width) = self.m.type_(*tyidx) else {
                     panic!()
                 };
                 // The `as`s are all safe because the IR guarantees that no more than `width` bits

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -185,14 +185,11 @@ impl<'a> X64CodeGen<'a> {
     /// Codegen an instruction.
     fn cg_inst(
         &mut self,
-        inst_idx: jit_ir::InstIdx,
+        iidx: jit_ir::InstIdx,
         inst: &jit_ir::Inst,
     ) -> Result<(), CompilationError> {
         #[cfg(any(debug_assertions, test))]
-        self.comment(
-            self.asm.offset(),
-            inst.display(inst_idx, self.m).to_string(),
-        );
+        self.comment(self.asm.offset(), inst.display(iidx, self.m).to_string());
 
         match inst {
             #[cfg(test)]
@@ -201,23 +198,23 @@ impl<'a> X64CodeGen<'a> {
                 unreachable!();
             }
 
-            jit_ir::Inst::BinOp(i) => self.cg_binop(inst_idx, i),
-            jit_ir::Inst::LoadTraceInput(i) => self.cg_loadtraceinput(inst_idx, i),
-            jit_ir::Inst::Load(i) => self.cg_load(inst_idx, i),
-            jit_ir::Inst::PtrAdd(i) => self.cg_ptradd(inst_idx, i),
-            jit_ir::Inst::DynPtrAdd(i) => self.cg_dynptradd(inst_idx, i),
+            jit_ir::Inst::BinOp(i) => self.cg_binop(iidx, i),
+            jit_ir::Inst::LoadTraceInput(i) => self.cg_loadtraceinput(iidx, i),
+            jit_ir::Inst::Load(i) => self.cg_load(iidx, i),
+            jit_ir::Inst::PtrAdd(i) => self.cg_ptradd(iidx, i),
+            jit_ir::Inst::DynPtrAdd(i) => self.cg_dynptradd(iidx, i),
             jit_ir::Inst::Store(i) => self.cg_store(i),
-            jit_ir::Inst::LookupGlobal(i) => self.cg_lookupglobal(inst_idx, i),
-            jit_ir::Inst::Call(i) => self.cg_call(inst_idx, i)?,
-            jit_ir::Inst::IndirectCall(i) => self.cg_indirectcall(inst_idx, i)?,
-            jit_ir::Inst::Icmp(i) => self.cg_icmp(inst_idx, i),
+            jit_ir::Inst::LookupGlobal(i) => self.cg_lookupglobal(iidx, i),
+            jit_ir::Inst::Call(i) => self.cg_call(iidx, i)?,
+            jit_ir::Inst::IndirectCall(i) => self.cg_indirectcall(iidx, i)?,
+            jit_ir::Inst::Icmp(i) => self.cg_icmp(iidx, i),
             jit_ir::Inst::Guard(i) => self.cg_guard(i),
-            jit_ir::Inst::Arg(i) => self.cg_arg(inst_idx, *i),
+            jit_ir::Inst::Arg(i) => self.cg_arg(iidx, *i),
             jit_ir::Inst::TraceLoopStart => self.cg_traceloopstart(),
-            jit_ir::Inst::SExt(i) => self.cg_sext(inst_idx, i),
-            jit_ir::Inst::ZeroExtend(i) => self.cg_zeroextend(inst_idx, i),
-            jit_ir::Inst::Trunc(i) => self.cg_trunc(inst_idx, i),
-            jit_ir::Inst::Select(i) => self.cg_select(inst_idx, i),
+            jit_ir::Inst::SExt(i) => self.cg_sext(iidx, i),
+            jit_ir::Inst::ZeroExtend(i) => self.cg_zeroextend(iidx, i),
+            jit_ir::Inst::Trunc(i) => self.cg_trunc(iidx, i),
+            jit_ir::Inst::Select(i) => self.cg_select(iidx, i),
         }
         Ok(())
     }
@@ -304,7 +301,7 @@ impl<'a> X64CodeGen<'a> {
 
     fn cg_binop(
         &mut self,
-        inst_idx: jit_ir::InstIdx,
+        iidx: jit_ir::InstIdx,
         jit_ir::BinOpInst { lhs, binop, rhs }: &jit_ir::BinOpInst,
     ) {
         let lhs = lhs.unpack(self.m);
@@ -321,7 +318,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; add Rb(WR0.code()), Rb(WR1.code())),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::And => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -333,7 +330,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; and Rb(WR0.code()), Rb(WR1.code())),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::AShr => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -345,7 +342,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; sar Rb(WR0.code()), cl),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::LShr => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -357,7 +354,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; shr Rb(WR0.code()), cl),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::Shl => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -369,7 +366,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; shl Rb(WR0.code()), cl),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::Mul => {
                 self.load_operand(Rq::RAX, &lhs); // FIXME: assumes value will fit in a reg.
@@ -383,7 +380,7 @@ impl<'a> X64CodeGen<'a> {
                 }
                 // Note that because we are code-genning an unchecked multiply, the higher-order part of
                 // the result in RDX is entirely ignored.
-                self.store_new_local(inst_idx, Rq::RAX);
+                self.store_new_local(iidx, Rq::RAX);
             }
             BinOp::Or => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -395,7 +392,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; or Rb(WR0.code()), Rb(WR1.code())),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::SDiv => {
                 // The dividend is hard-coded into DX:AX/EDX:EAX/RDX:RAX. However unless we have 128bit
@@ -417,7 +414,7 @@ impl<'a> X64CodeGen<'a> {
                     _ => todo!(),
                 }
                 // The quotient is stored in RAX. We don't care about the remainder stored in RDX.
-                self.store_new_local(inst_idx, Rq::RAX);
+                self.store_new_local(iidx, Rq::RAX);
             }
             BinOp::SRem => {
                 // The dividend is hard-coded into DX:AX/EDX:EAX/RDX:RAX. However unless we have 128bit
@@ -434,7 +431,7 @@ impl<'a> X64CodeGen<'a> {
                     _ => todo!(),
                 }
                 // The remainder is stored in RDX. We don't care about the quotient stored in RAX.
-                self.store_new_local(inst_idx, Rq::RDX);
+                self.store_new_local(iidx, Rq::RDX);
             }
             BinOp::Sub => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -446,7 +443,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; sub Rb(WR0.code()), Rb(WR1.code())),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::Xor => {
                 self.load_operand(WR0, &lhs); // FIXME: assumes value will fit in a reg.
@@ -458,7 +455,7 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm; xor Rb(WR0.code()), Rb(WR1.code())),
                     _ => todo!(),
                 }
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             BinOp::UDiv => {
                 // Like SDiv the dividend goes into AX, DX:AX, EDX:EAX, RDX:RAX. But since the
@@ -475,20 +472,20 @@ impl<'a> X64CodeGen<'a> {
                     _ => todo!(),
                 }
                 // The quotient is stored in RAX. We don't care about the remainder stored in RDX.
-                self.store_new_local(inst_idx, Rq::RAX);
+                self.store_new_local(iidx, Rq::RAX);
             }
             x => todo!("{x:?}"),
         }
     }
 
-    fn cg_loadtraceinput(&mut self, inst_idx: jit_ir::InstIdx, inst: &jit_ir::LoadTraceInputInst) {
+    fn cg_loadtraceinput(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::LoadTraceInputInst) {
         // Find the argument register containing the pointer to the live variables struct.
         let base_reg = ARG_REGS[JITFUNC_LIVEVARS_ARGIDX].code();
 
         // Now load the value into a new local variable from [base_reg+off].
         match i32::try_from(inst.off()) {
             Ok(off) => {
-                let size = self.m.inst(inst_idx).def_byte_size(self.m);
+                let size = self.m.inst(iidx).def_byte_size(self.m);
                 debug_assert!(size <= REG64_SIZE);
                 match size {
                     8 => dynasm!(self.asm ; mov Rq(WR0.code()), [Rq(base_reg) + off]),
@@ -497,15 +494,15 @@ impl<'a> X64CodeGen<'a> {
                     1 => dynasm!(self.asm ; movzx Rq(WR0.code()), BYTE [Rq(base_reg) + off]),
                     _ => todo!("{}", size),
                 };
-                self.store_new_local(inst_idx, WR0);
+                self.store_new_local(iidx, WR0);
             }
             _ => todo!(),
         }
     }
 
-    fn cg_load(&mut self, inst_idx: jit_ir::InstIdx, inst: &jit_ir::LoadInst) {
+    fn cg_load(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::LoadInst) {
         self.load_operand(WR0, &inst.operand(self.m)); // FIXME: assumes value will fit in a reg.
-        let size = self.m.inst(inst_idx).def_byte_size(self.m);
+        let size = self.m.inst(iidx).def_byte_size(self.m);
         debug_assert!(size <= REG64_SIZE);
         match size {
             8 => dynasm!(self.asm ; mov Rq(WR0.code()), [Rq(WR0.code())]),
@@ -514,20 +511,20 @@ impl<'a> X64CodeGen<'a> {
             1 => dynasm!(self.asm ; movzx Rq(WR0.code()), BYTE [Rq(WR0.code())]),
             _ => todo!("{}", size),
         };
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
-    fn cg_ptradd(&mut self, inst_idx: jit_ir::InstIdx, inst: &jit_ir::PtrAddInst) {
+    fn cg_ptradd(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::PtrAddInst) {
         self.load_operand(WR0, &inst.ptr(self.m));
         // LLVM semantics dictate that the offset should be sign-extended/truncated up/down to the
         // size of the LLVM pointer index type. For address space zero on x86, truncation can't
         // happen, and when an immediate second operand is used for x86_64 `add`, it is implicitly
         // sign extended.
         dynasm!(self.asm ; add Rq(WR0.code()), inst.off());
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
-    fn cg_dynptradd(&mut self, inst_idx: jit_ir::InstIdx, inst: &jit_ir::DynPtrAddInst) {
+    fn cg_dynptradd(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::DynPtrAddInst) {
         self.load_operand(WR0, &inst.num_elems(self.m));
         self.load_operand(WR1, &inst.ptr(self.m));
         // LLVM semantics dictate that the element size and number of elements should be
@@ -540,7 +537,7 @@ impl<'a> X64CodeGen<'a> {
             // add the result to the pointer.
             ; add Rq(WR0.code()), Rq(WR1.code())
         );
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
     fn cg_store(&mut self, inst: &jit_ir::StoreInst) {
@@ -557,14 +554,14 @@ impl<'a> X64CodeGen<'a> {
     }
 
     #[cfg(not(test))]
-    fn cg_lookupglobal(&mut self, inst_idx: jit_ir::InstIdx, inst: &jit_ir::LookupGlobalInst) {
+    fn cg_lookupglobal(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::LookupGlobalInst) {
         let decl = inst.decl(self.m);
         if decl.is_threadlocal() {
             todo!();
         }
         let sym_addr = self.m.globalvar_ptr(inst.global_decl_idx()).addr();
         dynasm!(self.asm ; mov Rq(WR0.code()), QWORD i64::try_from(sym_addr).unwrap());
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
     #[cfg(test)]
@@ -574,7 +571,7 @@ impl<'a> X64CodeGen<'a> {
 
     fn emit_call(
         &mut self,
-        inst_idx: InstIdx,
+        iidx: InstIdx,
         fty: &jit_ir::FuncTy,
         callee: Rq,
         args: &[Operand],
@@ -606,7 +603,7 @@ impl<'a> X64CodeGen<'a> {
 
         // If the function we called has a return value, then store it into a local variable.
         if fty.ret_type(self.m) != &Ty::Void {
-            self.store_new_local(inst_idx, Rq::RAX);
+            self.store_new_local(iidx, Rq::RAX);
         }
 
         Ok(())
@@ -615,7 +612,7 @@ impl<'a> X64CodeGen<'a> {
     /// Codegen a call.
     fn cg_call(
         &mut self,
-        inst_idx: InstIdx,
+        iidx: InstIdx,
         inst: &jit_ir::DirectCallInst,
     ) -> Result<(), CompilationError> {
         let func_decl_idx = inst.target();
@@ -628,13 +625,13 @@ impl<'a> X64CodeGen<'a> {
         let va = symbol_to_ptr(self.m.func_decl(func_decl_idx).name())
             .map_err(|e| CompilationError::General(e.to_string()))?;
         dynasm!(self.asm; mov Rq(WR0.code()), QWORD va as i64);
-        self.emit_call(inst_idx, fty, WR0, &args)
+        self.emit_call(iidx, fty, WR0, &args)
     }
 
     /// Codegen a indirect call.
     fn cg_indirectcall(
         &mut self,
-        inst_idx: InstIdx,
+        iidx: InstIdx,
         indirect_call_idx: &IndirectCallIdx,
     ) -> Result<(), CompilationError> {
         let inst = self.m.indirect_call(*indirect_call_idx);
@@ -645,10 +642,10 @@ impl<'a> X64CodeGen<'a> {
         let args = (0..(inst.num_args()))
             .map(|i| inst.operand(self.m, i))
             .collect::<Vec<_>>();
-        self.emit_call(inst_idx, fty, WR0, &args)
+        self.emit_call(iidx, fty, WR0, &args)
     }
 
-    fn cg_icmp(&mut self, inst_idx: InstIdx, inst: &jit_ir::IcmpInst) {
+    fn cg_icmp(&mut self, iidx: InstIdx, inst: &jit_ir::IcmpInst) {
         let (lhs, pred, rhs) = (inst.lhs(self.m), inst.predicate(), inst.rhs(self.m));
 
         // FIXME: assumes values fit in a registers
@@ -686,13 +683,13 @@ impl<'a> X64CodeGen<'a> {
             jit_ir::Predicate::SignedLessEqual => dynasm!(self.asm; setle Rb(WR0.code())),
             // Note: when float predicates added: `_ => panic!()`
         }
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
-    fn cg_arg(&mut self, inst_idx: InstIdx, idx: u16) {
+    fn cg_arg(&mut self, iidx: InstIdx, idx: u16) {
         // For arguments passed into the trace function we simply inform the register allocator
         // where they are stored and let the allocator take things from there.
-        self.store_new_local(inst_idx, ARG_REGS[usize::from(idx)]);
+        self.store_new_local(iidx, ARG_REGS[usize::from(idx)]);
     }
 
     fn cg_traceloopstart(&mut self) {
@@ -700,7 +697,7 @@ impl<'a> X64CodeGen<'a> {
         dynasm!(self.asm; ->tloop_start:);
     }
 
-    fn cg_sext(&mut self, inst_idx: InstIdx, i: &jit_ir::SExtInst) {
+    fn cg_sext(&mut self, iidx: InstIdx, i: &jit_ir::SExtInst) {
         let src_val = i.val(self.m);
         let src_type = self.m.type_(src_val.ty_idx(self.m));
         let src_size = src_type.byte_size().unwrap();
@@ -718,10 +715,10 @@ impl<'a> X64CodeGen<'a> {
             (4, 8) => dynasm!(self.asm; movsx Rq(WR0.code()), Rd(WR0.code())),
             _ => todo!("{} {}", src_size, dest_size),
         }
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
-    fn cg_zeroextend(&mut self, inst_idx: InstIdx, i: &jit_ir::ZeroExtendInst) {
+    fn cg_zeroextend(&mut self, iidx: InstIdx, i: &jit_ir::ZeroExtendInst) {
         let from_val = i.val(self.m);
         let from_type = self.m.type_(from_val.ty_idx(self.m));
         let from_size = from_type.byte_size().unwrap();
@@ -743,10 +740,10 @@ impl<'a> X64CodeGen<'a> {
         // FIXME: Assumes we don't assign to sub-registers.
         dynasm!(self.asm; mov Rq(WR0.code()), Rq(WR0.code()));
 
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
-    fn cg_trunc(&mut self, inst_idx: InstIdx, i: &jit_ir::TruncInst) {
+    fn cg_trunc(&mut self, iidx: InstIdx, i: &jit_ir::TruncInst) {
         let from_val = i.val(self.m);
         let from_type = self.m.type_(from_val.ty_idx(self.m));
         let from_size = from_type.byte_size().unwrap();
@@ -772,10 +769,10 @@ impl<'a> X64CodeGen<'a> {
         // this will change once we have a proper register allocator at which point we need to
         // revisit this implementation.
 
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
-    fn cg_select(&mut self, inst_idx: jit_ir::InstIdx, inst: &jit_ir::SelectInst) {
+    fn cg_select(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::SelectInst) {
         // First load the true case. We then immediately follow this up with a conditional move,
         // overwriting the value with the false case, if the condition was false.
         self.load_operand(WR0, &inst.trueval(self.m));
@@ -783,7 +780,7 @@ impl<'a> X64CodeGen<'a> {
         self.load_operand(WR2, &inst.falseval(self.m));
         dynasm!(self.asm ; cmp Rb(WR1.code()), 0);
         dynasm!(self.asm ; cmove Rq(WR0.code()), Rq(WR2.code()));
-        self.store_new_local(inst_idx, WR0);
+        self.store_new_local(iidx, WR0);
     }
 
     fn cg_guard(&mut self, inst: &jit_ir::GuardInst) {

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -65,14 +65,14 @@ pub(crate) struct Module {
     /// The type pool. Indexed by [TyIdx].
     types: IndexSet<Ty>,
     /// The type index of the void type. Cached for convenience.
-    void_ty_idx: TyIdx,
+    void_tyidx: TyIdx,
     /// The type index of a pointer type. Cached for convenience.
-    ptr_ty_idx: TyIdx,
+    ptr_tyidx: TyIdx,
     /// The type index of a 1-bit integer. Cached for convenience.
-    int1_ty_idx: TyIdx,
+    int1_tyidx: TyIdx,
     /// The type index of an 8-bit integer. Cached for convenience.
     #[cfg(test)]
-    int8_ty_idx: TyIdx,
+    int8_tyidx: TyIdx,
     /// The [ConstIdx] of the i1 value 1 / "true".
     true_constidx: ConstIdx,
     /// The [ConstIdx] of the i1 value 0 / "false".
@@ -128,19 +128,18 @@ impl Module {
     ) -> Result<Self, CompilationError> {
         // Create some commonly used types ahead of time. Aside from being convenient, this allows
         // us to find their (now statically known) indices in scenarios where Rust forbids us from
-        // holding a mutable reference to the Module (and thus we cannot use [Module::ty_idx]).
+        // holding a mutable reference to the Module (and thus we cannot use [Module::tyidx]).
         let mut types = IndexSet::new();
-        let void_ty_idx = TyIdx::new(types.insert_full(Ty::Void).0)?;
-        let ptr_ty_idx = TyIdx::new(types.insert_full(Ty::Ptr).0)?;
-        let int1_ty_idx = TyIdx::new(types.insert_full(Ty::Integer(1)).0).unwrap();
+        let void_tyidx = TyIdx::new(types.insert_full(Ty::Void).0)?;
+        let ptr_tyidx = TyIdx::new(types.insert_full(Ty::Ptr).0)?;
+        let int1_tyidx = TyIdx::new(types.insert_full(Ty::Integer(1)).0).unwrap();
         #[cfg(test)]
-        let int8_ty_idx = TyIdx::new(types.insert_full(Ty::Integer(8)).0).unwrap();
+        let int8_tyidx = TyIdx::new(types.insert_full(Ty::Integer(8)).0).unwrap();
 
         let mut consts = IndexSet::new();
-        let true_constidx =
-            ConstIdx::new(consts.insert_full(Const::Int(int1_ty_idx, 1)).0).unwrap();
+        let true_constidx = ConstIdx::new(consts.insert_full(Const::Int(int1_tyidx, 1)).0).unwrap();
         let false_constidx =
-            ConstIdx::new(consts.insert_full(Const::Int(int1_ty_idx, 0)).0).unwrap();
+            ConstIdx::new(consts.insert_full(Const::Int(int1_tyidx, 0)).0).unwrap();
 
         // Find the global variable pointer array in the address space.
         //
@@ -159,11 +158,11 @@ impl Module {
             args: Vec::new(),
             consts,
             types,
-            void_ty_idx,
-            ptr_ty_idx,
-            int1_ty_idx,
+            void_tyidx,
+            ptr_tyidx,
+            int1_tyidx,
             #[cfg(test)]
-            int8_ty_idx,
+            int8_tyidx,
             true_constidx,
             false_constidx,
             func_decls: IndexSet::new(),
@@ -189,24 +188,24 @@ impl Module {
     }
 
     /// Returns the type index of [Ty::Void].
-    pub(crate) fn void_ty_idx(&self) -> TyIdx {
-        self.void_ty_idx
+    pub(crate) fn void_tyidx(&self) -> TyIdx {
+        self.void_tyidx
     }
 
     /// Returns the type index of [Ty::Ptr].
-    pub(crate) fn ptr_ty_idx(&self) -> TyIdx {
-        self.ptr_ty_idx
+    pub(crate) fn ptr_tyidx(&self) -> TyIdx {
+        self.ptr_tyidx
     }
 
     /// Returns the type index of a 1-bit integer.
-    pub(crate) fn int1_ty_idx(&self) -> TyIdx {
-        self.int1_ty_idx
+    pub(crate) fn int1_tyidx(&self) -> TyIdx {
+        self.int1_tyidx
     }
 
     /// Returns the type index of an 8-bit integer.
     #[cfg(test)]
-    pub(crate) fn int8_ty_idx(&self) -> TyIdx {
-        self.int8_ty_idx
+    pub(crate) fn int8_tyidx(&self) -> TyIdx {
+        self.int8_tyidx
     }
 
     /// Return the instruction at the specified index.
@@ -390,7 +389,7 @@ impl Module {
     ///
     /// Panics if the index is out of bounds
     pub(crate) fn func_type(&self, idx: FuncDeclIdx) -> &FuncTy {
-        match self.type_(self.func_decl(idx).ty_idx) {
+        match self.type_(self.func_decl(idx).tyidx) {
             Ty::Func(ft) => ft,
             _ => unreachable!(),
         }
@@ -429,7 +428,7 @@ impl fmt::Display for Module {
                 f,
                 "func_decl {} {}",
                 x.name(),
-                self.type_(x.ty_idx()).display(self)
+                self.type_(x.tyidx()).display(self)
             )?;
         }
         for g in &self.global_decls {
@@ -688,16 +687,16 @@ pub(crate) struct FuncTy {
     /// Ty indices for the function's parameters.
     param_ty_idxs: Vec<TyIdx>,
     /// Ty index of the function's return type.
-    ret_ty_idx: TyIdx,
+    ret_tyidx: TyIdx,
     /// Is the function vararg?
     is_vararg: bool,
 }
 
 impl FuncTy {
-    pub(crate) fn new(param_ty_idxs: Vec<TyIdx>, ret_ty_idx: TyIdx, is_vararg: bool) -> Self {
+    pub(crate) fn new(param_ty_idxs: Vec<TyIdx>, ret_tyidx: TyIdx, is_vararg: bool) -> Self {
         Self {
             param_ty_idxs,
-            ret_ty_idx,
+            ret_tyidx,
             is_vararg,
         }
     }
@@ -721,12 +720,12 @@ impl FuncTy {
 
     /// Returns the type of the return value.
     pub(crate) fn ret_type<'a>(&self, m: &'a Module) -> &'a Ty {
-        m.type_(self.ret_ty_idx)
+        m.type_(self.ret_tyidx)
     }
 
     /// Returns the type index of the return value.
-    pub(crate) fn ret_ty_idx(&self) -> TyIdx {
-        self.ret_ty_idx
+    pub(crate) fn ret_tyidx(&self) -> TyIdx {
+        self.ret_tyidx
     }
 }
 
@@ -794,14 +793,14 @@ impl fmt::Display for DisplayableTy<'_> {
                 if x.is_vararg() {
                     args.push("...".to_string());
                 }
-                if x.ret_ty_idx() == self.m.void_ty_idx {
+                if x.ret_tyidx() == self.m.void_tyidx {
                     write!(f, "({})", args.join(", "))
                 } else {
                     write!(
                         f,
                         "({}) -> {}",
                         args.join(", "),
-                        self.m.type_(x.ret_ty_idx()).display(self.m)
+                        self.m.type_(x.ret_tyidx()).display(self.m)
                     )
                 }
             }
@@ -814,12 +813,12 @@ impl fmt::Display for DisplayableTy<'_> {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct FuncDecl {
     name: String,
-    ty_idx: TyIdx,
+    tyidx: TyIdx,
 }
 
 impl FuncDecl {
-    pub(crate) fn new(name: String, ty_idx: TyIdx) -> Self {
-        Self { name, ty_idx }
+    pub(crate) fn new(name: String, tyidx: TyIdx) -> Self {
+        Self { name, tyidx }
     }
 
     /// Return the name of this function declaration.
@@ -827,8 +826,8 @@ impl FuncDecl {
         &self.name
     }
 
-    pub(crate) fn ty_idx(&self) -> TyIdx {
-        self.ty_idx
+    pub(crate) fn tyidx(&self) -> TyIdx {
+        self.tyidx
     }
 }
 
@@ -908,15 +907,15 @@ impl Operand {
     pub(crate) fn byte_size(&self, m: &Module) -> usize {
         match self {
             Self::Local(l) => m.inst(*l).def_byte_size(m),
-            Self::Const(cidx) => m.type_(m.const_(*cidx).ty_idx(m)).byte_size().unwrap(),
+            Self::Const(cidx) => m.type_(m.const_(*cidx).tyidx(m)).byte_size().unwrap(),
         }
     }
 
     /// Returns the type index of the operand.
-    pub(crate) fn ty_idx(&self, m: &Module) -> TyIdx {
+    pub(crate) fn tyidx(&self, m: &Module) -> TyIdx {
         match self {
-            Self::Local(l) => m.inst(*l).ty_idx(m),
-            Self::Const(c) => m.const_(*c).ty_idx(m),
+            Self::Local(l) => m.inst(*l).tyidx(m),
+            Self::Const(c) => m.const_(*c).tyidx(m),
         }
     }
 
@@ -958,10 +957,10 @@ pub(crate) enum Const {
 }
 
 impl Const {
-    pub(crate) fn ty_idx(&self, m: &Module) -> TyIdx {
+    pub(crate) fn tyidx(&self, m: &Module) -> TyIdx {
         match self {
-            Const::Int(ty_idx, _) => *ty_idx,
-            Const::Ptr(_) => m.ptr_ty_idx,
+            Const::Int(tyidx, _) => *tyidx,
+            Const::Ptr(_) => m.ptr_tyidx,
         }
     }
 
@@ -980,7 +979,7 @@ impl Const {
     /// If `x` doesn't fit into the underlying integer type.
     pub(crate) fn u64_to_int(&self, x: u64) -> Const {
         match self {
-            Const::Int(ty_idx, _) => Const::Int(*ty_idx, x),
+            Const::Int(tyidx, _) => Const::Int(*tyidx, x),
             Const::Ptr(_) => panic!(),
         }
     }
@@ -998,8 +997,8 @@ pub(crate) struct DisplayableConst<'a> {
 impl fmt::Display for DisplayableConst<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.const_ {
-            Const::Int(ty_idx, x) => {
-                let Ty::Integer(width) = self.m.type_(*ty_idx) else {
+            Const::Int(tyidx, x) => {
+                let Ty::Integer(width) = self.m.type_(*tyidx) else {
                     panic!()
                 };
                 write!(f, "{x}i{width}")
@@ -1082,8 +1081,8 @@ pub(crate) enum Inst {
 impl Inst {
     /// Returns the type of the value that the instruction produces (if any).
     pub(crate) fn def_type<'a>(&self, m: &'a Module) -> Option<&'a Ty> {
-        let idx = self.ty_idx(m);
-        if idx != m.void_ty_idx() {
+        let idx = self.tyidx(m);
+        if idx != m.void_tyidx() {
             Some(m.type_(idx))
         } else {
             None
@@ -1092,36 +1091,36 @@ impl Inst {
 
     /// Returns the type index of the value that the instruction produces, or [Ty::Void] if it does
     /// not produce a value.
-    pub(crate) fn ty_idx(&self, m: &Module) -> TyIdx {
+    pub(crate) fn tyidx(&self, m: &Module) -> TyIdx {
         match self {
             #[cfg(test)]
-            Self::BlackBox(_) => m.void_ty_idx(),
-            Self::ProxyConst(x) => m.const_(*x).ty_idx(m),
-            Self::ProxyInst(x) => m.inst(*x).ty_idx(m),
+            Self::BlackBox(_) => m.void_tyidx(),
+            Self::ProxyConst(x) => m.const_(*x).tyidx(m),
+            Self::ProxyInst(x) => m.inst(*x).tyidx(m),
             Self::Tombstone => panic!(),
 
-            Self::BinOp(x) => x.ty_idx(m),
+            Self::BinOp(x) => x.tyidx(m),
             Self::IndirectCall(idx) => {
                 let inst = &m.indirect_calls[*idx];
-                let ty = m.type_(inst.fty_idx);
+                let ty = m.type_(inst.ftyidx);
                 let Ty::Func(fty) = ty else { panic!() };
-                fty.ret_ty_idx()
+                fty.ret_tyidx()
             }
-            Self::Load(li) => li.ty_idx(),
-            Self::LookupGlobal(..) => m.ptr_ty_idx(),
-            Self::LoadTraceInput(li) => li.ty_idx(),
-            Self::Call(ci) => m.func_type(ci.target()).ret_ty_idx(),
-            Self::PtrAdd(..) => m.ptr_ty_idx(),
-            Self::DynPtrAdd(..) => m.ptr_ty_idx(),
-            Self::Store(..) => m.void_ty_idx(),
-            Self::Icmp(_) => m.int1_ty_idx(),
-            Self::Guard(..) => m.void_ty_idx(),
-            Self::Arg(..) => m.ptr_ty_idx(),
-            Self::TraceLoopStart => m.void_ty_idx(),
-            Self::SExt(si) => si.dest_ty_idx(),
-            Self::ZeroExtend(si) => si.dest_ty_idx(),
-            Self::Trunc(t) => t.dest_ty_idx(),
-            Self::Select(s) => s.trueval(m).ty_idx(m),
+            Self::Load(li) => li.tyidx(),
+            Self::LookupGlobal(..) => m.ptr_tyidx(),
+            Self::LoadTraceInput(li) => li.tyidx(),
+            Self::Call(ci) => m.func_type(ci.target()).ret_tyidx(),
+            Self::PtrAdd(..) => m.ptr_tyidx(),
+            Self::DynPtrAdd(..) => m.ptr_tyidx(),
+            Self::Store(..) => m.void_tyidx(),
+            Self::Icmp(_) => m.int1_tyidx(),
+            Self::Guard(..) => m.void_tyidx(),
+            Self::Arg(..) => m.ptr_tyidx(),
+            Self::TraceLoopStart => m.void_tyidx(),
+            Self::SExt(si) => si.dest_tyidx(),
+            Self::ZeroExtend(si) => si.dest_tyidx(),
+            Self::Trunc(t) => t.dest_tyidx(),
+            Self::Select(s) => s.trueval(m).tyidx(m),
         }
     }
 
@@ -1253,7 +1252,7 @@ impl fmt::Display for DisplayableInst<'_> {
                     f,
                     "sext {}, {}",
                     i.val(self.m).display(self.m),
-                    self.m.type_(i.dest_ty_idx()).display(self.m)
+                    self.m.type_(i.dest_tyidx()).display(self.m)
                 )
             }
             Inst::ZeroExtend(i) => {
@@ -1261,7 +1260,7 @@ impl fmt::Display for DisplayableInst<'_> {
                     f,
                     "zext {}, {}",
                     i.val(self.m).display(self.m),
-                    self.m.type_(i.dest_ty_idx()).display(self.m)
+                    self.m.type_(i.dest_tyidx()).display(self.m)
                 )
             }
             Inst::Trunc(i) => {
@@ -1333,8 +1332,8 @@ impl BinOpInst {
     }
 
     /// Returns the type index of the operands being added.
-    pub(crate) fn ty_idx(&self, m: &Module) -> TyIdx {
-        self.lhs.unpack(m).ty_idx(m)
+    pub(crate) fn tyidx(&self, m: &Module) -> TyIdx {
+        self.lhs.unpack(m).tyidx(m)
     }
 }
 
@@ -1371,17 +1370,17 @@ pub struct LoadInst {
     /// The pointer to load from.
     op: PackedOperand,
     /// The type of the pointee.
-    ty_idx: TyIdx,
+    tyidx: TyIdx,
     /// Is this load volatile?
     volatile: bool,
 }
 
 impl LoadInst {
     // FIXME: why do we need to provide a type index? Can't we get that from the operand?
-    pub(crate) fn new(op: Operand, ty_idx: TyIdx, volatile: bool) -> LoadInst {
+    pub(crate) fn new(op: Operand, tyidx: TyIdx, volatile: bool) -> LoadInst {
         LoadInst {
             op: PackedOperand::new(&op),
-            ty_idx,
+            tyidx,
             volatile,
         }
     }
@@ -1392,8 +1391,8 @@ impl LoadInst {
     }
 
     /// Returns the type index of the loaded value.
-    pub(crate) fn ty_idx(&self) -> TyIdx {
-        self.ty_idx
+    pub(crate) fn tyidx(&self) -> TyIdx {
+        self.tyidx
     }
 }
 
@@ -1402,7 +1401,7 @@ impl LoadInst {
 /// ## Semantics
 ///
 /// Loads a trace input out of the trace input struct. The variable is loaded from the specified
-/// offset (`off`) and the resulting local variable is of the type indicated by the `ty_idx`.
+/// offset (`off`) and the resulting local variable is of the type indicated by the `tyidx`.
 ///
 /// FIXME (maybe): If we added a third `TraceInput` storage class to the register allocator, could
 /// we kill this instruction kind entirely?
@@ -1412,16 +1411,16 @@ pub struct LoadTraceInputInst {
     /// The byte offset to load from in the trace input struct.
     off: u32,
     /// The type of the resulting local variable.
-    ty_idx: TyIdx,
+    tyidx: TyIdx,
 }
 
 impl LoadTraceInputInst {
-    pub(crate) fn new(off: u32, ty_idx: TyIdx) -> LoadTraceInputInst {
-        Self { off, ty_idx }
+    pub(crate) fn new(off: u32, tyidx: TyIdx) -> LoadTraceInputInst {
+        Self { off, tyidx }
     }
 
-    pub(crate) fn ty_idx(&self) -> TyIdx {
-        self.ty_idx
+    pub(crate) fn tyidx(&self) -> TyIdx {
+        self.tyidx
     }
 
     pub(crate) fn off(&self) -> u32 {
@@ -1489,7 +1488,7 @@ pub struct IndirectCallInst {
     /// The callee.
     target: PackedOperand,
     // Type of the target function.
-    fty_idx: TyIdx,
+    ftyidx: TyIdx,
     /// How many arguments in [Module::extra_args] is this call passing?
     num_args: u16,
     /// At what index do the contiguous operands in [Module::extra_args] start?
@@ -1499,7 +1498,7 @@ pub struct IndirectCallInst {
 impl IndirectCallInst {
     pub(crate) fn new(
         m: &mut Module,
-        fty_idx: TyIdx,
+        ftyidx: TyIdx,
         target: Operand,
         args: Vec<Operand>,
     ) -> Result<IndirectCallInst, CompilationError> {
@@ -1513,15 +1512,15 @@ impl IndirectCallInst {
         let args_idx = m.push_args(args)?;
         Ok(Self {
             target: PackedOperand::new(&target),
-            fty_idx,
+            ftyidx,
             num_args,
             args_idx,
         })
     }
 
     /// Return the [TyIdx] of the callee.
-    pub(crate) fn fty_idx(&self) -> TyIdx {
-        self.fty_idx
+    pub(crate) fn ftyidx(&self) -> TyIdx {
+        self.ftyidx
     }
 
     /// Return the callee [Operand].
@@ -1863,14 +1862,14 @@ pub struct SExtInst {
     /// The value to extend.
     val: PackedOperand,
     /// The type to extend to.
-    dest_ty_idx: TyIdx,
+    dest_tyidx: TyIdx,
 }
 
 impl SExtInst {
-    pub(crate) fn new(val: &Operand, dest_ty_idx: TyIdx) -> Self {
+    pub(crate) fn new(val: &Operand, dest_tyidx: TyIdx) -> Self {
         Self {
             val: PackedOperand::new(val),
-            dest_ty_idx,
+            dest_tyidx,
         }
     }
 
@@ -1878,8 +1877,8 @@ impl SExtInst {
         self.val.unpack(m)
     }
 
-    pub(crate) fn dest_ty_idx(&self) -> TyIdx {
-        self.dest_ty_idx
+    pub(crate) fn dest_tyidx(&self) -> TyIdx {
+        self.dest_tyidx
     }
 }
 
@@ -1888,14 +1887,14 @@ pub struct ZeroExtendInst {
     /// The value to extend.
     val: PackedOperand,
     /// The type to extend to.
-    dest_ty_idx: TyIdx,
+    dest_tyidx: TyIdx,
 }
 
 impl ZeroExtendInst {
-    pub(crate) fn new(val: &Operand, dest_ty_idx: TyIdx) -> Self {
+    pub(crate) fn new(val: &Operand, dest_tyidx: TyIdx) -> Self {
         Self {
             val: PackedOperand::new(val),
-            dest_ty_idx,
+            dest_tyidx,
         }
     }
 
@@ -1903,8 +1902,8 @@ impl ZeroExtendInst {
         self.val.unpack(m)
     }
 
-    pub(crate) fn dest_ty_idx(&self) -> TyIdx {
-        self.dest_ty_idx
+    pub(crate) fn dest_tyidx(&self) -> TyIdx {
+        self.dest_tyidx
     }
 }
 
@@ -1913,14 +1912,14 @@ pub struct TruncInst {
     /// The value to extend.
     val: PackedOperand,
     /// The type to extend to.
-    dest_ty_idx: TyIdx,
+    dest_tyidx: TyIdx,
 }
 
 impl TruncInst {
-    pub(crate) fn new(val: &Operand, dest_ty_idx: TyIdx) -> Self {
+    pub(crate) fn new(val: &Operand, dest_tyidx: TyIdx) -> Self {
         Self {
             val: PackedOperand::new(val),
-            dest_ty_idx,
+            dest_tyidx,
         }
     }
 
@@ -1928,8 +1927,8 @@ impl TruncInst {
         self.val.unpack(m)
     }
 
-    pub(crate) fn dest_ty_idx(&self) -> TyIdx {
-        self.dest_ty_idx
+    pub(crate) fn dest_tyidx(&self) -> TyIdx {
+        self.dest_tyidx
     }
 }
 
@@ -1969,9 +1968,9 @@ mod tests {
         let mut m = Module::new_testing();
         let i32_tyidx = m.insert_ty(Ty::Integer(32)).unwrap();
         let func_ty = Ty::Func(FuncTy::new(vec![i32_tyidx; 3], i32_tyidx, true));
-        let func_ty_idx = m.insert_ty(func_ty).unwrap();
+        let func_tyidx = m.insert_ty(func_ty).unwrap();
         let func_decl_idx = m
-            .insert_func_decl(FuncDecl::new("foo".to_owned(), func_ty_idx))
+            .insert_func_decl(FuncDecl::new("foo".to_owned(), func_tyidx))
             .unwrap();
 
         // Build a call to the function.
@@ -2001,12 +2000,12 @@ mod tests {
     fn call_args_out_of_bounds() {
         // Set up a function to call.
         let mut m = Module::new_testing();
-        let arg_ty_idxs = vec![m.ptr_ty_idx(); 3];
-        let ret_ty_idx = m.insert_ty(Ty::Void).unwrap();
-        let func_ty = FuncTy::new(arg_ty_idxs, ret_ty_idx, false);
-        let func_ty_idx = m.insert_ty(Ty::Func(func_ty)).unwrap();
+        let arg_ty_idxs = vec![m.ptr_tyidx(); 3];
+        let ret_tyidx = m.insert_ty(Ty::Void).unwrap();
+        let func_ty = FuncTy::new(arg_ty_idxs, ret_tyidx, false);
+        let func_tyidx = m.insert_ty(Ty::Func(func_ty)).unwrap();
         let func_decl_idx = m
-            .insert_func_decl(FuncDecl::new("blah".into(), func_ty_idx))
+            .insert_func_decl(FuncDecl::new("blah".into(), func_tyidx))
             .unwrap();
 
         // Now build a call to the function.
@@ -2086,13 +2085,13 @@ mod tests {
     #[test]
     fn stringify_int_consts() {
         let mut m = Module::new_testing();
-        let i8_ty_idx = m.insert_ty(Ty::Integer(8)).unwrap();
-        assert_eq!(Const::Int(i8_ty_idx, 0).display(&m).to_string(), "0i8");
-        assert_eq!(Const::Int(i8_ty_idx, 255).display(&m).to_string(), "255i8");
-        let i64_ty_idx = m.insert_ty(Ty::Integer(64)).unwrap();
-        assert_eq!(Const::Int(i64_ty_idx, 0).display(&m).to_string(), "0i64");
+        let i8_tyidx = m.insert_ty(Ty::Integer(8)).unwrap();
+        assert_eq!(Const::Int(i8_tyidx, 0).display(&m).to_string(), "0i8");
+        assert_eq!(Const::Int(i8_tyidx, 255).display(&m).to_string(), "255i8");
+        let i64_tyidx = m.insert_ty(Ty::Integer(64)).unwrap();
+        assert_eq!(Const::Int(i64_tyidx, 0).display(&m).to_string(), "0i64");
         assert_eq!(
-            Const::Int(i64_ty_idx, 9223372036854775808)
+            Const::Int(i64_tyidx, 9223372036854775808)
                 .display(&m)
                 .to_string(),
             "9223372036854775808i64"
@@ -2113,11 +2112,11 @@ mod tests {
     #[test]
     fn print_module() {
         let mut m = Module::new_testing();
-        m.push(LoadTraceInputInst::new(0, m.int8_ty_idx()).into())
+        m.push(LoadTraceInputInst::new(0, m.int8_tyidx()).into())
             .unwrap();
-        m.push(LoadTraceInputInst::new(8, m.int8_ty_idx()).into())
+        m.push(LoadTraceInputInst::new(8, m.int8_tyidx()).into())
             .unwrap();
-        m.push(LoadTraceInputInst::new(16, m.int8_ty_idx()).into())
+        m.push(LoadTraceInputInst::new(16, m.int8_tyidx()).into())
             .unwrap();
         m.insert_global_decl(GlobalDecl::new(
             CString::new("some_global").unwrap(),

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -240,9 +240,9 @@ impl Module {
         }
     }
 
-    /// Replace the instruction at `inst_idx` with `inst`.
-    pub(crate) fn replace(&mut self, inst_idx: InstIdx, inst: Inst) {
-        self.insts[inst_idx] = inst;
+    /// Replace the instruction at `iidx` with `inst`.
+    pub(crate) fn replace(&mut self, iidx: InstIdx, inst: Inst) {
+        self.insts[iidx] = inst;
     }
 
     pub(crate) fn push_indirect_call(
@@ -1144,10 +1144,10 @@ impl Inst {
         }
     }
 
-    pub(crate) fn display<'a>(&'a self, inst_idx: InstIdx, m: &'a Module) -> DisplayableInst<'a> {
+    pub(crate) fn display<'a>(&'a self, iidx: InstIdx, m: &'a Module) -> DisplayableInst<'a> {
         DisplayableInst {
             inst: self,
-            inst_idx,
+            iidx,
             m,
         }
     }
@@ -1155,14 +1155,14 @@ impl Inst {
 
 pub(crate) struct DisplayableInst<'a> {
     inst: &'a Inst,
-    inst_idx: InstIdx,
+    iidx: InstIdx,
     m: &'a Module,
 }
 
 impl fmt::Display for DisplayableInst<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(dt) = self.inst.def_type(self.m) {
-            write!(f, "%{}: {} = ", self.inst_idx, dt.display(self.m))?;
+            write!(f, "%{}: {} = ", self.iidx, dt.display(self.m))?;
         }
         match self.inst {
             #[cfg(test)]

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -9,13 +9,16 @@
 //! use a number of abbreviations/conventions to keep the length of source down to something
 //! manageable (in alphabetical order):
 //!
+//!  * `cidx`: a [ConstIdx].
 //!  * `Const` and `const_`: a "constant"
 //!  * `decl`: a "declaration" (e.g. a "function declaration" is a reference to an existing
 //!    function somewhere else in the address space)
+//!  * `iidx`: an [InstIdx].
 //!  * `m`: the name conventionally given to the shared [Module] instance (i.e. `m: Module`)
 //!  * `Idx`: "index"
 //!  * `Inst`: "instruction"
 //!  * `Ty`: "type"
+//!  * `tyidx`: a [TyIdx].
 //!
 //! IR structures can be converted to human-readable strings either because:
 //!  1. they implement [std::fmt::Display] directly.

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -442,8 +442,8 @@ impl fmt::Display for Module {
             )?;
         }
         write!(f, "\nentry:")?;
-        for inst_i in self.iter_skipping_inst_idxs() {
-            write!(f, "\n    {}", self.insts[inst_i].display(inst_i, self))?
+        for iidx in self.iter_skipping_inst_idxs() {
+            write!(f, "\n    {}", self.insts[iidx].display(iidx, self))?
         }
 
         Ok(())
@@ -867,17 +867,17 @@ impl PackedOperand {
     /// Unpacks a [PackedOperand] into a [Operand].
     pub fn unpack(&self, m: &Module) -> Operand {
         if (self.0 & !OPERAND_IDX_MASK) == 0 {
-            let mut inst_i = InstIdx(self.0);
+            let mut iidx = InstIdx(self.0);
             loop {
-                match m.inst(inst_i) {
+                match m.inst(iidx) {
                     Inst::ProxyConst(x) => {
                         return Operand::Const(*x);
                     }
                     Inst::ProxyInst(x) => {
-                        inst_i = *x;
+                        iidx = *x;
                     }
                     _ => {
-                        return Operand::Local(inst_i);
+                        return Operand::Local(iidx);
                     }
                 }
             }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -688,7 +688,7 @@ index_16bit!(InstIdx);
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct FuncTy {
     /// Ty indices for the function's parameters.
-    param_ty_idxs: Vec<TyIdx>,
+    param_tyidxs: Vec<TyIdx>,
     /// Ty index of the function's return type.
     ret_tyidx: TyIdx,
     /// Is the function vararg?
@@ -696,9 +696,9 @@ pub(crate) struct FuncTy {
 }
 
 impl FuncTy {
-    pub(crate) fn new(param_ty_idxs: Vec<TyIdx>, ret_tyidx: TyIdx, is_vararg: bool) -> Self {
+    pub(crate) fn new(param_tyidxs: Vec<TyIdx>, ret_tyidx: TyIdx, is_vararg: bool) -> Self {
         Self {
-            param_ty_idxs,
+            param_tyidxs,
             ret_tyidx,
             is_vararg,
         }
@@ -707,13 +707,13 @@ impl FuncTy {
     /// Return the number of paramaters the function accepts (not including varargs).
     #[cfg(any(debug_assertions, test))]
     pub(crate) fn num_params(&self) -> usize {
-        self.param_ty_idxs.len()
+        self.param_tyidxs.len()
     }
 
     /// Return a slice of this function's non-varargs parameters.
     #[cfg(any(debug_assertions, test))]
     pub(crate) fn param_tys(&self) -> &[TyIdx] {
-        &self.param_ty_idxs
+        &self.param_tyidxs
     }
 
     /// Returns whether the function type has vararg arguments.
@@ -789,7 +789,7 @@ impl fmt::Display for DisplayableTy<'_> {
             Ty::Ptr => write!(f, "ptr"),
             Ty::Func(x) => {
                 let mut args = x
-                    .param_ty_idxs
+                    .param_tyidxs
                     .iter()
                     .map(|x| self.m.type_(*x).display(self.m).to_string())
                     .collect::<Vec<_>>();
@@ -2003,9 +2003,9 @@ mod tests {
     fn call_args_out_of_bounds() {
         // Set up a function to call.
         let mut m = Module::new_testing();
-        let arg_ty_idxs = vec![m.ptr_tyidx(); 3];
+        let arg_tyidxs = vec![m.ptr_tyidx(); 3];
         let ret_tyidx = m.insert_ty(Ty::Void).unwrap();
-        let func_ty = FuncTy::new(arg_ty_idxs, ret_tyidx, false);
+        let func_ty = FuncTy::new(arg_tyidxs, ret_tyidx, false);
         let func_tyidx = m.insert_ty(Ty::Func(func_ty)).unwrap();
         let func_decl_idx = m
             .insert_func_decl(FuncDecl::new("blah".into(), func_tyidx))

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -352,10 +352,10 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                     }
                     val
                 };
-                let ty_idx = self.m.insert_ty(Ty::Integer(width)).unwrap();
+                let tyidx = self.m.insert_ty(Ty::Integer(width)).unwrap();
                 Ok(Operand::Const(
                     self.m
-                        .insert_const(Const::Int(ty_idx, val))
+                        .insert_const(Const::Int(tyidx, val))
                         .map_err(|e| self.error_at_span(span, &e.to_string()))?,
                 ))
             }
@@ -395,8 +395,8 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                     .insert_ty(Ty::Integer(width))
                     .map_err(|e| self.error_at_span(span, &e.to_string()))
             }
-            ASTType::Ptr => Ok(self.m.ptr_ty_idx()),
-            ASTType::Void => Ok(self.m.void_ty_idx()),
+            ASTType::Ptr => Ok(self.m.ptr_tyidx()),
+            ASTType::Void => Ok(self.m.void_tyidx()),
         }
     }
 
@@ -555,12 +555,12 @@ mod tests {
     #[test]
     fn roundtrip() {
         let mut m = Module::new_testing();
-        let i16_ty_idx = m.insert_ty(Ty::Integer(16)).unwrap();
+        let i16_tyidx = m.insert_ty(Ty::Integer(16)).unwrap();
         let op1 = m
-            .push_and_make_operand(LoadTraceInputInst::new(0, i16_ty_idx).into())
+            .push_and_make_operand(LoadTraceInputInst::new(0, i16_tyidx).into())
             .unwrap();
         let op2 = m
-            .push_and_make_operand(LoadTraceInputInst::new(16, i16_ty_idx).into())
+            .push_and_make_operand(LoadTraceInputInst::new(16, i16_tyidx).into())
             .unwrap();
         let op3 = m
             .push_and_make_operand(BinOpInst::new(op1.clone(), BinOp::Add, op2.clone()).into())
@@ -676,41 +676,41 @@ mod tests {
         // declarations are actually added.
         assert_eq!(m.func_decls_len(), 4);
 
-        let f1_ty_idx = m
-            .insert_ty(Ty::Func(FuncTy::new(Vec::new(), m.void_ty_idx(), false)))
+        let f1_tyidx = m
+            .insert_ty(Ty::Func(FuncTy::new(Vec::new(), m.void_tyidx(), false)))
             .unwrap();
-        m.insert_func_decl(FuncDecl::new("f1".to_owned(), f1_ty_idx))
+        m.insert_func_decl(FuncDecl::new("f1".to_owned(), f1_tyidx))
             .unwrap();
         assert_eq!(m.func_decls_len(), 4);
 
-        let i32_ty_idx = m.insert_ty(Ty::Integer(32)).unwrap();
-        let f2_ty_idx = m
+        let i32_tyidx = m.insert_ty(Ty::Integer(32)).unwrap();
+        let f2_tyidx = m
             .insert_ty(Ty::Func(FuncTy::new(
-                vec![m.int8_ty_idx()],
-                i32_ty_idx,
+                vec![m.int8_tyidx()],
+                i32_tyidx,
                 false,
             )))
             .unwrap();
-        m.insert_func_decl(FuncDecl::new("f2".to_owned(), f2_ty_idx))
+        m.insert_func_decl(FuncDecl::new("f2".to_owned(), f2_tyidx))
             .unwrap();
         assert_eq!(m.func_decls_len(), 4);
 
-        let i64_ty_idx = m.insert_ty(Ty::Integer(64)).unwrap();
-        let f3_ty_idx = m
+        let i64_tyidx = m.insert_ty(Ty::Integer(64)).unwrap();
+        let f3_tyidx = m
             .insert_ty(Ty::Func(FuncTy::new(
-                vec![m.int8_ty_idx(), i32_ty_idx],
-                i64_ty_idx,
+                vec![m.int8_tyidx(), i32_tyidx],
+                i64_tyidx,
                 true,
             )))
             .unwrap();
-        m.insert_func_decl(FuncDecl::new("f3".to_owned(), f3_ty_idx))
+        m.insert_func_decl(FuncDecl::new("f3".to_owned(), f3_tyidx))
             .unwrap();
         assert_eq!(m.func_decls_len(), 4);
 
-        let f4_ty_idx = m
-            .insert_ty(Ty::Func(FuncTy::new(Vec::new(), m.void_ty_idx(), true)))
+        let f4_tyidx = m
+            .insert_ty(Ty::Func(FuncTy::new(Vec::new(), m.void_tyidx(), true)))
             .unwrap();
-        m.insert_func_decl(FuncDecl::new("f4".to_owned(), f4_ty_idx))
+        m.insert_func_decl(FuncDecl::new("f4".to_owned(), f4_tyidx))
             .unwrap();
         assert_eq!(m.func_decls_len(), 4);
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -21,7 +21,7 @@ impl Module {
             let inst = self.inst(iidx);
             match inst {
                 Inst::BinOp(BinOpInst { lhs, binop: _, rhs }) => {
-                    if lhs.unpack(self).ty_idx(self) != rhs.unpack(self).ty_idx(self) {
+                    if lhs.unpack(self).tyidx(self) != rhs.unpack(self).tyidx(self) {
                         panic!(
                             "Instruction at position {iidx} has different types on lhs and rhs\n  {}",
                             self.inst(iidx).display(iidx, self)
@@ -31,7 +31,7 @@ impl Module {
                 Inst::Call(x) => {
                     // Check number of parameters/arguments.
                     let fdecl = self.func_decl(x.target());
-                    let Ty::Func(fty) = self.type_(fdecl.ty_idx()) else {
+                    let Ty::Func(fty) = self.type_(fdecl.tyidx()) else {
                         panic!()
                     };
                     if x.num_args() < fty.num_params() {
@@ -51,7 +51,7 @@ impl Module {
                     for (j, (par_ty, arg_ty)) in fty
                         .param_tys()
                         .iter()
-                        .zip(x.iter_args_idx().map(|x| self.arg(x).ty_idx(self)))
+                        .zip(x.iter_args_idx().map(|x| self.arg(x).tyidx(self)))
                         .enumerate()
                     {
                         if *par_ty != arg_ty {
@@ -64,7 +64,7 @@ impl Module {
                 }
                 Inst::Guard(GuardInst { cond, expect, .. }) => {
                     let cond = cond.unpack(self);
-                    let tyidx = cond.ty_idx(self);
+                    let tyidx = cond.tyidx(self);
                     let Ty::Integer(1) = self.type_(tyidx) else {
                         panic!(
                             "Guard at position {iidx} does not have 'cond' of type 'i1'\n  {}",
@@ -84,7 +84,7 @@ impl Module {
                     }
                 }
                 Inst::Icmp(x) => {
-                    if x.lhs(self).ty_idx(self) != x.rhs(self).ty_idx(self) {
+                    if x.lhs(self).tyidx(self) != x.rhs(self).tyidx(self) {
                         panic!(
                             "Instruction at position {iidx} has different types on lhs and rhs\n  {}",
                             self.inst(iidx).display(iidx, self)
@@ -92,8 +92,8 @@ impl Module {
                     }
                 }
                 Inst::SExt(x) => {
-                    if self.type_(x.val(self).ty_idx(self)).byte_size()
-                        >= self.type_(x.dest_ty_idx()).byte_size()
+                    if self.type_(x.val(self).tyidx(self)).byte_size()
+                        >= self.type_(x.dest_tyidx()).byte_size()
                     {
                         panic!(
                             "Instruction at position {iidx} trying to sign extend from an equal-or-larger-than integer type\n  {}",

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -62,8 +62,8 @@ fn opt_mul(
 
                 if new_val == 0 {
                     // Replace `x * 0` with `0`.
-                    let const_idx = m.insert_const(old_const.u64_to_int(0))?;
-                    m.replace(iidx, Inst::ProxyConst(const_idx));
+                    let cidx = m.insert_const(old_const.u64_to_int(0))?;
+                    m.replace(iidx, Inst::ProxyConst(cidx));
                 } else if new_val == 1 {
                     // Replace `x * 1` with `x`.
                     m.replace(iidx, Inst::ProxyInst(mul_inst));

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -418,11 +418,11 @@ impl<'a> TraceBuilder<'a> {
                 let load = jit_ir::LookupGlobalInst::new(self.handle_global(*gd_idx)?)?;
                 self.jit_mod.push_and_make_operand(load.into())
             }
-            aot_ir::Operand::Arg { arg_idx, .. } => {
+            aot_ir::Operand::Arg { argidx, .. } => {
                 // Lookup the JIT instruction that was passed into this function as an argument.
                 // Unwrap is safe since an `Arg` means we are currently inlining a function.
                 // FIXME: Is the above correct? What about args in the control point frame?
-                Ok(self.frames.last().unwrap().args[usize::from(*arg_idx)].clone())
+                Ok(self.frames.last().unwrap().args[usize::from(*argidx)].clone())
             }
             _ => todo!("{}", op.display(self.aot_mod)),
         }
@@ -510,10 +510,10 @@ impl<'a> TraceBuilder<'a> {
             for op in safepoint.lives.iter() {
                 let op = match op {
                     aot_ir::Operand::LocalVariable(iid) => &self.local_map[iid],
-                    aot_ir::Operand::Arg { arg_idx, .. } => {
+                    aot_ir::Operand::Arg { argidx, .. } => {
                         // Lookup the JIT value of the argument from the caller (stored in
                         // the previous frame's `args` field).
-                        &frame_args[usize::from(*arg_idx)]
+                        &frame_args[usize::from(*argidx)]
                     }
                     _ => panic!(), // IR malformed.
                 };

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -288,7 +288,7 @@ impl<'a> TraceBuilder<'a> {
                     self.handle_phi(
                         bid,
                         iidx,
-                        &prevbb.as_ref().unwrap().bb_idx(),
+                        &prevbb.as_ref().unwrap().bbidx(),
                         incoming_bbs,
                         incoming_vals,
                     )
@@ -308,7 +308,7 @@ impl<'a> TraceBuilder<'a> {
     fn link_iid_to_last_inst(&mut self, bid: &aot_ir::BBlockId, aot_inst_idx: usize) {
         let aot_iid = aot_ir::InstID::new(
             bid.funcidx(),
-            bid.bb_idx(),
+            bid.bbidx(),
             aot_ir::InstIdx::new(aot_inst_idx),
         );
         // The unwrap is safe because we've already inserted an element at this index and proven
@@ -545,7 +545,7 @@ impl<'a> TraceBuilder<'a> {
         true_bb: &aot_ir::BBlockIdx,
     ) -> Result<(), CompilationError> {
         let jit_cond = self.handle_operand(cond)?;
-        let guard = self.create_guard(&jit_cond, *true_bb == next_bb.bb_idx(), safepoint)?;
+        let guard = self.create_guard(&jit_cond, *true_bb == next_bb.bbidx(), safepoint)?;
         self.jit_mod.push(guard.into())?;
         Ok(())
     }
@@ -695,7 +695,7 @@ impl<'a> TraceBuilder<'a> {
             // Create a new frame for the inlined call and pass in the arguments of the caller.
             let aot_iid = aot_ir::InstID::new(
                 bid.funcidx(),
-                bid.bb_idx(),
+                bid.bbidx(),
                 aot_ir::InstIdx::new(aot_inst_idx),
             );
             self.frames
@@ -837,7 +837,7 @@ impl<'a> TraceBuilder<'a> {
         let jit_tyidx = self.handle_type(test_val.type_(self.aot_mod))?;
 
         // Find out which case we traced.
-        let guard = match case_dests.iter().position(|&cd| cd == next_bb.bb_idx()) {
+        let guard = match case_dests.iter().position(|&cd| cd == next_bb.bbidx()) {
             Some(cidx) => {
                 // A non-default case was traced.
                 let val = case_values[cidx];
@@ -854,7 +854,7 @@ impl<'a> TraceBuilder<'a> {
                 let jit_cond = self.jit_mod.push_and_make_operand(cmp_inst.into())?;
 
                 // Guard the result of the comparison.
-                self.create_guard(&jit_cond, bb == next_bb.bb_idx(), safepoint)?
+                self.create_guard(&jit_cond, bb == next_bb.bbidx(), safepoint)?
             }
             None => {
                 // The default case was traced.
@@ -923,7 +923,7 @@ impl<'a> TraceBuilder<'a> {
         let chosen_val = &incoming_vals[incoming_bbs.iter().position(|bb| bb == prev_bb).unwrap()];
         let aot_iit = aot_ir::InstID::new(
             bid.funcidx(),
-            bid.bb_idx(),
+            bid.bbidx(),
             aot_ir::InstIdx::new(aot_inst_idx),
         );
         let op = self.handle_operand(chosen_val)?;

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -436,7 +436,7 @@ impl<'a> TraceBuilder<'a> {
             aot_ir::Ty::Ptr => jit_ir::Ty::Ptr,
             aot_ir::Ty::Func(ft) => {
                 let mut jit_args = Vec::new();
-                for aot_arg_tyidx in ft.arg_ty_idxs() {
+                for aot_arg_tyidx in ft.arg_tyidxs() {
                     let jit_ty = self.handle_type(self.aot_mod.type_(*aot_arg_tyidx))?;
                     jit_args.push(jit_ty);
                 }


### PR DESCRIPTION
This PR renames a number of things surrounding index types. The main motivation was that we used (very) different conventions for `iidx`. Once I'd done those in the first few commits, it seemed sensible to plough on and make more things consistent with that convention.

There are still some other cases we could do (e.g. perhaps function names should be `iter_iidxs` and not `iter_inst_idxs`), but this PR probably removes 80-90% of the inconsistency, so waiting longer to get the last bits probably isn't worth our while right now.