### PR TITLE
De-`TiVec`-ify

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -598,6 +598,14 @@ macro_rules! index_16bit {
                     .map_err(|_| index_overflow(stringify!($struct)))
                     .map(|u| Self(u))
             }
+
+            pub(crate) fn checked_add(&self, other: usize) -> Result<Self, CompilationError> {
+                Self::new(usize::from(self.0) + other)
+            }
+
+            pub(crate) fn checked_sub(&self, other: usize) -> Result<Self, CompilationError> {
+                Self::new(usize::from(self.0) - other)
+            }
         }
 
         impl From<$struct> for u16 {
@@ -1529,8 +1537,7 @@ impl IndirectCallInst {
     ///
     /// Panics if the operand index is out of bounds.
     pub(crate) fn operand(&self, m: &Module, idx: usize) -> Operand {
-        m.arg(ArgsIdx::new(usize::from(self.args_idx) + idx).unwrap())
-            .clone()
+        m.arg(self.args_idx.checked_add(idx).unwrap()).clone()
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -568,6 +568,8 @@ fn index_overflow(typ: &str) -> CompilationError {
 macro_rules! index_24bit {
     ($struct:ident) => {
         impl $struct {
+            /// Construct a new $struct from a `usize`, returning `CompilationError` if the `usize`
+            /// exceeds capacity.
             pub(crate) fn new(x: usize) -> Result<Self, CompilationError> {
                 match U24::try_from(x) {
                     Ok(x) => Ok(Self(x)),
@@ -576,16 +578,7 @@ macro_rules! index_24bit {
             }
         }
 
-        impl From<usize> for $struct {
-            /// Required for TiVec. **DO NOT USE INTERNALLY TO yk as this can `panic`!** Instead,
-            /// use [Self::new].
-            fn from(v: usize) -> Self {
-                Self::new(v).unwrap()
-            }
-        }
-
         impl From<$struct> for usize {
-            // Required for TiVec.
             fn from(x: $struct) -> Self {
                 usize::from(x.0)
             }
@@ -608,14 +601,6 @@ macro_rules! index_16bit {
 
             pub(crate) fn to_u16(self) -> u16 {
                 self.0
-            }
-        }
-
-        impl From<usize> for $struct {
-            /// Required for TiVec. **DO NOT USE INTERNALLY TO yk as this can `panic`!** Instead,
-            /// use [Self::new].
-            fn from(v: usize) -> Self {
-                Self::new(v).unwrap()
             }
         }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -598,9 +598,11 @@ macro_rules! index_16bit {
                     .map_err(|_| index_overflow(stringify!($struct)))
                     .map(|u| Self(u))
             }
+        }
 
-            pub(crate) fn to_u16(self) -> u16 {
-                self.0
+        impl From<$struct> for u16 {
+            fn from(s: $struct) -> u16 {
+                s.0
             }
         }
 
@@ -841,12 +843,12 @@ impl PackedOperand {
     pub fn new(op: &Operand) -> Self {
         match op {
             Operand::Local(lidx) => {
-                debug_assert!(lidx.to_u16() <= MAX_OPERAND_IDX);
-                PackedOperand(lidx.to_u16())
+                debug_assert!(u16::from(*lidx) <= MAX_OPERAND_IDX);
+                PackedOperand(u16::from(*lidx))
             }
             Operand::Const(constidx) => {
-                debug_assert!(constidx.to_u16() <= MAX_OPERAND_IDX);
-                PackedOperand(constidx.to_u16() | !OPERAND_IDX_MASK)
+                debug_assert!(u16::from(*constidx) <= MAX_OPERAND_IDX);
+                PackedOperand(u16::from(*constidx) | !OPERAND_IDX_MASK)
             }
         }
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -89,7 +89,7 @@ pub(crate) struct Module {
     /// reference. Because they are externally initialised, these are *declarations*.
     global_decls: IndexSet<GlobalDecl>,
     /// Additional information for guards.
-    guard_info: TiVec<GuardInfoIdx, GuardInfo>,
+    guard_info: Vec<GuardInfo>,
     /// Indirect calls.
     indirect_calls: TiVec<IndirectCallIdx, IndirectCallInst>,
     /// The virtual address of the global variable pointer array.
@@ -170,7 +170,7 @@ impl Module {
             false_constidx,
             func_decls: IndexSet::new(),
             global_decls: IndexSet::new(),
-            guard_info: TiVec::new(),
+            guard_info: Vec::new(),
             indirect_calls: TiVec::new(),
             #[cfg(not(test))]
             globalvar_ptrs,
@@ -1857,7 +1857,7 @@ impl GuardInst {
     }
 
     pub(crate) fn guard_info<'a>(&self, m: &'a Module) -> &'a GuardInfo {
-        &m.guard_info[self.gidx]
+        &m.guard_info[usize::from(self.gidx)]
     }
 }
 


### PR DESCRIPTION
`TiVec` has the unfortunate property that it requires us to implement `impl From<usize> for *Idx`, which means we have a method which silently takes an arbitrary `usize` and tries to squeeze it into a `u16`. Even though the method has a big warning on it, the nature of trait method resolution means that it's unlikely we'll notice that. The `From` is thus an unfortunate footgun.

On reflection, I think we don't really need `TiVec` *inside* `jit_ir/mod.rs` -- its main utility is to force users of the JIT IR to be careful with their use of types, which happens naturally because they're forced to use methods which take in, and return, `*Idx` types. This commit thus de-`TiVec`ifies `jit_ir/mod.rs`.