### PR TITLE
Handle trace iterator errors when peeking.

### DIFF
--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -1054,7 +1054,18 @@ impl<'a> TraceBuilder<'a> {
                             let nextbb = if let Some(tpeek) = trace_iter.peek() {
                                 match tpeek {
                                     Ok(tp) => self.lookup_aot_block(tp),
-                                    Err(_) => todo!(),
+                                    Err(e) => match e {
+                                        AOTTraceIteratorError::TraceTooLong => {
+                                            return Err(CompilationError::LimitExceeded(
+                                                "Trace too long.".into(),
+                                            ));
+                                        }
+                                        AOTTraceIteratorError::LongJmpEncountered => {
+                                            return Err(CompilationError::General(
+                                                "Long jump encountered.".into(),
+                                            ));
+                                        }
+                                    },
                                 }
                             } else {
                                 None


### PR DESCRIPTION
Though it's a bit annoying this is a duplicate of the code segment from further below, it's the smallest change to fix `utf8.lua`.