### PR TITLE
Implement `fadd`.

### DIFF
--- a/tests/c/float_add.newcg.c
+++ b/tests/c/float_add.newcg.c
@@ -1,0 +1,66 @@
+// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// Run-time:
+//   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG_JITSTATE=-
+//   stderr:
+//     jitstate: start-tracing
+//     4 -> 4.333300 4.840000
+//     jitstate: stop-tracing
+//     --- Begin aot ---
+//     ...
+//     func main(%arg0: i32, %arg1: ptr) -> i32 {
+//     ...
+//     %{{10_5}}: float = fadd %{{_}}, %{{_}}
+//     %{{10_6}}: double = fp_ext %{{10_5}}, double
+//     ...
+//     %{{10_9}}: double = fadd %{{_}}, %{{_}}
+//     ...
+//     %{{_}}: i32 = call fprintf(%{{_}}, @{{_}}, %{{_}}, %10_6, %10_9)
+//     ...
+//     --- End aot ---
+//     --- Begin jit-pre-opt ---
+//     ...
+//     %{{16}}: float = fadd %{{_}}, %{{_}}
+//     %{{17}}: double = fp_ext %{{16}}
+//     ...
+//     %{{20}}: double = fadd %{{_}}, %{{_}}
+//     ...
+//     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, %{{17}}, %{{20}})
+//     ...
+//     --- End jit-pre-opt ---
+//     3 -> 3.333300 3.840000
+//     jitstate: enter-jit-code
+//     2 -> 2.333300 2.840000
+//     1 -> 1.333300 1.840000
+//     jitstate: deoptimise
+
+// Check floating point addition works.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  float f = 0.3333;
+  double d = 0.84;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  NOOPT_VAL(f);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "%d -> %f %f\n", i, (float)i + f, (double)i + d);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_drop(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -504,6 +504,16 @@ impl<'a> X64CodeGen<'a> {
                 }
                 self.store_new_local_float(iidx, WF0);
             }
+            BinOp::FAdd => {
+                self.load_operand_float(WF0, &lhs);
+                self.load_operand_float(WF1, &rhs);
+                match lhs.byte_size(self.m) {
+                    8 => dynasm!(self.asm; addsd Rx(WF0.code()), Rx(WF1.code())),
+                    4 => dynasm!(self.asm; addss Rx(WF0.code()), Rx(WF1.code())),
+                    _ => todo!(),
+                }
+                self.store_new_local_float(iidx, WF0);
+            }
             x => todo!("{x:?}"),
         }
     }
@@ -1966,6 +1976,46 @@ mod tests {
                 ... movsd xmm0, qword ptr [rbp-0x08]
                 ... movsd xmm1, qword ptr [rbp-0x10]
                 ... divsd xmm0, xmm1
+                ... movsd [rbp-0x18], xmm0
+                ...
+                ",
+            );
+        }
+
+        #[test]
+        fn cg_fadd_float() {
+            test_with_spillalloc(
+                "
+              entry:
+                %0: float = load_ti 0
+                %1: float = load_ti 1
+                %2: float = fadd %0, %1
+            ",
+                "
+                ...
+                ... movss xmm0, dword ptr [rbp-0x04]
+                ... movss xmm1, dword ptr [rbp-0x08]
+                ... addss xmm0, xmm1
+                ... movss [rbp-0x0c], xmm0
+                ...
+                ",
+            );
+        }
+
+        #[test]
+        fn cg_fadd_double() {
+            test_with_spillalloc(
+                "
+              entry:
+                %0: double = load_ti 0
+                %1: double = load_ti 1
+                %2: double = fadd %0, %1
+            ",
+                "
+                ...
+                ... movsd xmm0, qword ptr [rbp-0x08]
+                ... movsd xmm1, qword ptr [rbp-0x10]
+                ... addsd xmm0, xmm1
                 ... movsd [rbp-0x18], xmm0
                 ...
                 ",


### PR DESCRIPTION
This allows `verybig.lua` to run to completion (with serial compilation).

Well-formedness already covered by blanket binop checks.

JIT IR syntax also already tested.