### PR TITLE
Use specific "testing only" `CompiledTrace` instances.

### DIFF
--- a/ykrt/src/compile/jitc_llvm/mod.rs
+++ b/ykrt/src/compile/jitc_llvm/mod.rs
@@ -195,19 +195,6 @@ impl LLVMCompiledTrace {
         todo!();
     }
 
-    /// Create a `CompiledTrace` suitable for testing purposes. The resulting instance is not
-    /// useful other than as a placeholder.
-    pub(crate) fn new_testing() -> Self {
-        Self { hl: None }
-    }
-
-    /// Create a `CompiledTrace` suitable for testing purposes. The resulting instance is not
-    /// useful other than as a placeholder: calling any of its methods other than `hl` will cause a
-    /// panic.
-    pub(crate) fn new_testing_with_hl(hl: Weak<Mutex<HotLocation>>) -> Self {
-        Self { hl: Some(hl) }
-    }
-
     fn smap(&self) -> &HashMap<u64, Vec<LiveVar>> {
         todo!();
     }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -148,3 +148,101 @@ impl GuardId {
         GuardId(usize::MAX)
     }
 }
+
+#[cfg(test)]
+mod compiled_trace_testing {
+    use super::*;
+
+    /// A [CompiledTrace] implementation suitable only for testing: when any of its methods are
+    /// called it will `panic`.
+    #[derive(Debug)]
+    pub(crate) struct CompiledTraceTesting;
+
+    impl CompiledTraceTesting {
+        pub(crate) fn new() -> Self {
+            Self
+        }
+    }
+
+    impl CompiledTrace for CompiledTraceTesting {
+        fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
+            panic!();
+        }
+
+        fn mt(&self) -> &Arc<MT> {
+            panic!();
+        }
+
+        fn guard(&self, _id: GuardId) -> &Guard {
+            panic!();
+        }
+
+        fn is_last_guard(&self, _id: GuardId) -> bool {
+            panic!();
+        }
+
+        fn aotvals(&self) -> *const c_void {
+            panic!();
+        }
+
+        fn entry(&self) -> *const c_void {
+            panic!();
+        }
+
+        fn hl(&self) -> &Weak<Mutex<HotLocation>> {
+            panic!();
+        }
+
+        fn disassemble(&self) -> Result<String, Box<dyn Error>> {
+            panic!();
+        }
+    }
+
+    /// A [CompiledTrace] implementation suitable only for testing. The `hl` method will return a
+    /// [HotLocation] but all other methods will `panic` if called.
+    #[derive(Debug)]
+    pub(crate) struct CompiledTraceTestingWithHl(Weak<Mutex<HotLocation>>);
+
+    impl CompiledTraceTestingWithHl {
+        pub(crate) fn new(hl: Weak<Mutex<HotLocation>>) -> Self {
+            Self(hl)
+        }
+    }
+
+    impl CompiledTrace for CompiledTraceTestingWithHl {
+        fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
+            panic!();
+        }
+
+        fn mt(&self) -> &Arc<MT> {
+            panic!();
+        }
+
+        fn guard(&self, _id: GuardId) -> &Guard {
+            panic!();
+        }
+
+        fn is_last_guard(&self, _id: GuardId) -> bool {
+            panic!();
+        }
+
+        fn aotvals(&self) -> *const c_void {
+            panic!();
+        }
+
+        fn entry(&self) -> *const c_void {
+            panic!();
+        }
+
+        fn hl(&self) -> &Weak<Mutex<HotLocation>> {
+            &self.0
+        }
+
+        fn disassemble(&self) -> Result<String, Box<dyn Error>> {
+            panic!();
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) use compiled_trace_testing::*;

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -787,7 +787,10 @@ pub(crate) enum TransitionGuardFailure {
 mod tests {
     extern crate test;
     use super::*;
-    use crate::{compile::jitc_llvm::LLVMCompiledTrace, trace::TraceRecorderError};
+    use crate::{
+        compile::{CompiledTraceTesting, CompiledTraceTestingWithHl},
+        trace::TraceRecorderError,
+    };
     use std::hint::black_box;
     use test::bench::Bencher;
 
@@ -847,7 +850,7 @@ mod tests {
         };
         let TransitionGuardFailure::StartSideTracing(hl) = mt.transition_guard_failure(
             sti,
-            Arc::new(LLVMCompiledTrace::new_testing_with_hl(Arc::downgrade(
+            Arc::new(CompiledTraceTestingWithHl::new(Arc::downgrade(
                 &loc.hot_location_arc_clone().unwrap(),
             ))),
         ) else {
@@ -886,7 +889,7 @@ mod tests {
             HotLocationKind::Compiling
         ));
         loc.hot_location().unwrap().lock().kind =
-            HotLocationKind::Compiled(Arc::new(LLVMCompiledTrace::new_testing()));
+            HotLocationKind::Compiled(Arc::new(CompiledTraceTesting::new()));
         assert!(matches!(
             dbg!(mt.transition_control_point(&loc)),
             TransitionControlPoint::Execute(_)
@@ -1181,9 +1184,8 @@ mod tests {
                                 loc.hot_location().unwrap().lock().kind,
                                 HotLocationKind::Compiling
                             ));
-                            loc.hot_location().unwrap().lock().kind = HotLocationKind::Compiled(
-                                Arc::new(LLVMCompiledTrace::new_testing()),
-                            );
+                            loc.hot_location().unwrap().lock().kind =
+                                HotLocationKind::Compiled(Arc::new(CompiledTraceTesting::new()));
                             loop {
                                 if let TransitionControlPoint::Execute(_) =
                                     mt.transition_control_point(&loc)
@@ -1277,7 +1279,7 @@ mod tests {
                 HotLocationKind::Compiling
             ));
             loc.hot_location().unwrap().lock().kind =
-                HotLocationKind::Compiled(Arc::new(LLVMCompiledTrace::new_testing()));
+                HotLocationKind::Compiled(Arc::new(CompiledTraceTesting::new()));
         }
 
         to_compiled(&mt, &loc1);
@@ -1345,7 +1347,7 @@ mod tests {
         expect_start_tracing(&mt, &loc1);
         expect_stop_tracing(&mt, &loc1);
         loc1.hot_location().unwrap().lock().kind =
-            HotLocationKind::Compiled(Arc::new(LLVMCompiledTrace::new_testing()));
+            HotLocationKind::Compiled(Arc::new(CompiledTraceTesting::new()));
 
         // If we transition `loc2` into `StartTracing`, then (for now) we should not execute the
         // trace for `loc1`, as another location is being traced and we don't want to trace the


### PR DESCRIPTION
Previously we abused `LLVMCompiledTrace` to also be the generic "use a `CompiledTrace` that doesn't do much except in testing". This wasn't ideal for several reasons, and since we soon want to remove the LLVM backend, the time has come to remove this.

The solution this commit introduces is relatively simple: we provide two new test-only structs (`CompiledTraceTesting` and
`CompiledTraceTestingWithHl`) that implement the `CompiledTrace` trait. This gives the effect we want in tests without overloading `LLVMCompiledTrace`.

Note: we could have provided only 1 struct, and used an `Option` type for the `HotLocation`. That said, forcing the user to choose what they want makes it clearer what testing-only functionality they want in different testing scenarios, which seems helpful.