### PR TITLE
Add a simple dead-code elimination function to `jit_ir::Module`.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -22,6 +22,7 @@ strum_macros = "0.26.1"
 tempfile = "3.8"
 thiserror = "1.0.56"
 typed-index-collections = "3.1.0"
+vob = "3.0.3"
 ykaddr = { path = "../ykaddr" }
 yksmp = { path = "../yksmp" }
 yktracec = { path = "../yktracec" }

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -1,0 +1,121 @@
+//! Dead code elimination.
+
+use super::{Inst, Module, Operand};
+use vob::Vob;
+
+impl Module {
+    /// Eliminate dead code from this module. Note that this does not compact the instructions: it
+    /// merely replaces them with [Inst::Tombstone]s.
+    fn dead_code_elimination(&mut self) {
+        // We perform a simple reverse reachability analysis, tracking what's alive with a single
+        // bit.
+        let mut used = Vob::from_elem(false, usize::from(self.last_inst_idx()) + 1);
+        for iidx in self.iter_inst_idxs().rev() {
+            let inst = self.inst(iidx);
+            if inst.always_alive() || used.get(usize::from(iidx)).unwrap() {
+                used.set(usize::from(iidx), true);
+                inst.map_operands(self, |op| match op {
+                    Operand::Const(_) => (),
+                    Operand::Local(x) => {
+                        used.set(usize::from(x), true);
+                    }
+                });
+            } else {
+                self.replace(iidx, Inst::Tombstone);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = load_ti 1
+            black_box %1
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %1: i8 = load_ti 1
+            black_box %1
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = add %0, %0
+            %2: i8 = add %0, %0
+            black_box %2
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %0: i8 = load_ti 0
+            %2: i8 = add %0, %0
+            black_box %2
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = load_ti 1
+            %2: i8 = add %1, %0
+            %3: i8 = add %1, %0
+            black_box %3
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = load_ti 1
+            %3: i8 = add %1, %0
+            black_box %3
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = load_ti 1
+            %2: i1 = ult %0, %0
+            %3: i1 = ult %1, %1
+            black_box %3
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %1: i8 = load_ti 1
+            %3: i1 = ult %1, %1
+            black_box %3
+        ",
+        );
+    }
+}

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -26,6 +26,8 @@
 //!     object which implements [std::fmt::Display].
 
 #[cfg(test)]
+mod dead_code;
+#[cfg(test)]
 mod parser;
 #[cfg(any(debug_assertions, test))]
 mod well_formed;
@@ -227,7 +229,7 @@ impl Module {
 
     /// Iterate, in order, over all `InstIdx`s of this module (including `Proxy*` and `Tombstone`
     /// instructions).
-    pub(crate) fn iter_inst_idxs(&self) -> impl Iterator<Item = InstIdx> {
+    pub(crate) fn iter_inst_idxs(&self) -> impl DoubleEndedIterator<Item = InstIdx> {
         (0..self.insts.len()).map(|x| InstIdx::new(x).unwrap())
     }
 
@@ -1129,6 +1131,78 @@ impl Inst {
             Self::Select(s) => s.trueval(m).tyidx(m),
             Self::SIToFP(i) => i.dest_ty_idx(),
             Self::FPExt(i) => i.dest_ty_idx(),
+        }
+    }
+
+    /// Must this instruction be considered alive, irrespective of its context? For example, side
+    /// effecting instructions will always be considered alive.
+    #[cfg(test)]
+    fn always_alive(&self) -> bool {
+        match self {
+            #[cfg(test)]
+            Inst::BlackBox(_) => true,
+            Inst::ProxyConst(_) => todo!(),
+            Inst::ProxyInst(_) => todo!(),
+            Inst::Tombstone => todo!(),
+            Inst::BinOp(_) => false,
+            Inst::Load(_) => todo!(),
+            Inst::LookupGlobal(_) => todo!(),
+            Inst::LoadTraceInput(_) => false,
+            Inst::Call(_) => todo!(),
+            Inst::IndirectCall(_) => todo!(),
+            Inst::PtrAdd(_) => todo!(),
+            Inst::DynPtrAdd(_) => todo!(),
+            Inst::Store(_) => todo!(),
+            Inst::Icmp(_) => false,
+            Inst::Guard(_) => todo!(),
+            Inst::Arg(_) => todo!(),
+            Inst::TraceLoopStart => todo!(),
+            Inst::SExt(_) => todo!(),
+            Inst::ZeroExtend(_) => todo!(),
+            Inst::Trunc(_) => todo!(),
+            Inst::Select(_) => todo!(),
+            Inst::SIToFP(_) => todo!(),
+            Inst::FPExt(_) => todo!(),
+        }
+    }
+
+    // Apply the function `f` to each of this instruction's [Operand]s (in no specified order).
+    #[cfg(test)]
+    fn map_operands<F>(&self, m: &Module, mut f: F)
+    where
+        F: FnMut(Operand),
+    {
+        match self {
+            #[cfg(test)]
+            Inst::BlackBox(BlackBoxInst { op }) => f(op.unpack(m)),
+            Inst::ProxyConst(_) => todo!(),
+            Inst::ProxyInst(_) => todo!(),
+            Inst::Tombstone => todo!(),
+            Inst::BinOp(BinOpInst { lhs, binop: _, rhs }) => {
+                f(lhs.unpack(m));
+                f(rhs.unpack(m))
+            }
+            Inst::Load(_) => todo!(),
+            Inst::LookupGlobal(_) => todo!(),
+            Inst::LoadTraceInput(_) => (),
+            Inst::Call(_) => todo!(),
+            Inst::IndirectCall(_) => todo!(),
+            Inst::PtrAdd(_) => todo!(),
+            Inst::DynPtrAdd(_) => todo!(),
+            Inst::Store(_) => todo!(),
+            Inst::Icmp(IcmpInst { lhs, pred: _, rhs }) => {
+                f(lhs.unpack(m));
+                f(rhs.unpack(m))
+            }
+            Inst::Guard(_) => todo!(),
+            Inst::Arg(_) => todo!(),
+            Inst::TraceLoopStart => todo!(),
+            Inst::SExt(_) => todo!(),
+            Inst::ZeroExtend(_) => todo!(),
+            Inst::Trunc(_) => todo!(),
+            Inst::Select(_) => todo!(),
+            Inst::SIToFP(_) => todo!(),
+            Inst::FPExt(_) => todo!(),
         }
     }
 


### PR DESCRIPTION
This currently only copes with a subset of the IR, because we probably want to implement some additional functionality before fully fleshing this out.

[Note: I'm currently happy with the `map_operands` call, as my previous attempts to solve this had all required heap allocation. I'm hoping I'll remain happy with it!]