### PR TITLE
Consistently use `dest_tyidx` as the spelling.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -838,7 +838,7 @@ impl<'a> X64CodeGen<'a> {
 
     fn cg_sitofp(&mut self, inst_idx: InstIdx, i: &jit_ir::SIToFPInst) {
         let from_val = i.val(self.m);
-        let to_type = self.m.type_(i.dest_ty_idx());
+        let to_type = self.m.type_(i.dest_tyidx());
 
         self.load_operand(WR0, &from_val);
         match to_type {
@@ -856,7 +856,7 @@ impl<'a> X64CodeGen<'a> {
     fn cg_fpext(&mut self, iidx: InstIdx, i: &jit_ir::FPExtInst) {
         let from_val = i.val(self.m);
         let from_type = self.m.type_(from_val.tyidx(self.m));
-        let to_type = self.m.type_(i.dest_ty_idx());
+        let to_type = self.m.type_(i.dest_tyidx());
 
         self.load_operand_float(WF0, &from_val);
         if let (

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1198,8 +1198,8 @@ impl Inst {
             Self::ZeroExtend(si) => si.dest_tyidx(),
             Self::Trunc(t) => t.dest_tyidx(),
             Self::Select(s) => s.trueval(m).tyidx(m),
-            Self::SIToFP(i) => i.dest_ty_idx(),
-            Self::FPExt(i) => i.dest_ty_idx(),
+            Self::SIToFP(i) => i.dest_tyidx(),
+            Self::FPExt(i) => i.dest_tyidx(),
         }
     }
 
@@ -2091,14 +2091,14 @@ pub struct SIToFPInst {
     /// The value to convert.
     val: PackedOperand,
     /// The type to convert to. Must be a floating point type.
-    dest_ty_idx: TyIdx,
+    dest_tyidx: TyIdx,
 }
 
 impl SIToFPInst {
-    pub(crate) fn new(val: &Operand, dest_ty_idx: TyIdx) -> Self {
+    pub(crate) fn new(val: &Operand, dest_tyidx: TyIdx) -> Self {
         Self {
             val: PackedOperand::new(val),
-            dest_ty_idx,
+            dest_tyidx,
         }
     }
 
@@ -2106,8 +2106,8 @@ impl SIToFPInst {
         self.val.unpack(m)
     }
 
-    pub(crate) fn dest_ty_idx(&self) -> TyIdx {
-        self.dest_ty_idx
+    pub(crate) fn dest_tyidx(&self) -> TyIdx {
+        self.dest_tyidx
     }
 }
 
@@ -2116,14 +2116,14 @@ pub struct FPExtInst {
     /// The value to convert.
     val: PackedOperand,
     /// The type to convert to. Must be a larger floating point type.
-    dest_ty_idx: TyIdx,
+    dest_tyidx: TyIdx,
 }
 
 impl FPExtInst {
-    pub(crate) fn new(val: &Operand, dest_ty_idx: TyIdx) -> Self {
+    pub(crate) fn new(val: &Operand, dest_tyidx: TyIdx) -> Self {
         Self {
             val: PackedOperand::new(val),
-            dest_ty_idx,
+            dest_tyidx,
         }
     }
 
@@ -2131,8 +2131,8 @@ impl FPExtInst {
         self.val.unpack(m)
     }
 
-    pub(crate) fn dest_ty_idx(&self) -> TyIdx {
-        self.dest_ty_idx
+    pub(crate) fn dest_tyidx(&self) -> TyIdx {
+        self.dest_tyidx
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -144,7 +144,7 @@ impl Module {
                 }
                 Inst::SIToFP(x) => {
                     let from_type = self.type_(x.val(self).tyidx(self));
-                    let to_type = self.type_(x.dest_ty_idx());
+                    let to_type = self.type_(x.dest_tyidx());
 
                     if !matches!(from_type, Ty::Integer(_)) {
                         panic!("Instruction at position {iidx} trying to convert a non-integer type\n  {}",
@@ -161,7 +161,7 @@ impl Module {
                 }
                 Inst::FPExt(x) => {
                     let from_type = self.type_(x.val(self).tyidx(self));
-                    let to_type = self.type_(x.dest_ty_idx());
+                    let to_type = self.type_(x.dest_tyidx());
                     if !matches!(from_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to extend from a non-float type\n  {}",
                             self.inst(iidx).display(iidx, self));


### PR DESCRIPTION
The alternative spelling (with two `_`s) was introduced relatively recently, so use the original precedent.