### PR TITLE
Largely complete dead code elimination

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -173,8 +173,8 @@ impl<'a> CodeGen<'a> for X64CodeGen<'a> {
     fn codegen(mut self: Box<Self>) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         let alloc_off = self.emit_prologue();
 
-        for idx in self.m.iter_skipping_inst_idxs() {
-            self.cg_inst(idx, self.m.inst(idx))?;
+        for (iidx, inst) in self.m.iter_skipping_insts() {
+            self.cg_inst(iidx, inst)?;
         }
 
         // Loop the JITted code if the `tloop_start` label is present.

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -1,24 +1,21 @@
 //! Dead code elimination.
 
-use super::{Inst, Module, Operand};
+use super::{Inst, Module};
 use vob::Vob;
 
 impl Module {
     /// Eliminate dead code from this module. Note that this does not compact the instructions: it
     /// merely replaces them with [Inst::Tombstone]s.
-    fn dead_code_elimination(&mut self) {
+    pub(crate) fn dead_code_elimination(&mut self) {
         // We perform a simple reverse reachability analysis, tracking what's alive with a single
         // bit.
         let mut used = Vob::from_elem(false, usize::from(self.last_inst_idx()) + 1);
         for iidx in self.iter_all_inst_idxs().rev() {
             let inst = self.inst_all(iidx);
-            if inst.always_alive() || used.get(usize::from(iidx)).unwrap() {
+            if used.get(usize::from(iidx)).unwrap() || inst.has_side_effect(self) {
                 used.set(usize::from(iidx), true);
-                inst.map_operands(self, |op| match op {
-                    Operand::Const(_) => (),
-                    Operand::Local(x) => {
-                        used.set(usize::from(x), true);
-                    }
+                inst.map_packed_operand_locals(self, &mut |x| {
+                    used.set(usize::from(x), true);
                 });
             } else {
                 self.replace(iidx, Inst::Tombstone);
@@ -115,6 +112,70 @@ mod test {
             %1: i8 = load_ti 1
             %3: i1 = ult %1, %1
             black_box %3
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = load_ti 0
+            %1: i1 = ult %0, 1i8
+            guard true, %1, []
+            black_box %1
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %0: i8 = load_ti 0
+            %1: i1 = ult %0, 1i8
+            guard true, %1, []
+            black_box %1
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          func_decl f(i8)
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = load_ti 1
+            call @f(%0)
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %0: i8 = load_ti 0
+            call @f(%0)
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          func_type t1(i8)
+          entry:
+            %0: ptr = load_ti 0
+            %1: i8 = load_ti 1
+            %2: i8 = load_ti 1
+            icall<t1> %0(%1)
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %0: ptr = load_ti 0
+            %1: i8 = load_ti 1
+            icall %0(%1)
         ",
         );
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -10,7 +10,7 @@ impl Module {
         // We perform a simple reverse reachability analysis, tracking what's alive with a single
         // bit.
         let mut used = Vob::from_elem(false, usize::from(self.last_inst_idx()) + 1);
-        for iidx in self.iter_inst_idxs().rev() {
+        for iidx in self.iter_all_inst_idxs().rev() {
             let inst = self.inst(iidx);
             if inst.always_alive() || used.get(usize::from(iidx)).unwrap() {
                 used.set(usize::from(iidx), true);

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -11,7 +11,7 @@ impl Module {
         // bit.
         let mut used = Vob::from_elem(false, usize::from(self.last_inst_idx()) + 1);
         for iidx in self.iter_all_inst_idxs().rev() {
-            let inst = self.inst(iidx);
+            let inst = self.inst_all(iidx);
             if inst.always_alive() || used.get(usize::from(iidx)).unwrap() {
                 used.set(usize::from(iidx), true);
                 inst.map_operands(self, |op| match op {

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -247,7 +247,7 @@ impl Module {
 
     /// Iterate, in order, over all `InstIdx`s of this module (including `Proxy*` and `Tombstone`
     /// instructions).
-    pub(crate) fn iter_inst_idxs(&self) -> impl DoubleEndedIterator<Item = InstIdx> {
+    pub(crate) fn iter_all_inst_idxs(&self) -> impl DoubleEndedIterator<Item = InstIdx> {
         (0..self.insts.len()).map(|x| InstIdx::new(x).unwrap())
     }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -34,7 +34,7 @@ impl Module {
                     if lhs_tyidx != rhs.unpack(self).tyidx(self) {
                         panic!(
                             "Instruction at position {iidx} has different types on lhs and rhs\n  {}",
-                            self.inst(iidx).display(iidx, self)
+                            self.inst_no_proxies(iidx).display(iidx, self)
                         );
                     }
                     match binop {
@@ -54,7 +54,7 @@ impl Module {
                             if matches!(self.type_(lhs_tyidx), Ty::Float(_)) {
                                 panic!(
                                     "Integer binop at position {iidx} operates on float operands\n  {}",
-                                    self.inst(iidx).display(iidx, self)
+                                    self.inst_no_proxies(iidx).display(iidx, self)
                                 );
                             }
                         }
@@ -62,7 +62,7 @@ impl Module {
                             if !matches!(self.type_(lhs_tyidx), Ty::Float(_)) {
                                 panic!(
                                     "Float binop at position {iidx} operates on integer operands\n  {}",
-                                    self.inst(iidx).display(iidx, self)
+                                    self.inst_no_proxies(iidx).display(iidx, self)
                                 );
                             }
                         }
@@ -108,7 +108,7 @@ impl Module {
                     let Ty::Integer(1) = self.type_(tyidx) else {
                         panic!(
                             "Guard at position {iidx} does not have 'cond' of type 'i1'\n  {}",
-                            self.inst(iidx).display(iidx, self)
+                            self.inst_no_proxies(iidx).display(iidx, self)
                         )
                     };
                     if let Operand::Const(x) = cond {
@@ -118,7 +118,7 @@ impl Module {
                         if (*expect && *v == 0) || (!*expect && *v == 1) {
                             panic!(
                                 "Guard at position {iidx} references a constant that is at odds with the guard itself\n  {}",
-                                self.inst(iidx).display(iidx, self)
+                                self.inst_no_proxies(iidx).display(iidx, self)
                             );
                         }
                     }
@@ -127,7 +127,7 @@ impl Module {
                     if x.lhs(self).tyidx(self) != x.rhs(self).tyidx(self) {
                         panic!(
                             "Instruction at position {iidx} has different types on lhs and rhs\n  {}",
-                            self.inst(iidx).display(iidx, self)
+                            self.inst_no_proxies(iidx).display(iidx, self)
                         );
                     }
                 }
@@ -137,7 +137,7 @@ impl Module {
                     {
                         panic!(
                             "Instruction at position {iidx} trying to sign extend from an equal-or-larger-than integer type\n  {}",
-                            self.inst(iidx).display(iidx, self)
+                            self.inst_no_proxies(iidx).display(iidx, self)
                         );
                     }
                 }
@@ -147,15 +147,15 @@ impl Module {
 
                     if !matches!(from_type, Ty::Integer(_)) {
                         panic!("Instruction at position {iidx} trying to convert a non-integer type\n  {}",
-                            self.inst(iidx).display(iidx, self));
+                            self.inst_no_proxies(iidx).display(iidx, self));
                     }
                     if !matches!(to_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to convert to a non-float type\n  {}",
-                            self.inst(iidx).display(iidx, self));
+                            self.inst_no_proxies(iidx).display(iidx, self));
                     }
                     if to_type.byte_size() < from_type.byte_size() {
                         panic!("Instruction at position {iidx} trying to convert to a smaller-sized float\n  {}",
-                            self.inst(iidx).display(iidx, self));
+                            self.inst_no_proxies(iidx).display(iidx, self));
                     }
                 }
                 Inst::FPExt(x) => {
@@ -163,15 +163,15 @@ impl Module {
                     let to_type = self.type_(x.dest_tyidx());
                     if !matches!(from_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to extend from a non-float type\n  {}",
-                            self.inst(iidx).display(iidx, self));
+                            self.inst_no_proxies(iidx).display(iidx, self));
                     }
                     if !matches!(to_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to extend to a non-float type\n  {}",
-                            self.inst(iidx).display(iidx, self));
+                            self.inst_no_proxies(iidx).display(iidx, self));
                     }
                     if to_type.byte_size() <= from_type.byte_size() {
                         panic!("Instruction at position {iidx} trying to extend to a smaller-sized float\n  {}",
-                            self.inst(iidx).display(iidx, self));
+                            self.inst_no_proxies(iidx).display(iidx, self));
                     }
                 }
                 _ => (),

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -27,8 +27,7 @@ use super::{BinOp, BinOpInst, Const, GuardInst, Inst, Module, Operand, Ty};
 
 impl Module {
     pub(crate) fn assert_well_formed(&self) {
-        for iidx in self.iter_skipping_inst_idxs() {
-            let inst = self.inst(iidx);
+        for (iidx, inst) in self.iter_skipping_insts() {
             match inst {
                 Inst::BinOp(BinOpInst { lhs, binop, rhs }) => {
                     let lhs_tyidx = lhs.unpack(self).tyidx(self);

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -4,7 +4,10 @@ use crate::compile::CompilationError;
 mod simple;
 
 /// Create JIT IR from the (`aot_mod`, `ta_iter`) tuple.
-#[allow(dead_code)]
 pub(super) fn opt(m: Module) -> Result<Module, CompilationError> {
-    simple::simple(m)
+    let mut m = simple::simple(m)?;
+    // FIXME: When code generation supports backwards register allocation, we won't need to
+    // explicitly perform dead code elimination and this function can be made `#[cfg(test)]` only.
+    m.dead_code_elimination();
+    Ok(m)
 }

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -12,7 +12,7 @@ use crate::compile::{
 };
 
 pub(super) fn simple(mut m: Module) -> Result<Module, CompilationError> {
-    for iidx in m.iter_inst_idxs() {
+    for iidx in m.iter_all_inst_idxs() {
         let inst = m.inst(iidx).clone();
         match inst {
             Inst::BinOp(BinOpInst {

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -13,7 +13,7 @@ use crate::compile::{
 
 pub(super) fn simple(mut m: Module) -> Result<Module, CompilationError> {
     for iidx in m.iter_all_inst_idxs() {
-        let inst = m.inst(iidx).clone();
+        let inst = m.inst_all(iidx).clone();
         match inst {
             Inst::BinOp(BinOpInst {
                 lhs,
@@ -47,7 +47,7 @@ fn opt_mul(
                     lhs: chain_lhs,
                     binop: BinOp::Mul,
                     rhs: chain_rhs,
-                }) = m.inst(mul_inst)
+                }) = m.inst_no_proxies(mul_inst)
                 {
                     if let (Operand::Local(chain_mul_inst), Operand::Const(chain_mul_const))
                     | (Operand::Const(chain_mul_const), Operand::Local(chain_mul_inst)) =


### PR DESCRIPTION
This PR largely completes dead code elimination in the final commit (https://github.com/ykjit/yk/commit/49374b42bef49df52786d4f2c4303baaf5bc256a). On the way to doing that, I realised that I had to more carefully think about how we handle `Proxy*` instructions (https://github.com/ykjit/yk/commit/b47ddc07e4c2211076d3cd09e5efdde3672b4f0c). With this, I can successfully run yklua and eliminate dead code in its traces.