### PR TITLE
Minimally deal with const ints of different sizes in the x86 backend.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
@@ -31,7 +31,12 @@ pub(crate) enum LocalAlloc {
     ///
     /// FIXME: unimplemented.
     Register,
-    ConstInt(u64),
+    /// A constant integer `bits` wide (see [jit_ir::Const::ConstInt] for the constraints on the
+    /// bit width) and with value `v`.
+    ConstInt {
+        bits: u32,
+        v: u64,
+    },
     ConstFloat(f64),
 }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
@@ -114,7 +114,7 @@ pub(crate) extern "C" fn __yk_deopt(
                     }
                 }
                 LocalAlloc::Register => todo!(),
-                LocalAlloc::ConstInt(c) => c,
+                LocalAlloc::ConstInt { bits: _, v } => v,
                 LocalAlloc::ConstFloat(f) => f.to_bits(),
             };
             varidx += 1;

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -1003,7 +1003,12 @@ impl<'a> X64CodeGen<'a> {
                     // it doesn't have an allocation. We can just push the actual value instead
                     // which will be written as is during deoptimisation.
                     match self.m.const_(*c) {
-                        Const::Int(_, c) => locs.push(LocalAlloc::ConstInt(*c)),
+                        Const::Int(tyidx, c) => {
+                            let Ty::Integer(bits) = self.m.type_(*tyidx) else {
+                                panic!()
+                            };
+                            locs.push(LocalAlloc::ConstInt { bits: *bits, v: *c })
+                        }
                         _ => todo!(),
                     };
                 }
@@ -1095,10 +1100,10 @@ impl<'a> X64CodeGen<'a> {
                 }
             }
             LocalAlloc::Register => todo!(),
-            LocalAlloc::ConstInt(c) => {
-                // FIXME: Adjust for different constant sizes. Requires storing the size in the
-                // variant.
-                dynasm!(self.asm; mov Rq(reg.code()), QWORD *c as i64);
+            LocalAlloc::ConstInt { bits, v } => {
+                // FIXME: Adjust for different constant sizes?
+                assert_eq!(*bits, 64);
+                dynasm!(self.asm; mov Rq(reg.code()), QWORD *v as i64);
             }
             LocalAlloc::ConstFloat(_) => todo!(),
         }
@@ -1143,7 +1148,7 @@ impl<'a> X64CodeGen<'a> {
                 Err(_) => todo!(),
             },
             LocalAlloc::Register => todo!(),
-            LocalAlloc::ConstInt(_) => todo!(),
+            LocalAlloc::ConstInt { .. } => todo!(),
             LocalAlloc::ConstFloat(fv) => imm_float_into_reg(*fv, reg, size, &mut self.asm),
         }
     }
@@ -1161,7 +1166,7 @@ impl<'a> X64CodeGen<'a> {
                 Err(_) => todo!("{}", size),
             },
             LocalAlloc::Register => todo!(),
-            LocalAlloc::ConstInt(_) => todo!(),
+            LocalAlloc::ConstInt { .. } => todo!(),
             LocalAlloc::ConstFloat(_) => todo!(),
         }
     }
@@ -1184,7 +1189,7 @@ impl<'a> X64CodeGen<'a> {
                 Err(_) => todo!("{}", size),
             },
             LocalAlloc::Register => todo!(),
-            LocalAlloc::ConstInt(_) => todo!(),
+            LocalAlloc::ConstInt { .. } => todo!(),
             LocalAlloc::ConstFloat(_) => todo!(),
         }
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -819,8 +819,8 @@ pub(crate) enum Ty {
     /// A fixed-width integer type.
     ///
     /// Note:
-    ///   1. These integers range in size from 1..2^23 (inc.) bits. This is inherited [from LLVM's
-    ///      integer type](https://llvm.org/docs/LangRef.html#integer-type).
+    ///   1. These integers range in size from 1..2^23 (inc.) bits (stored in the `u32`). This is
+    ///      inherited [from LLVM's integer type](https://llvm.org/docs/LangRef.html#integer-type).
     ///   2. Signedness is not specified. Interpretation of the bit pattern is delegated to operations
     ///      upon the integer.
     Integer(u32),


### PR DESCRIPTION
This isn't really a complete solution, because at the moment we store every constant integer in 64 bits worth of space, even if it's smaller. If/when we use less space, we might get some fun bugs as we find it breaks assumptions elsewhere, but it's difficult for us to deal with that until we encounter it.