### PR TITLE
Terminology tweaks

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -23,7 +23,7 @@ pub(crate) trait CodeGen: Send + Sync {
 
 pub(crate) fn default_codegen() -> Result<Arc<dyn CodeGen>, Box<dyn Error>> {
     #[cfg(target_arch = "x86_64")]
-    return Ok(x86_64::X64CodeGenFrontEnd::new()?);
+    return Ok(x86_64::X86_64CodeGen::new()?);
 
     #[cfg(not(target_arch = "x86_64"))]
     return Err("No code generator available for this platform".into());

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/spill_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/spill_alloc.rs
@@ -5,13 +5,13 @@
 
 use super::{
     super::{abs_stack::AbstractStack, jit_ir},
-    LocalAlloc, RegisterAllocator, StackDirection,
+    RegisterAllocator, StackDirection, VarLocation,
 };
 use std::collections::HashMap;
 
 pub(crate) struct SpillAllocator {
     /// Maps a local variable (the instruction that defines it) to its allocation.
-    allocs: HashMap<jit_ir::InstIdx, LocalAlloc>,
+    allocs: HashMap<jit_ir::InstIdx, VarLocation>,
     stack_dir: StackDirection,
 }
 
@@ -28,7 +28,7 @@ impl RegisterAllocator for SpillAllocator {
         local: jit_ir::InstIdx,
         size: usize,
         stack: &mut AbstractStack,
-    ) -> LocalAlloc {
+    ) -> VarLocation {
         // Align the stack to the size of the allocation.
         //
         // FIXME: perhaps we should align to the largest alignment of the constituent fields?
@@ -45,18 +45,17 @@ impl RegisterAllocator for SpillAllocator {
             StackDirection::GrowsDown => post_grow_off,
         };
 
-        let alloc = LocalAlloc::new_stack(alloc_off, size);
+        let alloc = VarLocation::new_stack(alloc_off, size);
         self.allocs.insert(local, alloc);
         alloc
     }
 
-    /// Returns the allocation for a local variable (by the index of the instruction that defines
-    /// the variable).
+    /// Returns the location for an SSA variable.
     ///
     /// # Panics
     ///
-    /// Panics if there is no allocation for the specified index.
-    fn allocation(&self, idx: jit_ir::InstIdx) -> &LocalAlloc {
+    /// Panics if there is no such SSA variable.
+    fn location(&self, idx: jit_ir::InstIdx) -> &VarLocation {
         &self.allocs[&idx]
     }
 }
@@ -66,7 +65,7 @@ mod tests {
     use crate::compile::jitc_yk::{
         codegen::{
             abs_stack::AbstractStack,
-            reg_alloc::{LocalAlloc, RegisterAllocator, SpillAllocator, StackDirection},
+            reg_alloc::{RegisterAllocator, SpillAllocator, StackDirection, VarLocation},
         },
         jit_ir::InstIdx,
     };
@@ -80,8 +79,8 @@ mod tests {
         sa.allocate(idx, 8, &mut stack);
         debug_assert_eq!(stack.size(), 8);
         debug_assert_eq!(
-            sa.allocation(idx),
-            &LocalAlloc::Stack {
+            sa.location(idx),
+            &VarLocation::Stack {
                 frame_off: 8,
                 size: 8
             }
@@ -91,8 +90,8 @@ mod tests {
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 9);
         debug_assert_eq!(
-            sa.allocation(idx),
-            &LocalAlloc::Stack {
+            sa.location(idx),
+            &VarLocation::Stack {
                 frame_off: 9,
                 size: 1
             }
@@ -108,8 +107,8 @@ mod tests {
         sa.allocate(idx, 8, &mut stack);
         debug_assert_eq!(stack.size(), 8);
         debug_assert_eq!(
-            sa.allocation(idx),
-            &LocalAlloc::Stack {
+            sa.location(idx),
+            &VarLocation::Stack {
                 frame_off: 0,
                 size: 8
             }
@@ -119,8 +118,8 @@ mod tests {
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 9);
         debug_assert_eq!(
-            sa.allocation(idx),
-            &LocalAlloc::Stack {
+            sa.location(idx),
+            &VarLocation::Stack {
                 frame_off: 8,
                 size: 1
             }
@@ -139,8 +138,8 @@ mod tests {
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 33);
         debug_assert_eq!(
-            sa.allocation(idx),
-            &LocalAlloc::Stack {
+            sa.location(idx),
+            &VarLocation::Stack {
                 frame_off: 33,
                 size: 1
             }
@@ -159,8 +158,8 @@ mod tests {
         sa.allocate(idx, 1, &mut stack);
         debug_assert_eq!(stack.size(), 33);
         debug_assert_eq!(
-            sa.allocation(idx),
-            &LocalAlloc::Stack {
+            sa.location(idx),
+            &VarLocation::Stack {
                 frame_off: 32,
                 size: 1
             }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    aotsmp::AOT_STACKMAPS, compile::jitc_yk::codegen::reg_alloc::LocalAlloc, log::log_jit_state,
+    aotsmp::AOT_STACKMAPS, compile::jitc_yk::codegen::reg_alloc::VarLocation, log::log_jit_state,
     mt::MTThread,
 };
 use libc::c_void;
@@ -103,7 +103,7 @@ pub(crate) extern "C" fn __yk_deopt(
         for aotvar in rec.live_vars.iter() {
             // Read live JIT values from the trace's stack frame.
             let jitval = match info.lives[varidx] {
-                LocalAlloc::Stack { frame_off, size } => {
+                VarLocation::Stack { frame_off, size } => {
                     let p = unsafe { jitrbp.byte_sub(frame_off) };
                     match size {
                         1 => unsafe { u64::from(std::ptr::read::<u8>(p as *const u8)) },
@@ -113,9 +113,9 @@ pub(crate) extern "C" fn __yk_deopt(
                         _ => todo!(),
                     }
                 }
-                LocalAlloc::Register => todo!(),
-                LocalAlloc::ConstInt { bits: _, v } => v,
-                LocalAlloc::ConstFloat(f) => f.to_bits(),
+                VarLocation::Register => todo!(),
+                VarLocation::ConstInt { bits: _, v } => v,
+                VarLocation::ConstFloat(f) => f.to_bits(),
             };
             varidx += 1;
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1053,10 +1053,10 @@ impl fmt::Display for DisplayableOperand<'_> {
 /// need to determine what notion of equality you wish to use on a given const.
 #[derive(Clone, Debug)]
 pub(crate) enum Const {
+    Float(TyIdx, f64),
     /// A constant integer at most 64 bits wide. This can be treated a signed or unsigned integer
     /// depending on the operations that use this constant (the [Ty::Integer] type itself has no
     /// concept of signedness).
-    Float(TyIdx, f64),
     Int(TyIdx, u64),
     Ptr(usize),
 }


### PR DESCRIPTION
This is a slightly half-hearted PR where I wanted to do something big, got bogged down in details, and then decided to salvage something minor.

The first commit somewhat addresses the comment from #1284 that the X86 structs weren't well named.

The second commit starts to make the register allocation terminology a bit clearer. Doing so has proven unintentionally useful: it makes clear that the `RegisterAllocator` trait fundamentally assumes that SSA variables have a single location, which means one can't express "store in a reg, spill to stack, reload from a reg" and so on. Doing something about that is going to be quite some work, hence this not-even-halfway-house PR.