### PR TITLE
Execute the trace inside the AOT frame.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -58,13 +58,15 @@ pub extern "C" fn __ykrt_control_point(
     ctrlp_vars: *mut c_void,
     // Frame address of caller.
     frameaddr: *mut c_void,
+    // Stackmap id for the control point.
+    smid: u64,
 ) {
     debug_assert!(!ctrlp_vars.is_null());
     if !loc.is_null() {
         let mt = unsafe { &*mt };
         let loc = unsafe { &*loc };
         let arc = unsafe { Arc::from_raw(mt) };
-        arc.control_point(loc, ctrlp_vars, frameaddr);
+        arc.control_point(loc, ctrlp_vars, frameaddr, smid);
         forget(arc);
     }
 }


### PR DESCRIPTION
This change resets the stack back to the AOT frame before executing a trace. Effectively, this pretends the control point never happened, placing the AOT frame and trace frame right next to each other. This will allow us to easily access the AOT frame from within the trace to read out live variables, which in turn enables us to get rid of the trace inputs, in a future commit.

Depends on: https://github.com/ykjit/ykllvm/pull/182