### PR TITLE
Implement codegen for fsub.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -605,6 +605,16 @@ impl<'a> Assemble<'a> {
                 }
                 self.store_new_local_float(iidx, WF0);
             }
+            BinOp::FSub => {
+                self.load_operand_float(WF0, &lhs);
+                self.load_operand_float(WF1, &rhs);
+                match lhs.byte_size(self.m) {
+                    4 => dynasm!(self.asm; subss Rx(WF0.code()), Rx(WF1.code())),
+                    8 => dynasm!(self.asm; subsd Rx(WF0.code()), Rx(WF1.code())),
+                    _ => todo!(),
+                }
+                self.store_new_local_float(iidx, WF0);
+            }
             x => todo!("{x:?}"),
         }
     }
@@ -2314,6 +2324,46 @@ mod tests {
                 ... movss xmm1, dword ptr [rbp-0x08]
                 ... addss xmm0, xmm1
                 ... movss [rbp-0x0c], xmm0
+                ...
+                ",
+            );
+        }
+
+        #[test]
+        fn cg_fsub_float() {
+            test_with_spillalloc(
+                "
+              entry:
+                %0: float = load_ti 0
+                %1: float = load_ti 1
+                %2: float = fsub %0, %1
+            ",
+                "
+                ...
+                ... movss xmm0, dword ptr [rbp-0x04]
+                ... movss xmm1, dword ptr [rbp-0x08]
+                ... subss xmm0, xmm1
+                ... movss [rbp-0x0c], xmm0
+                ...
+                ",
+            );
+        }
+
+        #[test]
+        fn cg_fsub_double() {
+            test_with_spillalloc(
+                "
+              entry:
+                %0: double = load_ti 0
+                %1: double = load_ti 1
+                %2: double = fsub %0, %1
+            ",
+                "
+                ...
+                ... movsd xmm0, qword ptr [rbp-0x08]
+                ... movsd xmm1, qword ptr [rbp-0x10]
+                ... subsd xmm0, xmm1
+                ... movsd [rbp-0x18], xmm0
                 ...
                 ",
             );


### PR DESCRIPTION
Lexer, parser and form checks already implemented for this, so just codegen and codegen tests in this change.

Lets NBody from AWFY get further.