### PR TITLE
Check the submodule commit is from `main` (best we can).

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -23,6 +23,13 @@ test_yklua() {
     cd ../..
 }
 
+# Check that the ykllvm commit in the submodule is from the main branch.
+# Due to the way github works, this may not be the case!
+cd ykllvm
+git log --pretty=format:%H -n 100 --no-show-signature origin/main | \
+    grep $(git rev-parse HEAD)
+cd ..
+
 # Install rustup.
 CARGO_HOME="$(pwd)/.cargo"
 export CARGO_HOME


### PR DESCRIPTION
We check that the HEAD commit is in the last 100 commits of main (which is all the history we have due to CI's shallow commit).

(only tested a bit :) )