### PR TITLE
Add well-formed check for undefined values

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -110,7 +110,7 @@ cargo install cargo-diff-tools
 if [ "$CI_RUNNER" = buildbot ] ; then
     # When running under buildbot, we need to `git fetch` data from the remote if we want
     # cargo-clippy-def to work later.
-    git fetch origin master:refs/remotes/origin/master
+    git fetch --no-recurse-submodules origin master:refs/remotes/origin/master
 fi
 for tracer in ${TRACERS}; do
     export YKB_TRACER="${tracer}"

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1416,7 +1416,15 @@ impl Inst {
             Inst::SExt(SExtInst { val, .. }) => val.map_iidx(f),
             Inst::ZeroExtend(ZeroExtendInst { val, .. }) => val.map_iidx(f),
             Inst::Trunc(TruncInst { val, .. }) => val.map_iidx(f),
-            Inst::Select(_) => todo!(),
+            Inst::Select(SelectInst {
+                cond,
+                trueval,
+                falseval,
+            }) => {
+                cond.map_iidx(f);
+                trueval.map_iidx(f);
+                falseval.map_iidx(f);
+            }
             Inst::SIToFP(SIToFPInst { val, .. }) => val.map_iidx(f),
             Inst::FPExt(FPExtInst { val, .. }) => val.map_iidx(f),
             Inst::FCmp(FCmpInst { lhs, pred: _, rhs }) => {

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -396,7 +396,7 @@ mod tests {
             %0: i1 = eq 0i8, 0i8
             guard true, %0, []
             %1: i1 = eq 0i8, 1i8
-            guard false, %1, [%0, %1]
+            guard false, %1, [%0]
         ",
             |m| simple(m).unwrap(),
             "


### PR DESCRIPTION
This checks that operand values inside each JIT IR instruction refers to a valid SSA variable.