### PR TITLE
Clarify enums

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -248,7 +248,17 @@ pub(crate) enum HotLocationKind {
     Tracing,
     /// While executing JIT compiled code, a guard failed often enough for us to want to generate a
     /// side trace for this HotLocation.
-    SideTracing(Arc<dyn CompiledTrace>, usize, Arc<dyn CompiledTrace>),
+    SideTracing {
+        /// The top-level [CompiledTrace]: while one thread is side tracing a (possibly many levels
+        /// deep) side trace that ultimately relates to this [CompiledTrace], other threads can
+        /// execute this compiled trace.
+        ctr: Arc<dyn CompiledTrace>,
+        /// The ID of the guard that failed (inside `parent`).
+        guardid: usize,
+        /// The [CompiledTrace] that the guard failed in. This will either be equal to `ctr` or a
+        /// (possibly many levels deep) child trace of `ctr`.
+        parent: Arc<dyn CompiledTrace>,
+    },
 }
 
 /// When a [HotLocation] has failed to compile a valid trace, should the [HotLocation] be tried

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -460,7 +460,11 @@ impl MT {
                                 }
                             }
                         }
-                        HotLocationKind::SideTracing(ref ctr, sti, ref parent) => {
+                        HotLocationKind::SideTracing {
+                            ref ctr,
+                            guardid,
+                            ref parent,
+                        } => {
                             let hl = loc.hot_location_arc_clone().unwrap();
                             match &*mtt.tstate.borrow() {
                                 MTThreadState::Tracing { hl: thread_hl, .. } => {
@@ -474,7 +478,7 @@ impl MT {
                                         let parent = Arc::clone(parent);
                                         lk.kind = HotLocationKind::Compiled(Arc::clone(ctr));
                                         drop(lk);
-                                        TransitionControlPoint::StopSideTracing(sti, parent)
+                                        TransitionControlPoint::StopSideTracing(guardid, parent)
                                     }
                                 }
                                 _ => {
@@ -526,7 +530,7 @@ impl MT {
     /// Perform the next step to `loc` in the `Location` state-machine for a guard failure.
     pub(crate) fn transition_guard_failure(
         self: &Arc<Self>,
-        gid: usize,
+        guardid: usize,
         parent: Arc<dyn CompiledTrace>,
     ) -> TransitionGuardFailure {
         if let Some(hl) = parent.hl().upgrade() {
@@ -535,7 +539,11 @@ impl MT {
                 debug_assert!(!mtt.is_tracing());
                 let mut lk = hl.lock();
                 if let HotLocationKind::Compiled(ref ctr) = lk.kind {
-                    lk.kind = HotLocationKind::SideTracing(Arc::clone(ctr), gid, parent);
+                    lk.kind = HotLocationKind::SideTracing {
+                        ctr: Arc::clone(ctr),
+                        guardid,
+                        parent,
+                    };
                     drop(lk);
                     TransitionGuardFailure::StartSideTracing(hl)
                 } else {


### PR DESCRIPTION
While I'm looking into #1302, these are a couple of useful (if cosmetic) clarifications about what relevant `enum`s do. If anyone else is looking at #1302 it'll probably help them too, so I think it's worth breaking this out now.