### PR TITLE
Rename `GuardId` to `GuardIdx` and use it consistently.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
@@ -1,6 +1,6 @@
 use crate::{
     aotsmp::AOT_STACKMAPS,
-    compile::{jitc_yk::codegen::reg_alloc::VarLocation, GuardId},
+    compile::{jitc_yk::codegen::reg_alloc::VarLocation, GuardIdx},
     log::{log_jit_state, stats::TimingState},
     mt::MTThread,
 };
@@ -13,17 +13,17 @@ use super::{X64CompiledTrace, RBP_DWARF_NUM, REG64_SIZE};
 #[no_mangle]
 pub(crate) extern "C" fn __yk_deopt(
     frameaddr: *const c_void,
-    guardid: u64,
+    gidx: u64,
     jitrbp: *const c_void,
 ) -> ! {
-    let guardid = GuardId::from(usize::try_from(guardid).unwrap());
+    let gidx = GuardIdx::from(usize::try_from(gidx).unwrap());
     let ctr = MTThread::with(|mtt| mtt.running_trace().unwrap())
         .as_any()
         .downcast::<X64CompiledTrace>()
         .unwrap();
-    debug_assert!(usize::from(guardid) < ctr.deoptinfo.len());
+    debug_assert!(usize::from(gidx) < ctr.deoptinfo.len());
     let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
-    let info = &ctr.deoptinfo[usize::from(guardid)];
+    let info = &ctr.deoptinfo[usize::from(gidx)];
 
     if let Some(st) = info.guard.ctr() {
         // Prepare the traceinputs "struct" (for now this is just a vector) and pass it into the
@@ -262,7 +262,7 @@ pub(crate) extern "C" fn __yk_deopt(
         // FIXME: Don't side trace the last guard of a side-trace as this guard always fails.
         // FIXME: Don't side-trace after switch instructions: not every guard failure is equal
         // and a trace compiled for case A won't work for case B.
-        ctr.mt.side_trace(guardid, ctr.clone());
+        ctr.mt.side_trace(gidx, ctr.clone());
     }
 
     // Since we won't return from this function, drop `ctr` manually.

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/deopt.rs
@@ -1,6 +1,6 @@
 use crate::{
     aotsmp::AOT_STACKMAPS,
-    compile::jitc_yk::codegen::reg_alloc::VarLocation,
+    compile::{jitc_yk::codegen::reg_alloc::VarLocation, GuardId},
     log::{log_jit_state, stats::TimingState},
     mt::MTThread,
 };
@@ -13,16 +13,17 @@ use super::{X64CompiledTrace, RBP_DWARF_NUM, REG64_SIZE};
 #[no_mangle]
 pub(crate) extern "C" fn __yk_deopt(
     frameaddr: *const c_void,
-    deoptid: usize,
+    guardid: u64,
     jitrbp: *const c_void,
 ) -> ! {
+    let guardid = GuardId::from(usize::try_from(guardid).unwrap());
     let ctr = MTThread::with(|mtt| mtt.running_trace().unwrap())
         .as_any()
         .downcast::<X64CompiledTrace>()
         .unwrap();
-    debug_assert!(deoptid < ctr.deoptinfo.len());
+    debug_assert!(usize::from(guardid) < ctr.deoptinfo.len());
     let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
-    let info = &ctr.deoptinfo[deoptid];
+    let info = &ctr.deoptinfo[usize::from(guardid)];
 
     if let Some(st) = info.guard.ctr() {
         // Prepare the traceinputs "struct" (for now this is just a vector) and pass it into the
@@ -261,7 +262,7 @@ pub(crate) extern "C" fn __yk_deopt(
         // FIXME: Don't side trace the last guard of a side-trace as this guard always fails.
         // FIXME: Don't side-trace after switch instructions: not every guard failure is equal
         // and a trace compiled for case A won't work for case B.
-        ctr.mt.side_trace(deoptid, ctr.clone());
+        ctr.mt.side_trace(guardid, ctr.clone());
     }
 
     // Since we won't return from this function, drop `ctr` manually.

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -26,7 +26,7 @@ use crate::{
             trace_builder::Frame,
             YkSideTraceInfo,
         },
-        CompiledTrace, Guard,
+        CompiledTrace, Guard, GuardId,
     },
     location::HotLocation,
     mt::{SideTraceInfo, MT},
@@ -1453,10 +1453,10 @@ impl CompiledTrace for X64CompiledTrace {
         self.buf.ptr(AssemblyOffset(0)) as *const libc::c_void
     }
 
-    fn sidetraceinfo(&self, guardid: usize) -> Arc<dyn SideTraceInfo> {
+    fn sidetraceinfo(&self, gidx: GuardId) -> Arc<dyn SideTraceInfo> {
         // FIXME: Can we reference these instead of copying them?
-        let aotlives = self.deoptinfo[guardid].aotlives.clone();
-        let callframes = self.deoptinfo[guardid].callframes.clone();
+        let aotlives = self.deoptinfo[usize::from(gidx)].aotlives.clone();
+        let callframes = self.deoptinfo[usize::from(gidx)].callframes.clone();
         Arc::new(YkSideTraceInfo {
             aotlives,
             callframes,

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -26,7 +26,7 @@ use crate::{
             trace_builder::Frame,
             YkSideTraceInfo,
         },
-        CompiledTrace, Guard, GuardId,
+        CompiledTrace, Guard, GuardIdx,
     },
     location::HotLocation,
     mt::{SideTraceInfo, MT},
@@ -1453,7 +1453,7 @@ impl CompiledTrace for X64CompiledTrace {
         self.buf.ptr(AssemblyOffset(0)) as *const libc::c_void
     }
 
-    fn sidetraceinfo(&self, gidx: GuardId) -> Arc<dyn SideTraceInfo> {
+    fn sidetraceinfo(&self, gidx: GuardIdx) -> Arc<dyn SideTraceInfo> {
         // FIXME: Can we reference these instead of copying them?
         let aotlives = self.deoptinfo[usize::from(gidx)].aotlives.clone();
         let callframes = self.deoptinfo[usize::from(gidx)].callframes.clone();
@@ -1463,7 +1463,7 @@ impl CompiledTrace for X64CompiledTrace {
         })
     }
 
-    fn guard(&self, id: crate::compile::GuardId) -> &crate::compile::Guard {
+    fn guard(&self, id: crate::compile::GuardIdx) -> &crate::compile::Guard {
         &self.deoptinfo[id.0].guard
     }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -132,9 +132,21 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     fn disassemble(&self) -> Result<String, Box<dyn Error>>;
 }
 
+/// Identify a [Guard] within a trace.
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
-pub(crate) struct GuardId(pub(crate) usize);
+pub(crate) struct GuardId(usize);
+
+impl From<usize> for GuardId {
+    fn from(v: usize) -> Self {
+        Self(v)
+    }
+}
+
+impl From<GuardId> for usize {
+    fn from(v: GuardId) -> Self {
+        v.0
+    }
+}
 
 #[cfg(test)]
 mod compiled_trace_testing {

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -115,10 +115,10 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     /// upcasting in Rust is incomplete.
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static>;
 
-    fn sidetraceinfo(&self, id: GuardId) -> Arc<dyn SideTraceInfo>;
+    fn sidetraceinfo(&self, gidx: GuardIdx) -> Arc<dyn SideTraceInfo>;
 
     /// Return a reference to the guard `id`.
-    fn guard(&self, id: GuardId) -> &Guard;
+    fn guard(&self, gidx: GuardIdx) -> &Guard;
 
     fn entry(&self) -> *const c_void;
 
@@ -133,17 +133,19 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
 }
 
 /// Identify a [Guard] within a trace.
+///
+/// This is guaranteed to be an index into an array that is freely convertible to/from [usize].
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct GuardId(usize);
+pub(crate) struct GuardIdx(usize);
 
-impl From<usize> for GuardId {
+impl From<usize> for GuardIdx {
     fn from(v: usize) -> Self {
         Self(v)
     }
 }
 
-impl From<GuardId> for usize {
-    fn from(v: GuardId) -> Self {
+impl From<GuardIdx> for usize {
+    fn from(v: GuardIdx) -> Self {
         v.0
     }
 }
@@ -168,11 +170,11 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn sidetraceinfo(&self, _id: GuardId) -> Arc<dyn SideTraceInfo> {
+        fn sidetraceinfo(&self, _gidx: GuardIdx) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
 
-        fn guard(&self, _id: GuardId) -> &Guard {
+        fn guard(&self, _gidx: GuardIdx) -> &Guard {
             panic!();
         }
 
@@ -205,11 +207,11 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn sidetraceinfo(&self, _id: GuardId) -> Arc<dyn SideTraceInfo> {
+        fn sidetraceinfo(&self, _gidx: GuardIdx) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
 
-        fn guard(&self, _id: GuardId) -> &Guard {
+        fn guard(&self, _gidx: GuardIdx) -> &Guard {
             panic!();
         }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -115,7 +115,7 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     /// upcasting in Rust is incomplete.
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static>;
 
-    fn sidetraceinfo(&self, guardid: usize) -> Arc<dyn SideTraceInfo>;
+    fn sidetraceinfo(&self, id: GuardId) -> Arc<dyn SideTraceInfo>;
 
     /// Return a reference to the guard `id`.
     fn guard(&self, id: GuardId) -> &Guard;
@@ -168,7 +168,7 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn sidetraceinfo(&self, _guardid: usize) -> Arc<dyn SideTraceInfo> {
+        fn sidetraceinfo(&self, _id: GuardId) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
 
@@ -205,7 +205,7 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn sidetraceinfo(&self, _guardid: usize) -> Arc<dyn SideTraceInfo> {
+        fn sidetraceinfo(&self, _id: GuardId) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
 

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    compile::{CompiledTrace, GuardId},
+    compile::{CompiledTrace, GuardIdx},
     mt::{HotThreshold, TraceCompilationErrorThreshold, MT},
 };
 use parking_lot::Mutex;
@@ -256,7 +256,7 @@ pub(crate) enum HotLocationKind {
         /// execute this compiled trace.
         root_ctr: Arc<dyn CompiledTrace>,
         /// The ID of the guard that failed (inside `parent`).
-        guardid: GuardId,
+        gidx: GuardIdx,
         /// The [CompiledTrace] that the guard failed in. This will either be `root_ctr` or a
         /// descendent of `root_ctr`.
         parent_ctr: Arc<dyn CompiledTrace>,

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    compile::CompiledTrace,
+    compile::{CompiledTrace, GuardId},
     mt::{HotThreshold, TraceCompilationErrorThreshold, MT},
 };
 use parking_lot::Mutex;
@@ -256,7 +256,7 @@ pub(crate) enum HotLocationKind {
         /// execute this compiled trace.
         root_ctr: Arc<dyn CompiledTrace>,
         /// The ID of the guard that failed (inside `parent`).
-        guardid: usize,
+        guardid: GuardId,
         /// The [CompiledTrace] that the guard failed in. This will either be `root_ctr` or a
         /// descendent of `root_ctr`.
         parent_ctr: Arc<dyn CompiledTrace>,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -623,7 +623,9 @@ impl MT {
             match compiler.compile(Arc::clone(&mt), trace_iter, sti, Arc::clone(&hl_arc)) {
                 Ok(ct) => {
                     if let Some((_, parent_ctr)) = sidetrace {
-                        parent_ctr.guard(GuardId(guardid.unwrap())).set_ctr(ct);
+                        parent_ctr
+                            .guard(GuardId::from(guardid.unwrap()))
+                            .set_ctr(ct);
                     } else {
                         let mut hl = hl_arc.lock();
                         debug_assert_matches!(hl.kind, HotLocationKind::Compiling);

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -22,7 +22,7 @@ use parking_lot_core::SpinWait;
 
 use crate::{
     aotsmp::{load_aot_stackmaps, AOT_STACKMAPS},
-    compile::{default_compiler, CompilationError, CompiledTrace, Compiler, GuardId},
+    compile::{default_compiler, CompilationError, CompiledTrace, Compiler, GuardIdx},
     location::{HotLocation, HotLocationKind, Location, TraceFailed},
     log::{
         log_jit_state,
@@ -327,7 +327,7 @@ impl MT {
                 }
             }
             TransitionControlPoint::StopSideTracing {
-                guardid,
+                gidx: guardid,
                 parent_ctr,
             } => {
                 // Assuming no bugs elsewhere, the `unwrap`s cannot fail, because
@@ -470,7 +470,7 @@ impl MT {
                         }
                         HotLocationKind::SideTracing {
                             ref root_ctr,
-                            guardid,
+                            gidx,
                             ref parent_ctr,
                         } => {
                             let hl = loc.hot_location_arc_clone().unwrap();
@@ -486,10 +486,7 @@ impl MT {
                                         let parent_ctr = Arc::clone(parent_ctr);
                                         lk.kind = HotLocationKind::Compiled(Arc::clone(root_ctr));
                                         drop(lk);
-                                        TransitionControlPoint::StopSideTracing {
-                                            guardid,
-                                            parent_ctr,
-                                        }
+                                        TransitionControlPoint::StopSideTracing { gidx, parent_ctr }
                                     }
                                 }
                                 _ => {
@@ -541,7 +538,7 @@ impl MT {
     /// Perform the next step to `loc` in the `Location` state-machine for a guard failure.
     pub(crate) fn transition_guard_failure(
         self: &Arc<Self>,
-        guardid: GuardId,
+        gidx: GuardIdx,
         parent_ctr: Arc<dyn CompiledTrace>,
     ) -> TransitionGuardFailure {
         if let Some(hl) = parent_ctr.hl().upgrade() {
@@ -552,7 +549,7 @@ impl MT {
                 if let HotLocationKind::Compiled(ref root_ctr) = lk.kind {
                     lk.kind = HotLocationKind::SideTracing {
                         root_ctr: Arc::clone(root_ctr),
-                        guardid,
+                        gidx,
                         parent_ctr,
                     };
                     drop(lk);
@@ -571,8 +568,8 @@ impl MT {
     }
 
     /// Start recording a side trace for a guard that failed in `ctr`.
-    pub(crate) fn side_trace(self: &Arc<Self>, gid: GuardId, parent: Arc<dyn CompiledTrace>) {
-        match self.transition_guard_failure(gid, parent) {
+    pub(crate) fn side_trace(self: &Arc<Self>, gidx: GuardIdx, parent: Arc<dyn CompiledTrace>) {
+        match self.transition_guard_failure(gidx, parent) {
             TransitionGuardFailure::NoAction => todo!(),
             TransitionGuardFailure::StartSideTracing(hl) => {
                 log_jit_state("start-side-tracing");
@@ -605,7 +602,7 @@ impl MT {
         self: &Arc<Self>,
         trace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
         hl_arc: Arc<Mutex<HotLocation>>,
-        sidetrace: Option<(GuardId, Arc<dyn CompiledTrace>)>,
+        sidetrace: Option<(GuardIdx, Arc<dyn CompiledTrace>)>,
     ) {
         self.stats.trace_recorded_ok();
         let mt = Arc::clone(self);
@@ -784,7 +781,7 @@ enum TransitionControlPoint {
     StartTracing(Arc<Mutex<HotLocation>>),
     StopTracing,
     StopSideTracing {
-        guardid: GuardId,
+        gidx: GuardIdx,
         parent_ctr: Arc<dyn CompiledTrace>,
     },
 }
@@ -856,7 +853,7 @@ mod tests {
 
     fn expect_start_side_tracing(mt: &Arc<MT>, loc: &Location) {
         let TransitionGuardFailure::StartSideTracing(hl) = mt.transition_guard_failure(
-            GuardId::from(0),
+            GuardIdx::from(0),
             Arc::new(CompiledTraceTestingWithHl::new(Arc::downgrade(
                 &loc.hot_location_arc_clone().unwrap(),
             ))),


### PR DESCRIPTION
Needs #1308 to be merged first.

We were previously inconsistent in (1) how we handled guard IDs (2) whether we used the `GuardId` type at all (3) whether `GuardId`s could be indexes into vectors or not. This PR sorts each thing out (hopefully).