### PR TITLE
Use fm's new matching features for x86 register matching.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -63,6 +63,7 @@ yk_testing = ["yktracec/yk_testing"]
 [dev-dependencies]
 cfgrammar = "0.13"
 fm = "0.3.0"
+lazy_static = "1.5.0"
 lrlex = "0.13"
 lrpar = "0.13"
 regex = { version = "1.9", features = ["std"] }


### PR DESCRIPTION
Instead of using concrete register names, one can refer to a class of registers e.g. `r.8` is all 8-bit registers. To match a register name but ignore its value uses `r.8._`: to match a register name use `r.8.x`. Suffixes: must be unique (i.e. `r.8.x` and `r.8.y` must refer to different registers); and they refer to the "underlying" register (e.g. `r.8.x` and `r.64.x` might match `al` and `RAX` which is considered the same register, but will fail to match against `al` and `RBX`).

To make this concrete these `assert`s all succeed:

```rust
let fmm = fmatcher("r.8.x r.8.y r.64.x");
assert!(fmm.matches("al bl rax").is_ok());
assert!(fmm.matches("al al rax").is_err());
assert!(fmm.matches("al bl rbx").is_err());
assert!(fmm.matches("al bl eax").is_err());
```

This commit is unfinished in the sense that not all the tests are ported: this is an RFC in its current state. Needs https://github.com/softdevteam/fm/pull/50.