### PR TITLE
Allow type_() to work on global operands.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -679,6 +679,10 @@ impl Operand {
                 self.to_inst(m).def_type(m).unwrap()
             }
             Self::Const(cidx) => m.type_(m.const_(*cidx).unwrap_val().tyidx()),
+            Self::Global(_) => {
+                // As is the case for LLVM IR, globals are always pointer-typed in Yk AOT IR.
+                &Ty::Ptr
+            }
             _ => todo!(),
         }
     }


### PR DESCRIPTION
The type is always `Ty::Ptr` for globals.

This fixes a crash where when you try to `YKD_LOG_IR=-:aot` and you have instructions that defer the type decision to operands which may be globals, e.g. `phi` and `switch`. Test included.

(The test would have been better as a unit test, but manually constructing an AOT module is painful, so I used an integration test)