### PR TITLE
Better spill heuristic

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
@@ -545,9 +545,8 @@ impl<'a> LSRegAlloc<'a> {
                     RegState::Reserved | RegState::Empty => unreachable!(),
                     RegState::FromConst(_) => todo!(),
                     RegState::FromInst(from_iidx) => {
-                        if self.is_inst_var_still_used_at(iidx, from_iidx) {
-                            self.spill_gp_if_not_already(asm, reg);
-                        }
+                        debug_assert!(self.is_inst_var_still_used_at(iidx, from_iidx));
+                        self.spill_gp_if_not_already(asm, reg);
                         self.gp_regset.unset(reg);
                         self.gp_reg_states[usize::from(reg.code())] = RegState::Empty;
                         reg
@@ -803,7 +802,6 @@ impl<'a> LSRegAlloc<'a> {
             RegState::Reserved | RegState::Empty | RegState::FromConst(_) => (),
             RegState::FromInst(iidx) => {
                 if self.spilled_insts[usize::from(iidx)] == usize::MAX {
-                    println!("woo");
                     let inst = self.m.inst_no_proxies(iidx);
                     let size = inst.def_byte_size(self.m);
                     self.stack.align(size); // FIXME
@@ -903,9 +901,8 @@ impl<'a> LSRegAlloc<'a> {
                     RegState::Reserved | RegState::Empty => unreachable!(),
                     RegState::FromConst(_) => todo!(),
                     RegState::FromInst(from_iidx) => {
-                        if self.is_inst_var_still_used_at(iidx, from_iidx) {
-                            self.spill_fp_if_not_already(asm, reg);
-                        }
+                        debug_assert!(self.is_inst_var_still_used_at(iidx, from_iidx));
+                        self.spill_fp_if_not_already(asm, reg);
                         self.fp_regset.unset(reg);
                         self.fp_reg_states[usize::from(reg.code())] = RegState::Empty;
                         reg


### PR DESCRIPTION
At some point every register allocator runs out of registers, and then we have to decide which unfortunate register to spill and reuse. Previously we semi-randomly picked a register (which, mostly, would end up being R15) and spilt it.

This PR uses a common heuristic in linear scan register allocators: spill the register whose value is last used furthest away. The idea here is that we already know when a value is last used, and the later a value is used, the more likely it is that it's not used soon. In other words, this is a rough proxy for "find the value which is least likely to be used soon and spill that".

Pleasingly, crude and simple though this is, it leads to noticeably less spills overall: big_loop.lua speeds up by a consistent 5.5%.