### PR TITLE
Type unimplemented AOT instructions.

### DIFF
--- a/tests/ir_lowering/mem_access.ll
+++ b/tests/ir_lowering/mem_access.ll
@@ -8,7 +8,7 @@
 ;         %0_2: i8 = load %0_0, volatile
 ;         %0_3: i8 = load %0_0
 ;         %0_4: i8 = load %0_0
-;         unimplemented <<  %6 = load i16, ptr %0, align 1>>
+;         %0_5: i16 = unimplemented <<  %6 = load i16, ptr %0, align 1>>
 ;         *%0_0 = 0i8
 ;         *%0_0 = 0i8, volatile
 ;         *%0_0 = 0i8

--- a/tests/ir_lowering/unsupported_variants.ll
+++ b/tests/ir_lowering/unsupported_variants.ll
@@ -4,44 +4,44 @@
 ;     func main(...
 ;       bb0:
 ;         ...
-;         unimplemented <<  %{{4}} = getelementptr i32, <8 x ptr> %{{1}}, i32 1>>
+;         %{{_}}: ?ty<<8 x ptr>> = unimplemented <<  %{{4}} = getelementptr i32, <8 x ptr> %{{1}}, i32 1>>
 ;         br bb1
 ;       bb1:
-;         unimplemented <<  %{{6}} = alloca inalloca i32, align 4>>
-;         unimplemented <<  %{{7}} = alloca i32, align 4, addrspace(4)>>
-;         unimplemented <<  %{{8}} = alloca i32, i32 %2, align 4>>
+;         %{{_}}: ptr = unimplemented <<  %{{6}} = alloca inalloca i32, align 4>>
+;         %{{_}}: ptr = unimplemented <<  %{{7}} = alloca i32, align 4, addrspace(4)>>
+;         %{{_}}: ptr = unimplemented <<  %{{8}} = alloca i32, i32 %2, align 4>>
 ;         br bb2
 ;      bb2:
-;         unimplemented <<  %{{13}} = fadd nnan float %{{3}}, %{{3}}>>
-;         unimplemented <<  %{{15}} = add <4 x i32> %{{44}}, %{{44}}>>
+;         %{{_}}: float = unimplemented <<  %{{13}} = fadd nnan float %{{3}}, %{{3}}>>
+;         %{{_}}: ?ty<<4 x i32>> = unimplemented <<  %{{15}} = add <4 x i32> %{{44}}, %{{44}}>>
 ;         br bb3
 ;      bb3:
-;         unimplemented <<  %{{17}} = call i32 @f(i32 swiftself 5)>>
-;         unimplemented <<  %{{18}} = call inreg i32 @f(i32 5)>>
-;         unimplemented <<  %{{19}} = call i32 @f(i32 5) #{{0}}>>
-;         unimplemented <<  %{{20}} = call nnan float @g()>>
-;         unimplemented <<  %{{21}} = call ghccc i32 @f(i32 5)>>
-;         unimplemented <<  %{{22}} = call i32 @f(i32 5) [ "kcfi"(i32 1234) ]>>
-;         unimplemented <<  %{{23}} = call addrspace(6) ptr @p()>>
+;         %{{_}}: i32 = unimplemented <<  %{{17}} = call i32 @f(i32 swiftself 5)>>
+;         %{{_}}: i32 = unimplemented <<  %{{18}} = call inreg i32 @f(i32 5)>>
+;         %{{_}}: i32 = unimplemented <<  %{{19}} = call i32 @f(i32 5) #{{0}}>>
+;         %{{_}}: float = unimplemented <<  %{{20}} = call nnan float @g()>>
+;         %{{_}}: i32 = unimplemented <<  %{{21}} = call ghccc i32 @f(i32 5)>>
+;         %{{_}}: i32 = unimplemented <<  %{{22}} = call i32 @f(i32 5) [ "kcfi"(i32 1234) ]>>
+;         %{{_}}: ptr = unimplemented <<  %{{23}} = call addrspace(6) ptr @p()>>
 ;         br bb4
 ;      bb4:
-;         unimplemented <<  %{{25}} = ptrtoint ptr %{{ptr}} to i8>>
-;         unimplemented <<  %{{26}} = ptrtoint <8 x ptr> %{{ptrs}} to <8 x i8>>>
-;         unimplemented <<  %{{_}} = sext <4 x i32> %{{_}} to <4 x i64>>>
-;         unimplemented <<  %{{_}} = zext <4 x i32> %{{_}} to <4 x i64>>>
-;         unimplemented <<  %{{_}} = trunc <4 x i32> %{{_}} to <4 x i8>>>
+;         %{{_}}: i8 = unimplemented <<  %{{25}} = ptrtoint ptr %{{ptr}} to i8>>
+;         %{{_}}: ?ty<<8 x i8>> = unimplemented <<  %{{26}} = ptrtoint <8 x ptr> %{{ptrs}} to <8 x i8>>>
+;         %{{_}}: ?ty<<4 x i64>> = unimplemented <<  %{{_}} = sext <4 x i32> %{{_}} to <4 x i64>>>
+;         %{{_}}: ?ty<<4 x i64>> = unimplemented <<  %{{_}} = zext <4 x i32> %{{_}} to <4 x i64>>>
+;         %{{_}}: ?ty<<4 x i8>> = unimplemented <<  %{{_}} = trunc <4 x i32> %{{_}} to <4 x i8>>>
 ;         br bb5
 ;     bb5:
-;         unimplemented <<  %{{27}} = icmp ne <4 x i32> %{{444}}, zeroinitializer>>
+;         %{{_}}: ?ty<<4 x i1>> = unimplemented <<  %{{27}} = icmp ne <4 x i32> %{{444}}, zeroinitializer>>
 ;         br bb6
 ;     bb6:
-;         unimplemented <<  %{{_}} = load atomic i32, ptr %{{_}} acquire, align 4>>
-;         unimplemented <<  %{{_}} = load i32, ptr addrspace(10) %{{_}}, align 4>>
-;         unimplemented <<  %{{_}} = load i32, ptr %{{_}}, align 2>>
+;         %{{_}}: i32 = unimplemented <<  %{{_}} = load atomic i32, ptr %{{_}} acquire, align 4>>
+;         %{{_}}: i32 = unimplemented <<  %{{_}} = load i32, ptr addrspace(10) %{{_}}, align 4>>
+;         %{{_}}: i32 = unimplemented <<  %{{_}} = load i32, ptr %{{_}}, align 2>>
 ;         br ...
 ;         ...
 ;     bb10:
-;       unimplemented <<  %{{_}} = phi nnan float...
+;       %{{_}}: float = unimplemented <<  %{{_}} = phi nnan float...
 ;       br bb11
 ;     bb11:
 ;       unimplemented <<  store atomic i32 0, ptr %0 release, align 4>>


### PR DESCRIPTION
Requires https://github.com/ykjit/ykllvm/pull/186

When trying to debug something, I realised that the AOT module printer can crash under certain circumstances involving unimplemented instructions.

Some instructions decide their type by asking for the type if their operands. If that operand is an unimplemented instruction then `def_type()` returns `None` and this can crash the IR printer.

This change makes unimplemented instructions define a value of the correct type, thus making the module at least "type consistent".