### PR TITLE
Pass live variables into trace via registers and stack.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -7,6 +7,7 @@
 //! other crates are regular `rlibs`.
 
 #![allow(clippy::missing_safety_doc)]
+#![feature(naked_functions)]
 
 use std::{
     ffi::{c_char, c_void, CString},
@@ -48,11 +49,53 @@ pub extern "C" fn yk_mt_control_point(_mt: *mut MT, _loc: *mut Location) {
     // Intentionally empty.
 }
 
-// The "real" control point, that is called once the interpreter has been patched by ykllvm.
-// Returns the address of a reconstructed stack or null if there wasn't a guard failure.
+// The new control point called after the interpreter has been patched by ykllvm.
+#[cfg(target_arch = "x86_64")]
+#[naked]
+#[no_mangle]
+pub extern "C" fn __ykrt_control_point(
+    mt: *const MT,
+    loc: *mut Location,
+    ctrlp_vars: *mut c_void,
+    // Frame address of caller.
+    frameaddr: *mut c_void,
+    // Stackmap id for the control point.
+    smid: u64,
+) {
+    // FIXME: We can possibly avoid the below (and this entire function) by patching the return
+    // address of the control point on the stack to point to the compiled trace. This means we
+    // still run the epilogue of the control point function call, which automatically restores the
+    // callee-saved registers for us (so we don't have to do it here).
+    unsafe {
+        std::arch::asm!(
+            // Push callee-saved registers to the stack as these may contain trace inputs (live
+            // variables) referenced by the control point's stackmap.
+            "push rbx",
+            "push rdi",
+            "push rsi",
+            "push r12",
+            "push r13",
+            "push r14",
+            "push r15",
+            "call __ykrt_control_point_real",
+            // Restore the previously pushed registers.
+            "pop r15",
+            "pop r14",
+            "pop r13",
+            "pop r12",
+            "pop rsi",
+            "pop rdi",
+            "pop rbx",
+            "ret",
+            options(noreturn)
+        );
+    }
+}
+
+// The actual control point, after we have pushed the callee-saved registers.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn __ykrt_control_point(
+pub extern "C" fn __ykrt_control_point_real(
     mt: *const MT,
     loc: *mut Location,
     ctrlp_vars: *mut c_void,

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -1698,33 +1698,6 @@ pub(crate) struct StructTy {
 }
 
 impl StructTy {
-    /// Returns the type index of the specified field index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the index is out of bounds.
-    pub(crate) fn field_tyidx(&self, idx: usize) -> TyIdx {
-        self.field_tyidxs[idx]
-    }
-
-    /// Returns the byte offset of the specified field index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the field is not byte-aligned or the index is out of bounds.
-    pub(crate) fn field_byte_off(&self, idx: usize) -> usize {
-        let bit_off = self.field_bit_offs[idx];
-        if bit_off % 8 != 0 {
-            todo!();
-        }
-        bit_off / 8
-    }
-
-    /// Returns the number of fields in the struct.
-    pub(crate) fn num_fields(&self) -> usize {
-        self.field_tyidxs.len()
-    }
-
     pub(crate) fn display<'a>(&'a self, m: &'a Module) -> DisplayableStructTy<'a> {
         DisplayableStructTy {
             struct_type: self,

--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc/mod.rs
@@ -4,6 +4,8 @@
 //!  - describes the generic interface to register allocators.
 //!  - contains concrete implementations of register allocators.
 
+use dynasmrt::x64::{Rq, Rx};
+
 /// Where is an SSA variable stored?
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum VarLocation {
@@ -14,13 +16,33 @@ pub(crate) enum VarLocation {
         /// Size in bytes of the allocation.
         size: usize,
     },
+    /// The SSA variable is a stack pointer with the value `RBP-frame_off`.
+    Direct {
+        /// The offset from the base of the trace's function frame.
+        frame_off: i32,
+        /// Size in bytes of the allocation.
+        size: usize,
+    },
+    /// The SSA variable is behind a pointer that's stored on the stack: `[RBP-frame_off]`.
+    Indirect {
+        /// The offset from the base of the trace's function frame.
+        frame_off: i32,
+        /// Size in bytes of the allocation.
+        size: usize,
+    },
     /// The SSA variable is in a register.
-    Register,
+    Register(Register),
     /// A constant integer `bits` wide (see [jit_ir::Const::ConstInt] for the constraints on the
     /// bit width) and with value `v`.
     ConstInt { bits: u32, v: u64 },
     /// A constant float.
     ConstFloat(f64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum Register {
+    GP(Rq), // general purpose
+    FP(Rx), // floating point
 }
 
 /// Indicates the direction of stack growth.

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
@@ -1077,6 +1077,14 @@ impl RegSet<Rq> {
             Some(GP_REGS[usize::try_from(15 - (!x).leading_zeros()).unwrap()])
         }
     }
+
+    pub(crate) fn from_vec(regs: &[Rq]) -> Self {
+        let mut s = Self::blank();
+        for reg in regs {
+            s.set(*reg);
+        }
+        s
+    }
 }
 
 impl From<Rq> for RegSet<Rq> {

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -13,7 +13,7 @@ use super::{
         jit_ir::{self, BinOp, FloatTy, Inst, InstIdx, Module, Operand, Ty},
         CompilationError,
     },
-    reg_alloc::{StackDirection, VarLocation},
+    reg_alloc::{self, StackDirection, VarLocation},
     CodeGen,
 };
 #[cfg(any(debug_assertions, test))]
@@ -81,6 +81,17 @@ static ARG_FP_REGS: [Rx; 8] = [
     Rx::XMM7,
 ];
 
+/// Registers used by stackmaps to store live variables.
+static STACKMAP_GP_REGS: [Rq; 7] = [
+    Rq::RBX,
+    Rq::R12,
+    Rq::R13,
+    Rq::R14,
+    Rq::R15,
+    Rq::RSI,
+    Rq::RDI,
+];
+
 /// The argument index of the live variables struct argument in the JITted code function.
 static JITFUNC_LIVEVARS_ARGIDX: usize = 0;
 
@@ -138,6 +149,7 @@ struct Assemble<'a> {
     asm: dynasmrt::x64::Assembler,
     /// Deopt info, with one entry per guard, in the order that the guards appear in the trace.
     deoptinfo: Vec<DeoptInfo>,
+    ///
     /// Maps assembly offsets to comments.
     ///
     /// Comments used by the trace printer for debugging and testing only.
@@ -332,7 +344,6 @@ impl<'a> Assemble<'a> {
             jit_ir::Inst::IndirectCall(i) => self.cg_indirectcall(iidx, i)?,
             jit_ir::Inst::ICmp(i) => self.cg_icmp(iidx, i),
             jit_ir::Inst::Guard(i) => self.cg_guard(iidx, i),
-            jit_ir::Inst::Arg(i) => self.cg_arg(iidx, *i),
             jit_ir::Inst::TraceLoopStart => self.cg_traceloopstart(),
             jit_ir::Inst::SExt(i) => self.cg_sext(iidx, i),
             jit_ir::Inst::ZeroExtend(i) => self.cg_zeroextend(iidx, i),
@@ -367,13 +378,12 @@ impl<'a> Assemble<'a> {
 
         // Start a frame for the JITted code.
         dynasm!(self.asm
-            ; push rbp
-            ; mov rbp, rsp
             // Save pointers to ctrlp_vars and frameaddr for later use.
             ; push rdi
             ; push rsi
-            // Reset the basepointer so the spill allocator doesn't overwrite the two values we
-            // just pushed.
+            // Save base pointer which we use to access the parent stack.
+            ; push rbp
+            // Reset base pointer.
             ; mov rbp, rsp
         );
 
@@ -737,44 +747,78 @@ impl<'a> Assemble<'a> {
 
     fn cg_loadtraceinput(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::LoadTraceInputInst) {
         // Find the argument register containing the pointer to the live variables struct.
-        let base_reg = ARG_GP_REGS[JITFUNC_LIVEVARS_ARGIDX];
         match self.m.type_(inst.tyidx()) {
             Ty::Integer(_) | Ty::Ptr => {
                 let [tgt_reg] = self.ra.get_gp_regs_avoiding(
                     &mut self.asm,
                     iidx,
                     [RegConstraint::Output],
-                    RegSet::from(base_reg),
+                    RegSet::from_vec(&STACKMAP_GP_REGS),
                 );
-                let off = i32::try_from(inst.off()).unwrap();
                 let size = self.m.inst_no_proxies(iidx).def_byte_size(self.m);
                 debug_assert!(size <= REG64_SIZE);
-                match size {
-                    1 => {
-                        dynasm!(self.asm ; movzx Rq(tgt_reg.code()), BYTE [Rq(base_reg.code()) + off])
+
+                match self.m.tilocs()[usize::try_from(inst.locidx()).unwrap()] {
+                    VarLocation::Register(reg_alloc::Register::GP(reg)) => {
+                        // FIXME: Map this iidx to `reg` without this `mov`. Requires way to
+                        // initialise register allocator with existing values.
+                        dynasm!(self.asm; mov Rq(tgt_reg.code()), Rq(reg.code()));
                     }
-                    2 => {
-                        dynasm!(self.asm ; movzx Rq(tgt_reg.code()), WORD [Rq(base_reg.code()) + off])
+                    VarLocation::Register(reg_alloc::Register::FP(_)) => {
+                        // The value is a integer and thus can't be stored in a float register.
+                        panic!()
                     }
-                    4 => dynasm!(self.asm ; mov Rd(tgt_reg.code()), [Rq(base_reg.code()) + off]),
-                    8 => dynasm!(self.asm ; mov Rq(tgt_reg.code()), [Rq(base_reg.code()) + off]),
-                    _ => todo!("{}", size),
-                };
+                    VarLocation::Direct { frame_off, size } => {
+                        // FIXME If we prime the register allocator with the interpreter frames
+                        // stack size and don't create a new frame in the trace epilogue we can
+                        // reference values directly using the current RBP value.
+                        dynasm!(self.asm; mov Rq(tgt_reg.code()), QWORD [Rq(Rq::RBP.code())]);
+                        match size {
+                            8 => {
+                                dynasm!(self.asm; lea Rq(tgt_reg.code()), [Rq(tgt_reg.code()) + frame_off])
+                            }
+                            _ => todo!(),
+                        }
+                    }
+                    VarLocation::Indirect { frame_off, size } => {
+                        dynasm!(self.asm; mov Rq(tgt_reg.code()), QWORD [Rq(Rq::RBP.code())]);
+                        match size {
+                            8 => {
+                                dynasm!(self.asm; mov Rq(tgt_reg.code()), [Rq(tgt_reg.code()) + frame_off])
+                            }
+                            _ => todo!(),
+                        }
+                    }
+                    _ => panic!(),
+                }
             }
-            Ty::Float(fty) => {
+            Ty::Float(_fty) => {
+                // FIXME: Work out which registers are used by stackmaps and avoid them.
                 let [tgt_reg] = self
                     .ra
                     .get_fp_regs(&mut self.asm, iidx, [RegConstraint::Output]);
-                let off = i32::try_from(inst.off()).unwrap();
                 let size = self.m.inst_no_proxies(iidx).def_byte_size(self.m);
                 debug_assert!(size <= REG64_SIZE);
-                match fty {
-                    FloatTy::Float => {
-                        dynasm!(self.asm; movss Rx(tgt_reg.code()), [Rq(base_reg.code()) + off])
+
+                match self.m.tilocs()[usize::try_from(inst.locidx()).unwrap()] {
+                    VarLocation::Register(reg_alloc::Register::FP(reg)) => {
+                        // FIXME: Map this iidx to `reg` without this `mov`. Requires way to
+                        // initialise register allocator with existing values.
+                        dynasm!(self.asm; movss Rx(tgt_reg.code()), Rx(reg.code()));
                     }
-                    FloatTy::Double => {
-                        dynasm!(self.asm; movsd Rx(tgt_reg.code()), [Rq(base_reg.code()) + off])
+                    VarLocation::Register(reg_alloc::Register::GP(_)) => {
+                        // The value is a float and thus can't be stored in a normal register.
+                        panic!()
                     }
+                    VarLocation::Direct { .. } => {
+                        // The value is a pointer and thus can't be of type float.
+                        panic!()
+                    }
+                    VarLocation::Indirect { .. } => {
+                        // The value is a pointer and thus can't be of type float.
+                        panic!()
+                    }
+                    _ => panic!(),
                 }
             }
             Ty::Func(_) | Ty::Void | Ty::Unimplemented(_) => unreachable!(),
@@ -1145,13 +1189,6 @@ impl<'a> Assemble<'a> {
                 );
             }
         }
-    }
-
-    fn cg_arg(&mut self, iidx: InstIdx, idx: u16) {
-        // For arguments passed into the trace function we simply inform the register allocator
-        // where they are stored and let the allocator take things from there.
-        self.ra
-            .assign_gp_reg_to_inst(ARG_GP_REGS[usize::from(idx)], iidx);
     }
 
     fn cg_traceloopstart(&mut self) {
@@ -1830,7 +1867,7 @@ mod tests {
             "
               entry:
                 %0: ptr = load_ti 0
-                %1: i32 = load_ti 8
+                %1: i32 = load_ti 1
                 %2: ptr = dyn_ptr_add %0, %1, 32
             ",
             "
@@ -1850,14 +1887,14 @@ mod tests {
             "
               entry:
                 %0: ptr = load_ti 0
-                %1: ptr = load_ti 8
+                %1: ptr = load_ti 1
                 *%1 = %0
             ",
             "
                 ...
-                ; %0: ptr = load_ti 0
+                ; %0: ptr = load_ti ...
                 {{_}} {{_}}: mov r.64.x, ...
-                ; %1: ptr = load_ti 8
+                ; %1: ptr = load_ti ...
                 {{_}} {{_}}: mov r.64.y, ...
                 ; *%1 = %0
                 {{_}} {{_}}: mov [r.64.y], r.64.x
@@ -1875,8 +1912,8 @@ mod tests {
             ",
             "
                 ...
-                ; %0: i8 = load_ti 0
-                {{_}} {{_}}: movzx r.64.x, byte ptr ...
+                ; %0: i8 = load_ti ...
+                {{_}} {{_}}: mov r.64.x, rbx
                 ...
                 ",
         );
@@ -1887,12 +1924,12 @@ mod tests {
         codegen_and_test(
             "
               entry:
-                %0: i16 = load_ti 32
+                %0: i16 = load_ti 0
             ",
             "
                 ...
-                ; %0: i16 = load_ti 32
-                {{_}} {{_}}: movzx r.64.x, word ptr ...
+                ; %0: i16 = load_ti ...
+                {{_}} {{_}}: mov r.64.x, rbx
                 ...
                 ",
         );
@@ -1966,8 +2003,8 @@ mod tests {
 
               entry:
                 %0: i32 = load_ti 0
-                %1: i32 = load_ti 4
-                %2: i32 = load_ti 8
+                %1: i32 = load_ti 1
+                %2: i32 = load_ti 2
                 call @puts(%0, %1, %2)
             ",
             &format!(
@@ -1975,9 +2012,10 @@ mod tests {
                 ...
                 ; call @puts(%0, %1, %2)
                 {{{{_}}}} {{{{_}}}}: mov r12, 0x{sym_addr:X}
-                {{{{_}}}} {{{{_}}}}: mov edi, r.32.x
-                {{{{_}}}} {{{{_}}}}: mov esi, r.32.y
-                {{{{_}}}} {{{{_}}}}: mov edx, r.32.z
+                ...
+                {{{{_}}}} {{{{_}}}}: mov edi, [rbp-...
+                {{{{_}}}} {{{{_}}}}: mov esi, [rbp-...
+                {{{{_}}}} {{{{_}}}}: mov edx, [rbp-...
                 {{{{_}}}} {{{{_}}}}: call r12
                 ...
             "
@@ -1994,11 +2032,11 @@ mod tests {
 
               entry:
                 %0: i8 = load_ti 0
-                %1: i16 = load_ti 8
-                %2: i32 = load_ti 16
-                %3: i64 = load_ti 24
-                %4: ptr = load_ti 32
-                %5: i8 = load_ti 40
+                %1: i16 = load_ti 1
+                %2: i32 = load_ti 2
+                %3: i64 = load_ti 3
+                %4: ptr = load_ti 4
+                %5: i8 = load_ti 5
                 call @puts(%0, %1, %2, %3, %4, %5)
             ",
             &format!(
@@ -2007,9 +2045,9 @@ mod tests {
                 ; call @puts(%0, %1, %2, %3, %4, %5)
                 {{{{_}}}} {{{{_}}}}: mov r12, 0x{sym_addr:X}
                 ...
-                {{{{_}}}} {{{{_}}}}: movzx rdi, r.8.x
-                {{{{_}}}} {{{{_}}}}: movzx rsi, r.16.y
-                {{{{_}}}} {{{{_}}}}: mov edx, r.32.z
+                {{{{_}}}} {{{{_}}}}: movzx rdi, byte ptr [rbp-...
+                {{{{_}}}} {{{{_}}}}: movzx rsi, word ptr [rbp-...
+                {{{{_}}}} {{{{_}}}}: mov edx, [rbp-...
                 {{{{_}}}} {{{{_}}}}: mov rcx, [rbp-0x18]
                 {{{{_}}}} {{{{_}}}}: mov r8, [rbp-0x10]
                 {{{{_}}}} {{{{_}}}}: movzx r9, byte ptr [rbp-0x01]
@@ -2191,7 +2229,7 @@ mod tests {
             ",
             "
                 ...
-                ; %0: i8 = load_ti 0
+                ; %0: i8 = load_ti ...
                 ...
                 ; tloop_start:
                 ; %2: i8 = add %0, %0
@@ -2233,10 +2271,10 @@ mod tests {
             ",
             "
                 ...
-                ; %0: i32 = load_ti 0
+                ; %0: i32 = load_ti ...
                 ...
                 ; %1: i8 = trunc %0
-                ... mov [rbp-0x04], r15d
+                {{_}} {{_}}: mov [rbp-0x04], r.32.x
                 ...
             ",
         );
@@ -2253,10 +2291,10 @@ mod tests {
             "
                 ...
                 ; %1: i32 = %0 ? 1i32 : 2i32
-                {{_}} {{_}}: mov r14d, 0x01
-                {{_}} {{_}}: mov r13d, 0x02
-                {{_}} {{_}}: cmp r15b, 0x00
-                {{_}} {{_}}: cmovz r14, r13
+                {{_}} {{_}}: mov r.32.x, 0x01
+                {{_}} {{_}}: mov r.32.y, 0x02
+                {{_}} {{_}}: cmp r.8.z, 0x00
+                {{_}} {{_}}: cmovz r.64.x, r.64.y
                 ...
             ",
         );
@@ -2387,8 +2425,8 @@ mod tests {
             ",
             "
                 ...
-                ; %0: float = load_ti 0
-                {{_}} {{_}}: movss fp.128.x, dword ptr ...
+                ; %0: float = load_ti ...
+                {{_}} {{_}}: movss fp.128.x, xmm0
                 ; %1: double = fp_ext %0
                 {{_}} {{_}}: movss [rbp-{{0x04}}], fp.128.x
                 {{_}} {{_}}: cvtss2sd fp.128.x, fp.128.x

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -44,7 +44,7 @@ mod test {
             "
           ...
           entry:
-            %1: i8 = load_ti 1
+            %1: i8 = load_ti Register(GP(RBX))
             black_box %1
         ",
         );
@@ -64,7 +64,7 @@ mod test {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
+            %0: i8 = load_ti Register(GP(RBX))
             %2: i8 = add %0, %0
             black_box %2
         ",
@@ -86,8 +86,8 @@ mod test {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
-            %1: i8 = load_ti 1
+            %0: i8 = load_ti Register(GP(RBX))
+            %1: i8 = load_ti Register(GP(RBX))
             %3: i8 = add %1, %0
             black_box %3
         ",
@@ -109,7 +109,7 @@ mod test {
             "
           ...
           entry:
-            %1: i8 = load_ti 1
+            %1: i8 = load_ti Register(GP(RBX))
             %3: i1 = ult %1, %1
             black_box %3
         ",
@@ -130,7 +130,7 @@ mod test {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
+            %0: i8 = load_ti Register(GP(RBX))
             %1: i1 = ult %0, 1i8
             guard true, %1, []
             black_box %1
@@ -152,7 +152,7 @@ mod test {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
+            %0: i8 = load_ti Register(GP(RBX))
             call @f(%0)
         ",
         );
@@ -163,7 +163,7 @@ mod test {
           entry:
             %0: ptr = load_ti 0
             %1: i8 = load_ti 1
-            %2: i8 = load_ti 1
+            %2: i8 = load_ti 2
             icall<t1> %0(%1)
         ",
             |mut m| {
@@ -173,8 +173,8 @@ mod test {
             "
           ...
           entry:
-            %0: ptr = load_ti 0
-            %1: i8 = load_ti 1
+            %0: ptr = load_ti Register(GP(RBX))
+            %1: i8 = load_ti Register(GP(RBX))
             icall %0(%1)
         ",
         );

--- a/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
+++ b/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
@@ -81,7 +81,7 @@ Inst -> Result<ASTInst, Box<dyn Error>>:
       Ok(ASTInst::Guard{operand: $4?, is_true: false, live_vars: $7?})
     }
   | "LOCAL_OPERAND" ":" Type "=" "LOAD_TI" "UINT" {
-      Ok(ASTInst::LoadTraceInput{assign: $1?.span(), type_: $3?, off: $6?.span()})
+      Ok(ASTInst::LoadTraceInput{assign: $1?.span(), type_: $3?, tiidx: $6?.span()})
     }
   | "LOCAL_OPERAND" ":" Type "=" BinOp Operand "," Operand  {
       Ok(ASTInst::BinOp{assign: $1?.span(), type_: $3?, bin_op: $5?, lhs: $6?, rhs: $8?})

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -187,8 +187,8 @@ mod tests {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
-            %1: i8 = load_ti 1
+            %0: i8 = load_ti Register(GP(RBX))
+            %1: i8 = load_ti Register(GP(RBX))
             %3: i8 = add %1, 0i8
             %5: i8 = add %1, 0i8
         ",
@@ -211,8 +211,8 @@ mod tests {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
-            %1: i8 = load_ti 1
+            %0: i8 = load_ti Register(GP(RBX))
+            %1: i8 = load_ti Register(GP(RBX))
             %3: i8 = add %1, %0
             %5: i8 = add %1, %0
         ",
@@ -234,7 +234,7 @@ mod tests {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
+            %0: i8 = load_ti Register(GP(RBX))
             black_box 0i8
         ",
         );
@@ -255,7 +255,7 @@ mod tests {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
+            %0: i8 = load_ti Register(GP(RBX))
             %1: i8 = mul %0, 3i8
             %2: i8 = mul %0, 12i8
             %3: i8 = mul %0, 60i8
@@ -280,7 +280,7 @@ mod tests {
             "
           ...
           entry:
-            %0: i64 = load_ti 0
+            %0: i64 = load_ti Register(GP(RBX))
             %1: i64 = shl %0, 1i64
             %2: i64 = shl %0, 2i64
             %3: i64 = shl %0, 62i64
@@ -421,7 +421,7 @@ mod tests {
             "
           ...
           entry:
-            %0: i8 = load_ti 0
+            %0: i8 = load_ti Register(GP(RBX))
             black_box %0
         ",
         );

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -3,14 +3,18 @@
 //! This takes in an (AOT IR, execution trace) pair and constructs a JIT IR trace from it.
 
 use super::aot_ir::{self, BBlockId, BinOp, FuncIdx, Module};
+use super::codegen::reg_alloc::{Register, VarLocation};
 use super::jit_ir::{self, Const};
 use super::YkSideTraceInfo;
+use crate::aotsmp::AOT_STACKMAPS;
 use crate::compile::CompilationError;
 use crate::trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction};
 use std::{collections::HashMap, ffi::CString, sync::Arc};
 
+// FIXME: Can we avoid a dynasm dependency here?
+use dynasmrt::x64::Rq;
+
 /// The argument index of the trace inputs struct in the trace function.
-const TRACE_FUNC_CTRLP_ARGIDX: u16 = 0;
 const U64SIZE: usize = 8;
 
 /// A TraceBuilder frame. Keeps track of inlined calls and stores information about the last
@@ -113,7 +117,7 @@ impl TraceBuilder {
     /// Create the prolog of the trace.
     fn create_trace_header(
         &mut self,
-        blk: &aot_ir::BBlock,
+        blk: &'static aot_ir::BBlock,
         is_sidetrace: bool,
     ) -> Result<(), CompilationError> {
         // Find trace input variables and emit `LoadTraceInput` instructions for them.
@@ -127,15 +131,81 @@ impl TraceBuilder {
         for (_, inst) in inst_iter.by_ref() {
             // Is it a call to the control point? If so, extract the live vars struct.
             if let Some(tis) = inst.control_point_call_trace_inputs(self.aot_mod) {
+                // FIXME Safepoint id should be an integer not Operand.
+                let safepoint = inst.safepoint().unwrap();
+                let aot_ir::Operand::Const(cidx) = safepoint.id else {
+                    panic!();
+                };
+                let c = self.aot_mod.const_(cidx);
+                let aot_ir::Ty::Integer(ity) = self.aot_mod.const_type(c) else {
+                    panic!();
+                };
+                assert!(ity.num_bits() == u64::BITS);
+                let id = u64::from_ne_bytes(c.unwrap_val().bytes()[0..8].try_into().unwrap());
+                let (rec, _) = AOT_STACKMAPS
+                    .as_ref()
+                    .unwrap()
+                    .get(usize::try_from(id).unwrap());
+
+                debug_assert!(safepoint.lives.len() == rec.live_vars.len());
+                for idx in 0..safepoint.lives.len() {
+                    let aot_op = &safepoint.lives[idx];
+                    let input_tyidx = self.handle_type(aot_op.type_(self.aot_mod))?;
+                    let load_ti_inst =
+                        jit_ir::LoadTraceInputInst::new(u32::try_from(idx).unwrap(), input_tyidx)
+                            .into();
+                    self.jit_mod.push(load_ti_inst)?;
+
+                    // Get the location for this input variable.
+                    let var = &rec.live_vars[idx];
+                    if var.len() > 1 {
+                        todo!();
+                    }
+                    let vl = match var.get(0).unwrap() {
+                        yksmp::Location::Register(3, ..) => {
+                            VarLocation::Register(Register::GP(Rq::RBX))
+                        }
+                        yksmp::Location::Register(4, ..) => {
+                            VarLocation::Register(Register::GP(Rq::RSI))
+                        }
+                        yksmp::Location::Register(5, ..) => {
+                            VarLocation::Register(Register::GP(Rq::RDI))
+                        }
+                        yksmp::Location::Register(12, ..) => {
+                            VarLocation::Register(Register::GP(Rq::R12))
+                        }
+                        yksmp::Location::Register(13, ..) => {
+                            VarLocation::Register(Register::GP(Rq::R13))
+                        }
+                        yksmp::Location::Register(14, ..) => {
+                            VarLocation::Register(Register::GP(Rq::R14))
+                        }
+                        yksmp::Location::Register(15, ..) => {
+                            VarLocation::Register(Register::GP(Rq::R15))
+                        }
+                        yksmp::Location::Direct(6, off, size) => VarLocation::Direct {
+                            frame_off: *off,
+                            size: usize::from(*size),
+                        },
+                        yksmp::Location::Indirect(6, off, size) => VarLocation::Indirect {
+                            frame_off: *off,
+                            size: usize::from(*size),
+                        },
+                        e => {
+                            todo!("{:?}", e);
+                        }
+                    };
+                    self.jit_mod.push_tiloc(vl);
+
+                    // If this take fails, we didn't see a corresponding store and the
+                    // IR is malformed.
+                    self.local_map.insert(
+                        aot_op.to_inst_id(),
+                        jit_ir::Operand::Local(self.jit_mod.last_inst_idx()),
+                    );
+                }
+
                 trace_inputs = Some(tis.to_inst(self.aot_mod));
-                let arg = jit_ir::Inst::Arg(TRACE_FUNC_CTRLP_ARGIDX);
-                self.jit_mod.push(arg)?;
-                // Add the trace input argument to the local map so it can be tracked and
-                // deoptimised.
-                self.local_map.insert(
-                    tis.to_inst_id(),
-                    jit_ir::Operand::Local(self.jit_mod.last_inst_idx()),
-                );
                 break;
             }
         }
@@ -143,28 +213,14 @@ impl TraceBuilder {
         // If this unwrap fails, we didn't find the call to the control point and something is
         // profoundly wrong with the AOT IR.
         let trace_inputs = trace_inputs.unwrap();
-        let trace_input_struct_ty = match trace_inputs {
-            aot_ir::Inst::Alloca { tyidx, .. } => {
-                let aot_ir::Ty::Struct(x) = self.aot_mod.type_(*tyidx) else {
-                    panic!()
-                };
-                x
-            }
-            _ => panic!(), // IR malformed.
-        };
-
-        // We visit the trace inputs in reverse order, so we start with high indices first. This
-        // value then decrements in the below loop.
-        let mut trace_input_idx = trace_input_struct_ty.num_fields();
 
         // PHASE 2:
         // Keep walking backwards over the ptradd/store pairs emitting LoadTraceInput instructions.
         //
         // FIXME: Can we do something at IR lowering time to make this easier?
-        let mut last_store_ptr = None;
         for (iidx, inst) in inst_iter {
             match inst {
-                aot_ir::Inst::Store { val, .. } => last_store_ptr = Some(val),
+                aot_ir::Inst::Store { .. } => {}
                 aot_ir::Inst::PtrAdd { ptr, .. } => {
                     // Is the pointer operand of this PtrAdd targeting the trace inputs?
                     if trace_inputs.ptr_eq(ptr.to_inst(self.aot_mod)) {
@@ -174,27 +230,6 @@ impl TraceBuilder {
                         //
                         // Note: This code assumes that the `PtrAdd` instructions in the AOT IR were
                         // emitted sequentially.
-                        trace_input_idx -= 1;
-                        // FIXME: assumes the field is byte-aligned. If it isn't, field_byte_off() will
-                        // crash.
-                        let aot_field_off = trace_input_struct_ty.field_byte_off(trace_input_idx);
-                        let aot_field_ty = trace_input_struct_ty.field_tyidx(trace_input_idx);
-                        // FIXME: we should check at compile-time that this will fit.
-                        let aot_field_off = u32::try_from(aot_field_off).unwrap();
-                        let input_tyidx = self.handle_type(self.aot_mod.type_(aot_field_ty))?;
-                        let load_ti_inst =
-                            jit_ir::LoadTraceInputInst::new(aot_field_off, input_tyidx).into();
-                        // We don't need to insert these loads when we are side-tracing,
-                        // since side-tracing handles inputs separately.
-                        if !is_sidetrace {
-                            self.jit_mod.push(load_ti_inst)?;
-                            // If this take fails, we didn't see a corresponding store and the
-                            // IR is malformed.
-                            self.local_map.insert(
-                                last_store_ptr.take().unwrap().to_inst_id(),
-                                jit_ir::Operand::Local(self.jit_mod.last_inst_idx()),
-                            );
-                        }
                         self.first_ti_idx = iidx;
                     }
                 }


### PR DESCRIPTION
This change gets rids of our reliance on the big trace inputs structs in order to pass live variables into a trace. Instead we place the trace frame right next to the main interpreter frame and load live variables directly from registers or the parent frame's stack.

There's is still some unnecessary moving of live variables at the beginning of the trace, since we currently can't set the live variable locations directly in the register allocator (e.g. we would like to say to the register allocator: this live variable lives in the parent stack frame at offset X). But this shouldn't be hard to fix in a future PR.

We also had to temporarily disable side-tracing (by setting the default threshold really high) as fixing this would have made this change even bigger than it already is. We will rectify this immediately in a follow-up PR.

Some crude experiments show this gives us a decent 25% speed-up. This will likely be higher once we remove the (now no longer required) trace inputs struct construction from ykllvm (also in a follow-up PR).

We can also reduce the amount of spills (and spill reloads) before (and after) each control point call, by naturally returning from the control point and jumping into the trace by overwriting the control-points return address (yet another follow-up PR).