### PR TITLE
Minimally fix software tracing for the new codegen.

### DIFF
--- a/tests/c/aot_debuginfo.newcg.c
+++ b/tests/c/aot_debuginfo.newcg.c
@@ -1,4 +1,5 @@
-// ignore-if: test $YK_CARGO_PROFILE != "debug"
+// ## FIXME: crashes under SWT
+// ignore-if: test $YK_CARGO_PROFILE != "debug" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/switch_many_guards_failing.newcg.c
+++ b/tests/c/switch_many_guards_failing.newcg.c
@@ -1,3 +1,5 @@
+// ## FIXME: crashes under SWT
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_JITSTATE=-

--- a/tests/c/switch_nested_guard.newcg.c
+++ b/tests/c/switch_nested_guard.newcg.c
@@ -1,3 +1,5 @@
+// ## FIXME: crashes under SWT
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stdout:

--- a/tests/c/truncate.newcg.c
+++ b/tests/c/truncate.newcg.c
@@ -1,6 +1,9 @@
 // ## Truncation currently always truncates to i32, no matter the target type.
 // ##ignore-if: true
 // ## ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ##
+// ## FIXME: crashes under SWT
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_JITSTATE=-

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -184,6 +184,11 @@ impl Module {
         &self.funcs[idx]
     }
 
+    #[cfg(tracer_swt)]
+    pub(crate) fn funcs(&self) -> &TiVec<FuncIdx, Func> {
+        &self.funcs
+    }
+
     /// Lookup a global variable declaration by its index.
     ///
     /// # Panics

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -37,7 +37,7 @@ static YKD_OPT: LazyLock<bool> = LazyLock::new(|| {
     }
 });
 
-static AOT_MOD: LazyLock<aot_ir::Module> = LazyLock::new(|| {
+pub(crate) static AOT_MOD: LazyLock<aot_ir::Module> = LazyLock::new(|| {
     let ir_slice = yk_ir_section().unwrap();
     aot_ir::deserialise_module(ir_slice).unwrap()
 });

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -3,10 +3,9 @@
 use super::{
     AOTTraceIterator, AOTTraceIteratorError, TraceAction, TraceRecorder, TraceRecorderError, Tracer,
 };
-use crate::{
-    compile::jitc_llvm::frame::BitcodeSection,
-    mt::{MTThread, DEFAULT_TRACE_TOO_LONG},
-};
+#[cfg(jitc_llvm)]
+use crate::compile::jitc_llvm::frame::BitcodeSection;
+use crate::mt::{MTThread, DEFAULT_TRACE_TOO_LONG};
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -21,7 +20,8 @@ struct TracingBBlock {
     block_index: usize,
 }
 
-// Mapping of function indexes to function names.
+/// Mapping of function indexes to function names.
+#[cfg(jitc_llvm)]
 static FUNC_NAMES: LazyLock<HashMap<usize, CString>> = LazyLock::new(|| {
     let mut fnames = HashMap::new();
     let mut functions: *mut IRFunctionNameIndex = std::ptr::null_mut();
@@ -39,6 +39,27 @@ static FUNC_NAMES: LazyLock<HashMap<usize, CString>> = LazyLock::new(|| {
         );
     }
     fnames
+});
+
+/// Mapping of function indices to function names.
+///
+/// FIXME: We shouldn't be reaching into codegen-backend-specific stuff here. There should probably
+/// be some kind of generic codegen interface that offers this information up.
+///
+/// FIXME: We also probably don't need a whole hashmap caching owned copies of all of the function
+/// names. Looking at the sole use-site of `FUNC_NAMES`, I reckon that (once the LLVM backend has
+/// been deleted) it would be sufficient to expose a thin wrapper around `Module::func_()` and use
+/// that for querying function names from indices.
+#[cfg(jitc_yk)]
+static FUNC_NAMES: LazyLock<HashMap<usize, CString>> = LazyLock::new(|| {
+    crate::compile::jitc_yk::AOT_MOD
+        .funcs()
+        .iter_enumerated()
+        .map(|(funcidx, func)| {
+            // unwrap cannot fail assuming that all symbols are UTF-8.
+            (usize::from(funcidx), CString::new(func.name()).unwrap())
+        })
+        .collect::<HashMap<_, _>>()
 });
 
 thread_local! {
@@ -66,6 +87,7 @@ pub extern "C" fn yk_trace_basicblock(function_index: usize, block_index: usize)
     });
 }
 
+#[cfg(jitc_llvm)]
 extern "C" {
     fn get_function_names(
         section: *const BitcodeSection,
@@ -74,6 +96,7 @@ extern "C" {
     );
 }
 
+#[cfg(jitc_llvm)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IRFunctionNameIndex {


### PR DESCRIPTION
This is extremely hacky.

I've proposed the "proper" way to do this, but it will be much easier to implement once the LLVM backend has been deleted.

Some (newish) tests fail (hitting either todo! or panic!). I've ignored them for now.

CC @Pavel-Durov 