### PR TITLE
Rethink normal logging.

### DIFF
--- a/docs/src/dev/runtime_config.md
+++ b/docs/src/dev/runtime_config.md
@@ -10,6 +10,19 @@ Variables prefixed with `YK_` allow the user to control aspects of yk's executio
 
 The following environment variables are available:
 
+* `YK_LOG=[<path>:]<level>` specifies where, and how much, general information
+  yk will log during execution.
+
+  If `<path>:` (i.e. a path followed by ":") is specified then output is sent
+  to that path. The special value `-` (i.e. a single dash) can be used for
+  `<path>` to indicate stderr. If not specified, logs to stderr.
+
+  `<level>` specifies the level of logging: level 0 turns off all yk logging;
+  level 1 shows major errors only; level 2 warnings; and level 3 and above
+  being increasingly granular information about transitions within yk. Some
+  information may or may not be displayed based on compile-time options.
+  Defaults to 1.
+
 * `YK_HOT_THRESHOLD`: an integer from 0..4294967295 (both inclusive) that
   determines how many executions of a hot loop are needed before it is traced.
   Defaults to 50.
@@ -26,5 +39,4 @@ The following environment variables are available (some only in certain configur
 
 * [`YKD_LOG_IR`](understanding_traces.html#ykd_log_ir) [with the `ykd` feature]
 * [`YKD_TRACE_DEBUGINFO`](understanding_traces.html#ykd_trace_debuginfo) [with the `ykd` feature]
-* [`YKD_LOG_JITSTATE`](understanding_traces.html#ykd_log_jitstate) [with the `ykd` feature]
 * [`YKD_LOG_STATS`](profiling.html#jit-statistics)

--- a/docs/src/dev/understanding_traces.md
+++ b/docs/src/dev/understanding_traces.md
@@ -32,27 +32,3 @@ to show higher-level representations of the code in the source view.
 
 This feature relies on the use of temporary files, which (in addition to being
 slow to create) are not guaranteed to be cleaned up.
-
-
-### `YKD_LOG_JITSTATE`
-
-If the `YKD_LOG_JITSTATE=<path>` environment variable is defined, then changes
-in the "JIT state" will be appended, as they occur, to the file at `<path>` as
-they occur. The special value `-` (i.e. a single dash) can be used for `<path>`
-to indicate stderr.
-
-The JIT states written are:
-
- * `jitstate: start-tracing` is printed when the system starts tracing.
- * `jitstate: stop-tracing` is printed when the system stops tracing.
- * `jitstate: enter-jit-code` is printed when the system starts executing
-   JITted code.
- * `jitstate: exit-jit-code` is printed when the system stops executing
-   JITted code.
-
-Note that there are no `start-interpreting` and `stop-interpreting`
-notifications: if the system is not currently tracing or executing JITted code,
-then it is implicitly interpreting.
-
-This variable is only available when building `ykrt` with the `ykd` Cargo
-feature enabled.

--- a/tests/c/arithmetic.newcg.c
+++ b/tests/c/arithmetic.newcg.c
@@ -2,13 +2,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     add 5
 //     sub 3
 //     mul 12
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{1}}: i32 = add %{{2}}, %{{argc}}
@@ -20,14 +20,14 @@
 //     add 4
 //     sub 2
 //     mul 9
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     add 3
 //     sub 1
 //     mul 6
 //     add 2
 //     sub 0
 //     mul 3
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test some binary operations.

--- a/tests/c/ashr_exact.newcg.c
+++ b/tests/c/ashr_exact.newcg.c
@@ -2,21 +2,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     ashr 4
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{result}}: i64 = ashr %{{1}}, 2i64
 //     ...
 //     --- End jit-pre-opt ---
 //     ashr 3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     ashr 2
 //     ashr 1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test ashr instructions with the exact keyword.

--- a/tests/c/double.newcg.c
+++ b/tests/c/double.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 4.000000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -24,10 +24,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 3.000000
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 2.000000
 //     1 -> 1.000000
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check basic 64-bit float (double) support.
 

--- a/tests/c/doubleinline.newcg.c
+++ b/tests/c/doubleinline.newcg.c
@@ -2,13 +2,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4
 //     foo-if
 //     bar
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -24,12 +24,12 @@
 //     3
 //     foo-if
 //     bar
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2
 //     foo-if
 //     bar
 //     1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     foo-else
 //     bar
 //     0

--- a/tests/c/dyn_ptradd_mixed.newcg.c
+++ b/tests/c/dyn_ptradd_mixed.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, y=7
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{9_4}}: ptr = ptr_add @line, 4 + (%{{9_3}} * 8)
@@ -19,10 +19,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, y=6
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, y=5
 //     i=1, y=4
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check dynamic ptradd instructions work.
 

--- a/tests/c/dyn_ptradd_multidim.newcg.c
+++ b/tests/c/dyn_ptradd_multidim.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=0, elem=000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{10_13}}: ptr = ptr_add %{{0_5}}, 0 + (%{{10_8}} * 64) + (%{{10_10}} * 16) + (%{{%10_12}} * 4)
@@ -20,10 +20,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=1, elem=111
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, elem=222
 //     i=3, elem=333
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check dynamic ptradd instructions work.
 

--- a/tests/c/dyn_ptradd_simple.newcg.c
+++ b/tests/c/dyn_ptradd_simple.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, elem=14
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{9_4}}: ptr = ptr_add @array, 0 + (%{{9_3}} * 4)
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, elem=13
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, elem=12
 //     i=1, elem=11
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check dynamic ptradd instructions work.
 

--- a/tests/c/fcmp_double.newcg.c
+++ b/tests/c/fcmp_double.newcg.c
@@ -2,9 +2,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -18,9 +18,9 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     ...
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -34,7 +34,7 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that double comparisons work.
 

--- a/tests/c/fcmp_float.newcg.c
+++ b/tests/c/fcmp_float.newcg.c
@@ -2,9 +2,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -18,9 +18,9 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     ...
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -34,7 +34,7 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that 32-bit float comparisons work.
 

--- a/tests/c/float.newcg.c
+++ b/tests/c/float.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 4.000000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -26,10 +26,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 3.000000
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 2.000000
 //     1 -> 1.000000
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check basic 32-bit float support.
 

--- a/tests/c/float_binop.newcg.c
+++ b/tests/c/float_binop.newcg.c
@@ -2,12 +2,12 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 4.333300 4.840000
 //     4 -> 3.666700 3.160000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -35,12 +35,12 @@
 //     --- End jit-pre-opt ---
 //     3 -> 3.333300 3.840000
 //     3 -> 2.666700 2.160000
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 2.333300 2.840000
 //     2 -> 1.666700 1.160000
 //     1 -> 1.333300 1.840000
 //     1 -> 0.666700 0.160000
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check floating point addition works.
 

--- a/tests/c/float_consts.newcg.c
+++ b/tests/c/float_consts.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 3.350000, 4.500000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -20,10 +20,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 3.350000, 4.500000
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 3.350000, 4.500000
 //     1 -> 3.350000, 4.500000
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check 32- and 64-bit float constants work properly.
 

--- a/tests/c/float_div.newcg.c
+++ b/tests/c/float_div.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 8.000000 20.000000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -30,10 +30,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 6.000000 15.000000
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 4.000000 10.000000
 //     1 -> 2.000000 5.000000
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check floating point division works.
 

--- a/tests/c/float_mul.newcg.c
+++ b/tests/c/float_mul.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 1.333200 3.360000
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -30,10 +30,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 0.999900 2.520000
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 0.666600 1.680000
 //     1 -> 0.333300 0.840000
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check floating point multiplication works.
 

--- a/tests/c/float_store.newcg.c
+++ b/tests/c/float_store.newcg.c
@@ -2,15 +2,15 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 -> 3.252033
 //     4 -> 3.252033
 //     4 -> 3.252033
 //     4 -> 3.252033
 //     4 -> 3.252033
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -30,7 +30,7 @@
 //     3 -> 2.439024
 //     3 -> 2.439024
 //     3 -> 2.439024
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 -> 1.626016
 //     2 -> 1.626016
 //     2 -> 1.626016
@@ -41,7 +41,7 @@
 //     1 -> 0.813008
 //     1 -> 0.813008
 //     1 -> 0.813008
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check basic 32-bit float support.
 

--- a/tests/c/fp_to_si.newcg.c
+++ b/tests/c/fp_to_si.newcg.c
@@ -2,13 +2,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -28,14 +28,14 @@
 //     i=3
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
 //     i=1
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check float to signed integer conversions.
 

--- a/tests/c/icmp_ptr.newcg.c
+++ b/tests/c/icmp_ptr.newcg.c
@@ -1,13 +1,13 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
 //     ...
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     p1==p2: 1, p2==p3: 0
 //     p1==p2: 1, p2==p3: 0
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     ...
 //
 

--- a/tests/c/indirect_call.newcg.c
+++ b/tests/c/indirect_call.newcg.c
@@ -2,21 +2,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     foo 7
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{1}}: i32 = icall %{{2}}(%{{3}})
 //     ...
 //     --- End jit-pre-opt ---
 //     foo 6
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     foo 5
 //     foo 4
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Check that indirect calls work.

--- a/tests/c/inline_const.newcg.c
+++ b/tests/c/inline_const.newcg.c
@@ -2,21 +2,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     foo 3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{2}}: i32 = call @fprintf(%{{3}}, %{{4}}, 3i32)
 //     ...
 //     --- End jit-pre-opt ---
 //     foo 3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     foo 3
 //     foo 3
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Check that constant return values of inlined functions are properly mapped.

--- a/tests/c/inst_type_depends_global.newcg.c
+++ b/tests/c/inst_type_depends_global.newcg.c
@@ -2,7 +2,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/neg_ptradd.newcg.c
+++ b/tests/c/neg_ptradd.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=9
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{14_2}}: ptr = ptr_add %{{14_1}}, -{{4}}
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=9
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=9
 //     i=9
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that basic trace compilation works.
 

--- a/tests/c/neg_ptradd_dyn.newcg.c
+++ b/tests/c/neg_ptradd_dyn.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=9
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{15_4}}: ptr = ptr_add %{{15_1}}, 0 + (%{{15_3}} * {{4}})
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=9
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=9
 //     i=9
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that basic trace compilation works.
 

--- a/tests/c/neg_ptradd_dyn_ptr.newcg.c
+++ b/tests/c/neg_ptradd_dyn_ptr.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=0, deref=9
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{15_3}}: ptr = ptr_add %{{15_1}}, 0 + (%{{15_2}} * {{4}})
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=1, deref=8
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, deref=7
 //     i=3, deref=6
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that basic trace compilation works.
 

--- a/tests/c/outline.newcg.c
+++ b/tests/c/outline.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, r=10
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, r=6
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, r=3
 //     i=1, r=1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     0
 //     exit
 

--- a/tests/c/outline_recursion.newcg.c
+++ b/tests/c/outline_recursion.newcg.c
@@ -2,15 +2,15 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     0
 //     1
 //     2
 //     3
 //     4
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -25,13 +25,13 @@
 //     1
 //     2
 //     3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     0
 //     1
 //     2
 //     0
 //     1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     0
 //     exit
 

--- a/tests/c/outline_recursion_indirect.newcg.c
+++ b/tests/c/outline_recursion_indirect.newcg.c
@@ -2,15 +2,15 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     0
 //     1
 //     2
 //     3
 //     4
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -25,13 +25,13 @@
 //     1
 //     2
 //     3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     0
 //     1
 //     2
 //     0
 //     1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     0
 //     exit
 

--- a/tests/c/phi1.newcg.c
+++ b/tests/c/phi1.newcg.c
@@ -1,12 +1,12 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, val=1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{_}}: i32 = phi bb{{_}} -> 2i32, bb{{_}} -> 1i32
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=1
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, val=1
 //     i=1, val=1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that PHI nodes JIT properly.
 

--- a/tests/c/phi2.newcg.c
+++ b/tests/c/phi2.newcg.c
@@ -1,12 +1,12 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, val=6
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{23_0}}: i32 = phi bb{{bb22}} -> 100i32, bb{{bb21}} -> 6i32
@@ -24,10 +24,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=6
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, val=6
 //     i=1, val=6
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that PHI nodes JIT properly.
 

--- a/tests/c/phi3.newcg.c
+++ b/tests/c/phi3.newcg.c
@@ -1,12 +1,12 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, val=3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ..~
 //     bb{{_}}:
@@ -33,10 +33,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, val=3
 //     i=1, val=3
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that PHI nodes JIT properly.
 

--- a/tests/c/ptradd.newcg.c
+++ b/tests/c/ptradd.newcg.c
@@ -1,12 +1,12 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4, val=3, p=4
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{13_2}}: i32 = call f() ...
@@ -28,10 +28,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=3, p=8
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2, val=3, p=12
 //     i=1, val=3, p=16
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that ptr addition in C input leads to the expected AOT and JIT IR.
 

--- a/tests/c/ptrtoint.newcg.c
+++ b/tests/c/ptrtoint.newcg.c
@@ -2,21 +2,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     ptr: {{ptr}}
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{1}}: i64 = zext %{{2}}, i64
 //     ...
 //     --- End jit-pre-opt ---
 //     ptr: {{ptr}}
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     ptr: {{ptr}}
 //     ptr: {{ptr}}
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Check that pointer to integer conversion works.

--- a/tests/c/safepoint_const.newcg.c
+++ b/tests/c/safepoint_const.newcg.c
@@ -2,7 +2,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 
 // Check deopt of constants works.
 

--- a/tests/c/sdiv.newcg.c
+++ b/tests/c/sdiv.newcg.c
@@ -2,9 +2,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     sdiv1 -10922
 //     sdiv2 -715827882
 //     sdiv3 -3074457345618258602
@@ -13,7 +13,7 @@
 //     sdiv6 -715827882
 //     sdiv7 -3074457345618258602
 //     sdiv8 -42
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{_}}: i16 = sdiv %{{_}}, 3i16
@@ -33,7 +33,7 @@
 //     sdiv6 -715827882
 //     sdiv7 -3074457345618258602
 //     sdiv8 -42
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     sdiv1 -10922
 //     sdiv2 -715827882
 //     sdiv3 -3074457345618258602
@@ -50,7 +50,7 @@
 //     sdiv6 -715827882
 //     sdiv7 -3074457345618258602
 //     sdiv8 -42
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test signed division.

--- a/tests/c/select.newcg.c
+++ b/tests/c/select.newcg.c
@@ -2,21 +2,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4 1 1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{13}}: i32 = %{{12}} ? 1i32 : 2i32
 //     ...
 //     --- End jit-pre-opt ---
 //     3 2 3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2 1 4
 //     1 2 6
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Check that select instructions work.

--- a/tests/c/setlongjmp.newcg.c
+++ b/tests/c/setlongjmp.newcg.c
@@ -2,12 +2,12 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     we jumped
-//     jitstate: stop-tracing
-//     jitstate: trace-compilation-aborted: longjmp encountered
+//     yk-jit-event: stop-tracing
+//     yk-warning: trace-compilation-aborted: longjmp encountered
 //     ...
 
 // Tests that we can deal with setjmp/longjmp.

--- a/tests/c/signextend_negative.newcg.c
+++ b/tests/c/signextend_negative.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     neg=-1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     ... = sext ...
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     neg=-2
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     neg=-3
 //     neg=-4
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that sign extending a negative value works.
 

--- a/tests/c/signextend_positive.newcg.c
+++ b/tests/c/signextend_positive.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     pos=1
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     ... = sext ...
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     pos=2
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     pos=3
 //     pos=4
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 
 // Check that sign extending with a positive value works.
 

--- a/tests/c/simple.newcg.c
+++ b/tests/c/simple.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -16,10 +16,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2
 //     1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Check that basic trace compilation works.

--- a/tests/c/simple_binop.newcg.c
+++ b/tests/c/simple_binop.newcg.c
@@ -2,9 +2,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     and 0
 //     or 5
 //     lshr 2
@@ -14,7 +14,7 @@
 //     xor2 -5
 //     shl 8
 //     ---
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{result}}: i32 = and %{{1}}, 1i32
@@ -29,7 +29,7 @@
 //     xor2 -4
 //     shl 6
 //     ---
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     and 0
 //     or 3
 //     lshr 1
@@ -48,7 +48,7 @@
 //     xor2 -2
 //     shl 2
 //     ---
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test some binary operations.

--- a/tests/c/simple_fprintf.newcg.c
+++ b/tests/c/simple_fprintf.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=4
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -18,11 +18,11 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=2
 //     i=1
 //     ...
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     ...
 //     exit
 

--- a/tests/c/simple_inline.newcg.c
+++ b/tests/c/simple_inline.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     foo 7
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{result}}: i32 = add %{{1}}, 3i32
@@ -15,10 +15,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     foo 6
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     foo 5
 //     foo 4
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Check that return values of inlined functions are properly mapped.

--- a/tests/c/simple_interp_loop1.newcg.c
+++ b/tests/c/simple_interp_loop1.newcg.c
@@ -1,19 +1,19 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     pc=0, mem=12
 //     pc=1, mem=11
 //     pc=2, mem=10
 //     pc=3, mem=9
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     pc=0, mem=9
 //     pc=1, mem=8
 //     pc=2, mem=7
 //     pc=3, mem=6
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     pc=0, mem=6
 //     pc=1, mem=5
 //     pc=2, mem=4
@@ -22,7 +22,7 @@
 //     pc=1, mem=2
 //     pc=2, mem=1
 //     pc=3, mem=0
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     pc=4, mem=0
 //     pc=5, mem=-1
 

--- a/tests/c/simple_interp_loop2.newcg.c
+++ b/tests/c/simple_interp_loop2.newcg.c
@@ -1,15 +1,15 @@
 // ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     pc=0, mem=4
 //     pc=1, mem=4
 //     pc=2, mem=4
 //     pc=3, mem=3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ..~
 //     guard true, %{{43}}, [%{{0}}, %{{8}}, %{{7}}, %{{6}}, %{{5}}, %{{4}}, %{{3}}, %{{43}}]
@@ -27,7 +27,7 @@
 //     pc=1, mem=3
 //     pc=2, mem=3
 //     pc=3, mem=2
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     pc=0, mem=2
 //     pc=1, mem=2
 //     pc=2, mem=2
@@ -36,7 +36,7 @@
 //     pc=1, mem=1
 //     pc=2, mem=1
 //     pc=3, mem=0
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     pc=4, mem=0
 //     pc=5, mem=0
 

--- a/tests/c/simplecall.newcg.c
+++ b/tests/c/simplecall.newcg.c
@@ -2,12 +2,12 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     4
 //     foo
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -22,11 +22,11 @@
 //     --- End jit-pre-opt ---
 //     3
 //     foo
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     2
 //     foo
 //     1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     bar
 //     0
 //     exit

--- a/tests/c/srem.newcg.c
+++ b/tests/c/srem.newcg.c
@@ -2,14 +2,14 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     srem 3
 //     srem2 3
 //     srem3 2
 //     srem4 3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{_}}: i32 = srem %{{_}}, %{{_}}
@@ -25,7 +25,7 @@
 //     srem2 1
 //     srem3 2
 //     srem4 1
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     srem 1
 //     srem2 1
 //     srem3 0
@@ -34,7 +34,7 @@
 //     srem2 0
 //     srem3 0
 //     srem4 0
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test signed division.

--- a/tests/c/switch_default.newcg.c
+++ b/tests/c/switch_default.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     switch %{{9_1}}, bb{{bb14}}, [299 -> bb{{bb10}}, 298 -> bb{{bb12}}] [safepoint: 0i64, (%{{0_0}}, %{{0_1}}, %{{0_3}}, %{{0_4}}, %{{0_5}}, %{{0_6}})]
@@ -21,9 +21,9 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=2
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     ...
 
 // Check that tracing the default arm of a switch works correctly.

--- a/tests/c/switch_many_guards_failing.newcg.c
+++ b/tests/c/switch_many_guards_failing.newcg.c
@@ -2,7 +2,7 @@
 // ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   stdout:
 //     jihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcba

--- a/tests/c/switch_non_default.newcg.c
+++ b/tests/c/switch_non_default.newcg.c
@@ -2,11 +2,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     i=3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     switch %{{10_1}}, bb{{bb14}}, [300 -> bb{{bb11}}, 299 -> bb{{bb12}}] [safepoint: {{safepoint_id}}, (%{{0_0}}, %{{0_1}}, %{{0_4}}, %{{0_5}}, %{{0_6}}, %{{10_1}})]
@@ -19,9 +19,9 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=2
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     i=1
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     ...
 
 // Check that tracing a non-default switch arm works correctly.

--- a/tests/c/truncate.newcg.c
+++ b/tests/c/truncate.newcg.c
@@ -6,24 +6,24 @@
 // ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     u64 18446744073709551615
 //     u32 4294967295
 //     u16 65535
 //     u8 255
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     u64 18446744073709551615
 //     u32 4294967295
 //     u16 65535
 //     u8 255
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     u64 18446744073709551615
 //     u32 4294967295
 //     u16 65535
 //     u8 255
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test truncation.

--- a/tests/c/udiv.newcg.c
+++ b/tests/c/udiv.newcg.c
@@ -2,14 +2,14 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     udiv 21845
 //     udiv2 715827882
 //     udiv3 1431655764
 //     udiv4 42
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{_}}: i16 = udiv %{{_}}, 3i16
@@ -25,7 +25,7 @@
 //     udiv2 715827882
 //     udiv3 1431655764
 //     udiv4 42
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     udiv 21845
 //     udiv2 715827882
 //     udiv3 1431655764
@@ -34,7 +34,7 @@
 //     udiv2 715827882
 //     udiv3 1431655764
 //     udiv4 42
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test unsigned division.

--- a/tests/c/zext.newcg.c
+++ b/tests/c/zext.newcg.c
@@ -2,13 +2,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG_JITSTATE=-
+//   env-var: YK_LOG=4
 //   stderr:
-//     jitstate: start-tracing
+//     yk-jit-event: start-tracing
 //     int to long 4
 //     long to long long 4
 //     uint8_t to uint32_t 3
-//     jitstate: stop-tracing
+//     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -20,14 +20,14 @@
 //     int to long 3
 //     long to long long 3
 //     uint8_t to uint32_t 3
-//     jitstate: enter-jit-code
+//     yk-jit-event: enter-jit-code
 //     int to long 2
 //     long to long long 2
 //     uint8_t to uint32_t 3
 //     int to long 1
 //     long to long long 1
 //     uint8_t to uint32_t 3
-//     jitstate: deoptimise
+//     yk-jit-event: deoptimise
 //     exit
 
 // Test zero extend.

--- a/ykrt/src/compile/jitc_llvm/deopt.rs
+++ b/ykrt/src/compile/jitc_llvm/deopt.rs
@@ -7,7 +7,6 @@ use super::{
 };
 use crate::{
     compile::{CompiledTrace, GuardId},
-    log::log_jit_state,
     log::stats::TimingState,
     mt::{MTThread, SideTraceInfo},
 };
@@ -363,14 +362,11 @@ unsafe extern "C" fn __ykrt_deopt(
                 mtt.set_running_trace(Some(st));
             });
 
-            log_jit_state("execute-side-trace");
             // FIXME: Calling this function overwrites the current (Rust) function frame,
             // rather than unwinding it. https://github.com/ykjit/yk/issues/778
             f(ykctrlpvars.as_ptr() as *mut c_void, frameaddr);
         }
     }
-
-    log_jit_state("deoptimise");
 
     MTThread::with(|mtt| {
         mtt.set_running_trace(None);


### PR DESCRIPTION
Previously we lumped a lot of logging under `YKD_LOG_JITSTATE` including JIT state transitions, location transitions, warnings, and genuine errors. That meant that you either saw everything or (most often) nothing.

This commit removes `YKD_LOG_JITSTATE` and adds
`YK_LOG=[<path|->:]<level>`. It defaults to logging to stderr at level 1 which is "log errors". I think everything up to level 3 is useful. I mostly don't find level 4 useful, but I'm keeping it for backwards compatibility.

Most of the C tests just change "jitstate" to "yk-jit-event" with the exception of `setlongjmp.newcg.c` which has this diff:

```
-//     jitstate: stop-tracing
-//     jitstate: trace-compilation-aborted: longjmp encountered
+//     yk-jit-event: stop-tracing
+//     yk-warning: trace-compilation-aborted: longjmp encountered
```