### PR TITLE
Work around rustc bug.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -717,7 +717,6 @@ impl Drop for MT {
     }
 }
 
-/// Execute a trace. Note: this overwrites the current (Rust) function frame.
 #[cfg(target_arch = "x86_64")]
 #[naked]
 unsafe extern "C" fn exec_trace(


### PR DESCRIPTION
I can't replicate this in a small example on play.rust-lang.org, but rustc is explicitly complaining about the existence of the doc comment. This commit removes it so we can get back on track.