### PR TITLE
Remove last `WR[0-1]` usages

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
@@ -995,23 +995,23 @@ impl<'a> LSRegAlloc<'a> {
 /// What constraints are there on registers for an instruction?
 #[derive(Debug)]
 pub(crate) enum RegConstraint<R: Register> {
-    // Make sure `Operand` is loaded into a register *R* on entry; its value must be unchanged
-    // after the instruction is executed.
+    /// Make sure `Operand` is loaded into a register *R* on entry; its value must be unchanged
+    /// after the instruction is executed.
     Input(Operand),
-    // Make sure `Operand` is loaded into register `R` on entry; its value must be unchanged
-    // after the instruction is executed.
+    /// Make sure `Operand` is loaded into register `R` on entry; its value must be unchanged
+    /// after the instruction is executed.
     InputIntoReg(Operand, R),
-    // Make sure `Operand` is loaded into register `R` on entry and considered clobbered on exit.
+    /// Make sure `Operand` is loaded into register `R` on entry and considered clobbered on exit.
     InputIntoRegAndClobber(Operand, R),
-    // Make sure `Operand` is loaded into a register *x* on entry and considered clobbered on exit.
-    // The result of this instruction will be stored in register *x*.
+    /// Make sure `Operand` is loaded into a register *x* on entry and considered clobbered on exit.
+    /// The result of this instruction will be stored in register *x*.
     InputOutput(Operand),
-    // Make sure `Operand` is loaded into register `R` on entry and considered clobbered on exit.
-    // The result of this instruction will be placed in `R`.
+    /// Make sure `Operand` is loaded into register `R` on entry and considered clobbered on exit.
+    /// The result of this instruction will be placed in `R`.
     InputOutputIntoReg(Operand, R),
-    // The result of this instruction will be stored in register *x*.
+    /// The result of this instruction will be stored in register *x*.
     Output,
-    // The result of this instruction will be stored in register `R`.
+    /// The result of this instruction will be stored in register `R`.
     OutputFromReg(R),
 }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/lsregalloc.rs
@@ -66,10 +66,6 @@ pub(crate) static GP_REGS: [Rq; 16] = [
 /// eval yet.
 const GP_REGS_LEN: usize = 16;
 
-/// FIXME: A temporary scratch register we guarantee not to use elsewhere. Every use of this is a
-/// hack.
-static WR0: Rq = Rq::R12;
-
 /// The complete set of floating point x64 registers, in the order that dynasmrt defines them.
 /// Note that large portions of the code rely on these registers mapping to the integers 0..15
 /// (both inc.) in order.
@@ -98,9 +94,7 @@ const FP_REGS_LEN: usize = 16;
 
 /// The set of general registers which we will never assign value to. RSP & RBP are reserved by
 /// SysV.
-///
-/// FIXME: R12 is a temporary hack because it's the "WR0" hack.
-static RESERVED_GP_REGS: [Rq; 3] = [Rq::RSP, Rq::RBP, Rq::R12];
+static RESERVED_GP_REGS: [Rq; 2] = [Rq::RSP, Rq::RBP];
 
 /// The set of floating point registers which we will never assign value to.
 static RESERVED_FP_REGS: [Rx; 0] = [];
@@ -910,33 +904,35 @@ impl<'a> LSRegAlloc<'a> {
     /// Load the constant from `cidx` into `reg`.
     fn load_const_into_fp_reg(&mut self, asm: &mut Assembler, cidx: ConstIdx, reg: Rx) {
         match self.m.const_(cidx) {
-            Const::Float(tyidx, val) => match self.m.type_(*tyidx) {
-                // There's no way to directly move an immediate value into an xmm, so we have to go
-                // via a general purpose register.
-                //
-                // We use WR0 here, but it might be used by parents (e.g.
-                // `x86_64/mod.rs::emit_call`) so we have to push/pop it to avoid clobbering that
-                // other use.
-                Ty::Float(fty) => match fty {
-                    FloatTy::Float => {
-                        dynasm!(asm
-                            ; push Rq(WR0.code())
-                            ; mov Rd(WR0.code()), DWORD (*val as f32).to_bits() as i64 as i32
-                            ; movd Rx(reg.code()), Rd(WR0.code())
-                            ; pop Rq(WR0.code())
-                        );
-                    }
-                    FloatTy::Double => {
-                        dynasm!(asm
-                            ; push Rq(WR0.code())
-                            ; mov Rq(WR0.code()), QWORD val.to_bits() as i64
-                            ; movq Rx(reg.code()), Rq(WR0.code())
-                            ; pop Rq(WR0.code())
-                        );
-                    }
-                },
-                _ => panic!(),
-            },
+            Const::Float(tyidx, val) => {
+                // FIXME: We need to use a temporary GP register to move immediate values into but
+                // we don't have a reliable way of expressing this to the register allocator at
+                // this point. We pick a random GP register and push/pop to avoid clobbering it.
+                // This is not just inefficient but also highlights a weakness in our general
+                // register allocator API.
+                let tmp_reg = Rq::RAX;
+                match self.m.type_(*tyidx) {
+                    Ty::Float(fty) => match fty {
+                        FloatTy::Float => {
+                            dynasm!(asm
+                                ; push Rq(tmp_reg.code())
+                                ; mov Rd(tmp_reg.code()), DWORD (*val as f32).to_bits() as i64 as i32
+                                ; movd Rx(reg.code()), Rd(tmp_reg.code())
+                                ; pop Rq(tmp_reg.code())
+                            );
+                        }
+                        FloatTy::Double => {
+                            dynasm!(asm
+                                ; push Rq(tmp_reg.code())
+                                ; mov Rq(tmp_reg.code()), QWORD val.to_bits() as i64
+                                ; movq Rx(reg.code()), Rq(tmp_reg.code())
+                                ; pop Rq(tmp_reg.code())
+                            );
+                        }
+                    },
+                    _ => panic!(),
+                }
+            }
             _ => panic!(),
         }
     }

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -105,7 +105,6 @@ static RBP_DWARF_NUM: u16 = 6;
 /// We choose callee-save registers so that we don't have to worry about storing/restoring them
 /// when we do a function call to external code.
 static WR0: Rq = Rq::R12;
-static WR1: Rq = Rq::R13;
 
 /// The X86_64 SysV ABI requires a 16-byte aligned stack prior to any call.
 const SYSV_CALL_STACK_ALIGN: usize = 16;

--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -1059,10 +1059,11 @@ impl<'a> Assemble<'a> {
         match (callee_reg, callee_op) {
             (Some(reg), None) => dynasm!(self.asm; call Rq(reg.code())),
             (None, Some(op)) => {
-                let [reg] = self.ra.get_gp_regs(
+                let [reg] = self.ra.get_gp_regs_avoiding(
                     &mut self.asm,
                     iidx,
-                    [RegConstraint::InputIntoRegAndClobber(op, WR0)],
+                    [RegConstraint::Input(op)],
+                    RegSet::from_vec(&CALLER_CLOBBER_REGS),
                 );
                 dynasm!(self.asm; call Rq(reg.code()));
             }


### PR DESCRIPTION
The old spill allocator used fixed work registers `WR0`, `WR1`, and `WR2`. The new register allocator remove `WR2`, and should have removed `WR1` (https://github.com/ykjit/yk/commit/4d762197eba048f60d4344379ee8811e3c657842). This PR removes `WR0`, allowing us to use `r12` as a general purpose register allocator. This doesn't make much of a benchmarking difference, because other inefficiencies mean that we don't gain much from having one more register to use, but at some point those other inefficiencies will go away, and then each register will be useful! In that sense, this PR is a small but useful step on that journey.