### PR TITLE
Don't preemptively spill variables before a guard.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -249,10 +249,14 @@ impl<'a> Assemble<'a> {
             for (deoptid, fail_label) in fail_labels.into_iter().enumerate() {
                 #[cfg(any(debug_assertions, test))]
                 self.comment(self.asm.offset(), format!("Deopt ID for guard {deoptid}"));
+                // FIXME: Why are `deoptid`s 64 bit? We're not going to have that many guards!
+                let deoptid = i32::try_from(deoptid).unwrap();
                 dynasm!(self.asm
                     ;=> fail_label
-                    ; mov rsi, QWORD deoptid as i64
-                    ; jmp =>deopt_label
+                    ; push rsi // FIXME: We push RSI now so we can fish it back out in
+                               // `deopt_label`.
+                    ; mov rsi, deoptid
+                    ; jmp => deopt_label
                 );
             }
 
@@ -262,11 +266,25 @@ impl<'a> Assemble<'a> {
             // is x86 only, we don't need to worry about portability.
             #[allow(clippy::fn_to_numeric_cast)]
             {
+                dynasm!(self.asm; => deopt_label);
+                // Push all the general purpose registers to the stack.
+                for (i, reg) in lsregalloc::GP_REGS.iter().rev().enumerate() {
+                    if *reg == Rq::RSI {
+                        // RSI is handled differently in `fail_label`: RSI now contains the deopt
+                        // ID, so we have to fish the actual value out of the stack. See the FIXME
+                        // in `fail_label`.
+                        let off = i32::try_from(i * 8).unwrap();
+                        dynasm!(self.asm; push QWORD [rsp + off]);
+                    } else {
+                        dynasm!(self.asm; push Rq(reg.code()));
+                    }
+                }
                 dynasm!(self.asm
-                    ;=> deopt_label
                     ; mov rdi, [rbp]
                     ; mov rdx, rbp
+                    ; mov rcx, rsp
                     ; mov rax, QWORD __yk_deopt as i64
+                    ; sub rsp, 8 // Align the stack
                     ; call rax
                 );
             }
@@ -1399,29 +1417,21 @@ impl<'a> Assemble<'a> {
         let mut locs: Vec<VarLocation> = Vec::new();
         let gi = inst.guard_info(self.m);
         for lidx in gi.lives() {
-            match self.m.inst_all(*lidx) {
-                jit_ir::Inst::ProxyConst(c) => {
-                    // The live variable is a constant (e.g. this can happen during inlining), so
-                    // it doesn't have an allocation. We can just push the actual value instead
-                    // which will be written as is during deoptimisation.
-                    match self.m.const_(*c) {
-                        Const::Int(tyidx, c) => {
-                            let Ty::Integer(bits) = self.m.type_(*tyidx) else {
-                                panic!()
-                            };
-                            locs.push(VarLocation::ConstInt { bits: *bits, v: *c })
-                        }
-                        _ => todo!(),
-                    };
+            if let jit_ir::Inst::ProxyConst(c) = self.m.inst_all(*lidx) {
+                // The live variable is a constant (e.g. this can happen during inlining), so
+                // it doesn't have an allocation. We can just push the actual value instead
+                // which will be written as is during deoptimisation.
+                match self.m.const_(*c) {
+                    Const::Int(tyidx, c) => {
+                        let Ty::Integer(bits) = self.m.type_(*tyidx) else {
+                            panic!()
+                        };
+                        locs.push(VarLocation::ConstInt { bits: *bits, v: *c })
+                    }
+                    _ => todo!(),
                 }
-                _ => {
-                    // FIXME: This is a temporary hack (notice the function name!), where we force
-                    // every live instruction to be spilled. This is only needed until deopt
-                    // supports reloading from registers.
-                    let frame_off = self.ra.stack_offset_gp_hack(&mut self.asm, *lidx);
-                    let size = self.m.inst_no_proxies(*lidx).def_byte_size(self.m);
-                    locs.push(VarLocation::Stack { frame_off, size });
-                }
+            } else {
+                locs.push(self.ra.var_location(*lidx));
             }
         }
 
@@ -2156,12 +2166,16 @@ mod tests {
                 {{_}} {{_}}: jnz 0x...
                 ...
                 ; deopt id for guard 0
+                {{_}} {{_}}: push rsi
                 ... mov rsi, 0x00
                 ... jmp ...
                 ; call __yk_deopt
+                ...
                 ... mov rdi, [rbp]
                 ... mov rdx, rbp
-                ... mov rax, ...
+                ... mov rcx, rsp
+                ... mov rax, 0x...
+                ... sub rsp, 0x08
                 ... call rax
             ",
         );
@@ -2182,12 +2196,16 @@ mod tests {
                 {{_}} {{_}}: jnz 0x...
                 ...
                 ; deopt id for guard 0
+                {{_}} {{_}}: push rsi
                 ... mov rsi, 0x00
                 ... jmp ...
                 ; call __yk_deopt
+                ...
                 ... mov rdi, [rbp]
                 ... mov rdx, rbp
-                ... mov rax, ...
+                ... mov rcx, rsp
+                ... mov rax, 0x...
+                ... sub rsp, 0x08
                 ... call rax
             ",
         );


### PR DESCRIPTION
Previously the only way to pass an instruction's value to a guard was via spill -- so if a value was referenced in a guard and not already spilled, we had to spill it just before the guard, even if there was no other reason to do so.

This commit removes this penalty from the fast path: guards and deopt (sort of...) can take values from registers rather than spills.

For example here's a guard from a test before this commit:

```
 ; guard true, %304, [<lots of live variables>]
 : mov [rbp-0x930], r10
 : mov [rbp-0x938], r9
 : mov [rbp-0x940], r8
 : mov [rbp-0x948], rdx
 : mov [rbp-0x950], rcx
 : mov [rbp-0x958], rax
 : mov [rbp-0x960], r11
 : cmp r15b, 0x01
 : jnz 0xCB3
 ; %306: ptr = load %6
```

and after:

```
 ; guard true, %304, [<lots of live variables>]
 : cmp r15b, 0x01
 : jnz 0xC4A
 ; %306: ptr = load %6
```

This is a fairly extreme example (most guards tend to spill 1 or 2 variables), but it shows 7 spills being removed entirely.

Now to some extent, what this commit does is shuffle the problem around a bit: we still have to pass lots of register values to deopt, and there's not enough room to do so. We could use the SysV ABI in a clever way, but instead we push all registers (including reserved registers... which is silly... but easy) in a failing guard to the stack, and then fish values out in deopt.

What this means is that the happy path (i.e. a guard that succeeds) doesn't encounter any spills, but the unhappy path encounters lots. Since the latter case is slow anyway, we don't really notice the costs: for benchmarks which have lots of failing guards, this commit has no real impact. For benchmarks which stay in JITed code we have a noticable benefit (e.g. big_loop.lua speeds up by a bit over 7%).

There's more we could do to make this more sophisticated and complete (e.g. we'll hit a `TODO` if/when we hit a guard which references a floating point variable --- none of our tests does so), but this is a step in the right direction.