### PR TITLE
Ignore SWT tracing function in trace builder and update tests.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,8 +2,7 @@
 
 set -eu
 
-# FIXME: Reenable swt once jitc_llvm is fully removed.
-TRACERS="hwt"
+TRACERS="hwt swt"
 
 # Build yklua and run the test suite.
 #

--- a/tests/c/aot_debuginfo.c
+++ b/tests/c/aot_debuginfo.c
@@ -1,4 +1,3 @@
-// ## FIXME: crashes under SWT
 // ignore-if: test $YK_CARGO_PROFILE != "debug" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot

--- a/tests/c/arithmetic.c
+++ b/tests/c/arithmetic.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/ashr_exact.c
+++ b/tests/c/ashr_exact.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/call_args.c
+++ b/tests/c/call_args.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/calls_double.c
+++ b/tests/c/calls_double.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/choice.c
+++ b/tests/c/choice.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Compiler:
 // Run-time:
 //   env-var: YK_LOG=4

--- a/tests/c/double.c
+++ b/tests/c/double.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/doubleinline.c
+++ b/tests/c/doubleinline.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/dyn_ptradd_mixed.c
+++ b/tests/c/dyn_ptradd_mixed.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/dyn_ptradd_multidim.c
+++ b/tests/c/dyn_ptradd_multidim.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/dyn_ptradd_simple.c
+++ b/tests/c/dyn_ptradd_simple.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/fcmp_double.c
+++ b/tests/c/fcmp_double.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/fcmp_float.c
+++ b/tests/c/fcmp_float.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/fib.c
+++ b/tests/c/fib.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/float.c
+++ b/tests/c/float.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/float_binop.c
+++ b/tests/c/float_binop.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/float_consts.c
+++ b/tests/c/float_consts.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/float_div.c
+++ b/tests/c/float_div.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/float_mul.c
+++ b/tests/c/float_mul.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/float_store.c
+++ b/tests/c/float_store.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/fp_to_si.c
+++ b/tests/c/fp_to_si.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/funcptrarg_noir.c
+++ b/tests/c/funcptrarg_noir.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=-:jit-pre-opt

--- a/tests/c/icmp_ptr.c
+++ b/tests/c/icmp_ptr.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/indirect_call.c
+++ b/tests/c/indirect_call.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/inline_const.c
+++ b/tests/c/inline_const.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/inst_type_depends_global.c
+++ b/tests/c/inst_type_depends_global.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/neg_ptradd.c
+++ b/tests/c/neg_ptradd.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/neg_ptradd_dyn.c
+++ b/tests/c/neg_ptradd_dyn.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/neg_ptradd_dyn_ptr.c
+++ b/tests/c/neg_ptradd_dyn_ptr.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/nested_writetoptr.c
+++ b/tests/c/nested_writetoptr.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/not_loopy_funcs_inlined_by_default.c
+++ b/tests/c/not_loopy_funcs_inlined_by_default.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=-:jit-pre-opt

--- a/tests/c/outline.c
+++ b/tests/c/outline.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/outline_recursion.c
+++ b/tests/c/outline_recursion.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/outline_recursion_indirect.c
+++ b/tests/c/outline_recursion_indirect.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/phi1.c
+++ b/tests/c/phi1.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YK_LOG=4

--- a/tests/c/phi2.c
+++ b/tests/c/phi2.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YK_LOG=4

--- a/tests/c/phi3.c
+++ b/tests/c/phi3.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YK_LOG=4

--- a/tests/c/promote.c
+++ b/tests/c/promote.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_OPT=1

--- a/tests/c/promote_expr.c
+++ b/tests/c/promote_expr.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/promote_guard.c
+++ b/tests/c/promote_guard.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/simple_inline.c
+++ b/tests/c/simple_inline.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/simple_nested.c
+++ b/tests/c/simple_nested.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/simplecall.c
+++ b/tests/c/simplecall.c
@@ -1,4 +1,4 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/switch_many_guards_failing.c
+++ b/tests/c/switch_many_guards_failing.c
@@ -1,5 +1,3 @@
-// ## FIXME: crashes under SWT
-// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/switch_nested_guard.c
+++ b/tests/c/switch_nested_guard.c
@@ -1,5 +1,3 @@
-// ## FIXME: crashes under SWT
-// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stdout:

--- a/tests/c/truncate.c
+++ b/tests/c/truncate.c
@@ -1,9 +1,3 @@
-// ## Truncation currently always truncates to i32, no matter the target type.
-// ##ignore-if: true
-// ## ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
-// ##
-// ## FIXME: crashes under SWT
-// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/c/udiv.c
+++ b/tests/c/udiv.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/void_ret.c
+++ b/tests/c/void_ret.c
@@ -1,3 +1,4 @@
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=-:jit-pre-opt

--- a/tests/c/zext.c
+++ b/tests/c/zext.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -3,8 +3,11 @@
 //! This takes in an (AOT IR, execution trace) pair and constructs a JIT IR trace from it.
 
 use super::aot_ir::{self, BBlockId, BinOp, FuncIdx, Module};
-use super::jit_ir::{self, Const};
 use super::YkSideTraceInfo;
+use super::{
+    jit_ir::{self, Const},
+    AOT_MOD,
+};
 use crate::aotsmp::AOT_STACKMAPS;
 use crate::compile::CompilationError;
 use crate::trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction};
@@ -693,7 +696,13 @@ impl TraceBuilder {
         if inst.is_debug_call(self.aot_mod) {
             return Ok(());
         }
-
+        // Ignore software tracer calls. Software tracer inserts
+        // `yk_trace_basicblock` instruction calls into the beginning of
+        // every basic block. These calls can be ignored as they are
+        // only used to collect runtime information for the tracer itself.
+        if AOT_MOD.func(*callee).name() == "yk_trace_basicblock" {
+            return Ok(());
+        }
         // Convert AOT args to JIT args.
         let mut jit_args = Vec::new();
         for arg in args {


### PR DESCRIPTION
## Changes

- Ignore the tracing function `yk_trace_basicblock` in tracer builder.
- Update ignored tests

## Tests

Tested multiple times as:
```shell
YKB_TRACER=hwt cargo test
```
```shell
YKB_TRACER=hwt YKD_NEW_CODEGEN=1 cargo test
```
```shell
YKB_TRACER=swt cargo test
```
```shell
YKB_TRACER=hwt YKD_NEW_CODEGEN=1 cargo test
```

## Notes
I did see `simple_binop.c` test failing one time with a warning: `yk-warning: trace-compilation-aborted: Trace too long.`
But I don't think it's relevant to my changes in the PR.