### PR TITLE
Move from `<index type>::new` to `<index type>::try_from`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x86_64/mod.rs
@@ -156,7 +156,7 @@ impl<'a> Assemble<'a> {
         #[cfg(debug_assertions)]
         m.assert_well_formed();
 
-        let mut inst_vals_alive_until = vec![InstIdx::new(0).unwrap(); m.insts_len()];
+        let mut inst_vals_alive_until = vec![InstIdx::try_from(0).unwrap(); m.insts_len()];
         for iidx in m.iter_all_inst_idxs() {
             let inst = m.inst_all(iidx);
             inst.map_packed_operand_locals(m, &mut |x| {
@@ -170,7 +170,7 @@ impl<'a> Assemble<'a> {
                 break;
             }
             inst_vals_alive_until[usize::from(iidx)] =
-                InstIdx::new(usize::from(m.last_inst_idx()) + 1)?;
+                InstIdx::try_from(usize::from(m.last_inst_idx()) + 1)?;
         }
 
         let asm = dynasmrt::x64::Assembler::new()

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -176,7 +176,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                             let iidx = self.lexer.span_str(span)[1..]
                                 .parse::<usize>()
                                 .map_err(|e| self.error_at_span(span, &e.to_string()))?;
-                            let iidx = InstIdx::new(iidx)
+                            let iidx = InstIdx::try_from(iidx)
                                 .map_err(|e| self.error_at_span(span, &e.to_string()))?;
                             if self.inst_idx_map.get(&iidx).is_none() {
                                 return Err(self.error_at_span(
@@ -572,7 +572,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                     .parse::<usize>()
                     .map_err(|e| self.error_at_span(span, &e.to_string()))?;
                 let idx =
-                    InstIdx::new(idx).map_err(|e| self.error_at_span(span, &e.to_string()))?;
+                    InstIdx::try_from(idx).map_err(|e| self.error_at_span(span, &e.to_string()))?;
                 let mapped_idx = self.inst_idx_map.get(&idx).ok_or_else(|| {
                     self.error_at_span(span, &format!("Undefined local operand '%{idx}'"))
                 })?;
@@ -612,7 +612,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
         let idx = self.lexer.span_str(span)[1..]
             .parse::<usize>()
             .map_err(|e| self.error_at_span(span, &e.to_string()))?;
-        let idx = InstIdx::new(idx).map_err(|e| self.error_at_span(span, &e.to_string()))?;
+        let idx = InstIdx::try_from(idx).map_err(|e| self.error_at_span(span, &e.to_string()))?;
         self.m.push(inst).unwrap();
         match self.inst_idx_map.insert(idx, self.m.last_inst_idx()) {
             None => Ok(()),


### PR DESCRIPTION
This commit makes use of the standard `TryFrom` trait to make clear that `InstIdx` and friends can return a `Result`. This is slightly wordier than `new`, but doing this will allow us to add another method in the future to make clear when we're overriding the possibility of an `Err` being returned.