### PR TITLE
Enabled `YKD_LOG_IR=jit-asm` in non-debug mode.

### DIFF
--- a/docs/src/dev/understanding_traces.md
+++ b/docs/src/dev/understanding_traces.md
@@ -19,8 +19,7 @@ The following `ir_stage`s are supported:
  - `aot`: the entire AOT IR for the interpreter.
  - `jit-pre-opt`: the JIT IR trace before optimisation.
  - `jit-post-opt`: the JIT IR trace after optimisation.
- - `jit-asm`: the assembler code of the compiled JIT IR trace. Note this stage
-   is only available for debug builds and unit tests.
+ - `jit-asm`: the assembler code of the compiled JIT IR trace.
 
 
 #### `YKD_TRACE_DEBUGINFO`

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -124,7 +124,6 @@ impl Compiler for JITCYk {
 
         let ct = self.codegen.codegen(jit_mod, mt, hl)?;
 
-        #[cfg(any(debug_assertions, test))]
         if should_log_ir(IRPhase::Asm) {
             log_ir(&format!(
                 "--- Begin jit-asm ---\n{}\n--- End jit-asm ---\n",

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -110,7 +110,6 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     fn hl(&self) -> &Weak<Mutex<HotLocation>>;
 
     /// Disassemble the JITted code into a string, for testing and deubgging.
-    #[cfg(any(debug_assertions, test))]
     fn disassemble(&self) -> Result<String, Box<dyn Error>>;
 }
 


### PR DESCRIPTION
For ages I've been slightly frustrated that I can only check jit-asm output if yk is compiled in debug mode. Since we typically tend to tie release builds of interpreters together with a release mode of yk, that means in practise that `YKD_LOG_IR=-:jit-asm` hasn't worked with release build of yklua.

This commit de-`debug_assertions` the code that generates comments when building a trace, which is all we need to produce jit-asm output. This does cause to do a bit more heap allocation at run-time, but it's going to be pretty minor compared to our other costs: even with synchronised compilation on, I can't measure any performance difference with/without this commit.