### PR TITLE
Make the JIT IR parser create -ve `Direct` offsets.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -759,14 +759,20 @@ impl<'a> Assemble<'a> {
             yksmp::Location::Register(15, ..) => {
                 VarLocation::Register(reg_alloc::Register::GP(Rq::R15))
             }
-            yksmp::Location::Direct(6, off, size) => VarLocation::Direct {
-                frame_off: *off,
-                size: usize::from(*size),
-            },
-            yksmp::Location::Indirect(6, off, size) => VarLocation::Indirect {
-                frame_off: *off,
-                size: usize::from(*size),
-            },
+            yksmp::Location::Direct(6, off, size) => {
+                debug_assert!(*off <= 0);
+                VarLocation::Direct {
+                    frame_off: *off,
+                    size: usize::from(*size),
+                }
+            }
+            yksmp::Location::Indirect(6, off, size) => {
+                debug_assert!(*off <= 0);
+                VarLocation::Indirect {
+                    frame_off: *off,
+                    size: usize::from(*size),
+                }
+            }
             e => {
                 todo!("{:?}", e);
             }

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -334,7 +334,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                 // FIXME: Why 6?!
                                 self.m.push_tiloc(yksmp::Location::Direct(
                                     6,
-                                    i32::try_from(ti_off).unwrap(),
+                                    -i32::try_from(ti_off).unwrap(),
                                     size,
                                 ));
                                 ti_off += u32::from(size);


### PR DESCRIPTION
Right now, as far as we know, `yksmp::Loaction::Direct` can only have negative offsets. We really need to check if that is always the case (I can create guesses for why positive offsets are possible, but I haven't yet seen a case which does so).

In the meantime, ensure that the "dummp" `Direct` information the JIT IR parser creates is always negative to match what we see in "real" code.