### PR TITLE
Use a known-working version of Rust.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -38,7 +38,7 @@ export RUSTUP_HOME
 export RUSTUP_INIT_SKIP_PATH_CHECK="yes"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
 sh rustup.sh --default-host x86_64-unknown-linux-gnu \
-    --default-toolchain nightly \
+    --default-toolchain nightly-2024-08-05 \
     --no-modify-path \
     --profile default \
     -y


### PR DESCRIPTION
I think this unbreaks CI. [I have partially tested this, but frequent "trace too long" errors in tryci means that I'm only about 80% sure this will fix things.]