### PR TITLE
Revert "We temporarily can't test yklua until it uses `yk_mt_shutdown`."

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -11,17 +11,16 @@ TRACERS="hwt"
 #  - `yk-config` must be in PATH.
 #  - YK_BUILD_TYPE must be set.
 test_yklua() {
-    true
-    # if [ ! -e "yklua" ]; then
-    #     git clone https://github.com/ykjit/yklua
-    # fi
-    # cd yklua
-    # make clean
-    # make -j $(nproc)
-    # cd tests
-    # YKD_SERIALISE_COMPILATION=1 ../src/lua -e"_U=true" all.lua
-    # ../src/lua -e"_U=true" all.lua
-    # cd ../..
+    if [ ! -e "yklua" ]; then
+        git clone https://github.com/ykjit/yklua
+    fi
+    cd yklua
+    make clean
+    make -j $(nproc)
+    cd tests
+    YKD_SERIALISE_COMPILATION=1 ../src/lua -e"_U=true" all.lua
+    ../src/lua -e"_U=true" all.lua
+    cd ../..
 }
 
 # Check that the ykllvm commit in the submodule is from the main branch.


### PR DESCRIPTION
This reverts commit 489323e5f63c0cc7afc627c50a046198cec2c224.