### PR TITLE
Enable simple.c test for swt.

### DIFF
--- a/tests/c/simple.c
+++ b/tests/c/simple.c
@@ -1,4 +1,3 @@
-// ignore-if: test $YK_JIT_COMPILER != "yk" -o "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1


### PR DESCRIPTION
Re-enable `simple.c` test for swt. 
Ignored by mistake,