### PR TITLE
Unbreak gdb_c_test.

### DIFF
--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -69,6 +69,7 @@ fn main() {
     // Now we have a test binary in a temporary directory, prepare an invocation of gdb, setting
     // environment variables as necessary.
     let mut gdb = Command::new("gdb");
+    gdb.arg(&binpath);
 
     if args.serialise_compilation {
         gdb.env("YKD_SERIALISE_COMPILATION", "1");


### PR DESCRIPTION
I removed this line:

```
gdb.arg(&binpath).env("YKD_TRACE_DEBUGINFO", "1");
```

in 811ca274 when I should only have removed the `.env(...)` part. Doing so caused gdb_c_test to compile but not to work. This commit restores the `.arg(...)` part, and allows gdb_c_test to work again.