### PR TITLE
Safepoint id is no longer an operand.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -149,10 +149,6 @@ impl Module {
         self.funcs[bid.funcidx].bblock(bid.bbidx)
     }
 
-    pub(crate) fn const_type(&self, c: &Const) -> &Ty {
-        &self.types[c.tyidx()]
-    }
-
     /// Lookup a constant by its index.
     ///
     /// # Panics
@@ -725,7 +721,7 @@ impl fmt::Display for DisplayableOperand<'_> {
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
 pub(crate) struct DeoptSafepoint {
-    pub(crate) id: Operand,
+    pub(crate) id: u64,
     #[deku(temp)]
     num_lives: u32,
     #[deku(count = "num_lives")]
@@ -752,12 +748,7 @@ impl fmt::Display for DisplayableDeoptSafepoint<'_> {
             .map(|a| a.display(self.m).to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        write!(
-            f,
-            "[safepoint: {}, ({})]",
-            self.safepoint.id.display(self.m),
-            lives_s
-        )
+        write!(f, "[safepoint: {}i64, ({})]", self.safepoint.id, lives_s)
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -130,19 +130,10 @@ impl TraceBuilder {
             if inst.is_control_point(self.aot_mod) {
                 // FIXME Safepoint id should be an integer not Operand.
                 let safepoint = inst.safepoint().unwrap();
-                let aot_ir::Operand::Const(cidx) = safepoint.id else {
-                    panic!();
-                };
-                let c = self.aot_mod.const_(cidx);
-                let aot_ir::Ty::Integer(ity) = self.aot_mod.const_type(c) else {
-                    panic!();
-                };
-                assert!(ity.num_bits() == u64::BITS);
-                let id = u64::from_ne_bytes(c.unwrap_val().bytes()[0..8].try_into().unwrap());
                 let (rec, _) = AOT_STACKMAPS
                     .as_ref()
                     .unwrap()
-                    .get(usize::try_from(id).unwrap());
+                    .get(usize::try_from(safepoint.id).unwrap());
 
                 debug_assert!(safepoint.lives.len() == rec.live_vars.len());
                 for idx in 0..safepoint.lives.len() {
@@ -517,16 +508,7 @@ impl TraceBuilder {
                 // instructions which we won't see at the beginning of a sidetrace.
                 Vec::new(),
             ));
-            let aot_ir::Operand::Const(cidx) = safepoint.id else {
-                panic!();
-            };
-            let c = self.aot_mod.const_(cidx);
-            let aot_ir::Ty::Integer(ity) = self.aot_mod.const_type(c) else {
-                panic!();
-            };
-            assert!(ity.num_bits() == u64::BITS);
-            let id = u64::from_ne_bytes(c.unwrap_val().bytes()[0..8].try_into().unwrap());
-            smids.push(id);
+            smids.push(safepoint.id);
 
             // Collect live variables.
             for op in safepoint.lives.iter() {


### PR DESCRIPTION
https://github.com/ykjit/ykllvm/pull/193 turns the stackmap id from an operand into a u64. There was no reason for this to be an operand and it just makes getting the actual integer value out unnecessarily complicated.

Also fix a test that broke due to https://github.com/ykjit/ykllvm/pull/192.