### PR TITLE
Passing Direct/Indirect straight to the register allocator.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -179,8 +179,20 @@ pub(crate) extern "C" fn __yk_deopt(
                 },
                 VarLocation::ConstInt { bits: _, v } => v,
                 VarLocation::ConstFloat(f) => f.to_bits(),
-                VarLocation::Direct { .. } => panic!(),
-                VarLocation::Indirect { .. } => panic!(),
+                VarLocation::Direct { .. } => {
+                    // See comment below: this case never needs to do anything.
+                    varidx += 1;
+                    continue;
+                }
+                VarLocation::Indirect { frame_off, size } => {
+                    assert_eq!(size, 8);
+                    unsafe {
+                        (jitrbp as *const *const u64)
+                            .read()
+                            .byte_offset(isize::try_from(frame_off).unwrap())
+                            .read()
+                    }
+                }
             };
             varidx += 1;
 

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -61,7 +61,7 @@ pub enum Location {
     Register(u16, u16, i32, u16),
     /// The live variable is a pointer into the stack. To avoid unnecessary spilling and
     /// dereferencing LLVM just records the value as an (offset, register) pair where the register
-    /// is typically the base pointer.
+    /// is typically the base pointer:
     /// * `u16`: Dwarf register number
     /// * `i32`: offset
     /// * `u16`: size of the value


### PR DESCRIPTION
This commit changes the code generator so that it accesses variables directly (via `yksmp::Location`) from the stack. That means that "load trace input" no longer generates any code, which simplifies the start of the trace. However, those costs are now moved into the body of the trace, so overall this commit slows JIT compiled code down because code that was once:

```
; %301: i32 = load %8
00007f5800eca70e 0000170e: mov r15, [rbp-0x18]
00007f5800eca715 00001715: mov r15d, [r15]
; %302: i32 = and %301, 127i32
00007f5800eca71a 0000171a: mov r14d, 0x7F
00007f5800eca720 00001720: and r15d, r14d
```

now becomes:

```
; %301: i32 = load %8
00007f3f3afb900b 0000000b: mov r15, [rbp]
00007f3f3afb900f 0000000f: mov r15, [r15-0x48]
00007f3f3afb9017 00000017: mov r15d, [r15]
; %302: i32 = and %301, 127i32
00007f3f3afb901c 0000001c: mov r13d, 0x7F
00007f3f3afb9022 00000022: and r15d, r13d
```

Notice the extra load of `mov r15, [rbp]` introduced by this PR. This makes big_loop.lua, for example, run 25% slower.

We hope/expect that upcoming efforts to move most variables off the shadow stack, removing most of these costs, and then loop peeling to remove the remainder and, probably, to actually speed things up.

This commit hopefully also makes introducing "trace labeled arguments" (or whatever we choose to call them) a bit easier. However, I don't mind if we don't merge this commit straight away: I think it's a useful stepping stone, but that might depend on other work that I'm not fully aware of yet.