### PR TITLE
Fix memory corruption in deopt.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -306,11 +306,14 @@ unsafe extern "C" fn __replace_stack(dst: *mut c_void, src: *const c_void, size:
         "mov rsp, rdi",
         // Move rsp to the end of the new stack.
         "sub rsp, rdx",
+        // Save src ptr into a callee-save reg so we can free it later.
+        "mov r12, rsi",
         // Copy the new stack over the old stack.
         "mov rdi, rsp",
         "call memcpy",
+        // Restore src ptr.
+        "mov rdi, r12",
         // Free the source which is no longer needed.
-        "mov rdi, rsi",
         "call free",
         // Recover live registers.
         "pop r15",


### PR DESCRIPTION
When copying the reconstructed frame onto the "live" stack, the src pointer was in RSI, but the call to memcpy(3) can trash it. We then hand the potentially trashed pointer to free(3). Chaos ensues.

This change fixes this. We stash the src pointer in an unused callee-save register and restore it before the call to free.

This fixes the Lua AWFY suite for us. I've also the yk and yklua tests a few times too. Seems OK.