### PR TITLE
Promote more than just `usize`

### DIFF
--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -70,7 +70,11 @@ void yk_location_drop(YkLocation);
 // Promote a value to a constant. This is a generic macro that will
 // automatically select the right `yk_promote` function to call based on the
 // type of the value passed.
-#define yk_promote(X) _Generic((X), uintptr_t: __yk_promote_usize)(X)
+#define yk_promote(X) _Generic((X), \
+                               int: __yk_promote_c_int, \
+                               uintptr_t: __yk_promote_usize \
+                              )(X)
+int __yk_promote_c_int(int);
 // Rust defines `usize` to be layout compatible with `uintptr_t`.
 uintptr_t __yk_promote_usize(uintptr_t);
 

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -85,7 +85,7 @@ impl Compiler for JITCYk {
         aottrace_iter: Box<dyn AOTTraceIterator>,
         sti: Option<Arc<dyn SideTraceInfo>>,
         hl: Arc<Mutex<HotLocation>>,
-        promotions: Box<[usize]>,
+        promotions: Box<[u8]>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         // If either `unwrap` fails, there is no chance of the system working correctly.
         let aot_mod = &*AOT_MOD;

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -54,23 +54,23 @@ pub(crate) struct TraceBuilder {
     jit_mod: jit_ir::Module,
     /// Maps an AOT instruction to a jit instruction via their index-based IDs.
     local_map: HashMap<aot_ir::InstID, jit_ir::Operand>,
-    // BBlock containing the current control point (i.e. the control point that started this trace).
+    /// BBlock containing the current control point (i.e. the control point that started this trace).
     cp_block: Option<aot_ir::BBlockId>,
-    // Index of the first traceinput instruction.
+    /// Index of the first traceinput instruction.
     first_ti_idx: usize,
-    // Inlined calls.
+    /// Inlined calls.
     frames: Vec<Frame>,
-    // The block at which to stop outlining.
+    /// The block at which to stop outlining.
     outline_target_blk: Option<BBlockId>,
-    // Current count of recursive calls to the function in which outlining was started. Will be 0
-    // if `outline_target_blk` is None.
+    /// Current count of recursive calls to the function in which outlining was started. Will be 0
+    /// if `outline_target_blk` is None.
     recursion_count: usize,
     /// Values promoted to trace-level constants. Values are stored as native-endian sequences of
     /// bytes: the AOT code must be examined to determine the size of a given a value at a given
     /// point. Currently (and probably forever) only values that are a multiple of 8 bits are
     /// supported.
     promotions: Box<[u8]>,
-    // The trace's current position in the promotions array.
+    /// The trace's current position in the promotions array.
     promote_idx: usize,
 }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -49,7 +49,7 @@ pub(crate) trait Compiler: Send + Sync {
         aottrace_iter: Box<dyn AOTTraceIterator>,
         sti: Option<Arc<dyn SideTraceInfo>>,
         hl: Arc<Mutex<HotLocation>>,
-        promotions: Box<[usize]>,
+        promotions: Box<[u8]>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -804,6 +804,22 @@ impl MTThread {
     /// If `false` is returned, the current trace is unable to record the promotion successfully
     /// and further calls are probably pointless, though they will not cause the tracer to enter
     /// undefined behaviour territory.
+    pub(crate) fn promote_i32(&self, val: i32) -> bool {
+        if let MTThreadState::Tracing {
+            ref mut promotions, ..
+        } = *self.tstate.borrow_mut()
+        {
+            promotions.extend_from_slice(&val.to_ne_bytes());
+        }
+        true
+    }
+
+    /// Records `val` as a value to be promoted. Returns `true` if either: no trace is being
+    /// recorded; or recording the promotion succeeded.
+    ///
+    /// If `false` is returned, the current trace is unable to record the promotion successfully
+    /// and further calls are probably pointless, though they will not cause the tracer to enter
+    /// undefined behaviour territory.
     pub(crate) fn promote_usize(&self, val: usize) -> bool {
         if let MTThreadState::Tracing {
             ref mut promotions, ..

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -259,7 +259,7 @@ impl MT {
     ///     in the `hl_arc`.
     fn queue_compile_job(
         self: &Arc<Self>,
-        trace_iter: (Box<dyn AOTTraceIterator>, Box<[usize]>),
+        trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>),
         hl_arc: Arc<Mutex<HotLocation>>,
         sidetrace: Option<(GuardIdx, Arc<dyn CompiledTrace>)>,
     ) {
@@ -731,7 +731,7 @@ enum MTThreadState {
         /// What tracer is being used to record this trace? Needed for trace mapping.
         thread_tracer: Box<dyn TraceRecorder>,
         /// Records the content of data recorded via `yk_promote`.
-        promotions: Vec<usize>,
+        promotions: Vec<u8>,
     },
     /// This thread is executing a trace. Note that the `dyn CompiledTrace` serves two different purposes:
     ///
@@ -809,7 +809,7 @@ impl MTThread {
             ref mut promotions, ..
         } = *self.tstate.borrow_mut()
         {
-            promotions.push(val);
+            promotions.extend_from_slice(&val.to_ne_bytes());
         }
         true
     }

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -1,13 +1,24 @@
 //! Trace promotion: promote values to constants when recording and compiling a trace.
+//!
+//! In C, these are exposed to the user via the `yk_promote` value which automatically picks the
+//! right method in this module to call.
 
 use crate::mt::MTThread;
+use std::ffi::c_int;
 
-/// Promote a value.
-///
-/// When encountered during trace recording, the returned value will be considered constant in the
-/// resulting compiled trace.
-///
-/// The user sees this as `yk_promote` via a macro.
+/// Promote a `usize` during trace recording.
+#[no_mangle]
+pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
+    println!("promote_c");
+    MTThread::with(|mtt| {
+        // We ignore the return value for `promote_usize` as we can't really cancel tracing from
+        // this function.
+        mtt.promote_i32(val);
+    });
+    val
+}
+
+/// Promote a `usize` during trace recording.
 #[no_mangle]
 pub extern "C" fn __yk_promote_usize(val: usize) -> usize {
     MTThread::with(|mtt| {


### PR DESCRIPTION
This PR alters yk so that we can promote things that aren't `usize`d. As an example (and because I need it for yklua) I've added support for promoting `i32`s (https://github.com/ykjit/yk/commit/916484c229d5d2f526120e323d63b8f0991e22eb).