### PR TITLE
Guards should store `PackedOperand`s

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1400,7 +1400,7 @@ impl<'a> Assemble<'a> {
             frames: gi.frames().to_vec(),
             lives: locs,
             aotlives: gi.aotlives().to_vec(),
-            callframes: gi.callframes.clone(),
+            callframes: gi.callframes().to_vec(),
             guard: Guard::new(),
         };
         self.deoptinfo.push(deoptinfo);

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1397,7 +1397,7 @@ impl<'a> Assemble<'a> {
         // FIXME: Move `frames` instead of copying them (requires JIT module to be consumable).
         let deoptinfo = DeoptInfo {
             fail_label,
-            frames: gi.frames().clone(),
+            frames: gi.frames().to_vec(),
             lives: locs,
             aotlives: gi.aotlives().to_vec(),
             callframes: gi.callframes.clone(),

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1374,7 +1374,7 @@ impl<'a> Assemble<'a> {
         // Convert the guard info into deopt info and store it on the heap.
         let mut locs: Vec<VarLocation> = Vec::new();
         let gi = inst.guard_info(self.m);
-        for lidx in gi.lives() {
+        for (_, lidx) in gi.live_vars() {
             if let jit_ir::Inst::ProxyConst(c) = self.m.inst_all(*lidx) {
                 // The live variable is a constant (e.g. this can happen during inlining), so
                 // it doesn't have an allocation. We can just push the actual value instead
@@ -1399,7 +1399,7 @@ impl<'a> Assemble<'a> {
             fail_label,
             frames: gi.frames().to_vec(),
             lives: locs,
-            aotlives: gi.aotlives().to_vec(),
+            aotlives: gi.live_vars().iter().map(|(x, _)| x.clone()).collect(),
             callframes: gi.callframes().to_vec(),
             guard: Guard::new(),
         };

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1208,7 +1208,7 @@ pub(crate) struct GuardInfo {
     aotlives: Vec<aot_ir::InstID>,
     // Inlined frames info.
     // FIXME With callframes, the frames and aotlives fields are redunant.
-    pub callframes: Vec<Frame>,
+    callframes: Vec<Frame>,
 }
 
 impl GuardInfo {
@@ -1239,6 +1239,11 @@ impl GuardInfo {
     /// Return the live AOT variables for this guard. Used to write live values to during deopt.
     pub(crate) fn aotlives(&self) -> &[aot_ir::InstID] {
         &self.aotlives
+    }
+
+    /// Return the call frames.
+    pub(crate) fn callframes(&self) -> &[Frame] {
+        &self.callframes
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1227,17 +1227,17 @@ impl GuardInfo {
     }
 
     /// Return the stackmap ids for the currently active call frames.
-    pub(crate) fn frames(&self) -> &Vec<u64> {
+    pub(crate) fn frames(&self) -> &[u64] {
         &self.frames
     }
 
     /// Return the live JIT variables for this guard. Used to read live values from during deopt.
-    pub(crate) fn lives(&self) -> &Vec<InstIdx> {
+    pub(crate) fn lives(&self) -> &[InstIdx] {
         &self.lives
     }
 
     /// Return the live AOT variables for this guard. Used to write live values to during deopt.
-    pub(crate) fn aotlives(&self) -> &Vec<aot_ir::InstID> {
+    pub(crate) fn aotlives(&self) -> &[aot_ir::InstID] {
         &self.aotlives
     }
 }

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -5,7 +5,7 @@
 //! makes it possible to write JIT IR tests using JIT IR concrete syntax.
 
 use super::super::{
-    aot_ir::{BinOp, FloatPredicate, Predicate},
+    aot_ir::{BinOp, FloatPredicate, InstID, Predicate},
     jit_ir::{
         BinOpInst, BlackBoxInst, Const, DirectCallInst, DynPtrAddInst, FCmpInst, FPExtInst,
         FPToSIInst, FloatTy, FuncDecl, FuncTy, GuardInfo, GuardInst, ICmpInst, IndirectCallInst,
@@ -191,16 +191,11 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                     &format!("No such local variable %{iidx}"),
                                 ));
                             }
-                            mlive_vars.push(iidx);
+                            mlive_vars.push((InstID::new(0.into(), 0.into(), 0.into()), iidx));
                         }
                         let gidx = self
                             .m
-                            .push_guardinfo(GuardInfo::new(
-                                Vec::new(),
-                                mlive_vars,
-                                Vec::new(),
-                                Vec::new(),
-                            ))
+                            .push_guardinfo(GuardInfo::new(Vec::new(), mlive_vars, Vec::new()))
                             .unwrap();
                         let inst = GuardInst::new(self.process_operand(operand)?, is_true, gidx);
                         self.m.push(inst.into()).unwrap();

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -9,8 +9,8 @@ use super::super::{
     jit_ir::{
         BinOpInst, BlackBoxInst, Const, DirectCallInst, DynPtrAddInst, FCmpInst, FPExtInst,
         FPToSIInst, FloatTy, FuncDecl, FuncTy, GuardInfo, GuardInst, ICmpInst, IndirectCallInst,
-        Inst, InstIdx, LoadInst, LoadTraceInputInst, Module, Operand, PtrAddInst, SExtInst,
-        SIToFPInst, SelectInst, StoreInst, TruncInst, Ty, TyIdx,
+        Inst, InstIdx, LoadInst, LoadTraceInputInst, Module, Operand, PackedOperand, PtrAddInst,
+        SExtInst, SIToFPInst, SelectInst, StoreInst, TruncInst, Ty, TyIdx,
     },
 };
 use fm::FMBuilder;
@@ -191,7 +191,10 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                     &format!("No such local variable %{iidx}"),
                                 ));
                             }
-                            mlive_vars.push((InstID::new(0.into(), 0.into(), 0.into()), iidx));
+                            mlive_vars.push((
+                                InstID::new(0.into(), 0.into(), 0.into()),
+                                PackedOperand::new(&Operand::Local(iidx)),
+                            ));
                         }
                         let gidx = self
                             .m

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -5,7 +5,7 @@
 use super::aot_ir::{self, BBlockId, BinOp, FuncIdx, Module};
 use super::YkSideTraceInfo;
 use super::{
-    jit_ir::{self, Const},
+    jit_ir::{self, Const, PackedOperand},
     AOT_MOD,
 };
 use crate::aotsmp::AOT_STACKMAPS;
@@ -516,7 +516,10 @@ impl TraceBuilder {
                 match op {
                     aot_ir::Operand::LocalVariable(iid) => {
                         match self.local_map[iid] {
-                            jit_ir::Operand::Local(lidx) => live_vars.push((iid.clone(), lidx)),
+                            jit_ir::Operand::Local(liidx) => live_vars.push((
+                                iid.clone(),
+                                PackedOperand::new(&jit_ir::Operand::Local(liidx)),
+                            )),
                             jit_ir::Operand::Const(_) => {
                                 // Since we are forcing constants into `ProxyConst`s during inlining, this
                                 // case should never happen. If you see this panic, then look for a

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -497,8 +497,7 @@ impl TraceBuilder {
         // previous frames to store inside the guard.
         // Unwrap-safe as each frame at this point must have a safepoint associated with it.
         let mut smids = Vec::new(); // List of stackmap ids of the current call stack.
-        let mut live_args = Vec::new(); // List of live JIT variables.
-        let mut live_aot = Vec::new();
+        let mut live_vars = Vec::new(); // (AOT var, JIT var) pairs
         let mut callframes = Vec::new();
         for frame in &self.frames {
             let safepoint = frame.safepoint.unwrap();
@@ -514,29 +513,25 @@ impl TraceBuilder {
 
             // Collect live variables.
             for op in safepoint.lives.iter() {
-                let op = match op {
+                match op {
                     aot_ir::Operand::LocalVariable(iid) => {
-                        live_aot.push(iid.clone());
-                        &self.local_map[iid]
+                        match self.local_map[iid] {
+                            jit_ir::Operand::Local(lidx) => live_vars.push((iid.clone(), lidx)),
+                            jit_ir::Operand::Const(_) => {
+                                // Since we are forcing constants into `ProxyConst`s during inlining, this
+                                // case should never happen. If you see this panic, then look for a
+                                // safepoint live variable that maps to a constant and make the builder
+                                // insert a `ProxyConst` for it instead.
+                                panic!("constant encountered while building guardinfo!")
+                            }
+                        }
                     }
                     _ => panic!(), // IR malformed.
-                };
-                match op {
-                    jit_ir::Operand::Local(lidx) => {
-                        live_args.push(*lidx);
-                    }
-                    jit_ir::Operand::Const(_) => {
-                        // Since we are forcing constants into `ProxyConst`s during inlining, this
-                        // case should never happen. If you see this panic, then look for a
-                        // safepoint live variable that maps to a constant and make the builder
-                        // insert a `ProxyConst` for it instead.
-                        panic!("constant encountered while building guardinfo!")
-                    }
                 }
             }
         }
 
-        let gi = jit_ir::GuardInfo::new(smids, live_args, live_aot, callframes);
+        let gi = jit_ir::GuardInfo::new(smids, live_vars, callframes);
         let gi_idx = self.jit_mod.push_guardinfo(gi)?;
 
         Ok(jit_ir::GuardInst::new(cond.clone(), expect, gi_idx))


### PR DESCRIPTION
The most important part of this PR is https://github.com/ykjit/yk/commit/424fee372a07aa14c999603be358f49cddf46f4b, which fixes a flaw which our current tests don't show, but a change I'll be making soon to `promote` highlights: `GuardInfo` stores `InstIdx` when it should be storing `PackedOperand`s. The other commits are some tidying up I did along the way to the more important changes.