### PR TITLE
Fix bug in trace loop jumping.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1196,7 +1196,7 @@ impl<'a> Assemble<'a> {
                                         mov rax, QWORD [rbp - i32::try_from(off).unwrap()];
                                         push rbp;
                                         mov rbp, [rbp];
-                                        mov QWORD [rbp - frame_off], rax;
+                                        mov QWORD [rbp + frame_off], rax;
                                         pop rbp;
                                         pop rax
                                     ),


### PR DESCRIPTION
Since `frame_off` is a negative value we need to add it to the base pointer. Substracting it writes values into the wrong frame leading to segfaults/UB.