### PR TITLE
Tidy up guards and frames

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -89,7 +89,7 @@ pub(crate) extern "C" fn __yk_deopt(
     let mut memsize = 15 * REG64_SIZE;
     // Calculate amount of space we need to allocate for each stack frame.
     for (i, iframe) in info.inlined_frames.iter().enumerate() {
-        let (rec, _) = aot_smaps.get(usize::try_from(iframe.safepoint.unwrap().id).unwrap());
+        let (rec, _) = aot_smaps.get(usize::try_from(iframe.safepoint.id).unwrap());
         debug_assert!(rec.size != u64::MAX);
         // The controlpoint frame (i == 0) doesn't need to be recreated.
         if i > 0 {
@@ -115,7 +115,7 @@ pub(crate) extern "C" fn __yk_deopt(
     let mut registers = [0; 16];
     let mut varidx = 0;
     for (i, iframe) in info.inlined_frames.iter().enumerate() {
-        let (rec, pinfo) = aot_smaps.get(usize::try_from(iframe.safepoint.unwrap().id).unwrap());
+        let (rec, pinfo) = aot_smaps.get(usize::try_from(iframe.safepoint.id).unwrap());
 
         // WRITE RBP
         // If the current frame has pushed RBP we need to do the same (unless we are processing
@@ -291,8 +291,7 @@ pub(crate) extern "C" fn __yk_deopt(
 
     // Compute the address to which we want to write the new stack. This is immediately after the
     // frame containing the control point.
-    let (rec, pinfo) =
-        aot_smaps.get(usize::try_from(info.inlined_frames[0].safepoint.unwrap().id).unwrap());
+    let (rec, pinfo) = aot_smaps.get(usize::try_from(info.inlined_frames[0].safepoint.id).unwrap());
     let mut newframedst = unsafe { frameaddr.byte_sub(usize::try_from(rec.size).unwrap()) };
     if pinfo.hasfp {
         newframedst = unsafe { newframedst.byte_add(REG64_SIZE) };

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -88,11 +88,11 @@ pub(crate) extern "C" fn __yk_deopt(
     // Add space for live register values which we'll be adding at the end.
     let mut memsize = 15 * REG64_SIZE;
     // Calculate amount of space we need to allocate for each stack frame.
-    for (frameid, smid) in info.frames_stackmap_id.iter().enumerate() {
-        let (rec, _) = aot_smaps.get(usize::try_from(*smid).unwrap());
+    for (i, iframe) in info.inlined_frames.iter().enumerate() {
+        let (rec, _) = aot_smaps.get(usize::try_from(iframe.safepoint.unwrap().id).unwrap());
         debug_assert!(rec.size != u64::MAX);
-        if frameid > 0 {
-            // The controlpoint frame doesn't need to be recreated.
+        // The controlpoint frame (i == 0) doesn't need to be recreated.
+        if i > 0 {
             // We are on x86_64 so this unwrap is safe.
             memsize += usize::try_from(rec.size).unwrap();
         }
@@ -114,13 +114,13 @@ pub(crate) extern "C" fn __yk_deopt(
     // Live register values that we need to write back into AOT registers.
     let mut registers = [0; 16];
     let mut varidx = 0;
-    for (frameid, smid) in info.frames_stackmap_id.iter().enumerate() {
-        let (rec, pinfo) = aot_smaps.get(usize::try_from(*smid).unwrap());
+    for (i, iframe) in info.inlined_frames.iter().enumerate() {
+        let (rec, pinfo) = aot_smaps.get(usize::try_from(iframe.safepoint.unwrap().id).unwrap());
 
         // WRITE RBP
         // If the current frame has pushed RBP we need to do the same (unless we are processing
         // the bottom-most frame).
-        if pinfo.hasfp && frameid > 0 {
+        if pinfo.hasfp && i > 0 {
             rsp = unsafe { rsp.sub(REG64_SIZE) };
             rbp = rsp;
             unsafe { ptr::write(rsp as *mut u64, lastframeaddr as u64) };
@@ -128,7 +128,7 @@ pub(crate) extern "C" fn __yk_deopt(
 
         // Calculate the this frame's address by substracting the last frame's size (plus return
         // address) from the last frame's address.
-        if frameid > 0 {
+        if i > 0 {
             lastframeaddr = unsafe { lastframeaddr.byte_sub(lastframesize + REG64_SIZE) };
         }
         lastframesize = usize::try_from(rec.size).unwrap();
@@ -146,7 +146,7 @@ pub(crate) extern "C" fn __yk_deopt(
         //   mov rbp, rsp
         //   push rbx     # this has index -2
         //   push r14     # this has index -3
-        if frameid > 0 {
+        if i > 0 {
             for (reg, idx) in &pinfo.csrs {
                 let mut tmp =
                     unsafe { rbp.byte_sub(usize::try_from(idx.abs()).unwrap() * REG64_SIZE) };
@@ -209,7 +209,7 @@ pub(crate) extern "C" fn __yk_deopt(
                         // this value to.
                         registers[usize::from(*extra - 1)] = jitval;
                     }
-                    if frameid == 0 {
+                    if i == 0 {
                         // skip first frame
                         continue;
                     }
@@ -235,12 +235,12 @@ pub(crate) extern "C" fn __yk_deopt(
                     // exceptions only appear (for now) at frame index 0 (where the control point
                     // is), and since this frame will not be re-written by deopt, there's no need
                     // to restore those direct locations anyway.
-                    debug_assert_eq!(frameid, 0);
+                    debug_assert_eq!(i, 0);
                     continue;
                 }
                 SMLocation::Indirect(reg, off, size) => {
                     debug_assert_eq!(*reg, RBP_DWARF_NUM);
-                    let temp = if frameid == 0 {
+                    let temp = if i == 0 {
                         // While the bottom frame is already on the stack and doesn't need to
                         // be recreated, we still need to copy over new values from the JIT.
                         // Luckily, we know the address of the bottom frame, so we can write
@@ -262,7 +262,7 @@ pub(crate) extern "C" fn __yk_deopt(
             }
         }
 
-        if frameid > 0 {
+        if i > 0 {
             // Advance the "virtual RSP" to the next frame.
             rsp = unsafe { rbp.byte_sub(usize::try_from(rec.size).unwrap()) };
             if pinfo.hasfp {
@@ -291,7 +291,8 @@ pub(crate) extern "C" fn __yk_deopt(
 
     // Compute the address to which we want to write the new stack. This is immediately after the
     // frame containing the control point.
-    let (rec, pinfo) = aot_smaps.get(usize::try_from(info.frames_stackmap_id[0]).unwrap());
+    let (rec, pinfo) =
+        aot_smaps.get(usize::try_from(info.inlined_frames[0].safepoint.unwrap().id).unwrap());
     let mut newframedst = unsafe { frameaddr.byte_sub(usize::try_from(rec.size).unwrap()) };
     if pinfo.hasfp {
         newframedst = unsafe { newframedst.byte_add(REG64_SIZE) };

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -88,7 +88,7 @@ pub(crate) extern "C" fn __yk_deopt(
     // Add space for live register values which we'll be adding at the end.
     let mut memsize = 15 * REG64_SIZE;
     // Calculate amount of space we need to allocate for each stack frame.
-    for (frameid, smid) in info.frames.iter().enumerate() {
+    for (frameid, smid) in info.frames_stackmap_id.iter().enumerate() {
         let (rec, _) = aot_smaps.get(usize::try_from(*smid).unwrap());
         debug_assert!(rec.size != u64::MAX);
         if frameid > 0 {
@@ -114,7 +114,7 @@ pub(crate) extern "C" fn __yk_deopt(
     // Live register values that we need to write back into AOT registers.
     let mut registers = [0; 16];
     let mut varidx = 0;
-    for (frameid, smid) in info.frames.iter().enumerate() {
+    for (frameid, smid) in info.frames_stackmap_id.iter().enumerate() {
         let (rec, pinfo) = aot_smaps.get(usize::try_from(*smid).unwrap());
 
         // WRITE RBP
@@ -291,7 +291,7 @@ pub(crate) extern "C" fn __yk_deopt(
 
     // Compute the address to which we want to write the new stack. This is immediately after the
     // frame containing the control point.
-    let (rec, pinfo) = aot_smaps.get(usize::try_from(info.frames[0]).unwrap());
+    let (rec, pinfo) = aot_smaps.get(usize::try_from(info.frames_stackmap_id[0]).unwrap());
     let mut newframedst = unsafe { frameaddr.byte_sub(usize::try_from(rec.size).unwrap()) };
     if pinfo.hasfp {
         newframedst = unsafe { newframedst.byte_add(REG64_SIZE) };

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -22,8 +22,7 @@ use crate::{
     compile::{
         jitc_yk::{
             aot_ir,
-            jit_ir::{Const, IndirectCallIdx},
-            trace_builder::Frame,
+            jit_ir::{Const, Frame, IndirectCallIdx},
             YkSideTraceInfo,
         },
         CompiledTrace, Guard, GuardIdx, SideTraceInfo,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     compile::{
         jitc_yk::{
             aot_ir,
-            jit_ir::{Const, Frame, IndirectCallIdx},
+            jit_ir::{Const, IndirectCallIdx, InlinedFrame},
             YkSideTraceInfo,
         },
         CompiledTrace, Guard, GuardIdx, SideTraceInfo,
@@ -1482,7 +1482,7 @@ impl<'a> Assemble<'a> {
             fail_label,
             frames_stackmap_id: gi.frames().to_vec(),
             live_vars: lives,
-            callframes: gi.callframes().to_vec(),
+            callframes: gi.inlined_frames().to_vec(),
             guard: Guard::new(),
         };
         self.deoptinfo.push(deoptinfo);
@@ -1508,7 +1508,7 @@ struct DeoptInfo {
     frames_stackmap_id: Vec<u64>,
     /// Live variables, mapping AOT vars to JIT vars.
     live_vars: Vec<(aot_ir::InstID, VarLocation)>,
-    callframes: Vec<Frame>,
+    callframes: Vec<InlinedFrame>,
     /// Keeps track of deopt amount and compiled side-trace.
     guard: Guard,
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1481,7 +1481,7 @@ impl<'a> Assemble<'a> {
         // FIXME: Move `frames` instead of copying them (requires JIT module to be consumable).
         let deoptinfo = DeoptInfo {
             fail_label,
-            frames: gi.frames().to_vec(),
+            frames_stackmap_id: gi.frames().to_vec(),
             live_vars: lives,
             callframes: gi.callframes().to_vec(),
             guard: Guard::new(),
@@ -1505,8 +1505,8 @@ impl<'a> Assemble<'a> {
 #[derive(Debug)]
 struct DeoptInfo {
     fail_label: DynamicLabel,
-    /// Vector of AOT stackmap IDs.
-    frames: Vec<u64>,
+    /// Store the stackmap ID relating to each call in the callstack.
+    frames_stackmap_id: Vec<u64>,
     /// Live variables, mapping AOT vars to JIT vars.
     live_vars: Vec<(aot_ir::InstID, VarLocation)>,
     callframes: Vec<Frame>,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1480,9 +1480,8 @@ impl<'a> Assemble<'a> {
         // FIXME: Move `frames` instead of copying them (requires JIT module to be consumable).
         let deoptinfo = DeoptInfo {
             fail_label,
-            frames_stackmap_id: gi.frames().to_vec(),
             live_vars: lives,
-            callframes: gi.inlined_frames().to_vec(),
+            inlined_frames: gi.inlined_frames().to_vec(),
             guard: Guard::new(),
         };
         self.deoptinfo.push(deoptinfo);
@@ -1504,11 +1503,9 @@ impl<'a> Assemble<'a> {
 #[derive(Debug)]
 struct DeoptInfo {
     fail_label: DynamicLabel,
-    /// Store the stackmap ID relating to each call in the callstack.
-    frames_stackmap_id: Vec<u64>,
     /// Live variables, mapping AOT vars to JIT vars.
     live_vars: Vec<(aot_ir::InstID, VarLocation)>,
-    callframes: Vec<InlinedFrame>,
+    inlined_frames: Vec<InlinedFrame>,
     /// Keeps track of deopt amount and compiled side-trace.
     guard: Guard,
 }
@@ -1547,7 +1544,7 @@ impl CompiledTrace for X64CompiledTrace {
             .iter()
             .map(|(iid, _)| iid.clone())
             .collect();
-        let callframes = self.deoptinfo[usize::from(gidx)].callframes.clone();
+        let callframes = self.deoptinfo[usize::from(gidx)].inlined_frames.clone();
         Arc::new(YkSideTraceInfo {
             aotlives,
             callframes,

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1235,7 +1235,7 @@ pub(crate) struct GuardInfo {
     /// Live variables, mapping AOT vars to JIT [Operand]s.
     live_vars: Vec<(aot_ir::InstID, PackedOperand)>,
     // Inlined frames info.
-    // FIXME With this field, the frames and aotlives fields are redunant.
+    // FIXME With this field, the aotlives field is redundant.
     inlined_frames: Vec<InlinedFrame>,
 }
 
@@ -1265,12 +1265,13 @@ impl GuardInfo {
 /// failing guard to reconstruct real call frames on the stack.
 #[derive(Debug, Clone)]
 pub(crate) struct InlinedFrame {
-    // The function that was inlined to create this abstract frame.
-    pub(crate) funcidx: Option<aot_ir::FuncIdx>,
     // The call instruction that led to [funcidx] being inlined.
     pub(crate) callinst: Option<aot_ir::InstID>,
+    // The function that was inlined to create this abstract frame. Will be `None` for the top-most
+    // function.
+    pub(crate) funcidx: aot_ir::FuncIdx,
     /// The deopt safepoint for [callinst].
-    pub(crate) safepoint: Option<&'static aot_ir::DeoptSafepoint>,
+    pub(crate) safepoint: &'static aot_ir::DeoptSafepoint,
     /// The [Operand]s passed to [funcidx].
     pub(crate) args: Vec<Operand>,
 }
@@ -1278,8 +1279,8 @@ pub(crate) struct InlinedFrame {
 impl InlinedFrame {
     pub(crate) fn new(
         callinst: Option<aot_ir::InstID>,
-        funcidx: Option<aot_ir::FuncIdx>,
-        safepoint: Option<&'static aot_ir::DeoptSafepoint>,
+        funcidx: aot_ir::FuncIdx,
+        safepoint: &'static aot_ir::DeoptSafepoint,
         args: Vec<Operand>,
     ) -> InlinedFrame {
         InlinedFrame {

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -68,7 +68,6 @@ mod parser;
 mod well_formed;
 
 use super::aot_ir;
-use crate::compile::jitc_yk::trace_builder::Frame;
 use crate::compile::CompilationError;
 use indexmap::IndexSet;
 use std::{
@@ -1268,6 +1267,36 @@ impl GuardInfo {
     /// Return the call frames.
     pub(crate) fn callframes(&self) -> &[Frame] {
         &self.callframes
+    }
+}
+
+/// Keep track of calls and store information about the last
+/// processed safepoint, call instruction and its arguments.
+#[derive(Debug, Clone)]
+pub(crate) struct Frame {
+    // The call instruction of this frame.
+    pub(crate) callinst: Option<aot_ir::InstID>,
+    // Index of the function of this frame.
+    pub(crate) funcidx: Option<aot_ir::FuncIdx>,
+    /// Safepoint for this frame.
+    pub(crate) safepoint: Option<&'static aot_ir::DeoptSafepoint>,
+    /// JIT arguments of this frame's caller.
+    pub(crate) args: Vec<Operand>,
+}
+
+impl Frame {
+    pub(crate) fn new(
+        callinst: Option<aot_ir::InstID>,
+        funcidx: Option<aot_ir::FuncIdx>,
+        safepoint: Option<&'static aot_ir::DeoptSafepoint>,
+        args: Vec<Operand>,
+    ) -> Frame {
+        Frame {
+            callinst,
+            funcidx,
+            safepoint,
+            args,
+        }
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1232,8 +1232,6 @@ impl fmt::Display for DisplayableConst<'_> {
 #[derive(Debug)]
 /// Stores additional guard information.
 pub(crate) struct GuardInfo {
-    /// Stackmap IDs for the active call frames.
-    frames: Vec<u64>,
     /// Live variables, mapping AOT vars to JIT [Operand]s.
     live_vars: Vec<(aot_ir::InstID, PackedOperand)>,
     // Inlined frames info.
@@ -1243,20 +1241,13 @@ pub(crate) struct GuardInfo {
 
 impl GuardInfo {
     pub(crate) fn new(
-        frames: Vec<u64>,
         live_vars: Vec<(aot_ir::InstID, PackedOperand)>,
         inlined_frames: Vec<InlinedFrame>,
     ) -> Self {
         Self {
-            frames,
             live_vars,
             inlined_frames,
         }
-    }
-
-    /// Return the stackmap ids for the currently active call frames.
-    pub(crate) fn frames(&self) -> &[u64] {
-        &self.frames
     }
 
     /// Return the `AOT instruction -> PackedOperand` mapping for this guard.

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -189,7 +189,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                         }
                         let gidx = self
                             .m
-                            .push_guardinfo(GuardInfo::new(Vec::new(), live_vars, Vec::new()))
+                            .push_guardinfo(GuardInfo::new(live_vars, Vec::new()))
                             .unwrap();
                         let inst = GuardInst::new(self.process_operand(cond)?, is_true, gidx);
                         self.m.push(inst.into()).unwrap();

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -40,7 +40,7 @@ pub(crate) static AOT_MOD: LazyLock<aot_ir::Module> = LazyLock::new(|| {
 });
 
 struct YkSideTraceInfo {
-    callframes: Vec<jit_ir::Frame>,
+    callframes: Vec<jit_ir::InlinedFrame>,
     aotlives: Vec<aot_ir::InstID>,
 }
 
@@ -53,7 +53,7 @@ impl SideTraceInfo for YkSideTraceInfo {
 impl YkSideTraceInfo {
     /// Return the live call frames which are required to setup the trace builder during
     /// side-tracing.
-    fn callframes(&self) -> &[jit_ir::Frame] {
+    fn callframes(&self) -> &[jit_ir::InlinedFrame] {
         &self.callframes
     }
 

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,10 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{
-        jitc_yk::codegen::CodeGen, jitc_yk::trace_builder::Frame, CompiledTrace, Compiler,
-        SideTraceInfo,
-    },
+    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, SideTraceInfo},
     location::HotLocation,
     log::{log_ir, should_log_ir, IRPhase},
     mt::MT,
@@ -43,7 +40,7 @@ pub(crate) static AOT_MOD: LazyLock<aot_ir::Module> = LazyLock::new(|| {
 });
 
 struct YkSideTraceInfo {
-    callframes: Vec<Frame>,
+    callframes: Vec<jit_ir::Frame>,
     aotlives: Vec<aot_ir::InstID>,
 }
 
@@ -56,7 +53,7 @@ impl SideTraceInfo for YkSideTraceInfo {
 impl YkSideTraceInfo {
     /// Return the live call frames which are required to setup the trace builder during
     /// side-tracing.
-    fn callframes(&self) -> &[Frame] {
+    fn callframes(&self) -> &[jit_ir::Frame] {
         &self.callframes
     }
 

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -2,10 +2,10 @@
 //!
 //! This takes in an (AOT IR, execution trace) pair and constructs a JIT IR trace from it.
 
-use super::aot_ir::{self, BBlockId, BinOp, FuncIdx, Module};
+use super::aot_ir::{self, BBlockId, BinOp, Module};
 use super::YkSideTraceInfo;
 use super::{
-    jit_ir::{self, Const, PackedOperand},
+    jit_ir::{self, Const, Frame, PackedOperand},
     AOT_MOD,
 };
 use crate::aotsmp::AOT_STACKMAPS;
@@ -15,36 +15,6 @@ use std::{collections::HashMap, ffi::CString, sync::Arc};
 
 /// The argument index of the trace inputs struct in the trace function.
 const U64SIZE: usize = 8;
-
-/// A TraceBuilder frame. Keeps track of inlined calls and stores information about the last
-/// processed safepoint, call instruction and its arguments.
-#[derive(Debug, Clone)]
-pub(crate) struct Frame {
-    // The call instruction of this frame.
-    callinst: Option<aot_ir::InstID>,
-    // Index of the function of this frame.
-    funcidx: Option<FuncIdx>,
-    /// Safepoint for this frame.
-    safepoint: Option<&'static aot_ir::DeoptSafepoint>,
-    /// JIT arguments of this frame's caller.
-    args: Vec<jit_ir::Operand>,
-}
-
-impl Frame {
-    fn new(
-        callinst: Option<aot_ir::InstID>,
-        funcidx: Option<FuncIdx>,
-        safepoint: Option<&'static aot_ir::DeoptSafepoint>,
-        args: Vec<jit_ir::Operand>,
-    ) -> Frame {
-        Frame {
-            callinst,
-            funcidx,
-            safepoint,
-            args,
-        }
-    }
-}
 
 /// Given an execution trace and AOT IR, creates a JIT IR trace.
 pub(crate) struct TraceBuilder {


### PR DESCRIPTION
This PR gradually fixes a number of minor ugly things surrounding (what was) `Frame` (and becomes `InlinedFrame`). Hopefully each commit justifies what it's doing.