### PR TITLE
Fix deproxying.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -125,7 +125,7 @@ pub(crate) struct LSRegAlloc<'a> {
 }
 
 impl<'a> LSRegAlloc<'a> {
-    pub(crate) fn new(m: &'a Module, inst_vals_alive_until: Vec<InstIdx>) -> Self {
+    pub(crate) fn new(m: &'a Module) -> Self {
         #[cfg(debug_assertions)]
         {
             // We rely on the registers in GP_REGS being numbered 0..15 (inc.) for correctness.
@@ -155,7 +155,7 @@ impl<'a> LSRegAlloc<'a> {
             gp_reg_states,
             fp_regset: RegSet::with_fp_reserved(),
             fp_reg_states,
-            inst_vals_alive_until,
+            inst_vals_alive_until: m.inst_vals_alive_until(),
             spills: vec![SpillState::Empty; m.insts_len()],
             stack: Default::default(),
         }
@@ -471,7 +471,7 @@ impl<'a> LSRegAlloc<'a> {
     ///
     /// If `iidx` has not previously been spilled.
     fn force_gp_unspill(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rq) {
-        let inst = self.m.inst_deproxy(iidx);
+        let (iidx, inst) = self.m.inst_deproxy(iidx);
         let size = inst.def_byte_size(self.m);
 
         if let Inst::ProxyConst(cidx) = inst {
@@ -656,7 +656,7 @@ impl<'a> LSRegAlloc<'a> {
         }) {
             VarLocation::Register(reg_alloc::Register::FP(FP_REGS[reg_i]))
         } else {
-            let inst = self.m.inst_deproxy(iidx);
+            let (iidx, inst) = self.m.inst_deproxy(iidx);
             let size = inst.def_byte_size(self.m);
             match inst {
                 Inst::ProxyInst(_) => panic!(),

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -11,7 +11,7 @@ impl Module {
         // bit.
         let mut used = Vob::from_elem(false, usize::from(self.last_inst_idx()) + 1);
         for iidx in self.iter_all_inst_idxs().rev() {
-            let inst = self.inst_deproxy(iidx);
+            let inst = self.inst_all(iidx);
             if used.get(usize::from(iidx)).unwrap() || inst.has_side_effect(self) {
                 used.set(usize::from(iidx), true);
                 inst.map_packed_operand_locals(self, &mut |x| {
@@ -176,6 +176,26 @@ mod test {
             %0: ptr = load_ti ...
             %1: i8 = load_ti ...
             icall %0(%1)
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          func_type t1(i8)
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = %0
+            black_box %1
+        ",
+            |mut m| {
+                m.dead_code_elimination();
+                m
+            },
+            "
+          ...
+          entry:
+            %0: i8 = load_ti ...
+            black_box %0
         ",
         );
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -281,11 +281,11 @@ impl Module {
 
     /// Return the instruction at the specified index, deproxying `ProxyInst` i.e. searching
     /// until a non-`ProxyInst` instruction is found.
-    pub(crate) fn inst_deproxy(&self, mut iidx: InstIdx) -> Inst {
+    pub(crate) fn inst_deproxy(&self, mut iidx: InstIdx) -> (InstIdx, Inst) {
         loop {
             match self.insts[usize::from(iidx)] {
                 Inst::ProxyInst(proxy_iidx) => iidx = proxy_iidx,
-                x => return x,
+                x => return (iidx, x),
             }
         }
     }
@@ -552,6 +552,32 @@ impl Module {
 
     pub(crate) fn push_loop_jump_var(&mut self, op: Operand) {
         self.loop_jump_vars.push(op);
+    }
+
+    pub(crate) fn inst_vals_alive_until(&self) -> Vec<InstIdx> {
+        let mut alives = vec![InstIdx::try_from(0).unwrap(); self.insts_len()];
+        for iidx in self.iter_all_inst_idxs() {
+            let inst = self.inst_all(iidx);
+            inst.map_operand_locals(self, &mut |x| {
+                let (x, _) = self.inst_deproxy(x);
+                debug_assert!(alives[usize::from(x)] <= iidx);
+                alives[usize::from(x)] = iidx;
+            });
+        }
+
+        // FIXME: this is a hack.
+        for (iidx, inst) in self.iter_skipping_insts() {
+            if let Inst::TraceLoopStart = inst {
+                break;
+            }
+            // FIXME: this `unwrap` *could* fail, but only because we haven't properly implemented
+            // backward jumps. When we do so, we will have implicitly guaranteed that every
+            // `InstIdx` is representable without the `unwrap` failing.
+            alives[usize::from(iidx)] =
+                InstIdx::try_from(usize::from(self.last_inst_idx()) + 1).unwrap();
+        }
+
+        alives
     }
 }
 
@@ -1086,6 +1112,16 @@ impl Operand {
     pub(crate) fn display<'a>(&'a self, m: &'a Module) -> DisplayableOperand<'a> {
         DisplayableOperand { operand: self, m }
     }
+
+    /// If this [Operand] represents a local instruction, call `f` with its `InstIdx`.
+    fn map_iidx<F>(&self, f: &mut F)
+    where
+        F: FnMut(InstIdx),
+    {
+        if let Operand::Local(iidx) = self {
+            f(*iidx)
+        }
+    }
 }
 
 pub(crate) struct DisplayableOperand<'a> {
@@ -1426,6 +1462,97 @@ impl Inst {
         }
     }
 
+    /// Apply the function `f` to each of this instruction's [Operand]s iff they are of type
+    /// [Operand::Local]. When an instruction references more than one [Operand], the order of
+    /// traversal is undefined.
+    pub(crate) fn map_operand_locals<F>(&self, m: &Module, f: &mut F)
+    where
+        F: FnMut(InstIdx),
+    {
+        match self {
+            #[cfg(test)]
+            Inst::BlackBox(BlackBoxInst { op }) => {
+                op.unpack(m).map_iidx(f);
+            }
+            Inst::ProxyConst(_) => (),
+            Inst::ProxyInst(_) => (),
+            Inst::Tombstone => (),
+            Inst::BinOp(BinOpInst { lhs, binop: _, rhs }) => {
+                lhs.unpack(m).map_iidx(f);
+                rhs.unpack(m).map_iidx(f);
+            }
+            Inst::Load(LoadInst { op, .. }) => op.unpack(m).map_iidx(f),
+            Inst::LookupGlobal(_) => (),
+            Inst::LoadTraceInput(_) => (),
+            Inst::Call(x) => {
+                for i in x.iter_args_idx() {
+                    m.arg(i).map_iidx(f);
+                }
+            }
+            Inst::IndirectCall(x) => {
+                let ici = m.indirect_call(*x);
+                let IndirectCallInst { target, .. } = ici;
+                target.unpack(m).map_iidx(f);
+                for i in ici.iter_args_idx() {
+                    m.arg(i).map_iidx(f);
+                }
+            }
+            Inst::PtrAdd(x) => {
+                let ptr = x.ptr;
+                ptr.unpack(m).map_iidx(f);
+            }
+            Inst::DynPtrAdd(x) => {
+                let ptr = x.ptr;
+                ptr.unpack(m).map_iidx(f);
+                let num_elems = x.num_elems;
+                num_elems.unpack(m).map_iidx(f);
+            }
+            Inst::Store(StoreInst { tgt, val, .. }) => {
+                tgt.unpack(m).map_iidx(f);
+                val.unpack(m).map_iidx(f);
+            }
+            Inst::ICmp(ICmpInst { lhs, pred: _, rhs }) => {
+                lhs.unpack(m).map_iidx(f);
+                rhs.unpack(m).map_iidx(f);
+            }
+            Inst::Guard(x @ GuardInst { cond, .. }) => {
+                cond.unpack(m).map_iidx(f);
+                for (_, pop) in x.guard_info(m).live_vars() {
+                    pop.unpack(m).map_iidx(f);
+                }
+            }
+            Inst::TraceLoopStart => {
+                for x in &m.loop_start_vars {
+                    x.map_iidx(f);
+                }
+            }
+            Inst::TraceLoopJump => {
+                for x in &m.loop_jump_vars {
+                    x.map_iidx(f);
+                }
+            }
+            Inst::SExt(SExtInst { val, .. }) => val.unpack(m).map_iidx(f),
+            Inst::ZeroExtend(ZeroExtendInst { val, .. }) => val.unpack(m).map_iidx(f),
+            Inst::Trunc(TruncInst { val, .. }) => val.unpack(m).map_iidx(f),
+            Inst::Select(SelectInst {
+                cond,
+                trueval,
+                falseval,
+            }) => {
+                cond.unpack(m).map_iidx(f);
+                trueval.unpack(m).map_iidx(f);
+                falseval.unpack(m).map_iidx(f);
+            }
+            Inst::SIToFP(SIToFPInst { val, .. }) => val.unpack(m).map_iidx(f),
+            Inst::FPExt(FPExtInst { val, .. }) => val.unpack(m).map_iidx(f),
+            Inst::FCmp(FCmpInst { lhs, pred: _, rhs }) => {
+                lhs.unpack(m).map_iidx(f);
+                rhs.unpack(m).map_iidx(f);
+            }
+            Inst::FPToSI(FPToSIInst { val, .. }) => val.unpack(m).map_iidx(f),
+        }
+    }
+
     /// Apply the function `f` to each of this instruction's [PackedOperand]s that references a
     /// local instruction. When an instruction references more than one [PackedOperand], the order
     /// of traversal is undefined.
@@ -1443,7 +1570,7 @@ impl Inst {
                 op.map_iidx(f);
             }
             Inst::ProxyConst(_) => (),
-            Inst::ProxyInst(_) => (),
+            Inst::ProxyInst(iidx) => f(*iidx),
             Inst::Tombstone => (),
             Inst::BinOp(BinOpInst { lhs, binop: _, rhs }) => {
                 lhs.map_iidx(f);
@@ -2741,5 +2868,44 @@ mod tests {
         assert_eq!(Ty::Integer(127).byte_size().unwrap(), 16);
         assert_eq!(Ty::Integer(128).byte_size().unwrap(), 16);
         assert_eq!(Ty::Integer(129).byte_size().unwrap(), 17);
+    }
+
+    #[test]
+    fn alive_until() {
+        let m = Module::from_str(
+            "
+            entry:
+              %0: i8 = load_ti 0
+              tloop_start [%0]
+              %2: i8 = %0
+              tloop_jump [%2]
+            ",
+        );
+        assert_eq!(
+            m.inst_vals_alive_until(),
+            vec![4, 0, 0, 0]
+                .iter()
+                .map(|x: &usize| InstIdx::try_from(*x).unwrap())
+                .collect::<Vec<_>>()
+        );
+
+        let m = Module::from_str(
+            "
+            entry:
+              %0: i8 = load_ti 0
+              tloop_start [%0]
+              %2: i8 = add %0, %0
+              %3: i8 = add %0, %0
+              %4: i8 = %2
+              tloop_jump [%4]
+            ",
+        );
+        assert_eq!(
+            m.inst_vals_alive_until(),
+            vec![6, 0, 5, 0, 0, 0]
+                .iter()
+                .map(|x: &usize| InstIdx::try_from(*x).unwrap())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -439,7 +439,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                     ASTInst::Proxy { assign, val } => {
                         let op = self.process_operand(val)?;
                         let inst = match op {
-                            Operand::Local(_) => todo!(),
+                            Operand::Local(iidx) => Inst::ProxyInst(iidx),
                             Operand::Const(cidx) => Inst::ProxyConst(cidx),
                         };
                         self.push_assign(inst.into(), assign)?;

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -34,9 +34,8 @@ impl Module {
 
         let mut last_inst = None;
         for (iidx, inst) in self.iter_skipping_insts() {
-            inst.map_packed_operand_locals(self, &mut |x| {
-                let i = self.inst_deproxy(x);
-                if i.def_type(self).is_none() {
+            inst.map_operand_locals(self, &mut |x| {
+                if let Inst::Tombstone = self.inst_all(x) {
                     panic!(
                         "Instruction at position {iidx} uses undefined value (%{x})\n  {}",
                         self.inst_no_proxies(iidx).display(iidx, self)

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -13,7 +13,7 @@ use crate::compile::{
 
 pub(super) fn simple(mut m: Module) -> Result<Module, CompilationError> {
     for iidx in m.iter_all_inst_idxs() {
-        let inst = m.inst_deproxy(iidx);
+        let (iidx, inst) = m.inst_deproxy(iidx);
         match inst {
             Inst::BinOp(BinOpInst {
                 lhs,


### PR DESCRIPTION
This was subtly broken (my fault!) before in two ways: `map_packed_operand_local`s is necessary for (our current) dead code elimination, but we also (incorrectly) used it elsewhere; and we didn't use the updated `iidx`s after calling `inst_deproxy`.

This commit fixes both aspects. However, I'm not sure this is the best long-term approach, and that perhaps the better thing to do is to continually update (i.e. deproxy) operands as we go along. That can wait for a later day once I've chewed this over sufficiently, however.