### PR TITLE
Enable mem2reg in the AOT pipeline.

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -10,21 +10,58 @@ if [ ! -d "${DIR}/../ykrt" ]; then
     exit 1
 fi
 
-# The post-link time optimisations that we can tolerate. At this moment this is
-# only the instcombine pass in the below configuration (copied over from the
-# default pipeline). Using `instcombine` on its own breaks, possibly due to the
-# missing `no-verify-fixpoint`.
-POSTLINK_PASSES_STR="instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>"
+set_aot_pipeline() {
+    level=$1
+    # env var always takes precident.
+    if [ ! -z "${YKB_AOT_OPTLEVEL}" ]; then
+        level=${YKB_AOT_OPTLEVEL}
+    fi
+    case ${level} in
+        0)
+            POSTLINK_PASSES=${POSTLINK_PASSES_AO0}
+            PRELINK_PASSES=${PRELINK_PASSES_AO0}
+            ;;
+        1)
+            POSTLINK_PASSES=${POSTLINK_PASSES_AO1}
+            PRELINK_PASSES=${PRELINK_PASSES_AO1}
+            ;;
+        *)
+            echo "error: invalid yk AOT optimisation level '${level}'" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# Canned pipelines.
+#
+# Ideally we'd detect the optimisation level from the CFLAGS env var, but it's
+# not easy to reliably parse that info out of CFLAGS. So for now we allow `--ao
+# <n>` to yk-config (or set YKB_AOT_OPTLEVEL in the env) to specify the AOT
+# optimisation level.
+#
+# Note that clang is still passed -O0 regardless. We just add our own pipeline
+# specification on top.
+PRELINK_PASSES_AO0=""
+POSTLINK_PASSES_AO0="instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>"
+PRELINK_PASSES_AO1=""
+POSTLINK_PASSES_AO1="instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>,mem2reg,instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>"
+# Initialise the AOT pipeline to level 0 unless YKB_AOT_OPTLEVEL is set.
+set_aot_pipeline 0
 
 OUTPUT=""
 
 usage() {
     echo "Generate C compiler flags for building against the yk JIT.\n"
     echo "Usage:"
-    echo "    yk-config <profile> [--prelink-pipeline <passes>] [--postlink-pipeline <passes>] <--cc|--cxx|--ar|--ranlib|--cppflags|--cflags|--ldflags>\n"
-    echo "    Where <profile> is a Rust cargo profile starting with either 'debug' or 'release'."
+    echo "    yk-config <profile> [--ao <0|1>] \\"
+    echo "        <--cc|--cxx|--ar|--ranlib|--cppflags|--cflags|--ldflags>\n"
+    echo "    Where <profile> is a Rust cargo profile starting with either 'debug' or 'release'.\n"
+    echo "    --cc, --cxx, --ar, --ranlib, --cppflags, --cflags and --ldflags specify "
+    echo "    what flags to output.\n"
+    echo "    --ao specifies the yk-specific AOT optimisation pipeline to use for flags "
+    echo "    that follow. Defaults to 0, but (if set) the YKB_AOT_OPTLEVEL environment "
+    echo "    variable always takes precedent."
 }
-
 
 handle_arg() {
     profile=$1
@@ -38,30 +75,11 @@ handle_arg() {
     fi
 
     case $1 in
+        --ao) set_aot_pipeline $2;;
         --cc) OUTPUT="${ykllvm_bin_dir}/clang" ;;
         --cxx) OUTPUT="${ykllvm_bin_dir}/clang++" ;;
         --ar) OUTPUT="${ykllvm_bin_dir}/llvm-ar" ;;
         --ranlib) OUTPUT="${ykllvm_bin_dir}/llvm-ranlib" ;;
-        --prelink-pipeline)
-            if [ -z "$2" ] || [ "$(echo $2 | cut -b 1,2)" = "--" ]; then
-                1>&2 echo "Error: Expected passes after --prelink-pipeline."
-                usage
-                exit 1
-            else
-                PRELINK_PASSES_STR=$2
-                shift
-            fi
-            ;;
-        --postlink-pipeline)
-            if [ -z "$2" ] || [ "$(echo $2 | cut -b 1,2)" = "--" ]; then
-                1>&2 echo "Error: Expected passes after --postlink-pipeline."
-                usage
-                exit 1
-            else
-                POSTLINK_PASSES_STR=$2
-                shift
-            fi
-            ;;
         --cflags)
             # FIXME: we can only do -O0 for now.
             OUTPUT="${OUTPUT} -O0"
@@ -74,8 +92,11 @@ handle_arg() {
             # Without this, clang will slap `optnone` attributes on every
             # function, causing optimisations to skip them.
             OUTPUT="${OUTPUT} -Xclang -disable-O0-optnone"
-            if [ ! -z "${PRELINK_PASSES_STR}" ]; then
-                OUTPUT="${OUTPUT} -mllvm --newpm-passes=${PRELINK_PASSES_STR}"
+            # Run these "prelink" optimisation passes.
+            #
+            # These are run on the individual pre-LTO-merged LLVM modules.
+            if [ ! -z "${PRELINK_PASSES}" ]; then
+                OUTPUT="${OUTPUT} -mllvm --newpm-passes=${PRELINK_PASSES}"
             fi
             case $profile in
                 debug*) OUTPUT="$OUTPUT -g" ;;
@@ -147,7 +168,12 @@ handle_arg() {
             # This pairs with `-Xclang -disable-O0-optnone`. See above.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-optnone-after-ir-passes"
 
-            OUTPUT="${OUTPUT} -Xlinker --lto-newpm-passes=${POSTLINK_PASSES_STR}"
+            # Run these post-link passes.
+            #
+            # These are run on the merged LTO LLVM module.
+            if [ ! -z "${POSTLINK_PASSES}" ]; then
+                OUTPUT="${OUTPUT} -Xlinker --lto-newpm-passes=${POSTLINK_PASSES}"
+            fi
 
             # Emit a basic block map section. Used for block mapping.
             OUTPUT="${OUTPUT} -Wl,--lto-basic-block-sections=labels"

--- a/tests/benches/collect_and_decode.rs
+++ b/tests/benches/collect_and_decode.rs
@@ -27,7 +27,7 @@ fn compile_runner(tempdir: &TempDir) -> PathBuf {
     exe.push(tempdir);
     exe.push(src.file_stem().unwrap());
 
-    let mut compiler = mk_compiler(&ykllvm_bin("clang"), &exe, &src, &[], false);
+    let mut compiler = mk_compiler(&ykllvm_bin("clang"), &exe, &src, &[], false, None);
     compiler.arg("-ltests");
     let out = compiler.output().unwrap();
     check_output(&out);

--- a/tests/benches/promote.rs
+++ b/tests/benches/promote.rs
@@ -25,7 +25,7 @@ fn compile_bench(tempdir: &TempDir, promote: bool) -> PathBuf {
     exe.push(tempdir);
     exe.push(src.file_stem().unwrap());
 
-    let mut compiler = mk_compiler(&ykllvm_bin("clang"), &exe, &src, &[], true);
+    let mut compiler = mk_compiler(&ykllvm_bin("clang"), &exe, &src, &[], true, None);
     compiler.arg("-ltests");
     if promote {
         compiler.arg("-DDO_PROMOTE");

--- a/tests/c/float_binop.c
+++ b/tests/c/float_binop.c
@@ -1,3 +1,4 @@
+// ## yk-config-env: YKB_AOT_OPTLEVEL=1
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
@@ -14,7 +15,7 @@
 //     %{{10_5}}: float = fadd %{{_}}, %{{_}}
 //     %{{10_6}}: double = fp_ext %{{10_5}}, double
 //     ...
-//     %{{10_9}}: double = fadd %{{_}}, %{{_}}
+//     %{{10_9}}: double = fadd %{{_}}, 0.84double
 //     %{{_}}: i32 = call fprintf(%{{_}}, @{{_}}, %{{_}}, %{{10_6}}, %{{10_9}})
 //     ...
 //     --- End aot ---
@@ -23,11 +24,11 @@
 //     %{{16}}: float = fadd %{{_}}, %{{_}}
 //     %{{17}}: double = fp_ext %{{16}}
 //     ...
-//     %{{20}}: double = fadd %{{_}}, %{{_}}
+//     %{{20}}: double = fadd %{{_}}, 0.84double
 //     ...
 //     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, %{{17}}, %{{20}})
 //     ...
-//     %{{x}}: double = fsub %{{_}}, %{{_}}
+//     %{{x}}: double = fadd %{{_}}, -0.84double
 //     ...
 //     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{x}})
 //     ...

--- a/tests/c/float_div.c
+++ b/tests/c/float_div.c
@@ -1,3 +1,4 @@
+// ## yk-config-env: YKB_AOT_OPTLEVEL=1
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
@@ -13,7 +14,7 @@
 //     %{{10_5}}: float = fdiv %{{_}}, %{{_}}
 //     %{{10_6}}: double = fp_ext %{{10_5}}, double
 //     ...
-//     %{{10_9}}: double = fdiv %{{_}}, %{{_}}
+//     %{{10_9}}: double = fdiv %{{_}}, 0.2double
 //     ...
 //     %{{_}}: i32 = call fprintf(%{{_}}, @{{_}}, %{{_}}, %{{10_6}}, %{{10_9}})
 //     ...
@@ -23,7 +24,7 @@
 //     %{{16}}: float = fdiv %{{_}}, %{{_}}
 //     %{{17}}: double = fp_ext %{{16}}
 //     ...
-//     %{{20}}: double = fdiv %{{_}}, %{{_}}
+//     %{{20}}: double = fdiv %{{_}}, 0.2double
 //     ...
 //     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, %{{17}}, %{{20}})
 //     ...

--- a/tests/c/float_mul.c
+++ b/tests/c/float_mul.c
@@ -1,3 +1,4 @@
+// ## yk-config-env: YKB_AOT_OPTLEVEL=1
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
@@ -13,7 +14,7 @@
 //     %{{10_5}}: float = fmul %{{_}}, %{{_}}
 //     %{{10_6}}: double = fp_ext %{{10_5}}, double
 //     ...
-//     %{{10_9}}: double = fmul %{{_}}, %{{_}}
+//     %{{10_9}}: double = fmul %{{_}}, 0.84double
 //     ...
 //     %{{_}}: i32 = call fprintf(%{{_}}, @{{_}}, %{{_}}, %{{10_6}}, %{{10_9}})
 //     ...
@@ -23,7 +24,7 @@
 //     %{{16}}: float = fmul %{{_}}, %{{_}}
 //     %{{17}}: double = fp_ext %{{16}}
 //     ...
-//     %{{20}}: double = fmul %{{_}}, %{{_}}
+//     %{{20}}: double = fmul %{{_}}, 0.84double
 //     ...
 //     %{{_}}: i32 = call @fprintf(%{{_}}, %{{_}}, %{{_}}, %{{17}}, %{{20}})
 //     ...

--- a/tests/c/indirect_call.c
+++ b/tests/c/indirect_call.c
@@ -39,6 +39,7 @@ int main(int argc, char **argv) {
 
   NOOPT_VAL(loc);
   NOOPT_VAL(i);
+  NOOPT_VAL(fn);
   while (i > 0) {
     yk_mt_control_point(mt, &loc);
     int x = fn(i);

--- a/tests/c/lua_array_len.c
+++ b/tests/c/lua_array_len.c
@@ -1,0 +1,89 @@
+// ## yk-config-env: YKB_AOT_OPTLEVEL=1
+// Run-time:
+//   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YK_LOG=4
+
+// This was reduced from yklua.
+//
+// In short a `ptradd %ptr, 0` was reducing to nothing in the tracebuilder and
+// the AOT instruction was being associated with the last JIT instruction
+// (which was nothing to do with the `ptr_add`!).
+//
+// This caused a runtime crash.
+//
+// I tried to reduce this to a test with a simple constant 0-byte offset field
+// access, but I can't get ykllvm to emit a constant zero offset GEP when
+// mem2reg is enabled.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+typedef unsigned char lu_byte;
+typedef long long lua_Integer;
+typedef unsigned long long lua_Unsigned;
+
+typedef union Value {
+  lua_Integer i;
+} Value;
+
+typedef struct TValue {
+  Value value_; lu_byte tt_;
+} TValue;
+
+typedef union StackValue {
+  TValue val;
+  struct {
+    Value value_; lu_byte tt_;
+    unsigned short delta;
+  } tbclist;
+} StackValue;
+
+typedef StackValue *StkId;
+typedef struct Table {} Table;
+
+union GCUnion {
+  struct Table h;
+};
+
+__attribute__((noinline))
+lua_Unsigned luaH_getn(Table *t) { return 0; }
+
+__attribute__((noinline))
+void luaV_objlen(StkId ra, const TValue *rb) {
+  Table *h = &((union GCUnion *)rb)->h;
+  TValue *io = (TValue *) ra;
+  io->value_.i = luaH_getn(h);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  StackValue sv;
+  sv.val.value_.i = 1;
+  TValue tv;
+  tv.value_.i = 1;
+  StkId ra = &sv;
+  TValue *rb = &tv;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  NOOPT_VAL(ra);
+  NOOPT_VAL(rb);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    luaV_objlen(ra, rb);
+    fprintf(stderr, "%d\n", i);
+    i--;
+  }
+  fprintf(stderr, "exit\n");
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/phi3.c
+++ b/tests/c/phi3.c
@@ -1,3 +1,4 @@
+// ## yk-config-env: YKB_AOT_OPTLEVEL=1
 // Run-time:
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   env-var: YK_LOG=4

--- a/tests/c/simple_interp_loop2.c
+++ b/tests/c/simple_interp_loop2.c
@@ -1,6 +1,5 @@
 // Run-time:
 //   env-var: YK_LOG=4
-//   env-var: YKD_LOG_IR=-:jit-pre-opt
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing
@@ -9,19 +8,6 @@
 //     pc=2, mem=4
 //     pc=3, mem=3
 //     yk-jit-event: stop-tracing
-//     --- Begin jit-pre-opt ---
-//     ..~
-//     guard true, %{{34}}, [{{_}}:%0_{{_}}: %0, {{_}}:%0_{{_}}: %1, {{_}}:%0_{{_}}: %2, {{_}}:%0_{{_}}: %3, {{_}}:%0_{{_}}: %4, {{_}}:%0_{{_}}: %5, {{_}}:%23_{{_}}: %{{34}}]
-//     %{{_}}: ptr = load %{{1}}
-//     %{{48}}: ptr = load %{{4}}
-//     %{{_}}: i32 = load %{{5}}
-//     %{{50}}: i64 = sext %{{_}}, i64
-//     %{{51}}: ptr = dyn_ptr_add %{{48}}, %{{50}}, 8
-//     %{{_}}: ptr = load %{{51}}
-//     %{{43}}: i32 = load %{{5}}
-//     %{{_}}: i1 = eq %{{43}}, 0i32
-//     ...
-//     --- End jit-pre-opt ---
 //     pc=0, mem=3
 //     pc=1, mem=3
 //     pc=2, mem=3

--- a/tests/c/trace_too_long.c
+++ b/tests/c/trace_too_long.c
@@ -3,7 +3,7 @@
 // ## where we know it'll run fast enough.
 // ##
 // ## FIXME: doesn't trigger "trace too long".
-// ignore-if: test "$YKB_TRACER" = "hwt"
+// ignore-if: test "$YKB_TRACER" != "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YK_LOG=4

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -1,8 +1,11 @@
 use lang_tester::LangTester;
 use regex::Regex;
 use std::{
+    collections::HashMap,
     env,
-    fs::read_to_string,
+    error::Error,
+    fs::{read_to_string, File},
+    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -11,6 +14,30 @@ use tests::{mk_compiler, EXTRA_LINK};
 use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
 
 const COMMENT: &str = "//";
+const COMMENT_PREFIX: &str = "##";
+
+/// Parse any "extra environment" to pass to yk-config out of the test file.
+fn parse_yk_config_env(p: &Path) -> Result<HashMap<String, String>, Box<dyn Error>> {
+    let f = File::open(p)?;
+    let rdr = BufReader::new(&f);
+    let mut extra = HashMap::new();
+    let env_prefix = format!("{} {} yk-config-env:", COMMENT, COMMENT_PREFIX);
+    for line in rdr.lines() {
+        let line = line?;
+        if !line.starts_with(COMMENT) {
+            break; // won't find any lower down the file.
+        }
+        if line.starts_with(&env_prefix) {
+            let sfx = &line[(&env_prefix).len()..];
+            let mut elems = sfx.split("=");
+            extra.insert(
+                elems.next().ok_or("bad yk-config-env line")?.trim().into(),
+                elems.next().ok_or("bad yk-config-env line")?.trim().into(),
+            );
+        }
+    }
+    Ok(extra)
+}
 
 fn main() {
     println!("Running C tests...");
@@ -36,7 +63,7 @@ fn main() {
     panic!("Unknown target_arch");
 
     LangTester::new()
-        .comment_prefix("##")
+        .comment_prefix(COMMENT_PREFIX)
         .test_dir("c")
         .test_path_filter(|p: &Path| {
             p.extension().as_ref().and_then(|p| p.to_str()) == Some("c")
@@ -66,7 +93,15 @@ fn main() {
                 .map(|l| l.generate_obj(tempdir.path()))
                 .collect::<Vec<PathBuf>>();
 
-            let mut compiler = mk_compiler(wrapper_path.as_path(), &exe, p, &extra_objs, true);
+            let yk_config_env = parse_yk_config_env(p).unwrap();
+            let mut compiler = mk_compiler(
+                wrapper_path.as_path(),
+                &exe,
+                p,
+                &extra_objs,
+                true,
+                Some(&yk_config_env),
+            );
             compiler.env("YK_COMPILER_PATH", ykllvm_bin("clang"));
             let runtime = Command::new(exe.clone());
             vec![("Compiler", compiler), ("Run-time", runtime)]

--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -61,6 +61,7 @@ fn main() {
         &test_path,
         &extra_objs,
         true,
+        None,
     );
     if !cmd.spawn().unwrap().wait().unwrap().success() {
         panic!("compilation failed");

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -768,6 +768,13 @@ impl TraceBuilder {
             jit_ptr = self
                 .jit_mod
                 .push_and_make_operand(jit_ir::PtrAddInst::new(jit_ptr, off_i32).into())?;
+        } else {
+            jit_ptr = match jit_ptr {
+                Operand::Local(iidx) => self
+                    .jit_mod
+                    .push_and_make_operand(jit_ir::Inst::ProxyInst(iidx))?,
+                _ => todo!(),
+            }
         }
 
         // Now apply any dynamic indices.


### PR DESCRIPTION
mem2reg replaces allocas with SSA variables so that they can be allocated to registers where possible:

https://llvm.org/docs/Passes.html#mem2reg-promote-memory-to-register

This commit contains about a week's worth of debugging work and now the yklua test suite runs to completion.

To make testing possible we also needed to add the ability for tests to specify an AOT opt level. This doesn't fit well with the current test harness, so it's a bit of a hack.

The test file needs a line at the top like:
// ## yk-config-env: YKB_AOT_OPTLEVEL=1