### PR TITLE
Fix stack overflow when asking for an AOT operand's type.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -917,6 +917,7 @@ pub(crate) enum Inst {
     },
     #[deku(id = "14")]
     Phi {
+        tyidx: TyIdx,
         #[deku(temp)]
         num_incoming: usize,
         #[deku(count = "num_incoming")]
@@ -1014,9 +1015,9 @@ impl Inst {
             Self::Store { .. } => None,
             Self::Cast { dest_tyidx, .. } => Some(m.type_(*dest_tyidx)),
             Self::Switch { .. } => None,
-            Self::Phi { incoming_vals, .. } => {
+            Self::Phi { tyidx, .. } => {
                 // Indexing cannot crash: correct PHI nodes have at least one incoming value.
-                Some(incoming_vals[0].type_(m))
+                Some(m.type_(*tyidx))
             }
             Self::IndirectCall { ftyidx, .. } => {
                 // The type of the newly-defined local is the return type of the callee.
@@ -1276,6 +1277,7 @@ impl fmt::Display for DisplayableInst<'_> {
             Inst::Phi {
                 incoming_vals,
                 incoming_bbs,
+                ..
             } => {
                 let args = incoming_bbs
                     .iter()

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -232,6 +232,7 @@ impl TraceBuilder {
                 aot_ir::Inst::Phi {
                     incoming_bbs,
                     incoming_vals,
+                    ..
                 } => {
                     debug_assert_eq!(prevbb.as_ref().unwrap().funcidx(), bid.funcidx());
                     self.handle_phi(


### PR DESCRIPTION
Requires https://github.com/ykjit/ykllvm/pull/200

When adding more passes to the AOT pipeline we found that the mere act of printing the AOT module can cause stack overflows.

If you have IR like:

```
bb0:
    %1 = ...
bb1:
    %2 = phi bb1 -> %3, bb0 -> %1
    %3 = %2 + 1
    goto bb1
```

Asking the type of %3 causes infinite recursion.

This is because an operation often asks its operands for their type to determine their own type.

Here, %3 asks %2, who asks %3, who asks %2, who asks... forever. Each "ask" is a function call, so this blows the stack.

This change breaks the cycle by putting a PHI's type into the instruction explicitly, so it doesn't have to search further afield to know it's type.

We haven't seen this before because usually the first operand to a PHI is from earlier (not later) in the module, so there is no cycle.