### PR TITLE
Remove "proxy" naming

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -447,7 +447,7 @@ impl<'a> LSRegAlloc<'a> {
             RegState::Reserved | RegState::Empty | RegState::FromConst(_) => (),
             RegState::FromInst(iidx) => {
                 if self.spills[usize::from(iidx)] == SpillState::Empty {
-                    let inst = self.m.inst_no_proxies(iidx);
+                    let inst = self.m.inst_no_copies(iidx);
                     let size = inst.def_byte_size(self.m);
                     self.stack.align(size); // FIXME
                     let frame_off = self.stack.grow(size);
@@ -471,7 +471,7 @@ impl<'a> LSRegAlloc<'a> {
     ///
     /// If `iidx` has not previously been spilled.
     fn force_gp_unspill(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rq) {
-        let (iidx, inst) = self.m.inst_deproxy(iidx);
+        let (iidx, inst) = self.m.inst_decopy(iidx);
         let size = inst.def_byte_size(self.m);
 
         if let Inst::Const(cidx) = inst {
@@ -666,7 +666,7 @@ impl<'a> LSRegAlloc<'a> {
         }) {
             VarLocation::Register(reg_alloc::Register::FP(FP_REGS[reg_i]))
         } else {
-            let (iidx, inst) = self.m.inst_deproxy(iidx);
+            let (iidx, inst) = self.m.inst_decopy(iidx);
             let size = inst.def_byte_size(self.m);
             match inst {
                 Inst::Copy(_) => panic!(),
@@ -865,7 +865,7 @@ impl<'a> LSRegAlloc<'a> {
             RegState::Reserved | RegState::Empty | RegState::FromConst(_) => (),
             RegState::FromInst(iidx) => {
                 if self.spills[usize::from(iidx)] == SpillState::Empty {
-                    let inst = self.m.inst_no_proxies(iidx);
+                    let inst = self.m.inst_no_copies(iidx);
                     let size = inst.def_byte_size(self.m);
                     self.stack.align(size); // FIXME
                     let frame_off = self.stack.grow(size);
@@ -887,7 +887,7 @@ impl<'a> LSRegAlloc<'a> {
     ///
     /// If `iidx` has not previously been spilled.
     fn force_fp_unspill(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rx) {
-        let inst = self.m.inst_no_proxies(iidx);
+        let inst = self.m.inst_no_copies(iidx);
         let size = inst.def_byte_size(self.m);
 
         match self.spills[usize::from(iidx)] {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -474,7 +474,7 @@ impl<'a> LSRegAlloc<'a> {
         let (iidx, inst) = self.m.inst_deproxy(iidx);
         let size = inst.def_byte_size(self.m);
 
-        if let Inst::ProxyConst(cidx) = inst {
+        if let Inst::Const(cidx) = inst {
             self.load_const_into_gp_reg(asm, cidx, reg);
             return;
         }
@@ -670,7 +670,7 @@ impl<'a> LSRegAlloc<'a> {
             let size = inst.def_byte_size(self.m);
             match inst {
                 Inst::Copy(_) => panic!(),
-                Inst::ProxyConst(cidx) => match self.m.const_(cidx) {
+                Inst::Const(cidx) => match self.m.const_(cidx) {
                     Const::Float(_, _) => todo!(),
                     Const::Int(tyidx, v) => {
                         let Ty::Integer(bits) = self.m.type_(*tyidx) else {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -669,7 +669,7 @@ impl<'a> LSRegAlloc<'a> {
             let (iidx, inst) = self.m.inst_deproxy(iidx);
             let size = inst.def_byte_size(self.m);
             match inst {
-                Inst::ProxyInst(_) => panic!(),
+                Inst::Copy(_) => panic!(),
                 Inst::ProxyConst(cidx) => match self.m.const_(cidx) {
                     Const::Float(_, _) => todo!(),
                     Const::Int(tyidx, v) => {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -281,7 +281,7 @@ impl<'a> Assemble<'a> {
         match inst {
             #[cfg(test)]
             jit_ir::Inst::BlackBox(_) => unreachable!(),
-            jit_ir::Inst::ProxyConst(_) | jit_ir::Inst::ProxyInst(_) | jit_ir::Inst::Tombstone => {
+            jit_ir::Inst::ProxyConst(_) | jit_ir::Inst::Copy(_) | jit_ir::Inst::Tombstone => {
                 unreachable!();
             }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -731,7 +731,7 @@ impl<'a> Assemble<'a> {
                 todo!("{:?}", e);
             }
         };
-        let size = self.m.inst_no_proxies(iidx).def_byte_size(self.m);
+        let size = self.m.inst_no_copies(iidx).def_byte_size(self.m);
         debug_assert!(size <= REG64_SIZE);
         match m {
             VarLocation::Register(reg_alloc::Register::GP(reg)) => {
@@ -758,7 +758,7 @@ impl<'a> Assemble<'a> {
                     iidx,
                     [RegConstraint::InputOutput(inst.operand(self.m))],
                 );
-                let size = self.m.inst_no_proxies(iidx).def_byte_size(self.m);
+                let size = self.m.inst_no_copies(iidx).def_byte_size(self.m);
                 debug_assert!(size <= REG64_SIZE);
                 match size {
                     1 => dynasm!(self.asm ; movzx Rq(reg.code()), BYTE [Rq(reg.code())]),
@@ -2434,7 +2434,7 @@ mod tests {
     }
 
     #[test]
-    fn cg_proxyconst() {
+    fn cg_const() {
         codegen_and_test(
             "
               entry:

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -281,7 +281,7 @@ impl<'a> Assemble<'a> {
         match inst {
             #[cfg(test)]
             jit_ir::Inst::BlackBox(_) => unreachable!(),
-            jit_ir::Inst::ProxyConst(_) | jit_ir::Inst::Copy(_) | jit_ir::Inst::Tombstone => {
+            jit_ir::Inst::Const(_) | jit_ir::Inst::Copy(_) | jit_ir::Inst::Tombstone => {
                 unreachable!();
             }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
+++ b/ykrt/src/compile/jitc_yk/jit_ir/jit_ir.y
@@ -135,7 +135,7 @@ Inst -> Result<ASTInst, Box<dyn Error>>:
       Ok(ASTInst::Select{assign: $1?.span(), cond: $5?, trueval: $7?, falseval: $9? })
     }
   | "LOCAL_OPERAND" ":" Type "=" Operand {
-      Ok(ASTInst::Proxy{assign: $1?.span(), val: $5? })
+      Ok(ASTInst::Assign{assign: $1?.span(), val: $5? })
     }
   | "TLOOP_START" "[" OperandsList "]" { Ok(ASTInst::TraceLoopStart($3?)) }
   | "TLOOP_JUMP"  "[" OperandsList "]" { Ok(ASTInst::TraceLoopJump($3?)) }

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -439,7 +439,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                     ASTInst::Proxy { assign, val } => {
                         let op = self.process_operand(val)?;
                         let inst = match op {
-                            Operand::Var(iidx) => Inst::ProxyInst(iidx),
+                            Operand::Var(iidx) => Inst::Copy(iidx),
                             Operand::Const(cidx) => Inst::ProxyConst(cidx),
                         };
                         self.push_assign(inst.into(), assign)?;

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -440,7 +440,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                         let op = self.process_operand(val)?;
                         let inst = match op {
                             Operand::Var(iidx) => Inst::Copy(iidx),
-                            Operand::Const(cidx) => Inst::ProxyConst(cidx),
+                            Operand::Const(cidx) => Inst::Const(cidx),
                         };
                         self.push_assign(inst.into(), assign)?;
                     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -38,7 +38,7 @@ impl Module {
                 if let Inst::Tombstone = self.inst_all(x) {
                     panic!(
                         "Instruction at position {iidx} uses undefined value (%{x})\n  {}",
-                        self.inst_no_proxies(iidx).display(iidx, self)
+                        self.inst_no_copies(iidx).display(iidx, self)
                     );
                 }
             });
@@ -48,7 +48,7 @@ impl Module {
                     if lhs_tyidx != rhs.unpack(self).tyidx(self) {
                         panic!(
                             "Instruction at position {iidx} has different types on lhs and rhs\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self)
+                            self.inst_no_copies(iidx).display(iidx, self)
                         );
                     }
                     match binop {
@@ -68,7 +68,7 @@ impl Module {
                             if matches!(self.type_(lhs_tyidx), Ty::Float(_)) {
                                 panic!(
                                     "Integer binop at position {iidx} operates on float operands\n  {}",
-                                    self.inst_no_proxies(iidx).display(iidx, self)
+                                    self.inst_no_copies(iidx).display(iidx, self)
                                 );
                             }
                         }
@@ -76,7 +76,7 @@ impl Module {
                             if !matches!(self.type_(lhs_tyidx), Ty::Float(_)) {
                                 panic!(
                                     "Float binop at position {iidx} operates on integer operands\n  {}",
-                                    self.inst_no_proxies(iidx).display(iidx, self)
+                                    self.inst_no_copies(iidx).display(iidx, self)
                                 );
                             }
                         }
@@ -122,7 +122,7 @@ impl Module {
                     let Ty::Integer(1) = self.type_(tyidx) else {
                         panic!(
                             "Guard at position {iidx} does not have 'cond' of type 'i1'\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self)
+                            self.inst_no_copies(iidx).display(iidx, self)
                         )
                     };
                     if let Operand::Const(x) = cond {
@@ -135,7 +135,7 @@ impl Module {
                         // if (*expect && *v == 0) || (!*expect && *v == 1) {
                         //     panic!(
                         //         "Guard at position {iidx} references a constant that is at odds with the guard itself\n  {}",
-                        //         self.inst_no_proxies(iidx).display(iidx, self)
+                        //         self.inst_no_copies(iidx).display(iidx, self)
                         //     );
                         // }
                     }
@@ -144,7 +144,7 @@ impl Module {
                     if x.lhs(self).tyidx(self) != x.rhs(self).tyidx(self) {
                         panic!(
                             "Instruction at position {iidx} has different types on lhs and rhs\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self)
+                            self.inst_no_copies(iidx).display(iidx, self)
                         );
                     }
                 }
@@ -154,7 +154,7 @@ impl Module {
                     {
                         panic!(
                             "Instruction at position {iidx} trying to sign extend from an equal-or-larger-than integer type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self)
+                            self.inst_no_copies(iidx).display(iidx, self)
                         );
                     }
                 }
@@ -164,15 +164,15 @@ impl Module {
 
                     if !matches!(from_type, Ty::Integer(_)) {
                         panic!("Instruction at position {iidx} trying to convert a non-integer type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                     if !matches!(to_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to convert to a non-float type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                     if to_type.byte_size() < from_type.byte_size() {
                         panic!("Instruction at position {iidx} trying to convert to a smaller-sized float\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                 }
                 Inst::FPExt(x) => {
@@ -180,15 +180,15 @@ impl Module {
                     let to_type = self.type_(x.dest_tyidx());
                     if !matches!(from_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to extend from a non-float type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                     if !matches!(to_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to extend to a non-float type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                     if to_type.byte_size() <= from_type.byte_size() {
                         panic!("Instruction at position {iidx} trying to extend to a smaller-sized float\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                 }
                 Inst::FPToSI(x) => {
@@ -197,18 +197,18 @@ impl Module {
 
                     if !matches!(from_type, Ty::Float(_)) {
                         panic!("Instruction at position {iidx} trying to convert a non-float type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                     if !matches!(to_type, Ty::Integer(_)) {
                         panic!("Instruction at position {iidx} trying to convert to a non-integer type\n  {}",
-                            self.inst_no_proxies(iidx).display(iidx, self));
+                            self.inst_no_copies(iidx).display(iidx, self));
                     }
                 }
                 Inst::LoadTraceInput(_) => {
                     if let Some(i) = last_inst {
                         if !matches!(i, Inst::LoadTraceInput(_)) {
                             panic!("LoadTraceInput instruction may only appear at the beginning of a trace or after another LoadTraceInput instruction\n  {}",
-                                self.inst_no_proxies(iidx).display(iidx, self));
+                                self.inst_no_copies(iidx).display(iidx, self));
                         }
                     }
                 }

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -66,7 +66,7 @@ fn opt_mul(
                     m.replace(iidx, Inst::ProxyConst(cidx));
                 } else if new_val == 1 {
                     // Replace `x * 1` with `x`.
-                    m.replace(iidx, Inst::ProxyInst(mul_inst));
+                    m.replace(iidx, Inst::Copy(mul_inst));
                 } else if new_val & (new_val - 1) == 0 {
                     // Replace `x * y` with `x << ...`.
                     let shl = u64::from(new_val.ilog2());

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -13,7 +13,7 @@ use crate::compile::{
 
 pub(super) fn simple(mut m: Module) -> Result<Module, CompilationError> {
     for iidx in m.iter_all_inst_idxs() {
-        let (iidx, inst) = m.inst_deproxy(iidx);
+        let (iidx, inst) = m.inst_decopy(iidx);
         match inst {
             Inst::BinOp(BinOpInst {
                 lhs,
@@ -47,7 +47,7 @@ fn opt_mul(
                     lhs: chain_lhs,
                     binop: BinOp::Mul,
                     rhs: chain_rhs,
-                }) = m.inst_no_proxies(mul_inst)
+                }) = m.inst_no_copies(mul_inst)
                 {
                     if let (Operand::Var(chain_mul_inst), Operand::Const(chain_mul_const))
                     | (Operand::Const(chain_mul_const), Operand::Var(chain_mul_inst)) =

--- a/ykrt/src/compile/jitc_yk/opt/simple.rs
+++ b/ykrt/src/compile/jitc_yk/opt/simple.rs
@@ -63,7 +63,7 @@ fn opt_mul(
                 if new_val == 0 {
                     // Replace `x * 0` with `0`.
                     let cidx = m.insert_const(old_const.u64_to_int(0))?;
-                    m.replace(iidx, Inst::ProxyConst(cidx));
+                    m.replace(iidx, Inst::Const(cidx));
                 } else if new_val == 1 {
                     // Replace `x * 1` with `x`.
                     m.replace(iidx, Inst::Copy(mul_inst));
@@ -90,7 +90,7 @@ fn opt_mul(
             // author is at fault.
             let new_val = x.int_to_u64().unwrap() * y.int_to_u64().unwrap();
             let new_const = m.insert_const(x.u64_to_int(new_val))?;
-            m.replace(iidx, Inst::ProxyConst(new_const));
+            m.replace(iidx, Inst::Const(new_const));
         }
         (Operand::Var(_), Operand::Var(_)) => (),
     }
@@ -141,9 +141,9 @@ fn opt_icmp(
             };
 
             if r {
-                m.replace(iidx, Inst::ProxyConst(m.true_constidx()));
+                m.replace(iidx, Inst::Const(m.true_constidx()));
             } else {
-                m.replace(iidx, Inst::ProxyConst(m.false_constidx()));
+                m.replace(iidx, Inst::Const(m.false_constidx()));
             }
         }
     }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -494,11 +494,11 @@ impl TraceBuilder {
                                 PackedOperand::new(&jit_ir::Operand::Var(liidx)),
                             )),
                             jit_ir::Operand::Const(_) => {
-                                // Since we are forcing constants into `ProxyConst`s during inlining, this
-                                // case should never happen. If you see this panic, then look for a
-                                // safepoint live variable that maps to a constant and make the builder
-                                // insert a `ProxyConst` for it instead.
-                                panic!("constant encountered while building guardinfo!")
+                                // Since we are forcing constants into `Inst::Const`s during
+                                // inlining, this case should never happen. If you see this panic,
+                                // then look for a safepoint live variable that maps to a constant
+                                // and make the builder insert an `Inst::Const` for it instead.
+                                panic!("Constant encountered while building guardinfo!")
                             }
                         }
                     }
@@ -666,7 +666,7 @@ impl TraceBuilder {
             match self.handle_operand(arg)? {
                 jit_ir::Operand::Const(c) => {
                     // We don't want to do constant propagation here as it makes our life harder
-                    // creating guards. Instead we simply create a proxy instruction here and
+                    // creating guards. Instead we simply create a `Const` instruction here and
                     // reference that.
                     let inst = jit_ir::Inst::Const(c);
                     self.jit_mod.push(inst)?;
@@ -954,7 +954,7 @@ impl TraceBuilder {
         let op = match self.handle_operand(chosen_val)? {
             jit_ir::Operand::Const(c) => {
                 // We don't want to do constant propagation here as it makes our life harder
-                // creating guards. Instead we simply create a proxy instruction here and
+                // creating guards. Instead we simply create a `Const` instruction here and
                 // reference that.
                 let inst = jit_ir::Inst::Const(c);
                 self.jit_mod.push(inst)?;

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -771,7 +771,7 @@ impl TraceBuilder {
             jit_ptr = match jit_ptr {
                 Operand::Var(iidx) => self
                     .jit_mod
-                    .push_and_make_operand(jit_ir::Inst::ProxyInst(iidx))?,
+                    .push_and_make_operand(jit_ir::Inst::Copy(iidx))?,
                 _ => todo!(),
             }
         }
@@ -1011,7 +1011,7 @@ impl TraceBuilder {
         }
         match self.handle_operand(val)? {
             jit_ir::Operand::Var(ref_iidx) => {
-                self.jit_mod.push(jit_ir::Inst::ProxyInst(ref_iidx))?;
+                self.jit_mod.push(jit_ir::Inst::Copy(ref_iidx))?;
                 self.link_iid_to_last_inst(bid, aot_inst_idx);
 
                 // Insert a guard to ensure the trace only runs if the value we encounter is the

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -668,7 +668,7 @@ impl TraceBuilder {
                     // We don't want to do constant propagation here as it makes our life harder
                     // creating guards. Instead we simply create a proxy instruction here and
                     // reference that.
-                    let inst = jit_ir::Inst::ProxyConst(c);
+                    let inst = jit_ir::Inst::Const(c);
                     self.jit_mod.push(inst)?;
                     let op = jit_ir::Operand::Var(self.jit_mod.last_inst_idx());
                     jit_args.push(op);
@@ -956,7 +956,7 @@ impl TraceBuilder {
                 // We don't want to do constant propagation here as it makes our life harder
                 // creating guards. Instead we simply create a proxy instruction here and
                 // reference that.
-                let inst = jit_ir::Inst::ProxyConst(c);
+                let inst = jit_ir::Inst::Const(c);
                 self.jit_mod.push(inst)?;
                 jit_ir::Operand::Var(self.jit_mod.last_inst_idx())
             }


### PR DESCRIPTION
The use of "Proxy" in instructions has become gradually more unfortunate. First, `ProxyConst` is *very* different to `ProxyInst`, so suggesting there's a link is misleading. Second, "proxy" isn't the standard SSA terminology. This PR fixes both things.