### PR TITLE
Adjust to ykllvm now tracking arbitrary numbers of locations.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -2839,7 +2839,7 @@ mod tests {
     #[test]
     fn print_module() {
         let mut m = Module::new_testing();
-        m.push_tiloc(yksmp::Location::Register(3, 1, 0, 0));
+        m.push_tiloc(yksmp::Location::Register(3, 1, 0, vec![]));
         m.push(LoadTraceInputInst::new(0, m.int8_tyidx()).into())
             .unwrap();
         m.insert_global_decl(GlobalDecl::new(
@@ -2861,7 +2861,7 @@ mod tests {
             "global_decl tls @some_thread_local",
             "",
             "entry:",
-            "    %0: i8 = load_ti Register(3, 1, 0, 0)",
+            "    %0: i8 = load_ti Register(3, 1, 0, [])",
         ]
         .join("\n");
         assert_eq!(m.to_string(), expect);

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -323,7 +323,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                     gp_reg_off,
                                     u16::try_from(size).unwrap(),
                                     0,
-                                    0,
+                                    vec![],
                                 ));
                                 gp_reg_off += 1;
                             }
@@ -332,7 +332,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                     fp_reg_off,
                                     u16::try_from(size).unwrap(),
                                     0,
-                                    0,
+                                    vec![],
                                 ));
                                 fp_reg_off += 1;
                             }
@@ -828,8 +828,8 @@ mod tests {
         let mut m = Module::new_testing();
         let i16_tyidx = m.insert_ty(Ty::Integer(16)).unwrap();
 
-        m.push_tiloc(yksmp::Location::Register(3, 1, 0, 0));
-        m.push_tiloc(yksmp::Location::Register(3, 1, 0, 0));
+        m.push_tiloc(yksmp::Location::Register(3, 1, 0, vec![]));
+        m.push_tiloc(yksmp::Location::Register(3, 1, 0, vec![]));
         let op1 = m
             .push_and_make_operand(LoadTraceInputInst::new(0, i16_tyidx).into())
             .unwrap();


### PR DESCRIPTION
We are now tracking arbitrarily many locations for each variable in ykllvm. This requires some changes in the stackmap parser and deopt to deal with this.

Depends on: https://github.com/ykjit/ykllvm/pull/204