### PR TITLE
Implement deopting a 16-bit deopt register.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -248,6 +248,7 @@ pub(crate) extern "C" fn __yk_deopt(
                                 // FIXME: Check that 16-byte writes are for float registers only.
                                 16 | 8 => unsafe { ptr::write::<u64>(temp as *mut u64, jitval) },
                                 4 => unsafe { ptr::write::<u32>(temp as *mut u32, jitval as u32) },
+                                2 => unsafe { ptr::write::<u16>(temp as *mut u16, jitval as u16) },
                                 _ => todo!("{}", size),
                             }
                         }


### PR DESCRIPTION
Fixes overnight awfy benchmarks in release mode.