### PR TITLE
Execute trace on the main interpreter loop frame.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
@@ -9,7 +9,8 @@ use dynasmrt::x64::{Rq, Rx};
 /// Where is an SSA variable stored?
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum VarLocation {
-    /// The SSA variable is on the stack.
+    /// The SSA variable is on the stack of the of the executed trace or the main interpreter loop.
+    /// Since we execute the trace on the main interpreter frame we can't distinguish the two.
     Stack {
         /// The offset from the base of the trace's function frame.
         frame_off: u32,
@@ -18,13 +19,6 @@ pub(crate) enum VarLocation {
     },
     /// The SSA variable is a stack pointer with the value `RBP-frame_off`.
     Direct {
-        /// The offset from the base of the trace's function frame.
-        frame_off: i32,
-        /// Size in bytes of the allocation.
-        size: usize,
-    },
-    /// The SSA variable is behind a pointer that's stored on the stack: `[RBP-frame_off]`.
-    Indirect {
         /// The offset from the base of the trace's function frame.
         frame_off: i32,
         /// Size in bytes of the allocation.

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -199,20 +199,17 @@ pub(crate) extern "C" fn __yk_deopt(
                 }
                 VarLocation::Indirect { frame_off, size } => match size {
                     8 => unsafe {
-                        (jitrbp as *const *const u64)
-                            .read()
+                        (jitrbp as *const u64)
                             .byte_offset(isize::try_from(frame_off).unwrap())
                             .read()
                     },
                     4 => unsafe {
-                        (jitrbp as *const *const u32)
-                            .read()
+                        (jitrbp as *const u32)
                             .byte_offset(isize::try_from(frame_off).unwrap())
                             .read() as u64
                     },
                     1 => unsafe {
-                        (jitrbp as *const *const u8)
-                            .read()
+                        (jitrbp as *const u8)
                             .byte_offset(isize::try_from(frame_off).unwrap())
                             .read() as u64
                     },
@@ -322,6 +319,8 @@ pub(crate) extern "C" fn __yk_deopt(
     let (rec, pinfo) = aot_smaps.get(usize::try_from(info.inlined_frames[0].safepoint.id).unwrap());
     let mut newframedst = unsafe { frameaddr.byte_sub(usize::try_from(rec.size).unwrap()) };
     if pinfo.hasfp {
+        // `frameaddr` is the RBP value of the bottom frame after pushing the previous frame's RBP.
+        // However, `rec.size` includes the pushed RBP, so we need to subtract it here again.
         newframedst = unsafe { newframedst.byte_add(REG64_SIZE) };
     }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -72,7 +72,6 @@ pub(crate) extern "C" fn __yk_deopt(
                 VarLocation::ConstFloat(_) => todo!(),
                 VarLocation::ConstInt { bits: _, v } => *v,
                 VarLocation::Direct { .. } => panic!(),
-                VarLocation::Indirect { .. } => panic!(),
             };
             ykctrlpvars.push(val);
         }
@@ -197,24 +196,6 @@ pub(crate) extern "C" fn __yk_deopt(
                     varidx += 1;
                     continue;
                 }
-                VarLocation::Indirect { frame_off, size } => match size {
-                    8 => unsafe {
-                        (jitrbp as *const u64)
-                            .byte_offset(isize::try_from(frame_off).unwrap())
-                            .read()
-                    },
-                    4 => unsafe {
-                        (jitrbp as *const u32)
-                            .byte_offset(isize::try_from(frame_off).unwrap())
-                            .read() as u64
-                    },
-                    1 => unsafe {
-                        (jitrbp as *const u8)
-                            .byte_offset(isize::try_from(frame_off).unwrap())
-                            .read() as u64
-                    },
-                    _ => todo!("size={}", size),
-                },
             };
             varidx += 1;
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -246,17 +246,16 @@ impl<'a> Assemble<'a> {
                         dynasm!(self.asm; push Rq(reg.code()));
                     }
                 }
-                dynasm!(self.asm; mov rcx, rsp);
+                dynasm!(self.asm; mov rdx, rsp);
                 for reg in lsregalloc::FP_REGS.iter().rev() {
                     dynasm!(self.asm
-                        ; movq r8, Rx(reg.code())
-                        ; push r8
+                        ; movq rcx, Rx(reg.code())
+                        ; push rcx
                     );
                 }
                 dynasm!(self.asm; mov r8, rsp);
                 dynasm!(self.asm
                     ; mov rdi, rbp
-                    ; mov rdx, rbp
                     ; mov rax, QWORD __yk_deopt as i64
                     ; sub rsp, 8 // Align the stack
                     ; call rax
@@ -2217,7 +2216,6 @@ mod tests {
                 ; call __yk_deopt
                 ...
                 ... mov rdi, rbp
-                ... mov rdx, rbp
                 ... mov rax, 0x...
                 ... sub rsp, 0x08
                 ... call rax
@@ -2246,7 +2244,6 @@ mod tests {
                 ; call __yk_deopt
                 ...
                 ... mov rdi, rbp
-                ... mov rdx, rbp
                 ... mov rax, 0x...
                 ... sub rsp, 0x08
                 ... call rax
@@ -2278,7 +2275,6 @@ mod tests {
                 ; call __yk_deopt
                 ...
                 ... mov rdi, rbp
-                ... mov rdx, rbp
                 ... mov rax, 0x...
                 ... sub rsp, 0x08
                 ... call rax

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,7 +2,10 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, SideTraceInfo},
+    compile::{
+        jitc_yk::codegen::CodeGen,
+        CompiledTrace, Compiler, SideTraceInfo,
+    },
     location::HotLocation,
     log::{log_ir, should_log_ir, IRPhase},
     mt::MT,

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,10 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{
-        jitc_yk::codegen::CodeGen,
-        CompiledTrace, Compiler, SideTraceInfo,
-    },
+    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, SideTraceInfo},
     location::HotLocation,
     log::{log_ir, should_log_ir, IRPhase},
     mt::MT,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -716,6 +716,7 @@ unsafe extern "C" fn exec_trace(
         "pop rbx",
         "pop rcx",
         "pop rax",
+        "add rsp, 8", // Remove return pointer
         // Call the trace function.
         "jmp rdx",
         "ret",


### PR DESCRIPTION
This simplifies and speeds up the way we access live variables stored on the main interpreter loop frame, as we no longer need to juggle around two base pointers.

We get a decent speed-up of 1.33x on `bigloop.lua`. Since we don't have side-tracing currently, there's not much speed-up to be found with the benchmark suite.