### PR TITLE
Remove unnecessary destination type in sext/zext.

### DIFF
--- a/tests/c/ptrtoint.c
+++ b/tests/c/ptrtoint.c
@@ -8,7 +8,7 @@
 //     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{1}}: i64 = zext %{{2}}, i64
+//     %{{1}}: i64 = zext %{{2}}
 //     ...
 //     --- End jit-pre-opt ---
 //     ptr: {{ptr}}

--- a/tests/c/signextend_negative.c
+++ b/tests/c/signextend_negative.c
@@ -13,7 +13,7 @@
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{22}}: i64 = sext %{{21}}, i64
+//     %{{22}}: i64 = sext %{{21}}
 //     ...
 //     --- End jit-pre-opt ---
 //     neg=-2

--- a/tests/c/signextend_positive.c
+++ b/tests/c/signextend_positive.c
@@ -13,7 +13,7 @@
 //     --- End aot ---
 //     --- Begin jit-pre-opt ---
 //     ...
-//     %{{22}}: i64 = sext %{{21}}, i64
+//     %{{22}}: i64 = sext %{{21}}
 //     ...
 //     --- End jit-pre-opt ---
 //     pos=2

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1836,20 +1836,10 @@ impl fmt::Display for DisplayableInst<'_> {
                 write!(f, "]:")
             }
             Inst::SExt(i) => {
-                write!(
-                    f,
-                    "sext {}, {}",
-                    i.val(self.m).display(self.m),
-                    self.m.type_(i.dest_tyidx()).display(self.m)
-                )
+                write!(f, "sext {}", i.val(self.m).display(self.m),)
             }
             Inst::ZeroExtend(i) => {
-                write!(
-                    f,
-                    "zext {}, {}",
-                    i.val(self.m).display(self.m),
-                    self.m.type_(i.dest_tyidx()).display(self.m)
-                )
+                write!(f, "zext {}", i.val(self.m).display(self.m),)
             }
             Inst::Trunc(i) => {
                 write!(f, "trunc {}", i.val(self.m).display(self.m))


### PR DESCRIPTION
Previously we printed `%x: T = zext %y, T` i.e. adding an unnecessary suffix (that duplicates the destination type). This commit removes the suffix. [Note: the JIT IR parser did not require this suffix, so there's nothing to remove there.]