### PR TITLE
Relax cg_zeroextend to allow zeroextends into pointer types.

### DIFF
--- a/tests/c/unintptr_t_to_ptr.c
+++ b/tests/c/unintptr_t_to_ptr.c
@@ -1,0 +1,45 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=-:aot
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YK_LOG=4
+//   stderr:
+//     yk-jit-event: start-tracing
+//     4: 0x4
+//     yk-jit-event: stop-tracing
+//     --- Begin aot ---
+//     ...
+//     %{{11_2}}: ptr = zext %{{11_1}}, ptr
+//     %{{11_3}}: i32 = call fprintf(%{{_}}, @{{_}}, %{{11_1}}, %{{11_2}})
+//     ...
+//     --- End aot ---
+//     3: 0x3
+//     yk-jit-event: enter-jit-code
+//     2: 0x2
+//     1: 0x1
+//     yk-jit-event: deoptimise
+
+// Check that converting an integer to a pointer works.
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  uintptr_t i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "%" PRIuPTR ": %p\n", i, (void *) i);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1345,7 +1345,11 @@ impl<'a> Assemble<'a> {
         let to_type = self.m.type_(i.dest_tyidx());
         let to_size = to_type.byte_size().unwrap();
 
-        debug_assert!(matches!(to_type, jit_ir::Ty::Integer(_)));
+        // Note that the src/dest types may be pointers for cases where non-truncating
+        // inttoptr/ptrtoint are serialised to zero-extends by ykllvm.
+        debug_assert!(
+            matches!(to_type, jit_ir::Ty::Integer(_)) || matches!(to_type, jit_ir::Ty::Ptr)
+        );
         debug_assert!(
             matches!(from_type, jit_ir::Ty::Integer(_)) || matches!(from_type, jit_ir::Ty::Ptr)
         );


### PR DESCRIPTION
Companion to https://github.com/ykjit/ykllvm/pull/208

This is required for non-truncating LLVM `inttoptr` instructions that get lowered to Yk zeroextend instructions.

(This routine has already been relaxed the opposing `ptrtoint` case)