### PR TITLE
A mish-mash of fixes to allow yk-benchmarks to run.

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -31,7 +31,7 @@ use deku::prelude::*;
 use std::{
     collections::HashMap,
     error::Error,
-    ffi::CString,
+    ffi::{CString, OsStr},
     fmt::{self, Display},
     fs,
     io::{BufRead, BufReader, Seek, SeekFrom},
@@ -1134,8 +1134,8 @@ impl fmt::Display for DisplayableInst<'_> {
         if let Some(instid) = &self.instid {
             if let Some(li) = self.m.line_infos.get(instid) {
                 let path = self.m.path(li.pathidx);
-                // Absolute path: unwrap cannot fail.
-                let basename = path.file_name().unwrap();
+                // Sometimes the filename cannot be determined.
+                let basename = path.file_name().unwrap_or(OsStr::new("<unknown-filename>"));
                 // We assume the filename is expressible in UTF-8.
                 let src = self.m.source_line(path, li.line_num);
                 write!(

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -43,9 +43,8 @@ pub(crate) extern "C" fn __yk_deopt(
         .as_any()
         .downcast::<X64CompiledTrace>()
         .unwrap();
-    debug_assert!(usize::from(gidx) < ctr.deoptinfo.len());
     let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
-    let info = &ctr.deoptinfo[usize::from(gidx)];
+    let info = &ctr.deoptinfo[&usize::from(gidx)];
     let mt = Arc::clone(&ctr.mt);
 
     if let Some(st) = info.guard.ctr() {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -887,8 +887,7 @@ impl LSRegAlloc<'_> {
                     .unwrap();
                 let cur_reg = FP_REGS[reg_i];
                 if cur_reg != reg {
-                    todo!();
-                    // dynasm!(asm; mov Rq(reg.code()), Rq(cur_reg.code()));
+                    dynasm!(asm; mov Rq(reg.code()), Rq(cur_reg.code()));
                 }
             }
             SpillState::Stack(off) => {

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -508,7 +508,7 @@ impl TraceBuilder {
         }
 
         let gi = jit_ir::GuardInfo::new(live_vars, callframes);
-        let gi_idx = self.jit_mod.push_guardinfo(gi)?;
+        let gi_idx = self.jit_mod.push_guardinfo(gi).unwrap();
 
         Ok(jit_ir::GuardInst::new(cond.clone(), expect, gi_idx))
     }


### PR DESCRIPTION
Most notably fix:
 - fix a bug in deoptinfo where optimising them out causes an index skew.
 - Fix (kind of) sign extend of non-byte sized integers.