### PR TITLE
Fix build WRT inline asm in naked functions.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -65,7 +65,7 @@ pub extern "C" fn __ykrt_control_point(
     // still run the epilogue of the control point function call, which automatically restores the
     // callee-saved registers for us (so we don't have to do it here).
     unsafe {
-        std::arch::asm!(
+        std::arch::naked_asm!(
             // Push all registers to the stack as these may contain trace inputs (live
             // variables) referenced by the control point's stackmap.
             //
@@ -107,7 +107,6 @@ pub extern "C" fn __ykrt_control_point(
             "pop rcx",
             "pop rax",
             "ret",
-            options(noreturn)
         );
     }
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -318,7 +318,7 @@ pub(crate) extern "C" fn __yk_deopt(
 #[naked]
 #[no_mangle]
 unsafe extern "C" fn __replace_stack(dst: *mut c_void, src: *const c_void, size: usize) -> ! {
-    std::arch::asm!(
+    std::arch::naked_asm!(
         // Reset RSP to the end of the control point frame (this doesn't include the
         // return address which will thus be overwritten in the process)
         "mov rsp, rdi",
@@ -382,6 +382,5 @@ unsafe extern "C" fn __replace_stack(dst: *mut c_void, src: *const c_void, size:
         "pop rdx",
         "pop rax",
         "ret",
-        options(noreturn)
     )
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -694,7 +694,7 @@ unsafe extern "C" fn exec_trace(
     rsp: *const c_void,
     trace: *const c_void,
 ) -> ! {
-    std::arch::asm!(
+    std::arch::naked_asm!(
         // Reset RBP
         "mov rbp, rdi",
         // Reset RSP to the end of the control point frame (this includes the registers we pushed
@@ -720,7 +720,6 @@ unsafe extern "C" fn exec_trace(
         // Call the trace function.
         "jmp rdx",
         "ret",
-        options(noreturn)
     )
 }
 


### PR DESCRIPTION
A recent Rust change causes:

```
error[E0787]: the `asm!` macro is not allowed in naked functions
   --> ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs:321:5
    |
321 | /     std::arch::asm!(
322 | |         // Reset RSP to the end of the control point frame (this doesn't include the
323 | |         // return address which will thus be overwritten in the process)
324 | |         "mov rsp, rdi",
...   |
385 | |         options(noreturn)
386 | |     )
    | |_____^ consider using the `naked_asm!` macro instead
```

This fixes that.