### PR TITLE
Emit add instructions with immediate operands where possible.

### DIFF
--- a/tests/c/x64_imm_add.c
+++ b/tests/c/x64_imm_add.c
@@ -1,0 +1,60 @@
+// ignore-if: test $(uname -m) != x86_64
+// Compiler:
+//   env-var: YKB_EXTRA_CC_FLAGS=-O2
+// Run-time:
+//   env-var: YKD_LOG_IR=-:jit-asm
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//
+//   stderr:
+//     ...
+//     --- Begin jit-asm ---
+//     ...
+//     ; %{{_}}: i64 = add %{{_}}, 9223372036854775807i64
+//     {{_}} {{_}}: mov r{{a}}, 0x7FFFFFFFFFFFFFFF
+//     {{_}} {{_}}: add r{{_}}, r{{a}}
+//     ...
+//     ; %{{_}}: i64 = add %{{_}}, 30i64
+//     {{_}} {{_}}: add r{{_}}, 0x1E
+//     ...
+//     ; %{{_}}: i64 = add %{{_}}, 18446744073709551615i64
+//     {{_}} {{_}}: add r{{_}}, 0xFFFFFFFFFFFFFFFF
+//     ...
+//     --- End jit-asm ---
+//     ...
+
+// Test emission of X64 add instructions with immediate operands.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  uint64_t x = 100;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    NOOPT_VAL(x);
+    // INT64_MAX too big for an immediate operand.
+    fprintf(stderr, "%" PRIu64 "\n", x + INT64_MAX);
+
+    // 30 can be imm8 operand.
+    fprintf(stderr, "%" PRIu64 "\n", x + 30);
+
+    // Can use imm8 operand, but note that the disassembler sign extends the
+    // operand up to 64-bit when it prints the operand.
+    fprintf(stderr, "%" PRIu64 "\n", x + -1);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
**This is a draft. Not all tests pass yet. Read on.**

An explanation of why I think this is correct:

Suppose we have the JIT IR instruction:

 %2: i32 = add %1, -1i32

Here, -1 is constant, and therefore we might be able to avoid loading it into a register.

The X64 ISA has no `add r/m64, imm64`, but it does have:
 - add r/m32, i8
 - add r/m32, i32

We can use the former instruction if our constant fits in a i8. We can use the latter instruction if our constant fits in a i32.

As it happens, -1 is expressible for all `i<n>` by setting all <n> bits (i.e. all ones). So -1u8 is simply 0xff and -1u32 is 0xffffffff. This means we could in fact emit either of the above instructions.

Let's use the first instruction encoding above. In the JIT IR, constant integers are stored as a u64, so we start by throwing away the undefined top bits with `let const_i32 = const_val as i32`. This gives us -1i32.

Then we check if we can narrow the type to i8 whilst retaining the same numeric value with `let const_i8 = i8::try_from(const_i32)`. As explained above this succeeds and we get -1i8 (0xff).

Supposing the result is to be stored in rax, we then emit the following instruction:

  add rax, BYTE const_i8

This approach only works for "normally-sized" integers like i8, i16, i32 and i64 for now. To use immediate operands for odd integer types like i3 we'd have to emit extra instructions to sign-extend the constant value up to the next usable bit-width with the appropriate instruction encoding. That's one for another day.

bigloop.lua runs under yklua and generates the correct value, but here's the mystery: this change consistently slows down yklua jitting bigloop.lua by about 8% (that's a release build of yklua with serialised compilation, master branch vs. this branch).

At first I thought it was due to register stalls (when you write to 8- or 16-bit registers), but if you look at my diff, those cases are todo!() and thus are not covered by bigloop.lua and therefore not the problem.

The trace contains 4 JIT IR add instructions:
 - 2 adds involve a constant that we "optimise". The constant values are -1 and -127.
 - 2 adds do not involve constants. Sadly this must include the blatent addition evident from the benchmark source code:

   `sum = sum + 1`

I guess we need to teach Lua to promote language level constants. @ltratt has talked about this problem before.

So I don't know why this slows us down. Do you see anything fishy? Am I using the register allocator correctly?