### PR TITLE
Optimise codegen for 64-bit addition with a constant that fits in 32-bits. 

### DIFF
--- a/tests/c/promote.c
+++ b/tests/c/promote.c
@@ -4,7 +4,7 @@
 //   env-var: YKD_LOG_IR=-:aot,jit-pre-opt
 //   stderr:
 //     yk-jit-event: start-tracing
-//     a=99 y=100
+//     a=99 b=765 y=100
 //     yk-jit-event: stop-tracing
 //     --- Begin aot ---
 //     ...
@@ -17,11 +17,11 @@
 //     guard true, %{{1}}, ...
 //     ...
 //     --- End jit-pre-opt ---
-//     a=99 y=200
+//     a=99 b=765 y=200
 //     yk-jit-event: enter-jit-code
-//     a=99 y=300
-//     a=99 y=400
-//     a=99 y=500
+//     a=99 b=765 y=300
+//     a=99 b=765 y=400
+//     a=99 b=765 y=500
 //     yk-jit-event: deoptimise
 
 // Check that promotion works in traces.
@@ -39,18 +39,21 @@ int main(int argc, char **argv) {
   YkLocation loc = yk_location_new();
 
   int a = 99;
+  long long b = 765;
   size_t x = 100;
   size_t y = 0;
   NOOPT_VAL(a);
+  NOOPT_VAL(b);
   NOOPT_VAL(x);
   NOOPT_VAL(y);
 
   for (int i = 0; i < 5; i++) {
     yk_mt_control_point(mt, &loc);
     a = yk_promote(a);
+    b = yk_promote(b);
     x = yk_promote(x);
     y += x;
-    fprintf(stderr, "a=%d y=%" PRIu64 "\n", a, y);
+    fprintf(stderr, "a=%d b=%lld y=%" PRIu64 "\n", a, b, y);
   }
 
   NOOPT_VAL(y);

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -72,9 +72,11 @@ void yk_location_drop(YkLocation);
 // type of the value passed.
 #define yk_promote(X) _Generic((X), \
                                int: __yk_promote_c_int, \
+                               long long: __yk_promote_c_long_long, \
                                uintptr_t: __yk_promote_usize \
                               )(X)
 int __yk_promote_c_int(int);
+long long __yk_promote_c_long_long(long long);
 // Rust defines `usize` to be layout compatible with `uintptr_t`.
 uintptr_t __yk_promote_usize(uintptr_t);
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -10,6 +10,7 @@
 
 use super::{
     super::{
+        int_signs::{SignExtend, Truncate},
         jit_ir::{self, BinOp, FloatTy, InstIdx, Module, Operand, Ty},
         CompilationError,
     },
@@ -419,13 +420,47 @@ impl<'a> Assemble<'a> {
 
         match inst.binop() {
             BinOp::Add => {
-                let size = lhs.byte_size(self.m);
+                let byte_size = lhs.byte_size(self.m);
+                match (&lhs, &rhs) {
+                    (Operand::Const(cidx), Operand::Var(_))
+                    | (Operand::Var(_), Operand::Const(cidx)) => {
+                        // Addition involves a constant. We may be able to emit more optimal code.
+                        let Const::Int(ctyidx, v) = self.m.const_(*cidx) else {
+                            unreachable!()
+                        };
+                        let Ty::Integer(bit_size) = self.m.type_(*ctyidx) else {
+                            unreachable!()
+                        };
+                        // If it's a 64-bit add and the numeric value of the constant can be
+                        // expressed in 32-bits...
+                        //
+                        // We are only optimising (exactly) 64-bit add operations for now, but
+                        // there is certainly oppertunity to optimised other cases later.
+                        //
+                        // We could have used Rust `as` casts to truncate and sign-extend here,
+                        // since we are currently only dealing with i32s and i64s, but if/when we
+                        // want to cover operations on other "odd-bit-size" integers we will need
+                        // these custom implementations.
+                        if *bit_size == 64 && v.truncate(32).sign_extend(32, 64) == *v {
+                            let v32 = v.truncate(32);
+                            let [lhs_reg] = self.ra.assign_gp_regs(
+                                &mut self.asm,
+                                iidx,
+                                [RegConstraint::InputOutput(lhs)],
+                            );
+                            dynasm!(self.asm; add Rq(lhs_reg.code()), v32 as i32);
+                            return;
+                        }
+                    }
+                    _ => (),
+                }
+
                 let [lhs_reg, rhs_reg] = self.ra.assign_gp_regs(
                     &mut self.asm,
                     iidx,
                     [RegConstraint::InputOutput(lhs), RegConstraint::Input(rhs)],
                 );
-                match size {
+                match byte_size {
                     1 => dynasm!(self.asm; add Rb(lhs_reg.code()), Rb(rhs_reg.code())),
                     2 => dynasm!(self.asm; add Rw(lhs_reg.code()), Rw(rhs_reg.code())),
                     4 => dynasm!(self.asm; add Rd(lhs_reg.code()), Rd(rhs_reg.code())),
@@ -2067,6 +2102,80 @@ mod tests {
                 ; %2: i64 = add %0, %1
                 ......
                 {{_}} {{_}}: add r.64.x, r.64.y
+                ...
+                ",
+        );
+    }
+
+    #[test]
+    fn cg_const_add_one_i64() {
+        codegen_and_test(
+            "
+              entry:
+                %0: i64 = load_ti 0
+                %1: i64 = add %0, 1i64
+            ",
+            "
+                ...
+                ; %1: i64 = add %0, 1i64
+                ......
+                {{_}} {{_}}: add r.64.x, 0x01
+                ...
+                ",
+        );
+    }
+
+    #[test]
+    fn cg_const_add_minus_one_i64() {
+        codegen_and_test(
+            "
+              entry:
+                %0: i64 = load_ti 0
+                %1: i64 = add %0, 18446744073709551615i64
+            ",
+            "
+                ...
+                ; %1: i64 = add %0, 18446744073709551615i64
+                ......
+                {{_}} {{_}}: add r.64.x, 0xffffffffffffffff
+                ...
+                ",
+        );
+        // note: disassembler sign-extended the immediate when displaying it.
+    }
+
+    #[test]
+    fn cg_const_add_i32max_i64() {
+        codegen_and_test(
+            "
+              entry:
+                %0: i64 = load_ti 0
+                %1: i64 = add %0, 2147483647i64
+            ",
+            "
+                ...
+                ; %1: i64 = add %0, 2147483647i64
+                ......
+                {{_}} {{_}}: add r.64.x, 0x7fffffff
+                ...
+                ",
+        );
+    }
+
+    #[test]
+    fn cg_const_add_i32max_plus_one_i64() {
+        codegen_and_test(
+            "
+              entry:
+                %0: i64 = load_ti 0
+                %1: i64 = add %0, 2147483648i64
+            ",
+            "
+                ...
+                ; %1: i64 = add %0, 2147483648i64
+                ......
+                {{_}} {{_}}: mov r.64.x, 0x80000000
+                {{_}} {{_}}: add r.64.y, r.64.x
                 ...
                 ",
         );

--- a/ykrt/src/compile/jitc_yk/int_signs.rs
+++ b/ykrt/src/compile/jitc_yk/int_signs.rs
@@ -1,0 +1,106 @@
+pub(crate) trait SignExtend {
+    /// Sign extend an `from-bits`-bit number stored in `self` up to a `to-bits`-bit number.
+    ///
+    /// "Unused" higher-order bits `Self::BITS..=to_bits` are zeroed.
+    ///
+    /// The following cases are undefined:
+    /// - `from_bits` outside the range `1..=Self::BITS`.
+    /// - `to_bits` outside the range `1..=Self::BITS`.
+    /// - `from_bits` >= `to_bits`.
+    fn sign_extend(&self, from_bits: u32, to_bits: u32) -> Self;
+}
+
+impl SignExtend for u64 {
+    fn sign_extend(&self, from_bits: u32, to_bits: u32) -> Self {
+        debug_assert!(
+            from_bits > 0 && from_bits <= Self::BITS,
+            "to_bits {to_bits} outside range 1..={}",
+            Self::BITS
+        );
+        debug_assert!(
+            to_bits > 0 && to_bits <= Self::BITS,
+            "to_bits {to_bits} outside range 1..={}",
+            Self::BITS
+        );
+        debug_assert!(from_bits <= to_bits);
+        // There are probably more clever ways to do this.
+        if from_bits == to_bits {
+            *self
+        } else if self & (1 << (from_bits - 1)) == 0 {
+            // Extend with zeros.
+            let shift = Self::BITS - from_bits;
+            (*self << shift) >> shift
+        } else {
+            // Extend with ones.
+            // How many high-order zero bits do we need?
+            let num_zeros = Self::BITS - to_bits;
+            let mask = ((Self::MAX << from_bits) << num_zeros) >> num_zeros;
+            *self | mask
+        }
+    }
+}
+
+pub(crate) trait Truncate {
+    /// Truncate the value to a `bits`-bit value by unsetting higher order bits.
+    ///
+    /// `bits` must be in the range `1..=Self::BITS`.
+    fn truncate(&self, bits: u32) -> Self;
+}
+
+impl Truncate for u64 {
+    fn truncate(&self, bits: u32) -> Self {
+        debug_assert!(
+            bits > 0 && bits <= Self::BITS,
+            "{bits} outside range 1..{}",
+            Self::BITS
+        );
+        if bits == Self::BITS {
+            *self
+        } else {
+            *self & ((1 as Self).wrapping_shl(bits) - 1)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SignExtend, Truncate};
+
+    #[test]
+    fn sign_extend() {
+        assert_eq!(0xffffffffu64.sign_extend(32, 64), u64::MAX);
+        assert_eq!(0xffffffffu64.sign_extend(32, 64), u64::MAX);
+        assert_eq!(u64::MAX.sign_extend(64, 64), u64::MAX);
+        assert_eq!(0xffffu64.sign_extend(16, 32), 0xffffffffu64);
+        assert_eq!(0x7fffu64.sign_extend(16, 32), 0x7fffu64);
+        assert_eq!(0xffu64.sign_extend(8, 8), 0xff);
+        assert_eq!(0x00u64.sign_extend(8, 8), 0x00);
+        for i in i8::MIN..i8::MAX {
+            // cast the value up to the backing store without sign extend.
+            let iu = i as u8 as u64;
+            // sign extending up to 16 bits should always give the same numeric value.
+            assert_eq!(iu.sign_extend(8, 16) as i16, i as i16);
+        }
+    }
+
+    #[test]
+    fn truncate() {
+        assert_eq!(u64::MAX.truncate(8), 0xff);
+        assert_eq!(u64::MAX.truncate(16), 0xffff);
+        assert_eq!(u64::MAX.truncate(24), 0xffffff);
+        assert_eq!(u64::MAX.truncate(32), 0xffffffff);
+        assert_eq!(u64::MAX.truncate(63), 0x7fffffffffffffff);
+        assert_eq!(u64::MAX.truncate(64), u64::MAX);
+        for i in 0u64..255 {
+            // These should all be no-ops.
+            assert_eq!(i.truncate(8), i);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
+    fn zero_bits() {
+        u64::MAX.truncate(0);
+    }
+}

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -21,6 +21,7 @@ pub mod aot_ir;
 mod codegen;
 #[cfg(any(debug_assertions, test))]
 mod gdb;
+mod int_signs;
 pub mod jit_ir;
 mod opt;
 mod trace_builder;

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -826,6 +826,22 @@ impl MTThread {
     /// If `false` is returned, the current trace is unable to record the promotion successfully
     /// and further calls are probably pointless, though they will not cause the tracer to enter
     /// undefined behaviour territory.
+    pub(crate) fn promote_i64(&self, val: i64) -> bool {
+        if let MTThreadState::Tracing {
+            ref mut promotions, ..
+        } = *self.tstate.borrow_mut()
+        {
+            promotions.extend_from_slice(&val.to_ne_bytes());
+        }
+        true
+    }
+
+    /// Records `val` as a value to be promoted. Returns `true` if either: no trace is being
+    /// recorded; or recording the promotion succeeded.
+    ///
+    /// If `false` is returned, the current trace is unable to record the promotion successfully
+    /// and further calls are probably pointless, though they will not cause the tracer to enter
+    /// undefined behaviour territory.
     pub(crate) fn promote_usize(&self, val: usize) -> bool {
         if let MTThreadState::Tracing {
             ref mut promotions, ..

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -4,15 +4,26 @@
 //! right method in this module to call.
 
 use crate::mt::MTThread;
-use std::ffi::c_int;
+use std::ffi::{c_int, c_longlong};
 
 /// Promote a `usize` during trace recording.
 #[no_mangle]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
     MTThread::with(|mtt| {
-        // We ignore the return value for `promote_usize` as we can't really cancel tracing from
-        // this function.
+        // We ignore the return value as we can't really cancel tracing from this function.
         mtt.promote_i32(val);
+    });
+    val
+}
+
+/// Promote a `usize` during trace recording.
+#[no_mangle]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+pub extern "C" fn __yk_promote_c_long_long(val: c_longlong) -> c_longlong {
+    MTThread::with(|mtt| {
+        // We ignore the return value as we can't really cancel tracing from this function.
+        mtt.promote_i64(val);
     });
     val
 }
@@ -21,8 +32,7 @@ pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
 #[no_mangle]
 pub extern "C" fn __yk_promote_usize(val: usize) -> usize {
     MTThread::with(|mtt| {
-        // We ignore the return value for `promote_usize` as we can't really cancel tracing from
-        // this function.
+        // We ignore the return value as we can't really cancel tracing from this function.
         mtt.promote_usize(val);
     });
     val


### PR DESCRIPTION
I started out trying to cover too many cases any getting confused, so
this optimises only one very specific case:

    %2: i64 = add %1, <const>

Where the numeric value of `<const>` is expressible in 32 bits.

For this we use the instruction encoding:
```
  add r64, imm32
```

This builds on a sketch @ltratt started and handed to me to look at. His
work is the first commit. It contains some semi-related promote
improvements also.

I had hoped to make a series of self-contained commits, but the work wen
through so much flux that it didn't work out, and would only force the
reviewer to review stale code.

Here's some miscellaneous notes on the changes:

 - Fix a bugs in `Truncate` and `SignExtend`.
 - Unit test and document `Truncate` and `SignExtend` too.
 - Fix incorrect bit size computation (byte_size * 8 isn't what we want).
 - Unit test the optimisation.
 - Add C test to check runtime semantics of the optimisation.
 - size -> byte_size, bits -> bit_size (for improved comprehension)

All lua tests and benchmarks work.

bigloop.lua uses this optimisation in the trace it generates.

I think @ltratt should review my changes, but since this PR is technically co-authored, also assigned @ptersilie .