### PR TITLE
Adjust the root jump target for side-traces.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -24,12 +24,15 @@ pub(crate) trait CodeGen: Send + Sync {
     ///
     /// * `sp_offset` - Stack pointer offset from the base pointer of the interpreter frame as
     ///   defined in [super::YkSideTraceInfo::sp_offset].
+    /// * `root_offset` - Stack pointer offset of the root trace as defined in
+    ///   [super::YkSideTraceInfo::sp_offset].
     fn codegen(
         &self,
         m: Module,
         mt: Arc<MT>,
         hl: Arc<Mutex<HotLocation>>,
         sp_offset: Option<usize>,
+        root_offset: Option<usize>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 


### PR DESCRIPTION
When side-traces jumped back to the root trace, they previously always jumped to the entry address of the root trace. Since we want to implement loop peeling soon, we need to be able to jump to an offset inside the root trace. For now this is simply the place after the trace's prologue. But later we want to change this to the place after the preamble and before the peeled loop.

This change required some additional changes to the way we calculate and reset the base pointer when jumping to the root trace.