### PR TITLE
Generate more immediates

### DIFF
--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -408,6 +408,7 @@ pub(crate) enum BinOp {
     /// The canonicalised form of `Add` in JIT IR is (Var, Var) or (Var, Const).
     Add = 0,
     Sub,
+    /// The canonicalised form of `Mul` in JIT IR is (Var, Var) or (Var, Const).
     Mul,
     Or,
     And,

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -405,6 +405,7 @@ fn map_to_lineinfo(v: Vec<RawLineInfoRec>) -> Result<HashMap<InstID, LineInfoLoc
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[deku(type = "u8")]
 pub(crate) enum BinOp {
+    /// The canonicalised form of `Add` in JIT IR is (Var, Var) or (Var, Const).
     Add = 0,
     Sub,
     Mul,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -236,7 +236,11 @@ impl<'a> LSRegAlloc<'a> {
 
     // Is the value produced by instruction `query_iidx` used after (but not including!)
     // instruction `cur_idx`?
-    fn is_inst_var_still_used_after(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> bool {
+    pub(crate) fn is_inst_var_still_used_after(
+        &self,
+        cur_iidx: InstIdx,
+        query_iidx: InstIdx,
+    ) -> bool {
         usize::from(cur_iidx) < usize::from(self.inst_vals_alive_until[usize::from(query_iidx)])
     }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -53,9 +53,13 @@ use dynasmrt::{
 };
 use indexmap::IndexMap;
 use parking_lot::Mutex;
-use std::sync::{Arc, Weak};
-use std::{cell::Cell, slice};
-use std::{collections::HashMap, error::Error};
+use std::{
+    cell::Cell,
+    collections::HashMap,
+    error::Error,
+    slice,
+    sync::{Arc, Weak},
+};
 use ykaddr::addr::symbol_to_ptr;
 use yksmp;
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -88,6 +88,8 @@ mod parser;
 #[cfg(any(debug_assertions, test))]
 mod well_formed;
 
+#[cfg(debug_assertions)]
+use super::int_signs::Truncate;
 use super::{aot_ir, codegen::reg_alloc::VarLocation};
 use crate::compile::CompilationError;
 use indexmap::IndexSet;
@@ -473,9 +475,26 @@ impl Module {
 
     /// Add a constant to the pool and return its index. If the constant already exists, an
     /// existing index will be returned.
-    pub fn insert_const(&mut self, c: Const) -> Result<ConstIdx, CompilationError> {
+    pub(crate) fn insert_const(&mut self, c: Const) -> Result<ConstIdx, CompilationError> {
         let (i, _) = self.consts.insert_full(ConstIndexSetWrapper(c));
         ConstIdx::try_from(i)
+    }
+
+    /// Convenience method for adding a `Const::Int` to the constant pool and, in debug mode,
+    /// checking that its bit size is not execeeded. See [Self::insert_const] for the return value.
+    pub(crate) fn insert_const_int(
+        &mut self,
+        tyidx: TyIdx,
+        v: u64,
+    ) -> Result<ConstIdx, CompilationError> {
+        #[cfg(debug_assertions)]
+        {
+            let Ty::Integer(bits) = self.type_(tyidx) else {
+                panic!()
+            };
+            assert_eq!(v.truncate(*bits), v);
+        }
+        self.insert_const(Const::Int(tyidx, v))
     }
 
     /// Return the const for the specified index.
@@ -1248,19 +1267,6 @@ impl Const {
             Const::Float(tyidx, _) => *tyidx,
             Const::Int(tyidx, _) => *tyidx,
             Const::Ptr(_) => m.ptr_tyidx,
-        }
-    }
-
-    /// Create an integer of the same underlying type and with the value `x`.
-    ///
-    /// # Panics
-    ///
-    /// If `x` doesn't fit into the underlying integer type.
-    pub(crate) fn u64_to_int(&self, x: u64) -> Const {
-        match self {
-            Const::Float(_, _) => panic!(),
-            Const::Int(tyidx, _) => Const::Int(*tyidx, x),
-            Const::Ptr(_) => panic!(),
         }
     }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -73,6 +73,14 @@
 //!  1. they implement [std::fmt::Display] directly.
 //!  2. or, when they need extra information, they expose a `display()` method, which returns an
 //!     object which implements [std::fmt::Display].
+//!
+//!
+//! ## Canonicalisation
+//!
+//! JIT IR has a canonicalised form: that is the "shape" that later stages can weakly assume the IR
+//! will be in. Canonicalisation is a weak promise, not a guarantee: later stages still have to
+//! deal with the other cases, but since they're mostly expected not to occur, they may be handled
+//! suboptimally if that makes the code easier.
 
 mod dead_code;
 #[cfg(test)]

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -70,7 +70,9 @@ impl Analyse {
                     }
                     (&Operand::Var(iidx), &Operand::Const(cidx))
                     | (&Operand::Const(cidx), &Operand::Var(iidx)) => {
-                        if pred == Predicate::Equal {
+                        if (g_inst.expect && pred == Predicate::Equal)
+                            || (!g_inst.expect && pred == Predicate::NotEqual)
+                        {
                             self.set_value(iidx, Value::Const(cidx));
                         }
                     }

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -57,12 +57,12 @@ impl Analyse {
     }
 
     /// Use the guard `inst` to update our knowledge about the variable used as its condition.
-    pub(super) fn guard(&mut self, m: &Module, inst: GuardInst) {
-        if let Operand::Var(iidx) = inst.cond(m) {
-            if let (_, Inst::ICmp(inst)) = m.inst_decopy(iidx) {
-                let lhs = self.op_map(m, inst.lhs(m));
-                let pred = inst.predicate();
-                let rhs = self.op_map(m, inst.rhs(m));
+    pub(super) fn guard(&mut self, m: &Module, g_inst: GuardInst) {
+        if let Operand::Var(iidx) = g_inst.cond(m) {
+            if let (_, Inst::ICmp(ic_inst)) = m.inst_decopy(iidx) {
+                let lhs = self.op_map(m, ic_inst.lhs(m));
+                let pred = ic_inst.predicate();
+                let rhs = self.op_map(m, ic_inst.rhs(m));
                 match (&lhs, &rhs) {
                     (&Operand::Const(_), &Operand::Const(_)) => {
                         // This will have been handled by icmp/guard optimisations.


### PR DESCRIPTION
This PR gradually winds its way towards generating more code with immediates, but it does so in several steps (some of which are a bit tangential as I worked out what I was doing). The overall effect is a 10% improvement in big_loop. The biggest single improvement is in https://github.com/ykjit/yk/commit/f66bb5ec1335d4d53faa4f40b04dcd9ecc2142cb, but a couple of the other commits improve things by a percentage point or two.