### PR TITLE
More trace and x64 optimisations

### DIFF
--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -72,10 +72,12 @@ void yk_location_drop(YkLocation);
 // type of the value passed.
 #define yk_promote(X) _Generic((X), \
                                int: __yk_promote_c_int, \
+                               unsigned int: __yk_promote_c_unsigned_int, \
                                long long: __yk_promote_c_long_long, \
                                uintptr_t: __yk_promote_usize \
                               )(X)
 int __yk_promote_c_int(int);
+unsigned int __yk_promote_c_unsigned_int(unsigned int);
 long long __yk_promote_c_long_long(long long);
 // Rust defines `usize` to be layout compatible with `uintptr_t`.
 uintptr_t __yk_promote_usize(uintptr_t);

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -234,8 +234,8 @@ impl<'a> LSRegAlloc<'a> {
         self.stack.size()
     }
 
-    // Is the value produced by instruction `query_iidx` used after (but not including!)
-    // instruction `cur_idx`?
+    /// Is the value produced by instruction `query_iidx` used after (but not including!)
+    /// instruction `cur_idx`?
     pub(crate) fn is_inst_var_still_used_after(
         &self,
         cur_iidx: InstIdx,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1745,7 +1745,10 @@ impl<'a> Assemble<'a> {
         let tgt_vars = tgt_vars.unwrap_or(self.loop_start_locs.as_slice());
         for (i, op) in self.m.loop_jump_vars().iter().enumerate() {
             let (iidx, src) = match op {
-                Operand::Var(iidx) => (*iidx, self.ra.var_location(*iidx)),
+                Operand::Var(iidx) => {
+                    let iidx = self.m.inst_decopy(*iidx).0;
+                    (iidx, self.ra.var_location(iidx))
+                }
                 _ => panic!(),
             };
             let dst = tgt_vars[i];

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -860,20 +860,37 @@ impl<'a> Assemble<'a> {
                 let Ty::Integer(bit_size) = self.m.type_(lhs.tyidx(self.m)) else {
                     unreachable!()
                 };
-                let [lhs_reg, rhs_reg] = self.ra.assign_gp_regs(
-                    &mut self.asm,
-                    iidx,
-                    [RegConstraint::InputOutput(lhs), RegConstraint::Input(rhs)],
-                );
-                match bit_size {
-                    0 => unreachable!(),
-                    32 => dynasm!(self.asm; sub Rd(lhs_reg.code()), Rd(rhs_reg.code())),
-                    1..=64 => {
-                        self.sign_extend_to_reg64(lhs_reg, u8::try_from(*bit_size).unwrap());
-                        self.sign_extend_to_reg64(rhs_reg, u8::try_from(*bit_size).unwrap());
-                        dynasm!(self.asm; sub Rq(lhs_reg.code()), Rq(rhs_reg.code()));
+                if let Some(0) = self.op_to_i32(&lhs) {
+                    let [rhs_reg] = self.ra.assign_gp_regs(
+                        &mut self.asm,
+                        iidx,
+                        [RegConstraint::InputOutput(rhs)],
+                    );
+                    match bit_size {
+                        0 => unreachable!(),
+                        32 => dynasm!(self.asm; neg Rd(rhs_reg.code())),
+                        1..=64 => {
+                            self.sign_extend_to_reg64(rhs_reg, u8::try_from(*bit_size).unwrap());
+                            dynasm!(self.asm; neg Rq(rhs_reg.code()));
+                        }
+                        _ => todo!(),
                     }
-                    _ => todo!(),
+                } else {
+                    let [lhs_reg, rhs_reg] = self.ra.assign_gp_regs(
+                        &mut self.asm,
+                        iidx,
+                        [RegConstraint::InputOutput(lhs), RegConstraint::Input(rhs)],
+                    );
+                    match bit_size {
+                        0 => unreachable!(),
+                        32 => dynasm!(self.asm; sub Rd(lhs_reg.code()), Rd(rhs_reg.code())),
+                        1..=64 => {
+                            self.sign_extend_to_reg64(lhs_reg, u8::try_from(*bit_size).unwrap());
+                            self.sign_extend_to_reg64(rhs_reg, u8::try_from(*bit_size).unwrap());
+                            dynasm!(self.asm; sub Rq(lhs_reg.code()), Rq(rhs_reg.code()));
+                        }
+                        _ => todo!(),
+                    }
                 }
             }
             BinOp::UDiv => {
@@ -3100,6 +3117,7 @@ mod tests {
                 %6: i16 = sub %0, %1
                 %7: i32 = sub %2, %3
                 %8: i63 = sub %4, %5
+                %9: i32 = sub 0i32, %7
             ",
             "
                 ...
@@ -3119,6 +3137,9 @@ mod tests {
                 {{_}} {{_}}: sar r.64.f, 0x01
                 {{_}} {{_}}: sub r.64.e, r.64.f
                 ...
+                ; %9: i32 = sub 0i32, %7
+                ......
+                {{_}} {{_}}: neg r.32.c
                 ",
         );
     }

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -223,6 +223,49 @@ impl Opt {
                         }
                         (Operand::Var(_), Operand::Var(_)) => (),
                     },
+                    BinOp::Or => match (
+                        self.an.op_map(&self.m, x.lhs(&self.m)),
+                        self.an.op_map(&self.m, x.rhs(&self.m)),
+                    ) {
+                        (Operand::Const(op_cidx), Operand::Var(op_iidx))
+                        | (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
+                            match self.m.const_(op_cidx) {
+                                Const::Int(_, 0) => {
+                                    // Replace `x | 0` with `x`.
+                                    self.m.replace(iidx, Inst::Copy(op_iidx));
+                                }
+                                _ => {
+                                    // Canonicalise to (Var, Const).
+                                    self.m.replace(
+                                        iidx,
+                                        BinOpInst::new(
+                                            Operand::Var(op_iidx),
+                                            BinOp::Or,
+                                            Operand::Const(op_cidx),
+                                        )
+                                        .into(),
+                                    );
+                                }
+                            }
+                        }
+                        (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
+                            match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
+                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
+                                    debug_assert_eq!(lhs_tyidx, rhs_tyidx);
+                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
+                                        panic!()
+                                    };
+                                    let cidx = self.m.insert_const_int(
+                                        *lhs_tyidx,
+                                        (lhs_v | rhs_v).truncate(*bits),
+                                    )?;
+                                    self.m.replace(iidx, Inst::Const(cidx));
+                                }
+                                _ => todo!(),
+                            }
+                        }
+                        (Operand::Var(_), Operand::Var(_)) => (),
+                    },
                     _ => (),
                 },
                 Inst::ICmp(x) => {
@@ -564,6 +607,47 @@ mod test {
           ...
           entry:
             black_box 1i8
+        ",
+        );
+    }
+
+    #[test]
+    fn opt_or_zero() {
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = load_ti 0
+            %1: i8 = or %0, 0i8
+            %2: i8 = or 0i8, %0
+            black_box %1
+            black_box %2
+        ",
+            |m| opt(m).unwrap(),
+            "
+          ...
+          entry:
+            %0: i8 = load_ti ...
+            black_box %0
+            black_box %0
+        ",
+        );
+    }
+
+    #[test]
+    fn opt_or_const() {
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: i8 = 2i8
+            %1: i8 = 1i8
+            %2: i8 = or %0, %1
+            black_box %2
+        ",
+            |m| opt(m).unwrap(),
+            "
+          ...
+          entry:
+            black_box 3i8
         ",
         );
     }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -846,6 +846,22 @@ impl MTThread {
     /// If `false` is returned, the current trace is unable to record the promotion successfully
     /// and further calls are probably pointless, though they will not cause the tracer to enter
     /// undefined behaviour territory.
+    pub(crate) fn promote_u32(&self, val: u32) -> bool {
+        if let MTThreadState::Tracing {
+            ref mut promotions, ..
+        } = *self.tstate.borrow_mut()
+        {
+            promotions.extend_from_slice(&val.to_ne_bytes());
+        }
+        true
+    }
+
+    /// Records `val` as a value to be promoted. Returns `true` if either: no trace is being
+    /// recorded; or recording the promotion succeeded.
+    ///
+    /// If `false` is returned, the current trace is unable to record the promotion successfully
+    /// and further calls are probably pointless, though they will not cause the tracer to enter
+    /// undefined behaviour territory.
     pub(crate) fn promote_i64(&self, val: i64) -> bool {
         if let MTThreadState::Tracing {
             ref mut promotions, ..

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -4,7 +4,7 @@
 //! right method in this module to call.
 
 use crate::mt::MTThread;
-use std::ffi::{c_int, c_longlong};
+use std::ffi::{c_int, c_longlong, c_uint};
 
 /// Promote a `c_int` during trace recording.
 #[no_mangle]
@@ -13,6 +13,17 @@ pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
     MTThread::with(|mtt| {
         // We ignore the return value as we can't really cancel tracing from this function.
         mtt.promote_i32(val);
+    });
+    val
+}
+
+/// Promote a `c_uint` during trace recording.
+#[no_mangle]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+pub extern "C" fn __yk_promote_c_unsigned_int(val: c_uint) -> c_uint {
+    MTThread::with(|mtt| {
+        // We ignore the return value as we can't really cancel tracing from this function.
+        mtt.promote_u32(val);
     });
     val
 }

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -6,7 +6,7 @@
 use crate::mt::MTThread;
 use std::ffi::{c_int, c_longlong};
 
-/// Promote a `usize` during trace recording.
+/// Promote a `c_int` during trace recording.
 #[no_mangle]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {


### PR DESCRIPTION
This PR bundles up a number of optimisations that benefit big_loop.lua: mostly trace optimisations, but also one x64 optimisation (and one bug fix). With a suitable `yk_promote` in yklua, this PR speeds big_loop up by about 43%. The main reason for this is that we are able to constant fold a lot of goop around instruction decoding, so a lot of stuff in `trace-pre-opt` disappears entirely by `trace-post-opt`.