### PR TITLE
Add support for executing GDB commands.

### DIFF
--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -32,6 +32,10 @@ struct Args {
     /// Don't immediately run the program.
     #[arg(short = 'n', long)]
     wait_at_prompt: bool,
+
+    /// Pass all arguments after `--` directly to GDB.
+    #[arg(last = true, required = false)]
+    gdb_args: Vec<String>,
 }
 
 fn main() {
@@ -95,6 +99,12 @@ fn main() {
         gdb.args(["-ex", "run"]);
     }
 
+    // Pass all GDB-specific arguments after '--'
+    if !args.gdb_args.is_empty() {
+        for gdb_arg in &args.gdb_args {
+            gdb.arg(gdb_arg);
+        }
+    }
     // Run gdb!
     gdb.spawn().expect("failed to spawn gdb").wait().unwrap();
 }


### PR DESCRIPTION

Added `gdb_args` to capture all arguments provided after `--`, allowing multiple GDB-specific arguments.

Usage example:
```shell
./bin/gdb_c_test -s -n simple.c -- --command=comms.gdb
```