### PR TITLE
Assert that decopying isn't needed here.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1991,7 +1991,10 @@ impl<'a> Assemble<'a> {
         // back around here we need to write the live variables back into these same locations.
         for var in self.m.loop_start_vars() {
             let loc = match var {
-                Operand::Var(iidx) => self.ra.var_location(*iidx),
+                Operand::Var(iidx) => {
+                    debug_assert_eq!(*iidx, self.m.inst_decopy(*iidx).0);
+                    self.ra.var_location(*iidx)
+                }
                 _ => panic!(),
             };
             self.loop_start_locs.push(loc);


### PR DESCRIPTION
This is belt and braces, because I'm about 99.9% sure that this condition can never be violated, but were it to be, all sorts of hard-to-debug things would occur.