### PR TITLE
Don't require updating the running trace during side-tracing.

### DIFF
--- a/tests/c/nested_sidetrace.c
+++ b/tests/c/nested_sidetrace.c
@@ -42,13 +42,10 @@
 //     yk-jit-event: enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     24
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     26
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     28
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     30
 //     ...
@@ -72,15 +69,12 @@
 //     yk-jit-event: execute-side-trace
 //     yk-jit-event: execute-side-trace
 //     51
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     yk-jit-event: execute-side-trace
 //     54
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     yk-jit-event: execute-side-trace
 //     57
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     yk-jit-event: execute-side-trace
 //     60

--- a/tests/c/side-trace.c
+++ b/tests/c/side-trace.c
@@ -43,13 +43,10 @@
 //     yk-jit-event: enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     24
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     26
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     28
-//     yk-jit-event: re-enter-jit-code
 //     yk-jit-event: execute-side-trace
 //     30
 //     yk-jit-event: deoptimise

--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -4,7 +4,11 @@
 #![allow(dead_code)]
 
 use super::CompilationError;
-use crate::{compile::jitc_yk::jit_ir::Module, compile::CompiledTrace, location::HotLocation, MT};
+use crate::{
+    compile::{jitc_yk::jit_ir::Module, CompiledTrace, GuardIdx},
+    location::HotLocation,
+    MT,
+};
 use parking_lot::Mutex;
 use std::{error::Error, sync::Arc};
 
@@ -26,6 +30,7 @@ pub(crate) trait CodeGen: Send + Sync {
     ///   defined in [super::YkSideTraceInfo::sp_offset].
     /// * `root_offset` - Stack pointer offset of the root trace as defined in
     ///   [super::YkSideTraceInfo::sp_offset].
+    /// * `prevguards` - List of [GuardIdx]'s of previous guards failures leading up to this trace.
     fn codegen(
         &self,
         m: Module,
@@ -33,6 +38,7 @@ pub(crate) trait CodeGen: Send + Sync {
         hl: Arc<Mutex<HotLocation>>,
         sp_offset: Option<usize>,
         root_offset: Option<usize>,
+        prevguards: Option<Vec<GuardIdx>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 


### PR DESCRIPTION
In order to find the correct information during a guard failure we had
to switch the running trace whenever we jumped from a root trace into a
side-trace and back. Not only does this slow us down, it occasionally
lead to bugs when trying to find the root trace.

This commit no longer requires updating the running trace and instead
passes down a list of all the guards that have failed leading up to the
current guard failure. This list can then be used to find the correct
running trace and guard failure information by traversing down from the
root trace.