### PR TITLE
Upgrade cached crate to fix an audit warning.

### DIFF
--- a/ykaddr/Cargo.toml
+++ b/ykaddr/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-cached = { version = "0.49.2", features = ["proc_macro"] }
+cached = { version = "0.54.0", features = ["proc_macro"] }
 libc = "0.2"
 memmap2 = "0.9.4"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -199,5 +199,5 @@ fn main() {
     // sooner (Windows suggests that if a process leaves it to the OS to do the unlocking
     // automatically, it might not be particularly speedy) and allow parallel runs to advance
     // quicker.
-    lock_file.unlock().unwrap();
+    FileExt::unlock(&lock_file).unwrap();
 }


### PR DESCRIPTION
```
Crate:     instant
Version:   0.1.13
Warning:   unmaintained
Title:     `instant` is unmaintained
Date:      2024-09-01
ID:        RUSTSEC-2024-0384
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0384
Dependency tree:
instant 0.1.13
└── cached 0.49.3
    └── ykaddr 0.1.0
        ├── ykrt 0.1.0
        │   ├── ykcapi 0.1.0
        │   │   └── tests 0.1.0
        │   └── tests 0.1.0
        └── hwtracer 0.1.0
            ├── ykrt 0.1.0
            └── tests 0.1.0
```