### PR TITLE
Fix incorrect prev_bid computation when outlining.

### DIFF
--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -1285,7 +1285,6 @@ impl TraceBuilder {
                             // data and haven't messed up the mapping.
                             #[cfg(tracer_hwt)]
                             {
-                                last_blk_is_return = self.aot_mod.bblock(&bid).is_return();
                                 // Due to hardware tracing we see the same block twice whenever
                                 // there is a call. We only need to process one of them. We can
                                 // skip the block if:
@@ -1293,9 +1292,11 @@ impl TraceBuilder {
                                 //  b) The previous block is unmappable and the current block isn't
                                 //  an entry block.
                                 if last_blk_is_return {
+                                    last_blk_is_return = self.aot_mod.bblock(&bid).is_return();
                                     prev_bid = Some(bid);
                                     continue;
                                 }
+                                last_blk_is_return = self.aot_mod.bblock(&bid).is_return();
                                 if prev_bid.is_none() && !bid.is_entry() {
                                     prev_bid = Some(bid);
                                     continue;
@@ -1350,10 +1351,6 @@ impl TraceBuilder {
                 }
                 None => {
                     // Unmappable block
-                    #[cfg(tracer_hwt)]
-                    {
-                        last_blk_is_return = false;
-                    }
                     prev_bid = None;
                 }
             }


### PR DESCRIPTION
The commit 43b346bc252ea45536336ac59ba29aaf1741602c (found by automated bisect) introduced incorrect logic WRT prev_bid which caused BigLoop to fail if run for more than a few outer iterations.

This fixes that.

Lukas thinks that this section of code could use refactoring, but that's one for later.