### PR TITLE
Split YKD_LOG_IR=asm into two different modes.

### DIFF
--- a/docs/src/dev/understanding_traces.md
+++ b/docs/src/dev/understanding_traces.md
@@ -20,3 +20,5 @@ The following `ir_stage`s are supported:
  - `jit-pre-opt`: the JIT IR trace before optimisation.
  - `jit-post-opt`: the JIT IR trace after optimisation.
  - `jit-asm`: the assembler code of the compiled JIT IR trace.
+ - `jit-asm-full`: the assembler code of the compiled JIT IR trace with
+   instruction offsets and virtual addresses annotated.

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -159,7 +159,13 @@ impl Compiler for JITCYk {
         if should_log_ir(IRPhase::Asm) {
             log_ir(&format!(
                 "--- Begin jit-asm ---\n{}\n--- End jit-asm ---\n",
-                ct.disassemble().unwrap()
+                ct.disassemble(false).unwrap()
+            ));
+        }
+        if should_log_ir(IRPhase::AsmFull) {
+            log_ir(&format!(
+                "--- Begin jit-asm-full ---\n{}\n--- End jit-asm-full ---\n",
+                ct.disassemble(true).unwrap()
             ));
         }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -86,7 +86,7 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     fn hl(&self) -> &Weak<Mutex<HotLocation>>;
 
     /// Disassemble the JITted code into a string, for testing and deubgging.
-    fn disassemble(&self) -> Result<String, Box<dyn Error>>;
+    fn disassemble(&self, with_addrs: bool) -> Result<String, Box<dyn Error>>;
 }
 
 /// Stores information required for compiling a side-trace. Passed down from a (parent) trace
@@ -137,7 +137,7 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn disassemble(&self) -> Result<String, Box<dyn Error>> {
+        fn disassemble(&self, _with_addrs: bool) -> Result<String, Box<dyn Error>> {
             panic!();
         }
     }
@@ -185,7 +185,7 @@ mod compiled_trace_testing {
             &self.hl
         }
 
-        fn disassemble(&self) -> Result<String, Box<dyn Error>> {
+        fn disassemble(&self, _with_addrs: bool) -> Result<String, Box<dyn Error>> {
             panic!();
         }
     }

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -102,10 +102,17 @@ impl Log {
 #[derive(Eq, Hash, PartialEq)]
 #[allow(dead_code)]
 pub(crate) enum IRPhase {
+    /// The AOT IR.
     AOT,
+    /// The JIT IR before it has been optimised.
     PreOpt,
+    /// The JIT IR after it has been optimised.
     PostOpt,
+    /// The assembler code of the compiled trace.
     Asm,
+    /// The assembler code of the compiled trace, including instruction offsets and virtual
+    /// addresses.
+    AsmFull,
 }
 
 #[cfg(not(feature = "ykd"))]
@@ -155,6 +162,7 @@ mod internals {
                 "jit-pre-opt" => Ok(Self::PreOpt),
                 "jit-post-opt" => Ok(Self::PostOpt),
                 "jit-asm" => Ok(Self::Asm),
+                "jit-asm-full" => Ok(Self::AsmFull),
                 _ => Err(format!("Invalid YKD_LOG_IR value: {s}").into()),
             }
         }


### PR DESCRIPTION
 - jit-asm: the asm *without* offsets or virtual addresses.
 - jit-asm-full: the asm *with* offsets or virtual addresses.

Requested by Laurie a while back, to make testing more concise if you don't need to match addresses.