### PR TITLE
Deal with input register aliasing.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -252,12 +252,30 @@ impl<'a> LSRegAlloc<'a> {
 
 /// The parts of the register allocator needed for general purpose registers.
 impl LSRegAlloc<'_> {
-    /// Forcibly assign the machine register `reg`, which must be in the [RegState::Empty] state,
-    /// to the value produced by instruction `iidx`.
-    pub(crate) fn force_assign_inst_gp_reg(&mut self, iidx: InstIdx, reg: Rq) {
-        debug_assert!(!self.gp_regset.is_set(reg));
-        self.gp_regset.set(reg);
-        self.gp_reg_states[usize::from(reg.code())] = RegState::FromInst(iidx);
+    /// Forcibly assign the machine register `reg` to the value produced by instruction `iidx`.
+    /// Note that if this register is already used, a spill will be generated instead.
+    pub(crate) fn force_assign_inst_gp_reg(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rq) {
+        if self.gp_regset.is_set(reg) {
+            debug_assert_eq!(self.spills[usize::from(iidx)], SpillState::Empty);
+            // Input values alias to a single register. To avoid the rest of the register allocator
+            // having to think about this, we "dealias" the values by spilling.
+            let inst = self.m.inst_no_copies(iidx);
+            let size = inst.def_byte_size(self.m);
+            self.stack.align(size); // FIXME
+            let frame_off = self.stack.grow(size);
+            let off = i32::try_from(frame_off).unwrap();
+            match size {
+                1 => dynasm!(asm; mov BYTE [rbp - off], Rb(reg.code())),
+                2 => dynasm!(asm; mov WORD [rbp - off], Rw(reg.code())),
+                4 => dynasm!(asm; mov DWORD [rbp - off], Rd(reg.code())),
+                8 => dynasm!(asm; mov QWORD [rbp - off], Rq(reg.code())),
+                _ => unreachable!(),
+            }
+            self.spills[usize::from(iidx)] = SpillState::Stack(off);
+        } else {
+            self.gp_regset.set(reg);
+            self.gp_reg_states[usize::from(reg.code())] = RegState::FromInst(iidx);
+        }
     }
 
     /// Forcibly assign the floating point register `reg`, which must be in the [RegState::Empty] state,


### PR DESCRIPTION
NB: do not merge until Edd has confirmed this works!

Currently our register allocator assumes that SSA variables can't alias. This is true for the parts under our control -- but isn't true of the inputs to a trace! For example both `%0` and `%1` might come from `RAX`. This caused a panic in the register allocator.

I'd noted the problem in https://github.com/ykjit/yk/issues/1449 but thought it happened rarely. Edd noticed that it happens in other, more common situations (including as a result of common subexpression elimination), including in a yklua benchmark, and created a test for it.

This commit is a "quick fix" (it's not pretty, or efficient): when we spot aliasing, we spill aliased variables onto the stack, implicitly dealiasing them. In other words, we avoid having to think about aliasing in the main bulk of the register allocator at the expense of having to spill (and potentially unspill) values unnecessarily.