### PR TITLE
Somewhat fix loop jump operands.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
@@ -31,6 +31,8 @@ pub(crate) enum VarLocation {
     ConstInt { bits: u32, v: u64 },
     /// A constant float.
     ConstFloat(f64),
+    /// A constant pointer.
+    ConstPtr(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -203,6 +203,7 @@ pub(crate) extern "C" fn __yk_deopt(
                 },
                 VarLocation::ConstInt { bits: _, v } => v,
                 VarLocation::ConstFloat(f) => f.to_bits(),
+                VarLocation::ConstPtr(v) => u64::try_from(v).unwrap(),
                 VarLocation::Direct { .. } => {
                     // See comment below: this case never needs to do anything.
                     varidx += 1;

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -769,7 +769,7 @@ impl LSRegAlloc<'_> {
     ///
     /// Note that it is undefined behaviour to ask for the location of an instruction which has not
     /// yet produced a value.
-    pub(crate) fn var_location(&mut self, iidx: InstIdx) -> VarLocation {
+    pub(crate) fn var_location(&self, iidx: InstIdx) -> VarLocation {
         if let Some(reg_i) = self.gp_reg_states.iter().position(|x| {
             if let RegState::FromInst(y) = x {
                 *y == iidx

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -449,7 +449,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                     ASTInst::TraceLoopJump(ops) => {
                         for op in ops {
                             let op = self.process_operand(op)?;
-                            self.m.loop_jump_vars.push(op);
+                            self.m.loop_jump_operands.push(PackedOperand::new(&op));
                         }
                         self.m.push(Inst::TraceLoopJump).unwrap();
                     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -29,10 +29,10 @@ use super::{BinOp, BinOpInst, Const, GuardInst, Inst, Module, Operand, Ty};
 impl Module {
     pub(crate) fn assert_well_formed(&self) {
         if !self.root_entry_vars.is_empty() {
-            if self.root_entry_vars.len() != self.loop_jump_vars.len() {
+            if self.root_entry_vars.len() != self.loop_jump_operands.len() {
                 panic!("Loop start/end variables have different lengths.");
             }
-        } else if self.loop_start_vars.len() != self.loop_jump_vars.len() {
+        } else if self.loop_start_vars.len() != self.loop_jump_operands.len() {
             panic!("Loop start/end variables have different lengths.");
         }
 


### PR DESCRIPTION
Previously we called these "loop jump variables", but they're not -- we can pass `Operand::Const`s!

This PR moves us further in the direction of "store `PackedOperand`s, use `Operand`s". [There is still Module::loop_start_vars which is `Vec<Operand>`, but I haven't fully thought that through yet.]

This PR fixes a bug in the way we represented big_loop.lua: we optimised away a variable (%81) since it was a constant (0) but erroneously printed out the variable in `tloop_jump` instead of the constant.

Unfortunately as part of this I've realised that `write_jump_vars` is very broken. It only happens to work right now by accident and I'm pretty sure one can create situations where it fails in confusing ways. Fixing that isn't going to be trivial, and the change in this PR is enough of an improvement on the status quo that I think it's worth merging, even though we know more work like this needs to be done.