### PR TITLE
Split root and sidetrace compilation

### DIFF
--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -102,9 +102,8 @@ impl JITCYk {
             codegen: codegen::default_codegen()?,
         }))
     }
-}
 
-impl Compiler for JITCYk {
+    // FIXME: This should probably be split into separate root / sidetrace functions.
     fn compile(
         &self,
         mt: Arc<MT>,
@@ -164,6 +163,29 @@ impl Compiler for JITCYk {
         }
 
         Ok(ct)
+    }
+}
+
+impl Compiler for JITCYk {
+    fn root_compile(
+        &self,
+        mt: Arc<MT>,
+        aottrace_iter: Box<dyn AOTTraceIterator>,
+        hl: Arc<Mutex<HotLocation>>,
+        promotions: Box<[u8]>,
+    ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
+        self.compile(mt, aottrace_iter, None, hl, promotions)
+    }
+
+    fn sidetrace_compile(
+        &self,
+        mt: Arc<MT>,
+        aottrace_iter: Box<dyn AOTTraceIterator>,
+        sti: Arc<dyn SideTraceInfo>,
+        hl: Arc<Mutex<HotLocation>>,
+        promotions: Box<[u8]>,
+    ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
+        self.compile(mt, aottrace_iter, Some(sti), hl, promotions)
     }
 }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -42,12 +42,21 @@ impl fmt::Display for CompilationError {
 
 /// The trait that every JIT compiler backend must implement.
 pub(crate) trait Compiler: Send + Sync {
-    /// Compile a mapped trace into machine code.
-    fn compile(
+    /// Compile a mapped root trace into machine code.
+    fn root_compile(
         &self,
         mt: Arc<MT>,
         aottrace_iter: Box<dyn AOTTraceIterator>,
-        sti: Option<Arc<dyn SideTraceInfo>>,
+        hl: Arc<Mutex<HotLocation>>,
+        promotions: Box<[u8]>,
+    ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
+
+    /// Compile a mapped root trace into machine code.
+    fn sidetrace_compile(
+        &self,
+        mt: Arc<MT>,
+        aottrace_iter: Box<dyn AOTTraceIterator>,
+        sti: Arc<dyn SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -227,10 +227,8 @@ impl HotLocation {
     pub(crate) fn tracecompilation_error(&mut self, mt: &Arc<MT>) -> TraceFailed {
         if self.tracecompilation_errors < mt.trace_failure_threshold() {
             self.tracecompilation_errors += 1;
-            self.kind = HotLocationKind::Tracing;
             TraceFailed::KeepTrying
         } else {
-            self.kind = HotLocationKind::DontTrace;
             TraceFailed::DontTrace
         }
     }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -275,10 +275,9 @@ impl MT {
                 Arc::clone(&*lk)
             };
             mt.stats.timing_state(TimingState::Compiling);
-            match compiler.compile(
+            match compiler.root_compile(
                 Arc::clone(&mt),
                 trace_iter.0,
-                None,
                 Arc::clone(&hl_arc),
                 trace_iter.1,
             ) {
@@ -354,10 +353,10 @@ impl MT {
             // FIXME: Can we pass in the root trace address, root trace entry variable locations,
             // and the base stack-size from here, rather than spreading them out via
             // DeoptInfo/SideTraceInfo, and CompiledTrace?
-            match compiler.compile(
+            match compiler.sidetrace_compile(
                 Arc::clone(&mt),
                 trace_iter.0,
-                Some(sti),
+                sti,
                 Arc::clone(&hl_arc),
                 trace_iter.1,
             ) {

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -250,18 +250,12 @@ impl MT {
         }
     }
 
-    /// Add a compilation job for to the global work queue:
-    ///   * `utrace` is the trace to be compiled.
-    ///   * `hl_arc` is the [HotLocation] this compilation job is related to.
-    ///   * `sidetrace`, if not `None`, specifies that this is a side-trace compilation job.
-    ///     The `Arc<dyn CompiledTrace>` is the parent [CompiledTrace] for the side-trace. Because
-    ///     side-traces can nest, this may or may not be the same [CompiledTrace] as contained
-    ///     in the `hl_arc`.
-    fn queue_compile_job(
+    /// Add a compilation job for a root trace where `hl_arc` is the [HotLocation] this compilation
+    /// job is related to.
+    fn queue_root_compile_job(
         self: &Arc<Self>,
         trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>),
         hl_arc: Arc<Mutex<HotLocation>>,
-        sidetrace: Option<(Arc<dyn CompiledTrace>, GuardIdx, Arc<dyn CompiledTrace>)>,
     ) {
         self.stats.trace_recorded_ok();
         let mt = Arc::clone(self);
@@ -271,14 +265,87 @@ impl MT {
                 Arc::clone(&*lk)
             };
             mt.stats.timing_state(TimingState::Compiling);
-            let (sti, guardid) = if let Some((root_ctr, guardid, ctr)) = &sidetrace {
-                (
-                    Some(ctr.sidetraceinfo(Arc::clone(root_ctr), *guardid)),
-                    Some(*guardid),
-                )
-            } else {
-                (None, None)
+            match compiler.compile(
+                Arc::clone(&mt),
+                trace_iter.0,
+                None,
+                Arc::clone(&hl_arc),
+                trace_iter.1,
+            ) {
+                Ok(ct) => {
+                    let mut hl = hl_arc.lock();
+                    debug_assert_matches!(hl.kind, HotLocationKind::Compiling);
+                    hl.kind = HotLocationKind::Compiled(ct);
+                    mt.stats.trace_compiled_ok();
+                }
+                Err(e) => {
+                    mt.stats.trace_compiled_err();
+                    hl_arc.lock().tracecompilation_error(&mt);
+                    match e {
+                        CompilationError::General(e) | CompilationError::LimitExceeded(e) => {
+                            mt.log.log(
+                                Verbosity::Warning,
+                                &format!("trace-compilation-aborted: {e}"),
+                            );
+                        }
+                        CompilationError::InternalError(e) => {
+                            #[cfg(feature = "ykd")]
+                            panic!("{e}");
+                            #[cfg(not(feature = "ykd"))]
+                            {
+                                mt.log.log(
+                                    Verbosity::Error,
+                                    &format!("trace-compilation-aborted: {e}"),
+                                );
+                            }
+                        }
+                        CompilationError::ResourceExhausted(e) => {
+                            mt.log
+                                .log(Verbosity::Error, &format!("trace-compilation-aborted: {e}"));
+                        }
+                    }
+                }
+            }
+
+            mt.stats.timing_state(TimingState::None);
+        };
+
+        #[cfg(feature = "yk_testing")]
+        if let Ok(true) = env::var("YKD_SERIALISE_COMPILATION").map(|x| x.as_str() == "1") {
+            // To ensure that we properly test that compilation can occur in another thread, we
+            // spin up a new thread for each compilation. This is only acceptable because a)
+            // `SERIALISE_COMPILATION` is an internal yk testing feature b) when we use it we're
+            // checking correctness, not performance.
+            thread::spawn(do_compile).join().unwrap();
+            return;
+        }
+
+        self.queue_job(Box::new(do_compile));
+    }
+
+    /// Add a compilation job for a sidetrace where: `hl_arc` is the [HotLocation] this compilation
+    ///   * `hl_arc` is the [HotLocation] this compilation job is related to.
+    ///   * The `Arc<dyn CompiledTrace>` is the parent [CompiledTrace] for the side-trace. Because
+    ///     side-traces can nest, this may or may not be the same [CompiledTrace] as contained in
+    ///     the `hl_arc`.
+    fn queue_sidetrace_compile_job(
+        self: &Arc<Self>,
+        trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>),
+        hl_arc: Arc<Mutex<HotLocation>>,
+        (root_ctr, guardid, parent_ctr): (Arc<dyn CompiledTrace>, GuardIdx, Arc<dyn CompiledTrace>),
+    ) {
+        self.stats.trace_recorded_ok();
+        let mt = Arc::clone(self);
+        let do_compile = move || {
+            let compiler = {
+                let lk = mt.compiler.lock();
+                Arc::clone(&*lk)
             };
+            mt.stats.timing_state(TimingState::Compiling);
+            let (sti, guardid) = (
+                Some(parent_ctr.sidetraceinfo(Arc::clone(&root_ctr), guardid)),
+                Some(guardid),
+            );
             // FIXME: Can we pass in the root trace address, root trace entry variable locations,
             // and the base stack-size from here, rather than spreading them out via
             // DeoptInfo/SideTraceInfo, and CompiledTrace?
@@ -290,13 +357,7 @@ impl MT {
                 trace_iter.1,
             ) {
                 Ok(ct) => {
-                    if let Some((_root_ctr, _, parent_ctr)) = sidetrace {
-                        parent_ctr.guard(guardid.unwrap()).set_ctr(ct);
-                    } else {
-                        let mut hl = hl_arc.lock();
-                        debug_assert_matches!(hl.kind, HotLocationKind::Compiling);
-                        hl.kind = HotLocationKind::Compiled(ct);
-                    }
+                    parent_ctr.guard(guardid.unwrap()).set_ctr(ct);
                     mt.stats.trace_compiled_ok();
                 }
                 Err(e) => {
@@ -406,7 +467,7 @@ impl MT {
                     Ok(utrace) => {
                         self.stats.timing_state(TimingState::None);
                         self.log.log(Verbosity::JITEvent, "stop-tracing");
-                        self.queue_compile_job((utrace, promotions.into_boxed_slice()), hl, None);
+                        self.queue_root_compile_job((utrace, promotions.into_boxed_slice()), hl);
                     }
                     Err(e) => {
                         self.stats.timing_state(TimingState::None);
@@ -439,10 +500,10 @@ impl MT {
                     Ok(utrace) => {
                         self.stats.timing_state(TimingState::None);
                         self.log.log(Verbosity::JITEvent, "stop-tracing");
-                        self.queue_compile_job(
+                        self.queue_sidetrace_compile_job(
                             (utrace, promotions.into_boxed_slice()),
                             hl,
-                            Some((root_ctr, guardid, parent_ctr)),
+                            (root_ctr, guardid, parent_ctr),
                         );
                     }
                     Err(e) => {


### PR DESCRIPTION
Previously we muddled together the compilation of root traces and sidetraces, in a way that allowed other bugs to creep in because of all the if/elseing. This PR gradually teases those two things apart (chiefly https://github.com/ykjit/yk/commit/ae805f8ca32f7746fdadf434604023fefc5c5461) and fixes some bugs that become apparent as a result (chiefly https://github.com/ykjit/yk/commit/b45deec7f78eaf8663e963ea7370c0066a6521a3).

There is more we could do here, but this is, I think, already a meaningful improvement.