### PR TITLE
Derive debugs in various places.

### DIFF
--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -81,7 +81,7 @@ pub trait Tracer: Send + Sync {
 }
 
 /// Represents a thread which is currently tracing.
-pub trait ThreadTracer {
+pub trait ThreadTracer: Debug {
     /// Stop collecting a trace of the current thread.
     fn stop_collector(self: Box<Self>) -> Result<Box<dyn Trace>, HWTracerError>;
 }

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -78,6 +78,7 @@ impl PerfTracer {
 }
 
 /// A collector that uses the Linux Perf interface to Intel Processor Trace.
+#[derive(Debug)]
 pub struct PerfThreadTracer {
     // Opaque C pointer representing the collector context.
     ctx: *mut c_void,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -796,6 +796,7 @@ unsafe extern "C" fn __yk_exec_trace(
 
 /// [MTThread]'s major job is to record what state in the "interpreting/tracing/executing"
 /// state-machine this thread is in. This enum contains the states.
+#[derive(Debug)]
 enum MTThreadState {
     /// This thread is executing in the normal interpreter: it is not executing a trace or
     /// recording a trace.
@@ -1006,6 +1007,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct DummyTraceRecorder;
 
     impl TraceRecorder for DummyTraceRecorder {

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -29,6 +29,7 @@ impl super::Tracer for HWTracer {
 }
 
 /// Hardware thread tracer.
+#[derive(Debug)]
 struct HWTTraceRecorder {
     thread_tracer: Box<dyn hwtracer::ThreadTracer>,
 }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! This module thus contains tracing backends which can record and process traces.
 
-use std::{error::Error, ffi::CString, sync::Arc};
+use std::{error::Error, ffi::CString, fmt, sync::Arc};
 use thiserror::Error;
 
 #[cfg(tracer_hwt)]
@@ -45,7 +45,7 @@ pub(crate) fn default_tracer() -> Result<Arc<dyn Tracer>, Box<dyn Error>> {
 }
 
 /// An instance of a [Tracer] which is currently recording a trace of the current thread.
-pub(crate) trait TraceRecorder {
+pub(crate) trait TraceRecorder: fmt::Debug {
     /// Stop recording a trace of the current thread and return an iterator which successively
     /// produces [TraceAction]s.
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, TraceRecorderError>;

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -79,6 +79,7 @@ impl Tracer for SWTracer {
     }
 }
 
+#[derive(Debug)]
 struct SWTTraceRecorder {}
 
 impl TraceRecorder for SWTTraceRecorder {


### PR DESCRIPTION
When hunting a bug in `mt.rs`, I found that I needed some missing `derive(Debug)`s. I suspect we will need those again, so this commit adds them in for whoever might need them in the future.