### PR TITLE
Make clear that parameter indexes are `InstIdx`s.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1077,7 +1077,7 @@ impl<'a> Assemble<'a> {
     /// Codegen a [jit_ir::ParamInst]. This only informs the register allocator about the
     /// locations of live variables without generating any actual machine code.
     fn cg_param(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::ParamInst) {
-        let m = match &self.m.params()[usize::try_from(inst.locidx()).unwrap()] {
+        let m = match self.m.param(inst.paramidx()) {
             yksmp::Location::Register(0, ..) => {
                 VarLocation::Register(reg_alloc::Register::GP(Rq::RAX))
             }
@@ -2548,7 +2548,7 @@ enum Immediate {
 mod tests {
     use super::{Assemble, X64CompiledTrace};
     use crate::compile::{
-        jitc_yk::jit_ir::{self, Module},
+        jitc_yk::jit_ir::{self, Inst, InstIdx, Module},
         CompiledTrace,
     };
     use crate::location::{HotLocation, HotLocationKind};
@@ -4503,10 +4503,16 @@ mod tests {
 
         // Create two trace paramaters whose locations alias.
         let loc = yksmp::Location::Register(13, 1, 0, [].into());
+        m.push_param(loc.clone());
+        let pinst1: Inst =
+            jit_ir::ParamInst::new(InstIdx::try_from(0).unwrap(), m.int8_tyidx()).into();
+        m.push(pinst1.clone()).unwrap();
         m.push_param(loc);
-        let param_inst = jit_ir::ParamInst::new(0, m.int8_tyidx());
-        let op1 = m.push_and_make_operand(param_inst.clone().into()).unwrap();
-        let op2 = m.push_and_make_operand(param_inst.into()).unwrap();
+        let pinst2: Inst =
+            jit_ir::ParamInst::new(InstIdx::try_from(1).unwrap(), m.int8_tyidx()).into();
+        m.push(pinst2.clone()).unwrap();
+        let op1 = m.push_and_make_operand(pinst1).unwrap();
+        let op2 = m.push_and_make_operand(pinst2).unwrap();
 
         let add_inst = jit_ir::BinOpInst::new(op1, jit_ir::BinOp::Add, op2);
         m.push(add_inst.into()).unwrap();

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -312,7 +312,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                         let off = self
                             .lexer
                             .span_str(tiidx)
-                            .parse::<u32>()
+                            .parse::<usize>()
                             .map_err(|e| self.error_at_span(tiidx, &e.to_string()))?;
                         assert_eq!(self.m.params.len(), usize::try_from(off).unwrap());
                         let type_ = self.process_type(type_)?;
@@ -354,7 +354,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                             }
                             Ty::Unimplemented(_) => todo!(),
                         }
-                        let inst = ParamInst::new(off, type_);
+                        let inst = ParamInst::new(InstIdx::try_from(off).unwrap(), type_);
                         self.push_assign(inst.into(), assign)?;
                     }
                     ASTInst::PtrAdd {
@@ -879,10 +879,10 @@ mod tests {
         m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
         m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
         let op1 = m
-            .push_and_make_operand(ParamInst::new(0, i16_tyidx).into())
+            .push_and_make_operand(ParamInst::new(InstIdx::try_from(0).unwrap(), i16_tyidx).into())
             .unwrap();
         let op2 = m
-            .push_and_make_operand(ParamInst::new(1, i16_tyidx).into())
+            .push_and_make_operand(ParamInst::new(InstIdx::try_from(1).unwrap(), i16_tyidx).into())
             .unwrap();
         let op3 = m
             .push_and_make_operand(BinOpInst::new(op1.clone(), BinOp::Add, op2.clone()).into())

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -354,11 +354,8 @@ impl Opt {
                 Inst::Param(x) => {
                     // FIXME: This feels like it should be handled by trace_builder, but we can't
                     // do so yet because of https://github.com/ykjit/yk/issues/1435.
-                    let locidx = x.locidx();
-                    if let yksmp::Location::Constant(v) =
-                        self.m.params()[usize::try_from(locidx).unwrap()]
-                    {
-                        let cidx = self.m.insert_const(Const::Int(x.tyidx(), v.into()))?;
+                    if let yksmp::Location::Constant(v) = self.m.param(x.paramidx()) {
+                        let cidx = self.m.insert_const(Const::Int(x.tyidx(), u64::from(*v)))?;
                         self.an.set_value(iidx, Value::Const(cidx));
                     }
                 }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -5,7 +5,7 @@
 use super::aot_ir::{self, BBlockId, BinOp, Module};
 use super::YkSideTraceInfo;
 use super::{
-    jit_ir::{self, Const, Operand, PackedOperand},
+    jit_ir::{self, Const, InstIdx, Operand, PackedOperand},
     AOT_MOD,
 };
 use crate::aotsmp::AOT_STACKMAPS;
@@ -117,15 +117,14 @@ impl TraceBuilder {
         for idx in 0..safepoint.lives.len() {
             let aot_op = &safepoint.lives[idx];
             let input_tyidx = self.handle_type(aot_op.type_(self.aot_mod))?;
-            let param_inst =
-                jit_ir::ParamInst::new(u32::try_from(idx).unwrap(), input_tyidx).into();
-            self.jit_mod.push(param_inst)?;
 
             // Get the location for this input variable.
             let var = &rec.live_vars[idx];
             if var.len() > 1 {
                 todo!("Deal with multi register locations");
             }
+            let param_inst = jit_ir::ParamInst::new(InstIdx::try_from(idx)?, input_tyidx).into();
+            self.jit_mod.push(param_inst)?;
             self.jit_mod.push_param(var.get(0).unwrap().clone());
             self.local_map.insert(
                 aot_op.to_inst_id(),
@@ -1181,7 +1180,7 @@ impl TraceBuilder {
                 let aotinst = self.aot_mod.inst(aotid);
                 let aotty = aotinst.def_type(self.aot_mod).unwrap();
                 let tyidx = self.handle_type(aotty)?;
-                let param_inst = jit_ir::ParamInst::new(u32::try_from(idx).unwrap(), tyidx).into();
+                let param_inst = jit_ir::ParamInst::new(InstIdx::try_from(idx)?, tyidx).into();
                 self.jit_mod.push(param_inst)?;
                 self.jit_mod.push_param(loc.clone());
                 self.local_map.insert(


### PR DESCRIPTION
Previously we used a `u32` (why such a big type? dunno!), requiring `ParamInst` to be `packed`. By definition a parameter is stored in an SSA variable which, in our context, means it's an `InstIdx`.

This commit makes this explicit:

  1. Parameters are now indexed by `InstIdx`.
  2. The vague `locidx` is now `paramidx`.
  3. The unnecessary largesse of the `params()` function returning a slice is hidden by a `param()` function which returns a single parameter.

This change did spot a bug in a test, so it is useful.