### PR TITLE
Test case for crashing fmul.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -4319,6 +4319,7 @@ mod tests {
                 %0: float = param 0
                 %1: float = param 1
                 %2: float = fmul %0, %1
+                %3: float = fmul %1, %1
             ",
             "
                 ...


### PR DESCRIPTION
```
$ cargo test cg_fmul_float
...
thread 'compile::jitc_yk::codegen::x64::tests::cg_fmul_float' panicked at ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs:1044:22:
called `Option::unwrap()` on a `None` value
```

(Oddly not triggered by `fmul %0, %0`)