### PR TITLE
Hack in "keep running if perf says it's busy".

### DIFF
--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -24,6 +24,8 @@ pub enum TemporaryErrorKind {
     TraceBufferOverflow,
     /// The trace was interrupted.
     TraceInterrupted,
+    /// Perf can't set itself up.
+    PerfBusy,
 }
 
 impl Display for TemporaryErrorKind {
@@ -32,6 +34,7 @@ impl Display for TemporaryErrorKind {
             TemporaryErrorKind::CantAllocate => write!(f, "Unable to allocate memory"),
             TemporaryErrorKind::TraceBufferOverflow => write!(f, "Trace buffer overflow"),
             TemporaryErrorKind::TraceInterrupted => write!(f, "Trace interrupted"),
+            TemporaryErrorKind::PerfBusy => write!(f, "Perf busy"),
         }
     }
 }

--- a/hwtracer/src/pt/c_errors.rs
+++ b/hwtracer/src/pt/c_errors.rs
@@ -52,6 +52,11 @@ impl From<PerfPTCError> for HWTracerError {
                 HWTracerError::Unrecoverable("PerfPTCErrorKind::Unknown".into())
             }
             PerfPTCErrorKind::Errno => {
+                #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+                if err.code == 16 {
+                    return HWTracerError::Temporary(TemporaryErrorKind::PerfBusy);
+                }
+
                 HWTracerError::Unrecoverable(format!("c set errno {}", err.code))
             }
             #[cfg(pt)]


### PR DESCRIPTION
This is a horrible way of doing things, but means that "perf can't open an FD" errors no longer stop the system. We can do better, but this is a reasonable temporary measure.