### PR TITLE
Introduce a `ParamIdx` type.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2548,7 +2548,7 @@ enum Immediate {
 mod tests {
     use super::{Assemble, X64CompiledTrace};
     use crate::compile::{
-        jitc_yk::jit_ir::{self, Inst, InstIdx, Module},
+        jitc_yk::jit_ir::{self, Inst, Module, ParamIdx},
         CompiledTrace,
     };
     use crate::location::{HotLocation, HotLocationKind};
@@ -4506,11 +4506,11 @@ mod tests {
         let loc = yksmp::Location::Register(13, 1, 0, [].into());
         m.push_param(loc.clone());
         let pinst1: Inst =
-            jit_ir::ParamInst::new(InstIdx::try_from(0).unwrap(), m.int8_tyidx()).into();
+            jit_ir::ParamInst::new(ParamIdx::try_from(0).unwrap(), m.int8_tyidx()).into();
         m.push(pinst1.clone()).unwrap();
         m.push_param(loc);
         let pinst2: Inst =
-            jit_ir::ParamInst::new(InstIdx::try_from(1).unwrap(), m.int8_tyidx()).into();
+            jit_ir::ParamInst::new(ParamIdx::try_from(1).unwrap(), m.int8_tyidx()).into();
         m.push(pinst2.clone()).unwrap();
         let op1 = m.push_and_make_operand(pinst1).unwrap();
         let op2 = m.push_and_make_operand(pinst2).unwrap();

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -94,7 +94,6 @@ use super::{aot_ir, codegen::reg_alloc::VarLocation};
 use crate::compile::CompilationError;
 use indexmap::IndexSet;
 use std::{
-    assert_matches::debug_assert_matches,
     ffi::{c_void, CString},
     fmt,
     hash::Hash,
@@ -450,9 +449,8 @@ impl Module {
     }
 
     /// Return the parameter at a given [InstIdx].
-    pub(crate) fn param(&self, iidx: InstIdx) -> &yksmp::Location {
-        debug_assert_matches!(self.inst_decopy(iidx).1, Inst::Param(_));
-        &self.params[usize::from(iidx)]
+    pub(crate) fn param(&self, pidx: ParamIdx) -> &yksmp::Location {
+        &self.params[usize::from(pidx)]
     }
 
     /// Add a [Ty] to the types pool and return its index. If the [Ty] already exists, an existing
@@ -920,12 +918,15 @@ index_24bit!(GlobalDeclIdx);
 pub(crate) struct IndirectCallIdx(U24);
 index_24bit!(IndirectCallIdx);
 
-/// An instruction index.
-///
-/// One of these is an index into the [Module::insts].
+/// An index into [Module::insts].
 #[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct InstIdx(u16);
 index_16bit!(InstIdx);
+
+/// An index into [Module::params].
+#[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct ParamIdx(u16);
+index_16bit!(ParamIdx);
 
 /// A function's type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -2157,22 +2158,19 @@ impl LoadInst {
 /// Specifies the [yksmp::Location] of a run-time argument.
 #[derive(Clone, Copy, Debug)]
 pub struct ParamInst {
-    /// The [InstIdx] of the [yksmp::Location] parameter.
-    paramidx: InstIdx,
+    /// The [ParamIdx] of the [yksmp::Location] parameter.
+    pidx: ParamIdx,
     /// The type of the resulting local variable.
     tyidx: TyIdx,
 }
 
 impl ParamInst {
-    pub(crate) fn new(locidx: InstIdx, tyidx: TyIdx) -> ParamInst {
-        Self {
-            paramidx: locidx,
-            tyidx,
-        }
+    pub(crate) fn new(pidx: ParamIdx, tyidx: TyIdx) -> ParamInst {
+        Self { pidx, tyidx }
     }
 
     pub(crate) fn decopy_eq(&self, other: Self) -> bool {
-        self.paramidx == other.paramidx && self.tyidx == other.tyidx
+        self.pidx == other.pidx && self.tyidx == other.tyidx
     }
 
     pub(crate) fn tyidx(&self) -> TyIdx {
@@ -2180,8 +2178,8 @@ impl ParamInst {
     }
 
     /// Return The [InstIdx] of the [yksmp::Location] parameter.
-    pub(crate) fn paramidx(&self) -> InstIdx {
-        self.paramidx
+    pub(crate) fn paramidx(&self) -> ParamIdx {
+        self.pidx
     }
 }
 
@@ -2947,8 +2945,8 @@ mod tests {
     #[test]
     fn use_case_update_inst() {
         let mut prog: Vec<Inst> = vec![
-            ParamInst::new(InstIdx::try_from(0).unwrap(), TyIdx::try_from(0).unwrap()).into(),
-            ParamInst::new(InstIdx::try_from(8).unwrap(), TyIdx::try_from(0).unwrap()).into(),
+            ParamInst::new(ParamIdx::try_from(0).unwrap(), TyIdx::try_from(0).unwrap()).into(),
+            ParamInst::new(ParamIdx::try_from(8).unwrap(), TyIdx::try_from(0).unwrap()).into(),
             LoadInst::new(
                 Operand::Var(InstIdx(0)),
                 TyIdx(U24::try_from(0).unwrap()),
@@ -2988,17 +2986,17 @@ mod tests {
             Operand::Var(InstIdx(2)),
         ];
         m.push(Inst::Param(ParamInst::new(
-            InstIdx::try_from(0).unwrap(),
+            ParamIdx::try_from(0).unwrap(),
             i32_tyidx,
         )))
         .unwrap();
         m.push(Inst::Param(ParamInst::new(
-            InstIdx::try_from(1).unwrap(),
+            ParamIdx::try_from(1).unwrap(),
             i32_tyidx,
         )))
         .unwrap();
         m.push(Inst::Param(ParamInst::new(
-            InstIdx::try_from(2).unwrap(),
+            ParamIdx::try_from(2).unwrap(),
             i32_tyidx,
         )))
         .unwrap();
@@ -3128,7 +3126,7 @@ mod tests {
     fn print_module() {
         let mut m = Module::new_testing();
         m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
-        m.push(ParamInst::new(InstIdx::try_from(0).unwrap(), m.int8_tyidx()).into())
+        m.push(ParamInst::new(ParamIdx::try_from(0).unwrap(), m.int8_tyidx()).into())
             .unwrap();
         m.insert_global_decl(GlobalDecl::new(
             CString::new("some_global").unwrap(),

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -11,8 +11,9 @@ use super::super::{
     jit_ir::{
         BinOpInst, BitCastInst, BlackBoxInst, Const, DirectCallInst, DynPtrAddInst, FCmpInst,
         FNegInst, FPExtInst, FPToSIInst, FloatTy, FuncDecl, FuncTy, GuardInfo, GuardInst, ICmpInst,
-        IndirectCallInst, Inst, InstIdx, LoadInst, Module, Operand, PackedOperand, ParamInst,
-        PtrAddInst, SExtInst, SIToFPInst, SelectInst, StoreInst, TruncInst, Ty, TyIdx, ZExtInst,
+        IndirectCallInst, Inst, InstIdx, LoadInst, Module, Operand, PackedOperand, ParamIdx,
+        ParamInst, PtrAddInst, SExtInst, SIToFPInst, SelectInst, StoreInst, TruncInst, Ty, TyIdx,
+        ZExtInst,
     },
 };
 use fm::FMBuilder;
@@ -354,7 +355,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                             }
                             Ty::Unimplemented(_) => todo!(),
                         }
-                        let inst = ParamInst::new(InstIdx::try_from(off).unwrap(), type_);
+                        let inst = ParamInst::new(ParamIdx::try_from(off).unwrap(), type_);
                         self.push_assign(inst.into(), assign)?;
                     }
                     ASTInst::PtrAdd {
@@ -879,10 +880,10 @@ mod tests {
         m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
         m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
         let op1 = m
-            .push_and_make_operand(ParamInst::new(InstIdx::try_from(0).unwrap(), i16_tyidx).into())
+            .push_and_make_operand(ParamInst::new(ParamIdx::try_from(0).unwrap(), i16_tyidx).into())
             .unwrap();
         let op2 = m
-            .push_and_make_operand(ParamInst::new(InstIdx::try_from(1).unwrap(), i16_tyidx).into())
+            .push_and_make_operand(ParamInst::new(ParamIdx::try_from(1).unwrap(), i16_tyidx).into())
             .unwrap();
         let op3 = m
             .push_and_make_operand(BinOpInst::new(op1.clone(), BinOp::Add, op2.clone()).into())

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -5,7 +5,7 @@
 use super::aot_ir::{self, BBlockId, BinOp, Module};
 use super::YkSideTraceInfo;
 use super::{
-    jit_ir::{self, Const, InstIdx, Operand, PackedOperand},
+    jit_ir::{self, Const, Operand, PackedOperand, ParamIdx},
     AOT_MOD,
 };
 use crate::aotsmp::AOT_STACKMAPS;
@@ -123,7 +123,7 @@ impl TraceBuilder {
             if var.len() > 1 {
                 todo!("Deal with multi register locations");
             }
-            let param_inst = jit_ir::ParamInst::new(InstIdx::try_from(idx)?, input_tyidx).into();
+            let param_inst = jit_ir::ParamInst::new(ParamIdx::try_from(idx)?, input_tyidx).into();
             self.jit_mod.push(param_inst)?;
             self.jit_mod.push_param(var.get(0).unwrap().clone());
             self.local_map.insert(
@@ -1180,7 +1180,7 @@ impl TraceBuilder {
                 let aotinst = self.aot_mod.inst(aotid);
                 let aotty = aotinst.def_type(self.aot_mod).unwrap();
                 let tyidx = self.handle_type(aotty)?;
-                let param_inst = jit_ir::ParamInst::new(InstIdx::try_from(idx)?, tyidx).into();
+                let param_inst = jit_ir::ParamInst::new(ParamIdx::try_from(idx)?, tyidx).into();
                 self.jit_mod.push(param_inst)?;
                 self.jit_mod.push_param(loc.clone());
                 self.local_map.insert(


### PR DESCRIPTION
Originally I thought we didn't need this, but it's now probable that loop peeling will require it, because we will (at some point) insert `ParamInst`s in the "middle" of a trace.