### PR TITLE
Use a pinned version of yklua in `.buildbot.sh`.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+# What git commit hash of yklua will we test in buildbot?
+YKLUA_COMMIT="7ced271cf4f36a78127d0cc745906cc21409ae0d"
+
 TRACERS="hwt swt"
 
 # Build yklua and run the test suite.
@@ -11,7 +14,10 @@ TRACERS="hwt swt"
 #  - YK_BUILD_TYPE must be set.
 test_yklua() {
     if [ ! -e "yklua" ]; then
-        git clone https://github.com/ykjit/yklua
+        git clone --depth=1 https://github.com/ykjit/yklua
+        cd yklua
+        git fetch --depth=1 origin "$YKLUA_COMMIT"
+        git checkout "$YKLUA_COMMIT"
     fi
     cd yklua
     make clean


### PR DESCRIPTION
Previously we have got ourselves into trouble when yklua has changed, and it causes later yk builds to break. There's no guaranteed way around this problem, but we can avoid most of the pain by forcing ourselves to use a specific version of yklua in tests.

This commit does that for `.buildbot.sh` (and, while I'm here, I've done a two-stage-clone-checkout to minimise network traffic). We could perhaps use a submodule for this, but since we don't use yklua anywhere else in the test suite, that feels a bit intrusive.