### PR TITLE
Remove various dangerous parts of the internal API

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -674,7 +674,7 @@ impl LSRegAlloc<'_> {
     ///
     /// If `iidx` has not previously been spilled.
     fn force_gp_unspill(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rq) {
-        let (iidx, inst) = self.m.inst_decopy(iidx);
+        let inst = self.m.inst_no_copies(iidx);
         let size = inst.def_byte_size(self.m);
 
         if let Inst::Const(cidx) = inst {
@@ -768,7 +768,7 @@ impl LSRegAlloc<'_> {
         }) {
             VarLocation::Register(reg_alloc::Register::FP(FP_REGS[reg_i]))
         } else {
-            let (iidx, inst) = self.m.inst_decopy(iidx);
+            let inst = self.m.inst_no_copies(iidx);
             let size = inst.def_byte_size(self.m);
             match inst {
                 Inst::Copy(_) => panic!(),

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -268,7 +268,7 @@ impl LSRegAlloc<'_> {
             debug_assert_eq!(self.spills[usize::from(iidx)], SpillState::Empty);
             // Input values alias to a single register. To avoid the rest of the register allocator
             // having to think about this, we "dealias" the values by spilling.
-            let inst = self.m.inst_no_copies(iidx);
+            let inst = self.m.inst(iidx);
             let size = inst.def_byte_size(self.m);
             self.stack.align(size); // FIXME
             let frame_off = self.stack.grow(size);
@@ -647,7 +647,7 @@ impl LSRegAlloc<'_> {
             RegState::Reserved | RegState::Empty | RegState::FromConst(_) => (),
             RegState::FromInst(iidx) => {
                 if self.spills[usize::from(iidx)] == SpillState::Empty {
-                    let inst = self.m.inst_no_copies(iidx);
+                    let inst = self.m.inst(iidx);
                     let size = inst.def_byte_size(self.m);
                     self.stack.align(size); // FIXME
                     let frame_off = self.stack.grow(size);
@@ -674,7 +674,7 @@ impl LSRegAlloc<'_> {
     ///
     /// If `iidx` has not previously been spilled.
     fn force_gp_unspill(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rq) {
-        let inst = self.m.inst_no_copies(iidx);
+        let inst = self.m.inst(iidx);
         let size = inst.def_byte_size(self.m);
 
         if let Inst::Const(cidx) = inst {
@@ -768,7 +768,7 @@ impl LSRegAlloc<'_> {
         }) {
             VarLocation::Register(reg_alloc::Register::FP(FP_REGS[reg_i]))
         } else {
-            let inst = self.m.inst_no_copies(iidx);
+            let inst = self.m.inst(iidx);
             let size = inst.def_byte_size(self.m);
             match inst {
                 Inst::Copy(_) => panic!(),
@@ -1138,7 +1138,7 @@ impl LSRegAlloc<'_> {
             RegState::Reserved | RegState::Empty | RegState::FromConst(_) => (),
             RegState::FromInst(iidx) => {
                 if self.spills[usize::from(iidx)] == SpillState::Empty {
-                    let inst = self.m.inst_no_copies(iidx);
+                    let inst = self.m.inst(iidx);
                     let size = inst.def_byte_size(self.m);
                     self.stack.align(size); // FIXME
                     let frame_off = self.stack.grow(size);
@@ -1160,7 +1160,7 @@ impl LSRegAlloc<'_> {
     ///
     /// If `iidx` has not previously been spilled.
     fn force_fp_unspill(&mut self, asm: &mut Assembler, iidx: InstIdx, reg: Rx) {
-        let inst = self.m.inst_no_copies(iidx);
+        let inst = self.m.inst(iidx);
         let size = inst.def_byte_size(self.m);
 
         match self.spills[usize::from(iidx)] {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1994,10 +1994,7 @@ impl<'a> Assemble<'a> {
         // back around here we need to write the live variables back into these same locations.
         for var in self.m.loop_start_vars() {
             let loc = match var {
-                Operand::Var(iidx) => {
-                    debug_assert_eq!(*iidx, self.m.inst_decopy(*iidx).0);
-                    self.ra.var_location(*iidx)
-                }
+                Operand::Var(iidx) => self.ra.var_location(*iidx),
                 _ => panic!(),
             };
             self.loop_start_locs.push(loc);

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1125,7 +1125,7 @@ impl<'a> Assemble<'a> {
             yksmp::Location::Constant(v) => {
                 // FIXME: This isn't fine-grained enough, as there may be constants of any
                 // bit-size.
-                let byte_size = self.m.inst_no_copies(iidx).def_byte_size(self.m);
+                let byte_size = self.m.inst(iidx).def_byte_size(self.m);
                 debug_assert!(byte_size <= 8);
                 VarLocation::ConstInt {
                     bits: u32::try_from(byte_size).unwrap() * 8,
@@ -1136,7 +1136,7 @@ impl<'a> Assemble<'a> {
                 todo!("{:?}", e);
             }
         };
-        let size = self.m.inst_no_copies(iidx).def_byte_size(self.m);
+        let size = self.m.inst(iidx).def_byte_size(self.m);
         debug_assert!(size <= REG64_BYTESIZE);
         match m {
             VarLocation::Register(reg_alloc::Register::GP(reg)) => {
@@ -1178,7 +1178,7 @@ impl<'a> Assemble<'a> {
                             iidx,
                             [RegConstraint::Input(ptr_op), RegConstraint::Output],
                         );
-                        let size = self.m.inst_no_copies(iidx).def_byte_size(self.m);
+                        let size = self.m.inst(iidx).def_byte_size(self.m);
                         debug_assert!(size <= REG64_BYTESIZE);
                         match size {
                             1 => {
@@ -1205,7 +1205,7 @@ impl<'a> Assemble<'a> {
                     iidx,
                     [RegConstraint::InputOutput(ptr_op)],
                 );
-                let size = self.m.inst_no_copies(iidx).def_byte_size(self.m);
+                let size = self.m.inst(iidx).def_byte_size(self.m);
                 debug_assert!(size <= REG64_BYTESIZE);
                 match size {
                     1 => dynasm!(self.asm ; movzx Rq(reg.code()), BYTE [Rq(reg.code()) + off]),

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -474,7 +474,7 @@ impl<'a> Assemble<'a> {
             }
             self.ra.expire_regs(iidx);
 
-            match inst {
+            match &inst {
                 #[cfg(test)]
                 jit_ir::Inst::BlackBox(_) => (),
                 jit_ir::Inst::Const(_) | jit_ir::Inst::Copy(_) | jit_ir::Inst::Tombstone => {
@@ -1663,7 +1663,7 @@ impl<'a> Assemble<'a> {
         ic_iidx: InstIdx,
         ic_inst: &jit_ir::ICmpInst,
         g_iidx: InstIdx,
-        g_inst: &jit_ir::GuardInst,
+        g_inst: jit_ir::GuardInst,
     ) {
         // Codegen ICmp
         let (lhs, pred, rhs) = (
@@ -1690,9 +1690,9 @@ impl<'a> Assemble<'a> {
         self.ra.expire_regs(g_iidx);
         self.comment(
             self.asm.offset(),
-            Inst::Guard(*g_inst).display(g_iidx, self.m).to_string(),
+            Inst::Guard(g_inst).display(g_iidx, self.m).to_string(),
         );
-        let fail_label = self.guard_to_deopt(g_inst);
+        let fail_label = self.guard_to_deopt(&g_inst);
 
         if g_inst.expect() {
             match pred {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -24,9 +24,7 @@ pub(super) fn rev_analyse(
     let mut inst_vals_alive_until = vec![InstIdx::try_from(0).unwrap(); m.insts_len()];
     let mut ptradds = vec![None; m.insts_len()];
     let mut used_insts = Vob::from_elem(false, usize::from(m.last_inst_idx()) + 1);
-    for iidx in m.iter_all_inst_idxs().rev() {
-        let inst = m.inst_raw(iidx);
-
+    for (iidx, inst) in m.iter_skipping_insts().rev() {
         if used_insts.get(usize::from(iidx)).unwrap()
             || inst.has_store_effect(m)
             || inst.is_barrier(m)

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -37,7 +37,7 @@ pub(super) fn rev_analyse(
             match inst {
                 Inst::Load(x) => {
                     if let Operand::Var(op_iidx) = x.operand(m) {
-                        if let Inst::PtrAdd(pa_inst) = m.inst_no_copies(op_iidx) {
+                        if let Inst::PtrAdd(pa_inst) = m.inst(op_iidx) {
                             ptradds[usize::from(iidx)] = Some(pa_inst);
                             if let Operand::Var(y) = pa_inst.ptr(m) {
                                 if inst_vals_alive_until[usize::from(y)] < iidx {
@@ -51,7 +51,7 @@ pub(super) fn rev_analyse(
                 }
                 Inst::Store(x) => {
                     if let Operand::Var(op_iidx) = x.tgt(m) {
-                        if let Inst::PtrAdd(pa_inst) = m.inst_no_copies(op_iidx) {
+                        if let Inst::PtrAdd(pa_inst) = m.inst(op_iidx) {
                             ptradds[usize::from(iidx)] = Some(pa_inst);
                             if let Operand::Var(y) = pa_inst.ptr(m) {
                                 if inst_vals_alive_until[usize::from(y)] < iidx {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -37,7 +37,7 @@ pub(super) fn rev_analyse(
             match inst {
                 Inst::Load(x) => {
                     if let Operand::Var(op_iidx) = x.operand(m) {
-                        if let Inst::PtrAdd(pa_inst) = m.inst_decopy(op_iidx).1 {
+                        if let Inst::PtrAdd(pa_inst) = m.inst_no_copies(op_iidx) {
                             ptradds[usize::from(iidx)] = Some(pa_inst);
                             if let Operand::Var(y) = pa_inst.ptr(m) {
                                 if inst_vals_alive_until[usize::from(y)] < iidx {
@@ -51,7 +51,7 @@ pub(super) fn rev_analyse(
                 }
                 Inst::Store(x) => {
                     if let Operand::Var(op_iidx) = x.tgt(m) {
-                        if let Inst::PtrAdd(pa_inst) = m.inst_decopy(op_iidx).1 {
+                        if let Inst::PtrAdd(pa_inst) = m.inst_no_copies(op_iidx) {
                             ptradds[usize::from(iidx)] = Some(pa_inst);
                             if let Operand::Var(y) = pa_inst.ptr(m) {
                                 if inst_vals_alive_until[usize::from(y)] < iidx {
@@ -74,7 +74,6 @@ pub(super) fn rev_analyse(
 
             // Calculate inst_vals_alive_until
             inst.map_operand_locals(m, &mut |x| {
-                let (x, _) = m.inst_decopy(x);
                 used_insts.set(usize::from(x), true);
                 if inst_vals_alive_until[usize::from(x)] < iidx {
                     inst_vals_alive_until[usize::from(x)] = iidx;

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -344,14 +344,6 @@ impl Module {
         InstIdx::try_from(self.insts.len()).inspect(|_| self.insts.push(inst))
     }
 
-    /// Iterate, in order, over all `InstIdx`s of this module (including `Const`, `Copy`, and
-    /// `Tombstone` instructions).
-    pub(crate) fn iter_all_inst_idxs(&self) -> impl DoubleEndedIterator<Item = InstIdx> {
-        // The `unchecked_from` is safe because we know from `Self::push` that we can't have
-        // exceeded `InstIdx`'s bounds.
-        (0..self.insts.len()).map(InstIdx::unchecked_from)
-    }
-
     /// Iterate, in order, over the `InstIdx`s of this module skipping `Const`, `Copy`, and
     /// `Tombstone` instructions.
     pub(crate) fn iter_skipping_insts(
@@ -363,6 +355,21 @@ impl Module {
             let inst = &self.insts[i];
             if !matches!(inst, Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone) {
                 Some((InstIdx::unchecked_from(i), inst))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Iterate, in order, over the `InstIdx`s of this module skipping `Const`, `Copy`, and
+    /// `Tombstone` instructions.
+    pub(crate) fn iter_skipping_inst_idxs(&self) -> impl DoubleEndedIterator<Item = InstIdx> + '_ {
+        // The `unchecked_from` is safe because we know from `Self::push` that we can't have
+        // exceeded `InstIdx`'s bounds.
+        (0..self.insts.len()).filter_map(|i| {
+            let inst = &self.insts[i];
+            if !matches!(inst, Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone) {
+                Some(InstIdx::unchecked_from(i))
             } else {
                 None
             }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -301,11 +301,10 @@ impl Module {
     ///
     /// # Panics
     ///
-    /// If `iidx` points to a `Copy` instruction.
-    pub(crate) fn inst_no_copies(&self, iidx: InstIdx) -> Inst {
+    /// If `iidx` points to a `Const`, `Copy`, or `Tombstone` instruction.
+    pub(crate) fn inst(&self, iidx: InstIdx) -> Inst {
         match self.insts[usize::from(iidx)] {
-            Inst::Const(_) => todo!(),
-            Inst::Copy(_) => panic!(),
+            Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone => todo!(),
             x => x,
         }
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -310,17 +310,6 @@ impl Module {
         }
     }
 
-    /// Return the decopied instruction at the specified index (i.e. searching
-    /// until a non-`Copy` instruction is found).
-    pub(crate) fn inst_decopy(&self, mut iidx: InstIdx) -> (InstIdx, Inst) {
-        loop {
-            match self.insts[usize::from(iidx)] {
-                Inst::Copy(copy_iidx) => iidx = copy_iidx,
-                x => return (iidx, x),
-            }
-        }
-    }
-
     /// Return the instruction at the specified index or `None` if it is a `Copy` instruction.
     pub(crate) fn inst_nocopy(&self, iidx: InstIdx) -> Option<Inst> {
         match self.insts[usize::from(iidx)] {

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -348,13 +348,13 @@ impl Module {
     /// `Tombstone` instructions.
     pub(crate) fn iter_skipping_insts(
         &self,
-    ) -> impl DoubleEndedIterator<Item = (InstIdx, &Inst)> + '_ {
+    ) -> impl DoubleEndedIterator<Item = (InstIdx, Inst)> + '_ {
         // The `unchecked_from` is safe because we know from `Self::push` that we can't have
         // exceeded `InstIdx`'s bounds.
         (0..self.insts.len()).filter_map(|i| {
             let inst = &self.insts[i];
             if !matches!(inst, Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone) {
-                Some((InstIdx::unchecked_from(i), inst))
+                Some((InstIdx::unchecked_from(i), *inst))
             } else {
                 None
             }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -322,7 +322,7 @@ impl Module {
     /// This function has very few uses and unless you explicitly know why you're using it, you
     /// should instead use [Self::inst_no_copies] because not handling `Copy` instructions
     /// correctly leads to undefined behaviour.
-    pub(crate) fn inst_raw(&self, iidx: InstIdx) -> Inst {
+    fn inst_raw(&self, iidx: InstIdx) -> Inst {
         self.insts[usize::from(iidx)]
     }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -364,13 +364,21 @@ impl Module {
         (0..self.insts.len()).map(InstIdx::unchecked_from)
     }
 
-    /// An iterator over instructions that skips `Const`, `Copy`, and `Tombstone` instructions.
-    ///
-    /// This implicitly deduplicates the callers view of instructions (since `Const` and `Copy`
-    /// instructions are skipped), but note that the indices, while strictly monotonically
-    /// increasing, may be non-consecutive (because of skipping).
-    pub(crate) fn iter_skipping_insts(&self) -> SkippingInstsIterator<'_> {
-        SkippingInstsIterator { m: self, cur: 0 }
+    /// Iterate, in order, over the `InstIdx`s of this module skipping `Const`, `Copy`, and
+    /// `Tombstone` instructions.
+    pub(crate) fn iter_skipping_insts(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (InstIdx, &Inst)> + '_ {
+        // The `unchecked_from` is safe because we know from `Self::push` that we can't have
+        // exceeded `InstIdx`'s bounds.
+        (0..self.insts.len()).filter_map(|i| {
+            let inst = &self.insts[i];
+            if !matches!(inst, Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone) {
+                Some((InstIdx::unchecked_from(i), inst))
+            } else {
+                None
+            }
+        })
     }
 
     /// Replace the instruction at `iidx` with `inst`.
@@ -431,16 +439,6 @@ impl Module {
     /// If `idx` is out of bounds.
     pub(crate) fn arg(&self, idx: ArgsIdx) -> Operand {
         self.args[usize::from(idx)].unpack(self)
-    }
-
-    /// Return the raw [PackedOperand] at args index `idx`. Unless you have a good reason for doing
-    /// so, use [Self::arg] instead.
-    ///
-    /// # Panics
-    ///
-    /// If `idx` is out of bounds.
-    pub(crate) fn arg_packed(&self, idx: ArgsIdx) -> PackedOperand {
-        self.args[usize::from(idx)]
     }
 
     /// Push the location of a trace parameter.
@@ -664,35 +662,6 @@ impl fmt::Display for Module {
         }
 
         Ok(())
-    }
-}
-
-/// An iterator over instructions that skips `Const`, `Copy`, and `Tombstone` instructions.
-///
-/// This implicitly deduplicates the callers view of instructions (since `Copy` and `Const`
-/// instructions are skipped), but note that the indices, while strictly monotonically increasing,
-/// may be non-consecutive (because of skipping).
-pub(crate) struct SkippingInstsIterator<'a> {
-    m: &'a Module,
-    cur: usize,
-}
-
-impl<'a> Iterator for SkippingInstsIterator<'a> {
-    type Item = (InstIdx, &'a Inst);
-    /// Return the next instruction index and its associated instruction or `None` if the end has
-    /// been reached.
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(x) = self.m.insts.get(self.cur) {
-            // We know that `self.cur` must fit in `InstIdx`, as otherwise `m.insts` wouldn't have
-            // had the instruction in the first place, so the `unchecked_from` is safe.
-            let old = InstIdx::unchecked_from(self.cur);
-            self.cur += 1;
-            match x {
-                Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone => (),
-                _ => return Some((old, &self.m.insts[usize::from(old)])),
-            }
-        }
-        None
     }
 }
 
@@ -1144,17 +1113,6 @@ impl PackedOperand {
             }
         } else {
             Operand::Const(ConstIdx(self.0 & OPERAND_IDX_MASK))
-        }
-    }
-
-    /// If this [PackedOperand] represents a local instruction, call `f` with its `InstIdx`. Note
-    /// that this does not perform any kind of decopying.
-    fn map_iidx<F>(&self, f: &mut F)
-    where
-        F: FnMut(InstIdx),
-    {
-        if (self.0 & !OPERAND_IDX_MASK) == 0 {
-            f(InstIdx(self.0))
         }
     }
 }
@@ -1628,111 +1586,6 @@ impl Inst {
             }
             Inst::FPToSI(FPToSIInst { val, .. }) => val.unpack(m).map_iidx(f),
             Inst::FNeg(FNegInst { val }) => val.unpack(m).map_iidx(f),
-        }
-    }
-
-    /// Apply the function `f` to each of this instruction's [PackedOperand]s that references a
-    /// local instruction. When an instruction references more than one [PackedOperand], the order
-    /// of traversal is undefined.
-    ///
-    /// Note that this function does not perform decopying, and thus must only be used when you
-    /// know that you want to know which local an instruction's operands directly refers to (e.g.
-    /// for dead code elimination).
-    pub(crate) fn map_packed_operand_locals<F>(&self, m: &Module, f: &mut F)
-    where
-        F: FnMut(InstIdx),
-    {
-        match self {
-            #[cfg(test)]
-            Inst::BlackBox(BlackBoxInst { op }) => {
-                op.map_iidx(f);
-            }
-            Inst::Const(_) => (),
-            Inst::Copy(iidx) => f(*iidx),
-            Inst::Tombstone => (),
-            Inst::BinOp(BinOpInst { lhs, binop: _, rhs }) => {
-                lhs.map_iidx(f);
-                rhs.map_iidx(f);
-            }
-            Inst::Load(LoadInst { op, .. }) => op.map_iidx(f),
-            Inst::LookupGlobal(_) => (),
-            Inst::Param(_) => (),
-            Inst::Call(x) => {
-                for i in x.iter_args_idx() {
-                    m.arg_packed(i).map_iidx(f);
-                }
-            }
-            Inst::IndirectCall(x) => {
-                let ici = m.indirect_call(*x);
-                let IndirectCallInst { target, .. } = ici;
-                target.map_iidx(f);
-                for i in ici.iter_args_idx() {
-                    m.arg_packed(i).map_iidx(f);
-                }
-            }
-            Inst::PtrAdd(x) => {
-                let ptr = x.ptr;
-                ptr.map_iidx(f);
-            }
-            Inst::DynPtrAdd(x) => {
-                let ptr = x.ptr;
-                ptr.map_iidx(f);
-                let num_elems = x.num_elems;
-                num_elems.map_iidx(f);
-            }
-            Inst::Store(StoreInst { tgt, val, .. }) => {
-                tgt.map_iidx(f);
-                val.map_iidx(f);
-            }
-            Inst::ICmp(ICmpInst { lhs, pred: _, rhs }) => {
-                lhs.map_iidx(f);
-                rhs.map_iidx(f);
-            }
-            Inst::Guard(x @ GuardInst { cond, .. }) => {
-                cond.map_iidx(f);
-                for (_, pop) in x.guard_info(m).live_vars() {
-                    pop.map_iidx(f);
-                }
-            }
-            Inst::TraceLoopStart => {
-                for val in &m.loop_start_vars {
-                    match val {
-                        Operand::Var(iidx) => f(*iidx),
-                        _ => panic!(),
-                    }
-                }
-            }
-            Inst::TraceLoopJump => {
-                for val in &m.loop_jump_operands {
-                    val.map_iidx(f);
-                }
-            }
-            Inst::RootJump => {
-                for val in &m.loop_jump_operands {
-                    val.map_iidx(f);
-                }
-            }
-            Inst::SExt(SExtInst { val, .. }) => val.map_iidx(f),
-            Inst::ZExt(ZExtInst { val, .. }) => val.map_iidx(f),
-            Inst::BitCast(BitCastInst { val, .. }) => val.map_iidx(f),
-            Inst::Trunc(TruncInst { val, .. }) => val.map_iidx(f),
-            Inst::Select(SelectInst {
-                cond,
-                trueval,
-                falseval,
-            }) => {
-                cond.map_iidx(f);
-                trueval.map_iidx(f);
-                falseval.map_iidx(f);
-            }
-            Inst::SIToFP(SIToFPInst { val, .. }) => val.map_iidx(f),
-            Inst::FPExt(FPExtInst { val, .. }) => val.map_iidx(f),
-            Inst::FCmp(FCmpInst { lhs, pred: _, rhs }) => {
-                lhs.map_iidx(f);
-                rhs.map_iidx(f);
-            }
-            Inst::FPToSI(FPToSIInst { val, .. }) => val.map_iidx(f),
-            Inst::FNeg(FNegInst { val }) => val.map_iidx(f),
         }
     }
 
@@ -3150,5 +3003,29 @@ mod tests {
         assert_eq!(Ty::Integer(127).byte_size().unwrap(), 16);
         assert_eq!(Ty::Integer(128).byte_size().unwrap(), 16);
         assert_eq!(Ty::Integer(129).byte_size().unwrap(), 17);
+    }
+
+    #[test]
+    fn iter_skipping_insts() {
+        let m = Module::from_str(
+            "
+        entry:
+          %0: i8 = param 0
+          %1: i8 = param 1
+          %2: i8 = param 2
+          %3: i8 = param 3
+          %4: i8 = param 4
+          %5: i8 = param 5
+        ",
+        );
+        let mut iter = m.iter_skipping_insts();
+        assert_eq!(Some(0), iter.next().map(|x| usize::from(x.0)));
+        assert_eq!(Some(5), iter.next_back().map(|x| usize::from(x.0)));
+        assert_eq!(Some(4), iter.next_back().map(|x| usize::from(x.0)));
+        assert_eq!(Some(1), iter.next().map(|x| usize::from(x.0)));
+        assert_eq!(Some(2), iter.next().map(|x| usize::from(x.0)));
+        assert_eq!(Some(3), iter.next().map(|x| usize::from(x.0)));
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
     }
 }

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -39,7 +39,7 @@ impl Module {
         let mut last_inst = None;
         for (iidx, inst) in self.iter_skipping_insts() {
             inst.map_operand_locals(self, &mut |x| {
-                if let Inst::Tombstone = self.inst_raw(x) {
+                if let Inst::Tombstone = self.insts[usize::from(x)] {
                     panic!(
                         "Instruction at position {iidx} uses undefined value (%{x})\n  {}",
                         self.inst(iidx).display(iidx, self)

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -290,7 +290,7 @@ impl Module {
                 }
                 _ => (),
             }
-            last_inst = Some(*inst);
+            last_inst = Some(inst);
         }
     }
 }

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -30,7 +30,7 @@ impl Analyse {
                 Value::Unknown => {
                     // Since we last saw an `ICmp` instruction, we may have gathered new knowledge
                     // that allows us to turn it into a constant.
-                    if let Inst::ICmp(inst) = m.inst_no_copies(iidx) {
+                    if let Inst::ICmp(inst) = m.inst(iidx) {
                         let lhs = self.op_map(m, inst.lhs(m));
                         let pred = inst.predicate();
                         let rhs = self.op_map(m, inst.rhs(m));
@@ -59,7 +59,7 @@ impl Analyse {
     /// Use the guard `inst` to update our knowledge about the variable used as its condition.
     pub(super) fn guard(&mut self, m: &Module, g_inst: GuardInst) {
         if let Operand::Var(iidx) = g_inst.cond(m) {
-            if let Inst::ICmp(ic_inst) = m.inst_no_copies(iidx) {
+            if let Inst::ICmp(ic_inst) = m.inst(iidx) {
                 let lhs = self.op_map(m, ic_inst.lhs(m));
                 let pred = ic_inst.predicate();
                 let rhs = self.op_map(m, ic_inst.rhs(m));

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -30,7 +30,7 @@ impl Analyse {
                 Value::Unknown => {
                     // Since we last saw an `ICmp` instruction, we may have gathered new knowledge
                     // that allows us to turn it into a constant.
-                    if let (iidx, Inst::ICmp(inst)) = m.inst_decopy(iidx) {
+                    if let Inst::ICmp(inst) = m.inst_no_copies(iidx) {
                         let lhs = self.op_map(m, inst.lhs(m));
                         let pred = inst.predicate();
                         let rhs = self.op_map(m, inst.rhs(m));
@@ -59,7 +59,7 @@ impl Analyse {
     /// Use the guard `inst` to update our knowledge about the variable used as its condition.
     pub(super) fn guard(&mut self, m: &Module, g_inst: GuardInst) {
         if let Operand::Var(iidx) = g_inst.cond(m) {
-            if let (_, Inst::ICmp(ic_inst)) = m.inst_decopy(iidx) {
+            if let Inst::ICmp(ic_inst) = m.inst_no_copies(iidx) {
                 let lhs = self.op_map(m, ic_inst.lhs(m));
                 let pred = ic_inst.predicate();
                 let rhs = self.op_map(m, ic_inst.rhs(m));

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -31,11 +31,12 @@ impl Opt {
     }
 
     fn opt(mut self) -> Result<Module, CompilationError> {
-        for iidx in self.m.iter_all_inst_idxs() {
-            match self.m.inst_raw(iidx) {
+        let skipping = self.m.iter_skipping_inst_idxs().collect::<Vec<_>>();
+        for iidx in skipping {
+            match self.m.inst(iidx) {
                 #[cfg(test)]
                 Inst::BlackBox(_) => (),
-                Inst::Const(cidx) => self.an.set_value(iidx, Value::Const(cidx)),
+                Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone => unreachable!(),
                 Inst::BinOp(x) => match x.binop() {
                     BinOp::Add => match (
                         self.an.op_map(&self.m, x.lhs(&self.m)),


### PR DESCRIPTION
Our recent mantra has been "store `PackedOperand`s, use `Operand`s" -- but we only partly lived up to that. Indeed, I partly got that wrong in https://github.com/ykjit/yk/pull/1490 and its predecessor. My excuse is that the API makes it easy to do the wrong thing: this API largely rectifies that.

In essence, https://github.com/ykjit/yk/pull/1478 sorted out a long-running problem that I did not appreciate in the past, where our storage of `Operand`s (rather than `PackedOperand`s!) leaked in weird ways into the rest of the system. By fixing things in that PR, we opened up the possibility of fixing more things. https://github.com/ykjit/yk/commit/eade0b8cf8b0d619e6ca7171713bb166f057dd69 is the next key to moving things forward: once that's done, the subsequent commits in this PR flow fairly naturally, gradually removing dangerous parts of the API (e.g. the horror of https://github.com/ykjit/yk/commit/ea6df96d575becccfa93f32cef19f4435f1d35e7).

There are still a couple of bits lurking around that I think can be made safer, but this PR captures the vast majority of the bits I can think of. Note that this PR is a win-win: it makes the code smaller, and harder to evolve in the future in incorrect ways!