### PR TITLE
Guards can only be replaced if their `expect`s match.

### DIFF
--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -312,8 +312,7 @@ impl Opt {
                             let Some(Inst::Guard(y)) = self.m.inst_nocopy(back_iidx) else {
                                 continue;
                             };
-                            if x.cond(&self.m) == y.cond(&self.m) {
-                                debug_assert_eq!(x.expect, y.expect);
+                            if x.cond(&self.m) == y.cond(&self.m) && x.expect() == y.expect() {
                                 self.m.replace(iidx, Inst::Tombstone);
                                 removed = true;
                                 break;
@@ -1038,6 +1037,7 @@ mod test {
             %2: i1 = eq %0, %1
             guard true, %2, [%0, %1]
             guard true, %2, [%0, %1]
+            guard false, %2, [%0, %1]
         ",
             |m| opt(m).unwrap(),
             "
@@ -1047,6 +1047,7 @@ mod test {
             %1: i8 = param ...
             %2: i1 = eq %0, %1
             guard true, %2, ...
+            guard false, %2, ...
         ",
         );
     }


### PR DESCRIPTION
Previously we treated `guard true, %x` and `guard false, %x` as equivalent, which is incorrect. We did have a `debug_assert_eq` to prevent this, but that wouldn't have helped in release mode.