### PR TITLE
Force JIT IR tests to use consecutive variable numbers.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -3000,8 +3000,8 @@ mod tests {
               entry:
                 %0: i16 = param 0
                 %1: i16 = param 1
-                %3: i16 = add %0, %1
-                black_box %3
+                %2: i16 = add %0, %1
+                black_box %2
             ",
             "
                 ...
@@ -3020,8 +3020,8 @@ mod tests {
               entry:
                 %0: i64 = param 0
                 %1: i64 = param 1
-                %3: i64 = add %0, %1
-                black_box %3
+                %2: i64 = add %0, %1
+                black_box %2
             ",
             "
                 ...
@@ -3903,8 +3903,8 @@ mod tests {
             "
               entry:
                 %0: i8 = param 0
-                %2: i1 = eq %0, 3i8
-                black_box %2
+                %1: i1 = eq %0, 3i8
+                black_box %1
             ",
             "
                 ...
@@ -3925,8 +3925,8 @@ mod tests {
             "
               entry:
                 %0: i8 = param 0
-                %2: i1 = eq %0, 3i8
-                guard true, %2, []
+                %1: i1 = eq %0, 3i8
+                guard true, %1, []
             ",
             "
                 ...
@@ -4489,8 +4489,8 @@ mod tests {
               entry:
                 %0: i8 = param 0
                 tloop_start [%0]
-                %1: i8 = 42i8
-                tloop_jump [%1]
+                %2: i8 = 42i8
+                tloop_jump [%2]
             ",
             "
                 ...

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -540,8 +540,8 @@ mod test {
           entry:
             %0: i1 = eq 0i8, 0i8
             guard true, %0, []
-            %1: i1 = eq 0i8, 1i8
-            guard false, %1, [%0]
+            %2: i1 = eq 0i8, 1i8
+            guard false, %2, [%0]
         ",
             |m| opt(m).unwrap(),
             "
@@ -598,10 +598,10 @@ mod test {
           entry:
             %0: i8 = 0i8
             %1: i8 = add %0, 1i8
-            %3: i64 = 18446744073709551614i64
-            %4: i64 = add %3, 4i64
+            %2: i64 = 18446744073709551614i64
+            %3: i64 = add %2, 4i64
             black_box %1
-            black_box %4
+            black_box %3
         ",
             |m| opt(m).unwrap(),
             "


### PR DESCRIPTION
Previously you could write tests like this:

```
entry:
  %0: i16 = param 0
  %3: i16 = param 1
```

even though after parsing you can see that what was tested looked like:

```
entry:
  %0: i16 = param 0
  %1: i16 = param 1
```

In other words, our input tests were deliberately misleading. I stumbled across this somewhat accidentally when I saw a test that made little sense at first. Then I remembered that at one point I deliberately allowed variables to be non-consecutive even though that has not turned out to be very useful. Now, indeed, it actively makes the system difficult to understand, as the predictable monotonic increment of variables is baked in everywhere.

This test makes the JIT IR parser capture such mistakes, and fixes all of those places that it points out. Fixing the "all JIT IR syntax" was particular fun.