### PR TITLE
Rework common subexpression elimination

### DIFF
--- a/ykrt/src/compile/jitc_yk/opt/instll.rs
+++ b/ykrt/src/compile/jitc_yk/opt/instll.rs
@@ -1,0 +1,169 @@
+//! A linked list of instruction types.
+//!
+//! This allows one to iterate backwards over a trace starting at instruction X and seeing all
+//! previous instructions of the same types as X.
+//!
+//! For example given the trace:
+//!
+//! ```text
+//! %0: i8 = param 0
+//! %1: ptr = param 1
+//! %2: i8 = add %0, %0
+//! %3: i8 = add %0, %0
+//! %4: i8 = load %1
+//! %5: i8 = add %0, %0
+//! ```
+//!
+//! If we iterate backwards from `%5`, this linked list will successively return the values `%3`
+//! and `%2`.
+//!
+//! The internal data structure is modelled on an equivalent in LuaJIT. It is highly efficient,
+//! requiring only a single memory allocation with one `InstIdx` per instruction in a trace.
+
+use crate::compile::jitc_yk::jit_ir::{Inst, InstIdx, Module};
+use strum::EnumCount;
+
+pub(super) struct InstLinkedList {
+    /// The head of the linked list with one entry for each [Inst] discriminant. This points to the
+    /// most recent entry in [Self::predecessors].
+    heads: [InstIdx; Inst::COUNT],
+    /// The linked list with one entry for each instruction in a trace.
+    predecessors: Vec<InstIdx>,
+}
+
+impl InstLinkedList {
+    /// Create an empty linked list for a module `m`. This does not prepopulate the linked-list:
+    /// instead call [Self::push] for each element in the trace as you encounter it.
+    pub(super) fn new(m: &Module) -> Self {
+        // Because we use `X::MAX` as our "we haven't seen anything here yet" value, we have to
+        // make sure we won't overlap with a genuine value. These are deliberately `assert`s,
+        // because we don't yet guarantee elsewhere that the max value of either is actually
+        // `max-1`. The second `assert` might seem like it should be `debug_assert`, but we don't
+        // know if `Inst::COUNT` has the same size in debug/release builds, so better safe than
+        // sorry (and, probably, the optimiser will prove it's a constant and remove it).
+        assert!(usize::from(InstIdx::max()) > m.insts_len());
+        assert!(usize::from(u8::MAX) > Inst::COUNT);
+        Self {
+            heads: [InstIdx::max(); Inst::COUNT],
+            predecessors: vec![InstIdx::max(); m.insts_len()],
+        }
+    }
+
+    /// As a trace is being optimised, this method should be called with each new instruction
+    /// generated.
+    pub(super) fn push(&mut self, iidx: InstIdx, inst: Inst) {
+        let dim_off = usize::from(inst.discriminant());
+        if self.heads[dim_off] != InstIdx::max() {
+            self.predecessors[usize::from(iidx)] = self.heads[dim_off];
+        }
+        self.heads[dim_off] = iidx;
+    }
+
+    /// Successively generate the backwardly reachable instructions of the same kind as `inst`.
+    pub(super) fn rev_iter<'a>(&'a self, m: &'a Module, inst: Inst) -> InstLLRevIterator<'a> {
+        InstLLRevIterator {
+            m,
+            instll: self,
+            next: self.heads[usize::from(inst.discriminant())],
+        }
+    }
+}
+
+pub(super) struct InstLLRevIterator<'a> {
+    m: &'a Module,
+    instll: &'a InstLinkedList,
+    next: InstIdx,
+}
+
+impl Iterator for InstLLRevIterator<'_> {
+    type Item = (InstIdx, Inst);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.next != InstIdx::max() {
+            let x = self.next;
+            self.next = self.instll.predecessors[usize::from(x)];
+            match self.m.inst_nocopy(x) {
+                None | Some(Inst::Const(_)) | Some(Inst::Tombstone) => (),
+                Some(y) => return Some((x, y)),
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::compile::jitc_yk::jit_ir::InstDiscriminants;
+
+    #[test]
+    fn recents_predecessors() {
+        let m = Module::from_str(
+            "
+            entry:
+              %0: i8 = param 0
+              %1: ptr = param 1
+              %2: i8 = add %0, %0
+              %3: i8 = add %0, %0
+              %4: i8 = load %1
+              %5: i8 = add %0, %0
+            ",
+        );
+        let mut instll = InstLinkedList::new(&m);
+        for (iidx, inst) in m.iter_skipping_insts() {
+            instll.push(iidx, inst);
+        }
+        assert_eq!(
+            instll
+                .heads
+                .iter()
+                .filter(|x| **x == InstIdx::max())
+                .count(),
+            Inst::COUNT - 3
+        );
+        assert_eq!(
+            instll.heads[InstDiscriminants::Param as usize],
+            InstIdx::unchecked_from(1)
+        );
+        assert_eq!(
+            instll.heads[InstDiscriminants::BinOp as usize],
+            InstIdx::unchecked_from(5)
+        );
+        assert_eq!(
+            instll.heads[InstDiscriminants::Load as usize],
+            InstIdx::unchecked_from(4)
+        );
+        assert_eq!(
+            instll.predecessors,
+            vec![
+                InstIdx::max(),
+                InstIdx::unchecked_from(0),
+                InstIdx::max(),
+                InstIdx::unchecked_from(2),
+                InstIdx::max(),
+                InstIdx::unchecked_from(3)
+            ]
+        );
+        assert_eq!(
+            instll
+                .rev_iter(&m, m.inst(InstIdx::unchecked_from(1)))
+                .map(|(iidx, _)| usize::from(iidx))
+                .collect::<Vec<_>>(),
+            vec![1, 0]
+        );
+        assert_eq!(
+            instll
+                .rev_iter(&m, m.inst(InstIdx::unchecked_from(5)))
+                .map(|(iidx, _)| usize::from(iidx))
+                .collect::<Vec<_>>(),
+            vec![5, 3, 2]
+        );
+        assert_eq!(
+            instll
+                .rev_iter(&m, m.inst(InstIdx::unchecked_from(4)))
+                .map(|(iidx, _)| usize::from(iidx))
+                .collect::<Vec<_>>(),
+            vec![4]
+        );
+    }
+}

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -16,24 +16,29 @@ use super::{
 use crate::compile::CompilationError;
 
 mod analyse;
+mod instll;
 
 use analyse::Analyse;
+use instll::InstLinkedList;
 
 struct Opt {
     m: Module,
     an: Analyse,
+    /// Needed for common subexpression elimination.
+    instll: InstLinkedList,
 }
 
 impl Opt {
     fn new(m: Module) -> Self {
         let an = Analyse::new(&m);
-        Self { m, an }
+        let instll = InstLinkedList::new(&m);
+        Self { m, an, instll }
     }
 
     fn opt(mut self) -> Result<Module, CompilationError> {
-        let skipping = self.m.iter_skipping_inst_idxs().collect::<Vec<_>>();
-        for iidx in skipping {
-            match self.m.inst(iidx) {
+        let skipping = self.m.iter_skipping_insts().collect::<Vec<_>>();
+        for (iidx, inst) in skipping.into_iter() {
+            match inst {
                 #[cfg(test)]
                 Inst::BlackBox(_) => (),
                 Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone => unreachable!(),
@@ -391,14 +396,14 @@ impl Opt {
 
     /// Attempt common subexpression elimination on `iidx`, replacing it with a `Copy` if possible.
     fn cse(&mut self, iidx: InstIdx) {
-        // If this instruction is already a `Copy`, then there is nothing for CSE to do.
-        let Some(inst) = self.m.inst_nocopy(iidx) else {
-            return;
+        let inst = match self.m.inst_nocopy(iidx) {
+            // If this instruction is already a `Copy`, then there is nothing for CSE to do.
+            None => return,
+            // There's no point in trying CSE on a `Const` or `Tombstone`.
+            Some(Inst::Const(_)) | Some(Inst::Tombstone) => return,
+            Some(x) => x,
         };
-        // There's no point in trying CSE on a `Tombstone`.
-        if let Inst::Tombstone = inst {
-            return;
-        }
+
         // We don't perform CSE on instructions that have / enforce effects.
         if inst.has_store_effect(&self.m)
             || inst.has_load_effect(&self.m)
@@ -407,20 +412,21 @@ impl Opt {
             return;
         }
 
-        // OPT: This is O(n), but most instructions can't possibly be CSE candidates.
-        for back_iidx in (0..usize::from(iidx)).rev() {
-            let back_iidx = InstIdx::unchecked_from(back_iidx);
-            // Only examine non-`Copy` instructions, to avoid us continually checking the same
-            // (subset of) instructions over and over again.
-            let Some(back) = self.m.inst_nocopy(back_iidx) else {
-                continue;
-            };
-
-            if inst.decopy_eq(&self.m, back) {
+        // Can we CSE the instruction at `iidx`?
+        for (back_iidx, back_inst) in self.instll.rev_iter(&self.m, inst) {
+            if inst.decopy_eq(&self.m, back_inst) {
                 self.m.replace(iidx, Inst::Copy(back_iidx));
                 return;
             }
         }
+
+        // We only need to `push` instructions that:
+        //
+        //   1. Can possibly be CSE candidates. Earlier in the function we've ruled out a number of
+        //      things that aren't CSE candidates, which saves us some pointless work.
+        //   2. Haven't been turned into `Copy`s. So only if we've failed to CSE a given
+        //      instruction is it worth pushing to the `instll`.
+        self.instll.push(iidx, inst);
     }
 
     /// Optimise an [ICmpInst].


### PR DESCRIPTION
This PR has been in the back of my mind now for ages -- as an optimisation. I've now realised it allows us to further simplify our internal APIs and remove a footgun or two.

In essence, we port over a datastructure from LuaJIT that allows us to efficiently iterate over all instructions of type T: this allows us to recast CSE in these terms (https://github.com/ykjit/yk/commit/ba5acf2d984a350d32dced2d8e37a795d88d3818). That then makes it clearer that we had a sort-of-second form of CSE, just for guards, which we can then fold into the main CSE (https://github.com/ykjit/yk/commit/7a292abaefe154ebc76d694b71395f47c2d876c2).

The performance difference of this PR is too small for me to able to measure, but that's less the point: basically we get to move some subtle code out of the `Opt` keeping the latter simpler, and also removing another "globalish" function from `Module`.