### PR TITLE
Stack aliasing

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
@@ -14,6 +14,8 @@ use dynasmrt::x64::{Rq, Rx};
 pub(crate) enum VarLocation {
     /// The SSA variable is on the stack of the of the executed trace or the main interpreter loop.
     /// Since we execute the trace on the main interpreter frame we can't distinguish the two.
+    ///
+    /// Note: two SSA variables can alias to the same `Stack` location.
     Stack {
         /// The offset from the base of the trace's function frame.
         frame_off: u32,
@@ -21,6 +23,8 @@ pub(crate) enum VarLocation {
         size: usize,
     },
     /// The SSA variable is a stack pointer with the value `RBP-frame_off`.
+    ///
+    /// Note: two SSA variables can alias to the same `Direct` location.
     Direct {
         /// The offset from the base of the trace's function frame.
         frame_off: i32,
@@ -28,6 +32,8 @@ pub(crate) enum VarLocation {
         size: usize,
     },
     /// The SSA variable is in a register.
+    ///
+    /// Note: two SSA variables can alias to the same `Register` location.
     Register(Register),
     /// A constant integer `bits` wide (see [jit_ir::Const::ConstInt] for the constraints on the
     /// bit width) and with value `v`.

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -119,7 +119,7 @@ pub(crate) struct LSRegAlloc<'a> {
     /// or `>=` the offset in this vector.
     inst_vals_alive_until: Vec<InstIdx>,
     /// Where on the stack is an instruction's value spilled? Set to `usize::MAX` if that offset is
-    /// currently unknown.
+    /// currently unknown. Note: multiple instructions can alias to the same [SpillState].
     spills: Vec<SpillState>,
     /// The abstract stack: shared between general purpose and floating point registers.
     stack: AbstractStack,
@@ -1541,8 +1541,12 @@ enum SpillState {
     /// This variable has not yet been spilt, or has been spilt and will not be used again.
     Empty,
     /// This variable is spilt to the stack with the same semantics as [VarLocation::Stack].
+    ///
+    /// Note: two SSA variables can alias to the same `Stack` location.
     Stack(i32),
     /// This variable is spilt to the stack with the same semantics as [VarLocation::Direct].
+    ///
+    /// Note: two SSA variables can alias to the same `Direct` location.
     Direct(i32),
     /// This variable is a constant.
     ConstInt { bits: u32, v: u64 },


### PR DESCRIPTION
This PR started as an experiment, but is useful enough that I think it's worth considering for merging. In essence, it shows that although currently our allocator doesn't allow aliasing for `Register`, it is happy for `Direct` and `Stack` to alias.

The way I experimented with this is to add a function to the register allocator mostly intended for `sext`/`zext` that allows them to generate no code in some situations (including, but only, when stack locations alias).

I now have a better handle on what we need to do to properly handle register aliasing. That won't be a small job, of course, but this PR does nudge the system in the right sort of direction.