### PR TITLE
Remove unused offset field from SMLocation::Register.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
@@ -164,7 +164,7 @@ impl From<&VarLocation> for yksmp::Location {
                 };
                 // We currently only use 8 byte registers, so the size is constant. Since these are
                 // JIT values there are no extra locations we need to worry about.
-                yksmp::Location::Register(dwarf, 8, 0, Vec::new())
+                yksmp::Location::Register(dwarf, 8, Vec::new())
             }
             VarLocation::ConstInt { bits, v } => {
                 if *bits <= 32 {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -246,7 +246,7 @@ pub(crate) extern "C" fn __yk_deopt(
                 todo!("Deal with multi register locations");
             };
             match aotloc {
-                SMLocation::Register(reg, size, off, extras) => {
+                SMLocation::Register(reg, size, extras) => {
                     #[cfg(debug_assertions)]
                     seen(isize::try_from(*reg).unwrap(), jitval);
                     registers[usize::from(*reg)] = jitval;
@@ -266,7 +266,6 @@ pub(crate) extern "C" fn __yk_deopt(
                                 // Write values to a reconstructed frame.
                                 unsafe { rbp.offset(isize::from(*extra)) }
                             };
-                            debug_assert!(*off < i32::try_from(rec.size).unwrap());
                             match size {
                                 // FIXME: Check that 16-byte writes are for float registers only.
                                 16 | 8 => unsafe { ptr::write::<u64>(temp as *mut u64, jitval) },

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -4462,7 +4462,7 @@ mod tests {
         let mut m = jit_ir::Module::new(0, 0).unwrap();
 
         // Create two trace paramaters whose locations alias.
-        let loc = yksmp::Location::Register(13, 1, 0, [].into());
+        let loc = yksmp::Location::Register(13, 1, [].into());
         m.push_param(loc.clone());
         let pinst1: Inst =
             jit_ir::ParamInst::new(ParamIdx::try_from(0).unwrap(), m.int8_tyidx()).into();

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -2957,7 +2957,7 @@ mod tests {
     #[test]
     fn print_module() {
         let mut m = Module::new_testing();
-        m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
+        m.push_param(yksmp::Location::Register(3, 1, vec![]));
         m.push(ParamInst::new(ParamIdx::try_from(0).unwrap(), m.int8_tyidx()).into())
             .unwrap();
         m.insert_global_decl(GlobalDecl::new(
@@ -2979,7 +2979,7 @@ mod tests {
             "global_decl tls @some_thread_local",
             "",
             "entry:",
-            "    %0: i8 = param Register(3, 1, 0, [])",
+            "    %0: i8 = param Register(3, 1, [])",
         ]
         .join("\n");
         assert_eq!(m.to_string(), expect);

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -332,7 +332,6 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                 self.m.push_param(yksmp::Location::Register(
                                     gp_reg_off,
                                     u16::try_from(size).unwrap(),
-                                    0,
                                     vec![],
                                 ));
                                 gp_reg_off += 1;
@@ -348,7 +347,6 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                 self.m.push_param(yksmp::Location::Register(
                                     fp_reg_off,
                                     u16::try_from(size).unwrap(),
-                                    0,
                                     vec![],
                                 ));
                                 fp_reg_off += 1;
@@ -884,8 +882,8 @@ mod tests {
         let mut m = Module::new_testing();
         let i16_tyidx = m.insert_ty(Ty::Integer(16)).unwrap();
 
-        m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
-        m.push_param(yksmp::Location::Register(3, 1, 0, vec![]));
+        m.push_param(yksmp::Location::Register(3, 1, vec![]));
+        m.push_param(yksmp::Location::Register(3, 1, vec![]));
         let op1 = m
             .push_and_make_operand(ParamInst::new(ParamIdx::try_from(0).unwrap(), i16_tyidx).into())
             .unwrap();


### PR DESCRIPTION
This was left over from the time where we only tracked one extra location.