### PR TITLE
Turn hard errors in trace decoding into a recoverable failure.

### DIFF
--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -222,16 +222,19 @@ impl Iterator for HWTTraceIterator {
                 }
                 Some(Err(e)) => todo!("{e:?}"),
                 None => {
-                    // The last block contains pointless unmappable code (the stop tracing call).
+                    // The last block should contains pointless unmappable code (the stop tracing call).
                     match self.upcoming.pop() {
                         Some(x) => {
                             // This is a rough proxy for "check that we removed only the thing we want to
                             // remove".
-                            assert!(matches!(x, TraceAction::UnmappableBBlock));
+                            if matches!(x, TraceAction::UnmappableBBlock) {
+                                return None;
+                            } else {
+                                return Some(Err(AOTTraceIteratorError::PrematureEnd));
+                            }
                         }
-                        _ => unreachable!(),
+                        None => return Some(Err(AOTTraceIteratorError::PrematureEnd)),
                     }
-                    return None;
                 }
             }
         }


### PR DESCRIPTION
We sometimes -- not often, but sometimes -- encounter either the `assert` or `unreachable` in the code below. This commit turns these cases into recoverable errors. Is that the right thing to do? I'm not entirely sure, and welcome Edd's comments!