### PR TITLE
`InlinedFrame` should store `PackedOperand` not `Operand`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1320,7 +1320,7 @@ pub(crate) struct InlinedFrame {
     /// The deopt safepoint for [callinst].
     pub(crate) safepoint: &'static aot_ir::DeoptSafepoint,
     /// The [Operand]s passed to [funcidx].
-    pub(crate) args: Vec<Operand>,
+    pub(crate) args: Vec<PackedOperand>,
 }
 
 impl InlinedFrame {
@@ -1334,7 +1334,7 @@ impl InlinedFrame {
             callinst,
             funcidx,
             safepoint,
-            args,
+            args: args.iter().map(PackedOperand::new).collect::<Vec<_>>(),
         }
     }
 }


### PR DESCRIPTION
This exposes (so far rare) additional opportunities for constants to be identified, so we have to remove the `panic` branch. I admit that I haven't been able to work out a small test for this, though it happens in the yklua test suite.