### PR TITLE
Percolate dladdr() errors upwards.

### DIFF
--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -17,6 +17,7 @@ pub use errors::{HWTracerError, TemporaryErrorKind};
 #[cfg(test)]
 use std::time::SystemTime;
 use std::{fmt::Debug, sync::Arc};
+use thiserror::Error;
 
 /// A builder for [Tracer]s. By default, will attempt to use the most appropriate [Tracer] for your
 /// platform/configuration. This can be overridden with [TracerBuilder::tracer_kind] and
@@ -93,7 +94,7 @@ pub trait Trace: Debug + Send {
     /// Iterate over the blocks of the trace.
     fn iter_blocks(
         self: Box<Self>,
-    ) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send>;
+    ) -> Box<dyn Iterator<Item = Result<Block, BlockIteratorError>> + Send>;
 
     #[cfg(test)]
     fn bytes(&self) -> &[u8];
@@ -105,6 +106,15 @@ pub trait Trace: Debug + Send {
     /// Get the size of the trace in bytes.
     #[cfg(test)]
     fn len(&self) -> usize;
+}
+
+#[derive(Debug, Error)]
+pub enum BlockIteratorError {
+    #[cfg(ykpt)]
+    #[error("dladdr() cannot map vaddr")]
+    NoSuchVAddr,
+    #[error("HWTracerError: {0}")]
+    HWTracerError(HWTracerError),
 }
 
 /// A loop that does some work that we can use to build a trace.

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -7,7 +7,7 @@ use crate::pt::c_errors::PerfPTCError;
 use crate::pt::ykpt::YkPTBlockIterator;
 use crate::{
     errors::{HWTracerError, TemporaryErrorKind},
-    Block, ThreadTracer, Trace, Tracer,
+    Block, BlockIteratorError, ThreadTracer, Trace, Tracer,
 };
 use libc::{c_void, free, geteuid, malloc, size_t};
 use std::{fs::read_to_string, sync::Arc};
@@ -182,7 +182,7 @@ impl Trace for PerfTrace {
     #[cfg(ykpt)]
     fn iter_blocks(
         mut self: Box<Self>,
-    ) -> Box<dyn Iterator<Item = Result<Block, HWTracerError>> + Send> {
+    ) -> Box<dyn Iterator<Item = Result<Block, BlockIteratorError>> + Send> {
         // We hand ownership for self.buf over to `YkPTBlockIterator` so we need to make sure that
         // we don't try and free it.
         let buf = std::mem::replace(&mut self.buf, PerfTraceBuf(std::ptr::null_mut()));

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -13,7 +13,7 @@
 //! To that end, the test files in `tests/hwtracer_ykpt` are compiled into test binaries (as a
 //! langtester suite) and then they call into this file to have assertions checked in Rust code.
 
-use hwtracer::{ThreadTracer, Trace, TracerBuilder};
+use hwtracer::{BlockIteratorError, ThreadTracer, Trace, TracerBuilder};
 use std::ffi::c_void;
 
 #[no_mangle]
@@ -52,7 +52,7 @@ pub extern "C" fn __hwykpt_decode_trace(trace: *mut Box<dyn Trace>) -> bool {
     for b in trace.iter_blocks() {
         match b {
             Ok(_) => (),
-            Err(HWTracerError::Temporary(_)) => return false,
+            Err(BlockIteratorError::HWTracerError(HWTracerError::Temporary(_))) => return false,
             Err(_) => panic!(),
         }
     }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -96,6 +96,9 @@ pub(crate) enum AOTTraceIteratorError {
     #[error("longjmp encountered")]
     #[allow(dead_code)]
     LongJmpEncountered,
+    #[error("{0}")]
+    #[allow(dead_code)]
+    Other(String),
 }
 
 /// A processed item from a trace.


### PR DESCRIPTION
The fundamental change here is to turn an `unwrap` in `vaddr_to_off` into an `Err` but this part of hwtracer is somewhat messy, so a seemingly simple change (`unwrap` -> `Err(...)`) requires lots of boilerplate.