### PR TITLE
Unbreak `YKD_OPT=0`.

### DIFF
--- a/tests/c/ykd_opt_off.c
+++ b/tests/c/ykd_opt_off.c
@@ -1,0 +1,47 @@
+// Run-time:
+//   env-var: YKD_OPT=0
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   stdout:
+//     10
+//     9
+//     8
+//     7
+//     7: 6
+//     7: 5
+//     7: 4
+//     7: 4: 3
+//     7: 4: 2
+//     7: 4: 1
+
+
+// Check that basic trace compilation works.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  yk_mt_sidetrace_threshold_set(mt, 1);
+  YkLocation loc = yk_location_new();
+
+  int i = 10;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    if (i < 7)
+      printf("7: ");
+    if (i < 4)
+      printf("4: ");
+    printf("%d\n", i);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -294,7 +294,7 @@ impl Module {
 
 #[cfg(test)]
 mod tests {
-    use super::{BinOp, BinOpInst, Const, Inst, Module, Operand};
+    use super::{super::TraceKind, BinOp, BinOpInst, Const, Inst, Module, Operand};
 
     #[should_panic(expected = "Instruction at position 0 passing too few arguments")]
     #[test]
@@ -365,7 +365,7 @@ mod tests {
     fn cg_add_wrong_types() {
         // The parser will reject a binop with a result type different from either operand, so to
         // get the test we want, we can't use the parser.
-        let mut m = Module::new(0, 0).unwrap();
+        let mut m = Module::new(TraceKind::HeaderOnly, 0, 0).unwrap();
         let c1 = m.insert_const(Const::Int(m.int1_tyidx(), 0)).unwrap();
         let c2 = m.insert_const(Const::Int(m.int8_tyidx(), 0)).unwrap();
         m.push(Inst::BinOp(BinOpInst::new(

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -10,7 +10,7 @@ use super::{
     int_signs::{SignExtend, Truncate},
     jit_ir::{
         BinOp, BinOpInst, Const, ConstIdx, ICmpInst, Inst, InstIdx, Module, Operand, Predicate,
-        PtrAddInst, Ty,
+        PtrAddInst, TraceKind, Ty,
     },
 };
 use crate::compile::CompilationError;
@@ -68,6 +68,9 @@ impl Opt {
         if !peel {
             return Ok(self.m);
         }
+
+        debug_assert_eq!(self.m.tracekind(), TraceKind::HeaderOnly);
+        self.m.set_tracekind(TraceKind::HeaderAndBody);
 
         // Now that we've processed the trace header, duplicate it to create the loop body.
         let mut iidx_map = vec![InstIdx::max(); base];


### PR DESCRIPTION
When adding support for loop peeling, we forgot that loops are only peeled when optimisations are turned on. When they were turned off, we generated code with no backjump e.g.:

```
; %294: ptr = load %293
mov rsi, [rdi+0x588]
; header_end [...]
; Deopt ID for guard 0
push rsi
mov rsi, 0x00
```

Notice no `jmp` between `header_end` and `Deopt`. That meant that we fell through to whichever guard's deopt happened to come first, with confusing results. For example, before this commit the new test `ykd_opt_off` would print:

```
10
9
8
7: 7
```

even though the code shows this is clearly "impossible":

```rust
if (i < 7)
  printf("7: ");
```

This commit not only fixes that, but brings a bit more order to three kinds of traces we can compile: "header only" traces (most tests, and when `YKD_OPT=0`); "header and body" traces (with loop peeling); and "side traces". A new `TraceKind` captures these, and allows us to simplify quite a bit of code in the x64 backend, which no longer has to guess what kind of trace it has.

Perhaps inevitably this also showed up a few tests where we'd muddled header and body.