### PR TITLE
Change and extend the reverse analyser

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -169,7 +169,7 @@ impl<'a> LSRegAlloc<'a> {
 
     /// Reset the register allocator. We use this when moving from the trace header into the trace
     /// body.
-    pub(crate) fn reset(&mut self) {
+    pub(crate) fn reset(&mut self, header_end_vlocs: &[VarLocation]) {
         for rs in self.gp_reg_states.iter_mut() {
             *rs = RegState::Empty;
         }
@@ -186,7 +186,7 @@ impl<'a> LSRegAlloc<'a> {
         }
         self.fp_regset = RegSet::with_fp_reserved();
 
-        self.rev_an.analyse_body();
+        self.rev_an.analyse_body(header_end_vlocs);
     }
 
     /// Before generating code for the instruction at `iidx`, see which registers are no longer

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -124,7 +124,7 @@ pub(crate) struct LSRegAlloc<'a> {
     /// The abstract stack: shared between general purpose and floating point registers.
     stack: AbstractStack,
     /// What [VarLocation] should an instruction aim to put its output to?
-    vloc_hints: Vec<Option<VarLocation>>,
+    reg_hints: Vec<Option<VarLocation>>,
 }
 
 impl<'a> LSRegAlloc<'a> {
@@ -133,7 +133,7 @@ impl<'a> LSRegAlloc<'a> {
     pub(crate) fn new(
         m: &'a Module,
         inst_vals_alive_until: Vec<InstIdx>,
-        vloc_hints: Vec<Option<VarLocation>>,
+        reg_hints: Vec<Option<VarLocation>>,
         interp_stack_len: usize,
     ) -> Self {
         #[cfg(debug_assertions)]
@@ -169,7 +169,7 @@ impl<'a> LSRegAlloc<'a> {
             fp_regset: RegSet::with_fp_reserved(),
             fp_reg_states,
             inst_vals_alive_until,
-            vloc_hints,
+            reg_hints,
             spills: vec![SpillState::Empty; m.insts_len()],
             stack,
         }
@@ -439,7 +439,7 @@ impl LSRegAlloc<'_> {
         for i in 0..constraints.len() {
             if let RegConstraint::OutputCanBeSameAsInput(search_op) = constraints[i].clone() {
                 if let Some(VarLocation::Register(reg_alloc::Register::GP(reg))) =
-                    self.vloc_hints[usize::from(iidx)]
+                    self.reg_hints[usize::from(iidx)]
                 {
                     if avoid.is_set(reg) {
                         continue;
@@ -470,7 +470,7 @@ impl LSRegAlloc<'_> {
                 | RegConstraint::OutputCanBeSameAsInput(_)
                 | RegConstraint::InputOutput(_) => {
                     if let Some(VarLocation::Register(reg_alloc::Register::GP(reg))) =
-                        self.vloc_hints[usize::from(iidx)]
+                        self.reg_hints[usize::from(iidx)]
                     {
                         if !avoid.is_set(reg) {
                             *cnstr = match cnstr {
@@ -756,7 +756,7 @@ impl LSRegAlloc<'_> {
                     let mut new_reg = None;
                     // Try to use `query_iidx`s hint, if there is one, and it's not in use...
                     if let Some(VarLocation::Register(reg_alloc::Register::GP(reg))) =
-                        self.vloc_hints[usize::from(query_iidx)]
+                        self.reg_hints[usize::from(query_iidx)]
                     {
                         if !self.gp_regset.is_set(reg) && !avoid.is_set(reg) {
                             new_reg = Some(reg);

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -154,7 +154,7 @@ impl<'a> LSRegAlloc<'a> {
         stack.grow(interp_stack_len);
 
         let mut rev_an = RevAnalyse::new(m);
-        rev_an.analyse();
+        rev_an.analyse_header();
         LSRegAlloc {
             m,
             rev_an,
@@ -185,6 +185,8 @@ impl<'a> LSRegAlloc<'a> {
             self.fp_reg_states[usize::from(reg.code())] = RegState::Reserved;
         }
         self.fp_regset = RegSet::with_fp_reserved();
+
+        self.rev_an.analyse_body();
     }
 
     /// Before generating code for the instruction at `iidx`, see which registers are no longer

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -27,13 +27,14 @@
 //! where it has spilled an instruction's value: it guarantees to spill an instruction to at most
 //! one place on the stack.
 
+use super::rev_analyse::RevAnalyse;
 use crate::compile::jitc_yk::{
     codegen::{
         abs_stack::AbstractStack,
         reg_alloc::{self, VarLocation},
         x64::REG64_BYTESIZE,
     },
-    jit_ir::{Const, ConstIdx, FloatTy, Inst, InstIdx, Module, Operand, Ty},
+    jit_ir::{Const, ConstIdx, FloatTy, Inst, InstIdx, Module, Operand, PtrAddInst, Ty},
 };
 use dynasmrt::{
     dynasm,
@@ -106,6 +107,7 @@ static RESERVED_FP_REGS: [Rx; 0] = [];
 /// A linear scan register allocator.
 pub(crate) struct LSRegAlloc<'a> {
     m: &'a Module,
+    rev_an: RevAnalyse<'a>,
     /// Which general purpose registers are active?
     gp_regset: RegSet<Rq>,
     /// In what state are the general purpose registers?
@@ -114,28 +116,17 @@ pub(crate) struct LSRegAlloc<'a> {
     fp_regset: RegSet<Rx>,
     /// In what state are the floating point registers?
     fp_reg_states: [RegState; FP_REGS_LEN],
-    /// Record the [InstIdx] of the last instruction that the value produced by an instruction is
-    /// used. By definition this must either be unused (if an instruction does not produce a value)
-    /// or `>=` the offset in this vector.
-    inst_vals_alive_until: Vec<InstIdx>,
     /// Where on the stack is an instruction's value spilled? Set to `usize::MAX` if that offset is
     /// currently unknown. Note: multiple instructions can alias to the same [SpillState].
     spills: Vec<SpillState>,
     /// The abstract stack: shared between general purpose and floating point registers.
     stack: AbstractStack,
-    /// What [Register] should an instruction aim to put its output to?
-    reg_hints: Vec<Option<reg_alloc::Register>>,
 }
 
 impl<'a> LSRegAlloc<'a> {
     /// Create a new register allocator, with the existing interpreter frame spanning
     /// `interp_stack_len` bytes.
-    pub(crate) fn new(
-        m: &'a Module,
-        inst_vals_alive_until: Vec<InstIdx>,
-        reg_hints: Vec<Option<reg_alloc::Register>>,
-        interp_stack_len: usize,
-    ) -> Self {
+    pub(crate) fn new(m: &'a Module, interp_stack_len: usize) -> Self {
         #[cfg(debug_assertions)]
         {
             // We rely on the registers in GP_REGS being numbered 0..15 (inc.) for correctness.
@@ -162,14 +153,15 @@ impl<'a> LSRegAlloc<'a> {
         let mut stack = AbstractStack::default();
         stack.grow(interp_stack_len);
 
+        let mut rev_an = RevAnalyse::new(m);
+        rev_an.analyse();
         LSRegAlloc {
             m,
+            rev_an,
             gp_regset: RegSet::with_gp_reserved(),
             gp_reg_states,
             fp_regset: RegSet::with_fp_reserved(),
             fp_reg_states,
-            inst_vals_alive_until,
-            reg_hints,
             spills: vec![SpillState::Empty; m.insts_len()],
             stack,
         }
@@ -262,6 +254,12 @@ impl<'a> LSRegAlloc<'a> {
         self.stack.size()
     }
 
+    /// Is the instruction at [iidx] a tombstone or otherwise known to be dead (i.e. equivalent to
+    /// a tombstone)?
+    pub(crate) fn is_inst_tombstone(&self, iidx: InstIdx) -> bool {
+        self.rev_an.is_inst_tombstone(iidx)
+    }
+
     /// Is the value produced by instruction `query_iidx` used after (but not including!)
     /// instruction `cur_idx`?
     pub(crate) fn is_inst_var_still_used_after(
@@ -269,17 +267,24 @@ impl<'a> LSRegAlloc<'a> {
         cur_iidx: InstIdx,
         query_iidx: InstIdx,
     ) -> bool {
-        usize::from(cur_iidx) < usize::from(self.inst_vals_alive_until[usize::from(query_iidx)])
+        usize::from(cur_iidx)
+            < usize::from(self.rev_an.inst_vals_alive_until[usize::from(query_iidx)])
     }
 
     /// Is the value produced by instruction `query_iidx` used at or after instruction `cur_idx`?
     fn is_inst_var_still_used_at(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> bool {
-        usize::from(cur_iidx) <= usize::from(self.inst_vals_alive_until[usize::from(query_iidx)])
+        usize::from(cur_iidx)
+            <= usize::from(self.rev_an.inst_vals_alive_until[usize::from(query_iidx)])
     }
 
     #[cfg(test)]
     pub(crate) fn inst_vals_alive_until(&self) -> &Vec<InstIdx> {
-        &self.inst_vals_alive_until
+        &self.rev_an.inst_vals_alive_until
+    }
+
+    /// Return the inline [PtrAddInst] for a load/store, if there is one.
+    pub(crate) fn ptradd(&self, iidx: InstIdx) -> Option<PtrAddInst> {
+        self.rev_an.ptradds[usize::from(iidx)]
     }
 }
 
@@ -438,7 +443,8 @@ impl LSRegAlloc<'_> {
         // Deal with `OutputCanBeSameAsInput`.
         for i in 0..constraints.len() {
             if let RegConstraint::OutputCanBeSameAsInput(search_op) = constraints[i].clone() {
-                if let Some(reg_alloc::Register::GP(reg)) = self.reg_hints[usize::from(iidx)] {
+                if let Some(reg_alloc::Register::GP(reg)) = self.rev_an.reg_hints[usize::from(iidx)]
+                {
                     if avoid.is_set(reg) {
                         continue;
                     }
@@ -467,7 +473,9 @@ impl LSRegAlloc<'_> {
                 RegConstraint::Output
                 | RegConstraint::OutputCanBeSameAsInput(_)
                 | RegConstraint::InputOutput(_) => {
-                    if let Some(reg_alloc::Register::GP(reg)) = self.reg_hints[usize::from(iidx)] {
+                    if let Some(reg_alloc::Register::GP(reg)) =
+                        self.rev_an.reg_hints[usize::from(iidx)]
+                    {
                         if !avoid.is_set(reg) {
                             *cnstr = match cnstr {
                                 RegConstraint::Output => RegConstraint::OutputFromReg(reg),
@@ -560,8 +568,9 @@ impl LSRegAlloc<'_> {
                                 if furthest.is_none() {
                                     furthest = Some((reg, from_iidx));
                                 } else if let Some((_, furthest_iidx)) = furthest {
-                                    if self.inst_vals_alive_until[usize::from(from_iidx)]
-                                        >= self.inst_vals_alive_until[usize::from(furthest_iidx)]
+                                    if self.rev_an.inst_vals_alive_until[usize::from(from_iidx)]
+                                        >= self.rev_an.inst_vals_alive_until
+                                            [usize::from(furthest_iidx)]
                                     {
                                         furthest = Some((reg, from_iidx))
                                     }
@@ -752,7 +761,7 @@ impl LSRegAlloc<'_> {
                     let mut new_reg = None;
                     // Try to use `query_iidx`s hint, if there is one, and it's not in use...
                     if let Some(reg_alloc::Register::GP(reg)) =
-                        self.reg_hints[usize::from(query_iidx)]
+                        self.rev_an.reg_hints[usize::from(query_iidx)]
                     {
                         if !self.gp_regset.is_set(reg) && !avoid.is_set(reg) {
                             new_reg = Some(reg);
@@ -1090,8 +1099,9 @@ impl LSRegAlloc<'_> {
                                 if furthest.is_none() {
                                     furthest = Some((reg, from_iidx));
                                 } else if let Some((_, furthest_iidx)) = furthest {
-                                    if self.inst_vals_alive_until[usize::from(from_iidx)]
-                                        >= self.inst_vals_alive_until[usize::from(furthest_iidx)]
+                                    if self.rev_an.inst_vals_alive_until[usize::from(from_iidx)]
+                                        >= self.rev_an.inst_vals_alive_until
+                                            [usize::from(furthest_iidx)]
                                     {
                                         furthest = Some((reg, from_iidx))
                                     }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -269,8 +269,8 @@ impl<'a> LSRegAlloc<'a> {
         cur_iidx: InstIdx,
         query_iidx: InstIdx,
     ) -> bool {
-        usize::from(cur_iidx)
-            < usize::from(self.rev_an.inst_vals_alive_until[usize::from(query_iidx)])
+        self.rev_an
+            .is_inst_var_still_used_after(cur_iidx, query_iidx)
     }
 
     /// Is the value produced by instruction `query_iidx` used at or after instruction `cur_idx`?

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1961,14 +1961,15 @@ impl<'a> Assemble<'a> {
                 // that have become constants during the trace header. So we will always have to either
                 // update the [ParamInst]s of the trace body, which isn't ideal since it requires the
                 // [Module] the be mutable. Or we do what we do below just for constants.
-                let mut varlocs = Vec::new();
-                for var in self.m.trace_header_end().iter() {
-                    let varloc = self.op_to_var_location(var.unpack(self.m));
-                    varlocs.push(varloc);
-                }
+                let varlocs = self
+                    .m
+                    .trace_header_end()
+                    .iter()
+                    .map(|pop| self.op_to_var_location(pop.unpack(self.m)))
+                    .collect::<Vec<_>>();
                 // Reset the register allocator before priming it with information about the trace body
                 // inputs.
-                self.ra.reset();
+                self.ra.reset(varlocs.as_slice());
                 for (i, op) in self.m.trace_body_start().iter().enumerate() {
                     // By definition these can only be variables.
                     let iidx = match op.unpack(self.m) {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -251,11 +251,11 @@ impl<'a> Assemble<'a> {
             }
         };
 
-        let (inst_vals_alive_until, used_insts, ptradds, vloc_hints) = rev_analyse::rev_analyse(m)?;
+        let (inst_vals_alive_until, used_insts, ptradds, reg_hints) = rev_analyse::rev_analyse(m)?;
 
         Ok(Box::new(Self {
             m,
-            ra: LSRegAlloc::new(m, inst_vals_alive_until, vloc_hints, sp_offset),
+            ra: LSRegAlloc::new(m, inst_vals_alive_until, reg_hints, sp_offset),
             asm,
             header_start_locs: Vec::new(),
             body_start_locs: Vec::new(),

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -23,7 +23,7 @@
 use super::{
     super::{
         int_signs::{SignExtend, Truncate},
-        jit_ir::{self, BinOp, FloatTy, Inst, InstIdx, Module, Operand, PtrAddInst, TraceKind, Ty},
+        jit_ir::{self, BinOp, FloatTy, Inst, InstIdx, Module, Operand, TraceKind, Ty},
         CompilationError,
     },
     reg_alloc::{self, VarLocation},
@@ -60,7 +60,6 @@ use std::{
     slice,
     sync::{Arc, Weak},
 };
-use vob::Vob;
 use ykaddr::addr::symbol_to_ptr;
 
 mod deopt;
@@ -195,12 +194,6 @@ struct Assemble<'a> {
     /// The stack pointer offset of the root trace's frame from the base pointer of the interpreter
     /// frame. If this is the root trace, this will be None.
     root_offset: Option<usize>,
-    /// Does this Load/Store instruction reference a [PtrAddInst]?
-    ptradds: Vec<Option<PtrAddInst>>,
-    /// For each instruction, does this code generator use its value? This is implicitly a second
-    /// layer of dead-code elimination: it doesn't cause JIT IR instructions to be removed, but
-    /// it will stop any code being (directly) generated for some of them.
-    used_insts: Vob,
     /// The offset after the trace's prologue. This is the re-entry point when returning from
     /// side-traces.
     prologue_offset: AssemblyOffset,
@@ -251,11 +244,9 @@ impl<'a> Assemble<'a> {
             }
         };
 
-        let (inst_vals_alive_until, used_insts, ptradds, reg_hints) = rev_analyse::rev_analyse(m)?;
-
         Ok(Box::new(Self {
             m,
-            ra: LSRegAlloc::new(m, inst_vals_alive_until, reg_hints, sp_offset),
+            ra: LSRegAlloc::new(m, sp_offset),
             asm,
             header_start_locs: Vec::new(),
             body_start_locs: Vec::new(),
@@ -263,8 +254,6 @@ impl<'a> Assemble<'a> {
             comments: Cell::new(IndexMap::new()),
             sp_offset,
             root_offset,
-            used_insts,
-            ptradds,
             prologue_offset: AssemblyOffset(0),
         }))
     }
@@ -468,7 +457,7 @@ impl<'a> Assemble<'a> {
         let mut in_header = true;
         while let Some((iidx, inst)) = next {
             self.comment(self.asm.offset(), inst.display(self.m, iidx).to_string());
-            if !self.used_insts[usize::from(iidx)] {
+            if self.ra.is_inst_tombstone(iidx) {
                 next = iter.next();
                 continue;
             }
@@ -1104,7 +1093,7 @@ impl<'a> Assemble<'a> {
     /// Generate code for a [LoadInst], loading from a `register + off`. `off` should only be
     /// non-zero if the [LoadInst] references a [PtrAddInst].
     fn cg_load(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::LoadInst) {
-        let (ptr_op, off) = match self.ptradds[usize::from(iidx)] {
+        let (ptr_op, off) = match self.ra.ptradd(iidx) {
             Some(x) => (x.ptr(self.m), x.off()),
             None => (inst.operand(self.m), 0),
         };
@@ -1216,7 +1205,7 @@ impl<'a> Assemble<'a> {
     /// Generate code for a [StoreInst], storing it at a `register + off`. `off` should only be
     /// non-zero if the [StoreInst] references a [PtrAddInst].
     fn cg_store(&mut self, iidx: InstIdx, inst: &jit_ir::StoreInst) {
-        let (tgt_op, off) = match self.ptradds[usize::from(iidx)] {
+        let (tgt_op, off) = match self.ra.ptradd(iidx) {
             Some(x) => (x.ptr(self.m), x.off()),
             None => (inst.tgt(self.m), 0),
         };

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -144,6 +144,7 @@ impl JITCYk {
         if *YKD_OPT {
             jit_mod = opt::opt(jit_mod)?;
             if should_log_ir(IRPhase::PostOpt) {
+                jit_mod.dead_code_elimination();
                 log_ir(&format!(
                     "--- Begin jit-post-opt ---\n{jit_mod}\n--- End jit-post-opt ---\n",
                 ));

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -70,9 +70,6 @@ impl Opt {
                 }
             }
         }
-        // FIXME: When code generation supports backwards register allocation, we won't need to
-        // explicitly perform dead code elimination and this function can be made `#[cfg(test)]` only.
-        self.m.dead_code_elimination();
 
         if !peel {
             return Ok(self.m);
@@ -149,8 +146,6 @@ impl Opt {
             }
         }
 
-        // FIXME: Apply CSE and run another pass of optimisations on the peeled loop.
-        self.m.dead_code_elimination();
         Ok(self.m)
     }
 
@@ -687,6 +682,14 @@ pub(super) fn opt(m: Module) -> Result<Module, CompilationError> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn opt(m: Module) -> Result<Module, CompilationError> {
+        Opt::new(m).opt().map(|mut m| {
+            // Testing is much easier if we explicitly run DCE.
+            m.dead_code_elimination();
+            m
+        })
+    }
 
     #[test]
     fn opt_const_guard() {


### PR DESCRIPTION
This PR gradually gets the reverse analyser in better shape, ultimately speeding big_loop up by another 5%. There are really 3 things going on here:

1. We're only ever propagating register hints, not (the more general) `VarLocation`s (https://github.com/ykjit/yk/commit/277a52bcd789faaf74a7cfedebcc69f2ffa5380f and https://github.com/ykjit/yk/commit/c3680da61d1e3e0641e6ef123147954813428b51).
2. Previously we forced the trace header *and* body to have the same hints, but this misses an opportunity: the header can leave additional things in registers for the body. This requires a number of refactorings, as we now have to run reverse analysis in two phases: once for the header, then we run the code generator, then we reverse analyse the body (https://github.com/ykjit/yk/commit/8f3aab78555ac925314301f3c3c846e9477d9993 and https://github.com/ykjit/yk/commit/4a9454b86e723ecee0fb19e0aa55cf6c3f198364).
3. We were generating inappropriate hints for `OutputCanBeSameAsInput` instructions (https://github.com/ykjit/yk/commit/6ceac885bb5e63de1c91ee2e866634c28061cbac).

[FWIW, I experimented with a couple of designs for (2), but came to the conclusion that there's not much point in wholesale change here. It *might* be marginally better to treat header and body as separate `Module`s which we `jmp` between (I think that would be closer in spirit to RPython), but we are now fairly well set-up to deal with the two combined. I don't think changing now would gain us much, and it would cause a lot of churn.]