### PR TITLE
Teach the reverse analyser about calls

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -260,7 +260,7 @@ impl<'a> RevAnalyse<'a> {
         let mut gp_regs = ARG_GP_REGS.iter();
         let mut fp_regs = ARG_FP_REGS.iter();
         for aidx in cinst.iter_args_idx() {
-            match self.m.type_(self.m.arg(aidx).tyidx(&self.m)) {
+            match self.m.type_(self.m.arg(aidx).tyidx(self.m)) {
                 Ty::Void => unreachable!(),
                 Ty::Integer(_) | Ty::Ptr => {
                     if let Some(reg) = gp_regs.next() {


### PR DESCRIPTION
The main commit ensures that operands tend to end up in the right register for calls; the second commit is the bare minimum necessary to take advantage of this for FP arguments.