### PR TITLE
Implement debug strings

### DIFF
--- a/tests/c/yk_debug_str.c
+++ b/tests/c/yk_debug_str.c
@@ -1,0 +1,70 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YK_LOG=4
+//   stderr:
+//     ...
+//     --- Begin aot ---
+//     ...
+//     debug_str %{{10_0}}
+//     ...
+//     ...call fprintf(...
+//     ...
+//     debug_str %{{13_0}}
+//     ...
+//     --- End aot ---
+//     ...
+//     --- Begin jit-pre-opt ---
+//     ...
+//     ; debug_str: before fprintf: 4
+//     ...
+//     ...call @fprintf(...
+//     ...
+//     ; debug_str: after fprintf: 5
+//     ...
+//     --- End jit-pre-opt ---
+//     ...
+//     --- Begin jit-post-opt ---
+//     ...
+//     ; debug_str: before fprintf: 4
+//     ...
+//     ...call @fprintf(...
+//     ...
+//     ; debug_str: after fprintf: 5
+//     ...
+//     --- End jit-post-opt ---
+//     ...
+
+// Check that yk_debug_str() works and is not optimised out.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define MAX_MSG 128
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+  char msg[MAX_MSG];
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    snprintf(msg, MAX_MSG, "before fprintf: %d", i);
+    yk_debug_str(msg);
+    fprintf(stderr, "%d\n", i);
+    snprintf(msg, MAX_MSG, "after fprintf: %d", i + 1);
+    yk_debug_str(msg);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/yk_debug_str_outline.c
+++ b/tests/c/yk_debug_str_outline.c
@@ -1,0 +1,76 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YK_LOG=4
+//   stderr:
+//     ...
+//     --- Begin aot ---
+//     ...
+//     debug_str %{{10_0}}
+//     ...
+//     ...call fprintf(...
+//     ...
+//     debug_str %{{13_0}}
+//     ...
+//     --- End aot ---
+//     ...
+//     --- Begin jit-pre-opt ---
+//     ...
+//     ; debug_str: before fprintf: 4
+//     ...
+//     ...call @fprintf(...
+//     ...
+//     ; debug_str: after fprintf: 5
+//     ...
+//     --- End jit-pre-opt ---
+//     ...
+//     --- Begin jit-post-opt ---
+//     ...
+//     ; debug_str: before fprintf: 4
+//     ...
+//     ...call @fprintf(...
+//     ...
+//     ; debug_str: after fprintf: 5
+//     ...
+//     --- End jit-post-opt ---
+//     ...
+
+// Check that yk_debug_str() works and is not optimised out.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define MAX_MSG 128
+
+__attribute__((yk_outline,noinline))
+void f() {
+  yk_debug_str("inside f");
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+  char msg[MAX_MSG];
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    snprintf(msg, MAX_MSG, "before fprintf: %d", i);
+    yk_debug_str(msg);
+    f();
+    fprintf(stderr, "%d\n", i);
+    snprintf(msg, MAX_MSG, "after fprintf: %d", i + 1);
+    yk_debug_str(msg);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -6,6 +6,12 @@
 //! The sane solution is to have only one `cdylib` crate in our workspace (this crate) and all
 //! other crates are regular `rlibs`.
 
+// FIXME: This crate was designed to contain the entire public C API surface of Yk. Over time C API
+// functions have leaked elsewhere. For example yk_debug_str() and yk_promote_*() are defined
+// elsewhere. We should either move all the C API back into this file, or maybe move all of the C
+// API into (e.g.) `ykrt::api::c` (and make ykrt a cdylib). The former means you have to `pub`
+// stuff in `ykrt`, so perhaps the latter?
+
 #![allow(clippy::missing_safety_doc)]
 #![feature(naked_functions)]
 

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -82,4 +82,12 @@ long long __yk_promote_c_long_long(long long);
 // Rust defines `usize` to be layout compatible with `uintptr_t`.
 uintptr_t __yk_promote_usize(uintptr_t);
 
+/// Insert a debugging string.
+///
+/// When a call to this function is traced, the dynamic value of `msg` will be
+/// shown when the trace is displayed.
+///
+/// `msg` must be a pointer to a UTF-8 compatible string.
+void yk_debug_str(char *fmt, ...);
+
 #endif

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -1002,6 +1002,8 @@ pub(crate) enum Inst {
     },
     #[deku(id = "20")]
     FNeg { val: Operand },
+    #[deku(id = "21")]
+    DebugStr { msg: Operand },
     #[deku(id = "255")]
     Unimplemented {
         tyidx: TyIdx,
@@ -1095,6 +1097,7 @@ impl Inst {
             Self::FCmp { tyidx, .. } => Some(m.type_(*tyidx)),
             Self::Promote { tyidx, .. } => Some(m.type_(*tyidx)),
             Self::FNeg { val } => Some(val.type_(m)),
+            Self::DebugStr { .. } => None,
         }
     }
 
@@ -1383,6 +1386,7 @@ impl fmt::Display for DisplayableInst<'_> {
             Inst::FNeg { val } => {
                 write!(f, "fneg {}", val.display(self.m),)
             }
+            Inst::DebugStr { msg } => write!(f, "debug_str {}", msg.display(self.m)),
         }
     }
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -652,6 +652,7 @@ impl<'a> Assemble<'a> {
                 jit_ir::Inst::FCmp(i) => self.cg_fcmp(iidx, i),
                 jit_ir::Inst::FPToSI(i) => self.cg_fptosi(iidx, i),
                 jit_ir::Inst::FNeg(i) => self.cg_fneg(iidx, i),
+                jit_ir::Inst::DebugStr(..) => (),
             }
 
             next = iter.next();

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -132,6 +132,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         sti: Option<Arc<dyn SideTraceInfo>>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
+        debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         // If either `unwrap` fails, there is no chance of the system working correctly.
         let aot_mod = &*AOT_MOD;
@@ -154,6 +155,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
             aottrace_iter,
             sti,
             promotions,
+            debug_strs,
         )?;
 
         if should_log_ir(IRPhase::PreOpt) {
@@ -201,8 +203,9 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         aottrace_iter: Box<dyn AOTTraceIterator>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
+        debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
-        self.compile(mt, aottrace_iter, None, hl, promotions)
+        self.compile(mt, aottrace_iter, None, hl, promotions, debug_strs)
     }
 
     fn sidetrace_compile(
@@ -212,8 +215,9 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         sti: Arc<dyn SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
+        debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
-        self.compile(mt, aottrace_iter, Some(sti), hl, promotions)
+        self.compile(mt, aottrace_iter, Some(sti), hl, promotions, debug_strs)
     }
 }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -49,6 +49,7 @@ pub(crate) trait Compiler: Send + Sync {
         aottrace_iter: Box<dyn AOTTraceIterator>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
+        debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 
     /// Compile a mapped root trace into machine code.
@@ -59,6 +60,7 @@ pub(crate) trait Compiler: Send + Sync {
         sti: Arc<dyn SideTraceInfo>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
+        debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -20,4 +20,13 @@ pub(crate) mod thread_intercept;
 pub mod trace;
 
 pub use self::location::Location;
-pub use self::mt::{HotThreshold, MT};
+pub use self::mt::{HotThreshold, MTThread, MT};
+use std::ffi::{c_char, CStr};
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn yk_debug_str(msg: *const c_char) {
+    MTThread::with(|mtt| {
+        mtt.insert_debug_str(unsafe { CStr::from_ptr(msg).to_str().unwrap().to_owned() });
+    });
+}

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -265,7 +265,7 @@ impl MT {
     /// job is related to.
     fn queue_root_compile_job(
         self: &Arc<Self>,
-        trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>),
+        trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>, Vec<String>),
         hl_arc: Arc<Mutex<HotLocation>>,
     ) {
         self.stats.trace_recorded_ok();
@@ -281,6 +281,7 @@ impl MT {
                 trace_iter.0,
                 Arc::clone(&hl_arc),
                 trace_iter.1,
+                trace_iter.2,
             ) {
                 Ok(ct) => {
                     let mut hl = hl_arc.lock();
@@ -336,7 +337,7 @@ impl MT {
     ///   * `guardid` is the ID of the guard in `parent_ctr` which failed.
     fn queue_sidetrace_compile_job(
         self: &Arc<Self>,
-        trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>),
+        trace_iter: (Box<dyn AOTTraceIterator>, Box<[u8]>, Vec<String>),
         hl_arc: Arc<Mutex<HotLocation>>,
         root_ctr: Arc<dyn CompiledTrace>,
         parent_ctr: Arc<dyn CompiledTrace>,
@@ -360,6 +361,7 @@ impl MT {
                 sti,
                 Arc::clone(&hl_arc),
                 trace_iter.1,
+                trace_iter.2,
             ) {
                 Ok(ct) => {
                     parent_ctr.guard(guardid).set_ctr(ct);
@@ -450,6 +452,7 @@ impl MT {
                             hl,
                             thread_tracer: tt,
                             promotions: Vec::new(),
+                            debug_strs: Vec::new(),
                             frameaddr,
                         };
                     }),
@@ -480,17 +483,18 @@ impl MT {
             TransitionControlPoint::StopTracing => {
                 // Assuming no bugs elsewhere, the `unwrap`s cannot fail, because `StartTracing`
                 // will have put a `Some` in the `Rc`.
-                let (hl, thread_tracer, promotions) =
+                let (hl, thread_tracer, promotions, debug_strs) =
                     MTThread::with(
                         |mtt| match mtt.tstate.replace(MTThreadState::Interpreting) {
                             MTThreadState::Tracing {
                                 hl,
                                 thread_tracer,
                                 promotions,
+                                debug_strs,
                                 frameaddr: tracing_frameaddr,
                             } => {
                                 assert_eq!(frameaddr, tracing_frameaddr);
-                                (hl, thread_tracer, promotions)
+                                (hl, thread_tracer, promotions, debug_strs)
                             }
                             _ => unreachable!(),
                         },
@@ -499,7 +503,10 @@ impl MT {
                     Ok(utrace) => {
                         self.stats.timing_state(TimingState::None);
                         self.log.log(Verbosity::JITEvent, "stop-tracing");
-                        self.queue_root_compile_job((utrace, promotions.into_boxed_slice()), hl);
+                        self.queue_root_compile_job(
+                            (utrace, promotions.into_boxed_slice(), debug_strs),
+                            hl,
+                        );
                     }
                     Err(e) => {
                         self.stats.timing_state(TimingState::None);
@@ -516,17 +523,18 @@ impl MT {
             } => {
                 // Assuming no bugs elsewhere, the `unwrap`s cannot fail, because
                 // `StartSideTracing` will have put a `Some` in the `Rc`.
-                let (hl, thread_tracer, promotions) =
+                let (hl, thread_tracer, promotions, debug_strs) =
                     MTThread::with(
                         |mtt| match mtt.tstate.replace(MTThreadState::Interpreting) {
                             MTThreadState::Tracing {
                                 hl,
                                 thread_tracer,
                                 promotions,
+                                debug_strs,
                                 frameaddr: tracing_frameaddr,
                             } => {
                                 assert_eq!(frameaddr, tracing_frameaddr);
-                                (hl, thread_tracer, promotions)
+                                (hl, thread_tracer, promotions, debug_strs)
                             }
                             _ => unreachable!(),
                         },
@@ -537,7 +545,7 @@ impl MT {
                         self.stats.timing_state(TimingState::None);
                         self.log.log(Verbosity::JITEvent, "stop-tracing");
                         self.queue_sidetrace_compile_job(
-                            (utrace, promotions.into_boxed_slice()),
+                            (utrace, promotions.into_boxed_slice(), debug_strs),
                             hl,
                             root_ctr,
                             parent_ctr,
@@ -869,6 +877,7 @@ impl MT {
                             hl,
                             thread_tracer: tt,
                             promotions: Vec::new(),
+                            debug_strs: Vec::new(),
                             frameaddr,
                         };
                     }),
@@ -932,6 +941,8 @@ enum MTThreadState {
         thread_tracer: Box<dyn TraceRecorder>,
         /// Records the content of data recorded via `yk_promote`.
         promotions: Vec<u8>,
+        /// Records the content of data recorded via `yk_debug_str`.
+        debug_strs: Vec<String>,
         /// The `frameaddr` when tracing started. This allows us to tell if we're finishing tracing
         /// at the same point that we started.
         frameaddr: *mut c_void,
@@ -958,7 +969,7 @@ enum MTThreadState {
 
 /// Meta-tracer per-thread state. Note that this struct is neither `Send` nor `Sync`: it can only
 /// be accessed from within a single thread.
-pub(crate) struct MTThread {
+pub struct MTThread {
     /// Where in the "interpreting/tracing/executing" is this thread?
     tstate: RefCell<MTThreadState>,
     // Raw pointers are neither send nor sync.
@@ -1081,6 +1092,17 @@ impl MTThread {
         }
         true
     }
+
+    /// Record a debug string.
+    pub fn insert_debug_str(&self, msg: String) -> bool {
+        if let MTThreadState::Tracing {
+            ref mut debug_strs, ..
+        } = *self.tstate.borrow_mut()
+        {
+            debug_strs.push(msg);
+        }
+        true
+    }
 }
 
 /// What action should a caller of [MT::transition_control_point] take?
@@ -1153,6 +1175,7 @@ mod tests {
                 hl,
                 thread_tracer: Box::new(DummyTraceRecorder),
                 promotions: Vec::new(),
+                debug_strs: Vec::new(),
                 frameaddr: ptr::null_mut(),
             };
         });
@@ -1179,6 +1202,7 @@ mod tests {
                 hl,
                 thread_tracer: Box::new(DummyTraceRecorder),
                 promotions: Vec::new(),
+                debug_strs: Vec::new(),
                 frameaddr: ptr::null_mut(),
             };
         });
@@ -1301,6 +1325,7 @@ mod tests {
                             hl,
                             thread_tracer: Box::new(DummyTraceRecorder),
                             promotions: Vec::new(),
+                            debug_strs: Vec::new(),
                             frameaddr: ptr::null_mut(),
                         };
                     });
@@ -1495,6 +1520,7 @@ mod tests {
                                     hl,
                                     thread_tracer: Box::new(DummyTraceRecorder),
                                     promotions: Vec::new(),
+                                    debug_strs: Vec::new(),
                                     frameaddr: ptr::null_mut(),
                                 };
                             });


### PR DESCRIPTION
[This requires a compiler change and a llvm sync]

@vext01
[Implement debug strings.](https://github.com/ykjit/yk/pull/1540/commits/6fb181e32544a6466730e693d64c213d4bc290f4)
[6fb181e](https://github.com/ykjit/yk/pull/1540/commits/6fb181e32544a6466730e693d64c213d4bc290f4)

This allows the interpreter author to insert special comments into the
trace IR for helping with debugging.

In the interpreter source code you can add a call like
`yk_debug_str(debug_string)` and when it is traced, a special `DebugStr`
bytecode is inserted into the JIT IR, which when printed, displays the
dynamic value of `debug_string` at the time the instruction was traced.

Under the hood, this works a lot like promotion. Calls to `yk_debug_str`
(when tracing is enabled) causes `debug_string` to be copied into a
vector which is passed down the pipeline.

Here's an example for yklua:
```diff
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -27,6 +27,7 @@
 #include "lgc.h"
 #include "lobject.h"
 #include "lopcodes.h"
+#include "lopnames.h"
 #include "lstate.h"
 #include "lstring.h"
 #include "ltable.h"
@@ -1234,6 +1235,10 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
     lua_assert(base <= L->top.p && L->top.p <= L->stack_last.p);
     /* invalidate top for instructions not expecting it */
     lua_assert(isIT(i) || (cast_void(L->top.p = base), 1));
+    char dbgmsg[128];
+    snprintf(dbgmsg, 128, "%s", opnames[GET_OPCODE(i)]);
+    yk_debug_str(dbgmsg);
+
     vmdispatch (GET_OPCODE(i)) {
       vmcase(OP_MOVE) {
         StkId ra = RA(i);
```

Will give a trace with debug strings inside like:
```
    ...
    %408: ptr = ptr_add %361, 152
    %409: ptr = load %408
    %410: i32 = call @snprintf(%320, 128i64, %364, %409)
    ; debug_str: NEWTABLE
    %412: ptr = ptr_add %351, 592
    %413: i32 = shl 1i32, 4294967295i32
    ...
```

The strings are formatted as a comment.

(Obviously you'd probably want to guard the debug string logic in the
interpreter somehow so the overhead doesn't arise in production)

For this facility to be useful, the `DebugStr` bytecode must never be
optimised out. We tell the trace optimiser that this bytecode is an
"internal" bytecode, which stops DCE from killing it.

When adding the code to outline the contents of `yk_debug_str()` I
needed to copy logic from `handle_promote()` and found several other
copies of that same code in other places in the trace builder. Thic
change also de-duplicates the copies into a function
`outline_until_after_call()`.