### PR TITLE
The 16 byte case here can't possibly be correct in general.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -267,8 +267,7 @@ pub(crate) extern "C" fn __yk_deopt(
                                 unsafe { rbp.offset(isize::from(*extra)) }
                             };
                             match size {
-                                // FIXME: Check that 16-byte writes are for float registers only.
-                                16 | 8 => unsafe { ptr::write::<u64>(temp as *mut u64, jitval) },
+                                8 => unsafe { ptr::write::<u64>(temp as *mut u64, jitval) },
                                 4 => unsafe { ptr::write::<u32>(temp as *mut u32, jitval as u32) },
                                 2 => unsafe { ptr::write::<u16>(temp as *mut u16, jitval as u16) },
                                 _ => todo!("{}", size),


### PR DESCRIPTION
I'm not sure why we ever ended up with this: I don't see anything that triggers it. If there is something that relies on it, it surely only works by accident, and we're better hitting the `todo` and then fixing this properly.