### PR TITLE
Break some unfortunate dependencies in jitc_yk

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/reg_alloc.rs
@@ -4,14 +4,9 @@
 //!  - describes the generic interface to register allocators.
 //!  - contains concrete implementations of register allocators.
 
-use crate::compile::jitc_yk::jit_ir::{InstIdx, Module};
-use dynasmrt::x64::{Rq, Rx};
-
 /// Where is an SSA variable stored?
-///
-/// FIXME: Too much of this is hard-coded to the x64 backend.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum VarLocation {
+pub(crate) enum VarLocation<R> {
     /// The SSA variable is on the stack of the of the executed trace or the main interpreter loop.
     /// Since we execute the trace on the main interpreter frame we can't distinguish the two.
     ///
@@ -34,7 +29,7 @@ pub(crate) enum VarLocation {
     /// The SSA variable is in a register.
     ///
     /// Note: two SSA variables can alias to the same `Register` location.
-    Register(Register),
+    Register(R),
     /// A constant integer `bits` wide (see [jit_ir::Const::ConstInt] for the constraints on the
     /// bit width) and with value `v`.
     ConstInt { bits: u32, v: u64 },
@@ -42,132 +37,4 @@ pub(crate) enum VarLocation {
     ConstFloat(f64),
     /// A constant pointer.
     ConstPtr(usize),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum Register {
-    GP(Rq), // general purpose
-    FP(Rx), // floating point
-}
-
-#[cfg(target_arch = "x86_64")]
-impl VarLocation {
-    pub(crate) fn from_yksmp_location(m: &Module, iidx: InstIdx, x: &yksmp::Location) -> Self {
-        match x {
-            yksmp::Location::Register(0, ..) => VarLocation::Register(Register::GP(Rq::RAX)),
-            yksmp::Location::Register(1, ..) => {
-                // Since the control point passes the stackmap ID via RDX this case only happens in
-                // side-traces.
-                VarLocation::Register(Register::GP(Rq::RDX))
-            }
-            yksmp::Location::Register(2, ..) => VarLocation::Register(Register::GP(Rq::RCX)),
-            yksmp::Location::Register(3, ..) => VarLocation::Register(Register::GP(Rq::RBX)),
-            yksmp::Location::Register(4, ..) => VarLocation::Register(Register::GP(Rq::RSI)),
-            yksmp::Location::Register(5, ..) => VarLocation::Register(Register::GP(Rq::RDI)),
-            yksmp::Location::Register(8, ..) => VarLocation::Register(Register::GP(Rq::R8)),
-            yksmp::Location::Register(9, ..) => VarLocation::Register(Register::GP(Rq::R9)),
-            yksmp::Location::Register(10, ..) => VarLocation::Register(Register::GP(Rq::R10)),
-            yksmp::Location::Register(11, ..) => VarLocation::Register(Register::GP(Rq::R11)),
-            yksmp::Location::Register(12, ..) => VarLocation::Register(Register::GP(Rq::R12)),
-            yksmp::Location::Register(13, ..) => VarLocation::Register(Register::GP(Rq::R13)),
-            yksmp::Location::Register(14, ..) => VarLocation::Register(Register::GP(Rq::R14)),
-            yksmp::Location::Register(15, ..) => VarLocation::Register(Register::GP(Rq::R15)),
-            yksmp::Location::Register(x, ..) if *x >= 17 && *x <= 32 => VarLocation::Register(
-                Register::FP(super::x64::lsregalloc::FP_REGS[usize::from(x - 17)]),
-            ),
-            yksmp::Location::Direct(6, off, size) => VarLocation::Direct {
-                frame_off: *off,
-                size: usize::from(*size),
-            },
-            // Since the trace shares the same stack frame as the main interpreter loop, we can
-            // translate indirect locations into normal stack locations. Note that while stackmaps
-            // use negative offsets, we use positive offsets for stack locations.
-            yksmp::Location::Indirect(6, off, size) => VarLocation::Stack {
-                frame_off: u32::try_from(*off * -1).unwrap(),
-                size: usize::from(*size),
-            },
-            yksmp::Location::Constant(v) => {
-                // FIXME: This isn't fine-grained enough, as there may be constants of any
-                // bit-size.
-                let byte_size = m.inst(iidx).def_byte_size(m);
-                debug_assert!(byte_size <= 8);
-                VarLocation::ConstInt {
-                    bits: u32::try_from(byte_size).unwrap() * 8,
-                    v: u64::from(*v),
-                }
-            }
-            e => {
-                todo!("{:?}", e);
-            }
-        }
-    }
-}
-
-impl From<&VarLocation> for yksmp::Location {
-    fn from(val: &VarLocation) -> Self {
-        match val {
-            VarLocation::Stack { frame_off, size } => {
-                // A stack location translates is an offset in relation to RBP which has the DWARF
-                // number 6.
-                yksmp::Location::Indirect(
-                    6,
-                    -i32::try_from(*frame_off).unwrap(),
-                    u16::try_from(*size).unwrap(),
-                )
-            }
-            VarLocation::Direct { frame_off, size } => {
-                yksmp::Location::Direct(6, *frame_off, u16::try_from(*size).unwrap())
-            }
-            VarLocation::Register(reg) => {
-                let dwarf = match reg {
-                    Register::GP(reg) => match reg {
-                        Rq::RAX => 0,
-                        Rq::RDX => 1,
-                        Rq::RCX => 2,
-                        Rq::RBX => 3,
-                        Rq::RSI => 4,
-                        Rq::RDI => 5,
-                        Rq::R8 => 8,
-                        Rq::R9 => 9,
-                        Rq::R10 => 10,
-                        Rq::R11 => 11,
-                        Rq::R12 => 12,
-                        Rq::R13 => 13,
-                        Rq::R14 => 14,
-                        Rq::R15 => 15,
-                        e => todo!("{:?}", e),
-                    },
-                    Register::FP(reg) => match reg {
-                        Rx::XMM0 => 17,
-                        Rx::XMM1 => 18,
-                        Rx::XMM2 => 19,
-                        Rx::XMM3 => 20,
-                        Rx::XMM4 => 21,
-                        Rx::XMM5 => 22,
-                        Rx::XMM6 => 23,
-                        Rx::XMM7 => 24,
-                        Rx::XMM8 => 25,
-                        Rx::XMM9 => 26,
-                        Rx::XMM10 => 27,
-                        Rx::XMM11 => 28,
-                        Rx::XMM12 => 29,
-                        Rx::XMM13 => 30,
-                        Rx::XMM14 => 31,
-                        Rx::XMM15 => 32,
-                    },
-                };
-                // We currently only use 8 byte registers, so the size is constant. Since these are
-                // JIT values there are no extra locations we need to worry about.
-                yksmp::Location::Register(dwarf, 8, Vec::new())
-            }
-            VarLocation::ConstInt { bits, v } => {
-                if *bits <= 32 {
-                    yksmp::Location::Constant(u32::try_from(*v).unwrap())
-                } else {
-                    todo!(">32 bit constant")
-                }
-            }
-            e => todo!("{:?}", e),
-        }
-    }
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -1,12 +1,5 @@
-use crate::{
-    aotsmp::AOT_STACKMAPS,
-    compile::{
-        jitc_yk::codegen::reg_alloc::{Register, VarLocation},
-        GuardIdx,
-    },
-    log::Verbosity,
-    mt::MTThread,
-};
+use super::{Register, VarLocation};
+use crate::{aotsmp::AOT_STACKMAPS, compile::GuardIdx, log::Verbosity, mt::MTThread};
 use dynasmrt::Register as _;
 use libc::c_void;
 #[cfg(debug_assertions)]

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -1029,9 +1029,7 @@ impl LSRegAlloc<'_> {
                 RegConstraint::Output
                 | RegConstraint::OutputCanBeSameAsInput(_)
                 | RegConstraint::InputOutput(_) => {
-                    if let Some(reg_alloc::Register::FP(reg)) =
-                        self.rev_an.reg_hints[usize::from(iidx)]
-                    {
+                    if let Some(Register::FP(reg)) = self.rev_an.reg_hints[usize::from(iidx)] {
                         if !avoid.is_set(reg) {
                             *cnstr = match cnstr {
                                 RegConstraint::Output => RegConstraint::OutputFromReg(reg),

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -27,13 +27,9 @@
 //! where it has spilled an instruction's value: it guarantees to spill an instruction to at most
 //! one place on the stack.
 
-use super::rev_analyse::RevAnalyse;
+use super::{rev_analyse::RevAnalyse, Register, VarLocation};
 use crate::compile::jitc_yk::{
-    codegen::{
-        abs_stack::AbstractStack,
-        reg_alloc::{self, VarLocation},
-        x64::REG64_BYTESIZE,
-    },
+    codegen::{abs_stack::AbstractStack, x64::REG64_BYTESIZE},
     jit_ir::{Const, ConstIdx, FloatTy, Inst, InstIdx, Module, Operand, PtrAddInst, Ty},
 };
 use dynasmrt::{
@@ -41,7 +37,7 @@ use dynasmrt::{
     x64::{
         Assembler, {Rq, Rx},
     },
-    DynasmApi, Register,
+    DynasmApi, Register as dynasmrtRegister,
 };
 use std::{marker::PhantomData, mem};
 
@@ -445,8 +441,7 @@ impl LSRegAlloc<'_> {
         // Deal with `OutputCanBeSameAsInput`.
         for i in 0..constraints.len() {
             if let RegConstraint::OutputCanBeSameAsInput(search_op) = constraints[i].clone() {
-                if let Some(reg_alloc::Register::GP(reg)) = self.rev_an.reg_hints[usize::from(iidx)]
-                {
+                if let Some(Register::GP(reg)) = self.rev_an.reg_hints[usize::from(iidx)] {
                     if avoid.is_set(reg) {
                         continue;
                     }
@@ -475,9 +470,7 @@ impl LSRegAlloc<'_> {
                 RegConstraint::Output
                 | RegConstraint::OutputCanBeSameAsInput(_)
                 | RegConstraint::InputOutput(_) => {
-                    if let Some(reg_alloc::Register::GP(reg)) =
-                        self.rev_an.reg_hints[usize::from(iidx)]
-                    {
+                    if let Some(Register::GP(reg)) = self.rev_an.reg_hints[usize::from(iidx)] {
                         if !avoid.is_set(reg) {
                             *cnstr = match cnstr {
                                 RegConstraint::Output => RegConstraint::OutputFromReg(reg),
@@ -762,8 +755,7 @@ impl LSRegAlloc<'_> {
                 if self.is_inst_var_still_used_after(cur_iidx, query_iidx) {
                     let mut new_reg = None;
                     // Try to use `query_iidx`s hint, if there is one, and it's not in use...
-                    if let Some(reg_alloc::Register::GP(reg)) =
-                        self.rev_an.reg_hints[usize::from(query_iidx)]
+                    if let Some(Register::GP(reg)) = self.rev_an.reg_hints[usize::from(query_iidx)]
                     {
                         if !self.gp_regset.is_set(reg) && !avoid.is_set(reg) {
                             new_reg = Some(reg);
@@ -913,7 +905,7 @@ impl LSRegAlloc<'_> {
                 false
             }
         }) {
-            VarLocation::Register(reg_alloc::Register::GP(GP_REGS[reg_i]))
+            VarLocation::Register(Register::GP(GP_REGS[reg_i]))
         } else if let Some(reg_i) = self.fp_reg_states.iter().position(|x| {
             if let RegState::FromInst(y) = x {
                 *y == iidx
@@ -921,7 +913,7 @@ impl LSRegAlloc<'_> {
                 false
             }
         }) {
-            VarLocation::Register(reg_alloc::Register::FP(FP_REGS[reg_i]))
+            VarLocation::Register(Register::FP(FP_REGS[reg_i]))
         } else {
             let inst = self.m.inst(iidx);
             let size = inst.def_byte_size(self.m);
@@ -1446,7 +1438,7 @@ impl LSRegAlloc<'_> {
 /// In the following `R` is a fixed register specified inside the variant, whereas *x* is an
 /// unspecified register determined by the allocator.
 #[derive(Clone, Debug)]
-pub(crate) enum RegConstraint<R: Register> {
+pub(crate) enum RegConstraint<R: dynasmrt::Register> {
     /// Make sure `Operand` is loaded into a register *x* on entry; its value must be unchanged
     /// after the instruction is executed.
     Input(Operand),
@@ -1515,7 +1507,7 @@ enum RegState {
 #[derive(Clone, Copy, Debug)]
 struct RegSet<R>(u16, PhantomData<R>);
 
-impl<R: Register> RegSet<R> {
+impl<R: dynasmrt::Register> RegSet<R> {
     /// Create a [RegSet] with all registers unused.
     fn blank() -> Self {
         Self(0, PhantomData)

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -12,7 +12,7 @@
 //!      subsumes the functionality of `dead_code.rs`, so if you use this module for you don't need
 //!      to use `dead_code.rs` as well.
 
-use super::reg_alloc::{Register, VarLocation};
+use super::{Register, VarLocation};
 use crate::compile::jitc_yk::{
     codegen::x64::{ARG_FP_REGS, ARG_GP_REGS},
     jit_ir::{

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -98,7 +98,7 @@ mod well_formed;
 
 #[cfg(debug_assertions)]
 use super::int_signs::Truncate;
-use super::{aot_ir, codegen::reg_alloc::VarLocation};
+use super::{aot_ir, VarLocation};
 use crate::compile::CompilationError;
 use indexmap::IndexSet;
 use std::{

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -96,16 +96,17 @@ mod parser;
 #[cfg(any(debug_assertions, test))]
 mod well_formed;
 
+use super::aot_ir;
 #[cfg(debug_assertions)]
 use super::int_signs::Truncate;
-use super::{aot_ir, VarLocation};
-use crate::compile::CompilationError;
+use crate::compile::{CompilationError, SideTraceInfo};
 use indexmap::IndexSet;
 use std::{
     ffi::{c_void, CString},
     fmt,
     hash::Hash,
     mem,
+    sync::Arc,
 };
 use strum::{EnumCount, EnumDiscriminants};
 #[cfg(not(test))]
@@ -115,7 +116,7 @@ use ykaddr::addr::symbol_to_ptr;
 pub(crate) use super::aot_ir::{BinOp, FloatPredicate, FloatTy, Predicate};
 
 /// What kind of trace does this module represent?
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) enum TraceKind {
     /// A trace which contains only a header: the trace must loop back to the very start every
     /// time.
@@ -123,7 +124,7 @@ pub(crate) enum TraceKind {
     /// A trace with a header and a body: the trace must loop back to the start of the body.
     HeaderAndBody,
     /// A sidetrace: the trace must loop back to the root of the trace tree.
-    Sidetrace,
+    Sidetrace(Arc<dyn SideTraceInfo>),
 }
 
 /// The `Module` is the top-level container for JIT IR.
@@ -180,8 +181,6 @@ pub(crate) struct Module {
     guard_info: Vec<GuardInfo>,
     /// Indirect calls.
     indirect_calls: Vec<IndirectCallInst>,
-    /// Live variables at the beginning of the root trace.
-    root_entry_vars: Vec<VarLocation>,
     /// Live variables at the beginning of the trace body.
     pub(crate) trace_body_start: Vec<PackedOperand>,
     /// The ordered sequence of operands at the end of the trace body: there will be one per
@@ -215,15 +214,15 @@ impl Module {
 
     /// Returns this module's current [TraceKind]. Note: this can change as a result of calling
     /// [Self::set_tracekind]!
-    pub(crate) fn tracekind(&self) -> TraceKind {
-        self.tracekind
+    pub(crate) fn tracekind(&self) -> &TraceKind {
+        &self.tracekind
     }
 
     /// Returns this module's current [TraceKind]. Currently the only transition allowed is from
     /// [TraceKind::HeaderOnly] to [TraceKind::HeaderAndBody].
     pub(crate) fn set_tracekind(&mut self, tracekind: TraceKind) {
-        match (self.tracekind, tracekind) {
-            (TraceKind::HeaderOnly, TraceKind::HeaderAndBody) => (),
+        match (&self.tracekind, &tracekind) {
+            (&TraceKind::HeaderOnly, &TraceKind::HeaderAndBody) => (),
             (from, to) => panic!("Can't transition from a {from:?} trace to a {to:?} trace"),
         }
         self.tracekind = tracekind;
@@ -304,7 +303,6 @@ impl Module {
             global_decls: IndexSet::new(),
             guard_info: Vec::new(),
             indirect_calls: Vec::new(),
-            root_entry_vars: Vec::new(),
             trace_body_start: Vec::new(),
             trace_body_end: Vec::new(),
             trace_header_start: Vec::new(),
@@ -642,36 +640,13 @@ impl Module {
         self.trace_header_start.push(PackedOperand::new(&op));
     }
 
-    /// Store the entry live variables of the root traces so we can copy this side-trace's live
-    /// variables to the right place before jumping back to the root trace.
-    pub(crate) fn set_root_entry_vars(&mut self, entry_vars: &[VarLocation]) {
-        self.root_entry_vars.extend_from_slice(entry_vars);
-    }
-
     /// Return the loop jump operands.
     pub(crate) fn trace_body_end(&self) -> &[PackedOperand] {
         &self.trace_body_end
     }
 
-    /// Get the entry live variables of the root trace.
-    pub(crate) fn root_entry_vars(&self) -> &[VarLocation] {
-        &self.root_entry_vars
-    }
-
     pub(crate) fn push_header_end_var(&mut self, op: Operand) {
         self.trace_header_end.push(PackedOperand::new(&op));
-    }
-
-    /// Get the address of the root trace. This is where we need jump to at the end of a
-    /// side-trace.
-    pub(crate) fn root_jump_addr(&self) -> *const libc::c_void {
-        self.root_jump_ptr
-    }
-
-    /// Set the entry address of the root trace. This is where we need jump to at the end of a
-    /// side-trace.
-    pub(crate) fn set_root_jump_addr(&mut self, ptr: *const libc::c_void) {
-        self.root_jump_ptr = ptr;
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -28,12 +28,17 @@ use super::{BinOp, BinOpInst, Const, GuardInst, Inst, Module, Operand, Ty};
 
 impl Module {
     pub(crate) fn assert_well_formed(&self) {
-        if !self.root_entry_vars.is_empty() {
-            if self.root_entry_vars.len() != self.trace_header_end.len() {
-                panic!("Loop start/end variables have different lengths.");
+        match self.tracekind() {
+            super::TraceKind::HeaderOnly | super::TraceKind::HeaderAndBody => {
+                if self.trace_header_start.len() != self.trace_header_end.len() {
+                    panic!(
+                        "Loop start ({}) / end ({}) variables have different length.",
+                        self.trace_header_start.len(),
+                        self.trace_header_end.len()
+                    );
+                }
             }
-        } else if self.trace_header_start.len() != self.trace_header_end.len() {
-            panic!("Loop start/end variables have different lengths.");
+            super::TraceKind::Sidetrace(_) => (),
         }
 
         let mut last_inst = None;

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -12,6 +12,8 @@ use parking_lot::Mutex;
 use std::{
     env,
     error::Error,
+    fmt,
+    marker::PhantomData,
     slice,
     sync::{Arc, LazyLock},
 };
@@ -26,10 +28,6 @@ mod int_signs;
 pub mod jit_ir;
 mod opt;
 mod trace_builder;
-
-#[cfg(target_arch = "x86_64")]
-/// FIXME: Push the generics down into `Module`.
-type VarLocation = codegen::reg_alloc::VarLocation<codegen::x64::Register>;
 
 /// Should we turn trace optimisations on or off? Defaults to "on".
 static YKD_OPT: LazyLock<bool> = LazyLock::new(|| {
@@ -50,7 +48,7 @@ unsafe impl Send for RootTracePtr {}
 unsafe impl Sync for RootTracePtr {}
 
 /// Contains information required for side-tracing.
-struct YkSideTraceInfo {
+struct YkSideTraceInfo<Register: Send + Sync> {
     /// The AOT IR block the failing guard originated from.
     bid: aot_ir::BBlockId,
     /// The `GuardIdx`s of all failing guards leading up to here.
@@ -68,7 +66,7 @@ struct YkSideTraceInfo {
     /// the root trace's frame, before jumping back to it.
     root_offset: usize,
     /// The live variables at the entry point of the root trace.
-    entry_vars: Vec<VarLocation>,
+    entry_vars: Vec<codegen::reg_alloc::VarLocation<Register>>,
     /// Stack pointer offset from the base pointer of the interpreter frame including the
     /// interpreter frame itself and all parent traces. Since all traces execute in the interpreter
     /// frame, each trace adds to this value, making extra space on the stack. This then forms the
@@ -76,13 +74,13 @@ struct YkSideTraceInfo {
     sp_offset: usize,
 }
 
-impl SideTraceInfo for YkSideTraceInfo {
+impl<Register: Send + Sync + 'static> SideTraceInfo for YkSideTraceInfo<Register> {
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
         self
     }
 }
 
-impl YkSideTraceInfo {
+impl<Register: Send + Sync> YkSideTraceInfo<Register> {
     /// Return the live call frames which are required to setup the trace builder during
     /// side-tracing.
     fn callframes(&self) -> &[jit_ir::InlinedFrame] {
@@ -93,19 +91,39 @@ impl YkSideTraceInfo {
     fn lives(&self) -> &[(aot_ir::InstID, Location)] {
         &self.lives
     }
+
+    /// Get the address of the root trace. This is where we need jump to at the end of a
+    /// side-trace.
+    fn root_addr(&self) -> *const libc::c_void {
+        self.root_addr.0
+    }
+
+    fn root_offset(&self) -> usize {
+        self.root_offset
+    }
 }
 
-pub(crate) struct JITCYk {
+impl<Register: Send + Sync> fmt::Debug for YkSideTraceInfo<Register> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "YkSideTraceInfo {{ ... }}")
+    }
+}
+
+pub(crate) struct JITCYk<Register> {
     codegen: Arc<dyn CodeGen>,
+    phantom: PhantomData<Register>,
 }
 
-impl JITCYk {
+impl JITCYk<codegen::x64::Register> {
     pub(crate) fn new() -> Result<Arc<Self>, Box<dyn Error>> {
         Ok(Arc::new(Self {
             codegen: codegen::default_codegen()?,
+            phantom: PhantomData,
         }))
     }
+}
 
+impl<Register: Send + Sync + 'static> JITCYk<Register> {
     // FIXME: This should probably be split into separate root / sidetrace functions.
     fn compile(
         &self,
@@ -125,7 +143,7 @@ impl JITCYk {
             ));
         }
 
-        let sti = sti.map(|s| s.as_any().downcast::<YkSideTraceInfo>().unwrap());
+        let sti = sti.map(|s| s.as_any().downcast::<YkSideTraceInfo<Register>>().unwrap());
         let sp_offset = sti.as_ref().map(|x| x.sp_offset);
         let root_offset = sti.as_ref().map(|x| x.root_offset);
         let guards = sti.as_ref().map(|x| x.guards.clone());
@@ -176,7 +194,7 @@ impl JITCYk {
     }
 }
 
-impl Compiler for JITCYk {
+impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
     fn root_compile(
         &self,
         mt: Arc<MT>,

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     mt::MT,
     trace::AOTTraceIterator,
 };
-use codegen::reg_alloc::VarLocation;
 use parking_lot::Mutex;
 use std::{
     env,
@@ -27,6 +26,10 @@ mod int_signs;
 pub mod jit_ir;
 mod opt;
 mod trace_builder;
+
+#[cfg(target_arch = "x86_64")]
+/// FIXME: Push the generics down into `Module`.
+type VarLocation = codegen::reg_alloc::VarLocation<codegen::x64::Register>;
 
 /// Should we turn trace optimisations on or off? Defaults to "on".
 static YKD_OPT: LazyLock<bool> = LazyLock::new(|| {

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -14,6 +14,7 @@ use super::{
     },
 };
 use crate::compile::CompilationError;
+use std::assert_matches::debug_assert_matches;
 
 mod analyse;
 mod heapvalues;
@@ -55,7 +56,7 @@ impl Opt {
             TraceKind::HeaderAndBody => unreachable!(),
             // If this is a sidetrace, we perform optimisations up to, but not including, loop
             // peeling.
-            TraceKind::Sidetrace => false,
+            TraceKind::Sidetrace(_) => false,
         };
 
         // Note that since we will apply loop peeling here, the list of instructions grows as this
@@ -77,7 +78,7 @@ impl Opt {
             return Ok(self.m);
         }
 
-        debug_assert_eq!(self.m.tracekind(), TraceKind::HeaderOnly);
+        debug_assert_matches!(self.m.tracekind(), TraceKind::HeaderOnly);
         self.m.set_tracekind(TraceKind::HeaderAndBody);
 
         // Now that we've processed the trace header, duplicate it to create the loop body.

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -100,7 +100,7 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
 
 /// Stores information required for compiling a side-trace. Passed down from a (parent) trace
 /// during deoptimisation.
-pub(crate) trait SideTraceInfo {
+pub(crate) trait SideTraceInfo: fmt::Debug {
     /// Upcast this [SideTraceInfo] to `Any`. This method is a hack that's only needed since trait
     /// upcasting in Rust is incomplete.
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static>;


### PR DESCRIPTION
In essence this PR -- which will be a bit hard to review -- breaks some unfortunate dependencies in jitc_yk:

1. `VarLocation` was specific to our x86 backend. https://github.com/ykjit/yk/commit/b411c0e49bd7f5bd628aff9c51df8ee5f6d6ff4f largely hacks that out.
2. `jir_ir::Module` was also -- though it wasn't obvious! -- also x86 backend specific because of side-traces. https://github.com/ykjit/yk/commit/170c2f119befadd83b6105ac27ef5879200f509a hacks that out.

Neither of these commits ends us up with a perfect design, but overall this does nudge us towards something that makes other changes easier to understand IMHO.