### PR TITLE
Shuffle parts of the register allocator around a bit

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -288,6 +288,20 @@ impl<'a> LSRegAlloc<'a> {
     pub(crate) fn ptradd(&self, iidx: InstIdx) -> Option<PtrAddInst> {
         self.rev_an.ptradds[usize::from(iidx)]
     }
+
+    /// Assign registers for the instruction at position `iidx`.
+    pub(crate) fn assign_regs<const NG: usize, const NF: usize>(
+        &mut self,
+        asm: &mut Assembler,
+        iidx: InstIdx,
+        gp_constraints: [RegConstraint<Rq>; NG],
+        fp_constraints: [RegConstraint<Rx>; NF],
+    ) -> ([Rq; NG], [Rx; NF]) {
+        (
+            self.assign_gp_regs(asm, iidx, gp_constraints),
+            self.assign_fp_regs(asm, iidx, fp_constraints),
+        )
+    }
 }
 
 /// The parts of the register allocator needed for general purpose registers.
@@ -378,7 +392,9 @@ impl LSRegAlloc<'_> {
         }
     }
 
-    /// Assign registers for the instruction at position `iidx`.
+    /// Assign general purpose registers for the instruction at position `iidx`.
+    ///
+    /// This is a convenience function for [Self::assign_regs] when there are no FP registers.
     pub(crate) fn assign_gp_regs<const N: usize>(
         &mut self,
         asm: &mut Assembler,
@@ -958,7 +974,9 @@ impl LSRegAlloc<'_> {
 }
 
 impl LSRegAlloc<'_> {
-    /// Assign registers for the instruction at position `iidx`.
+    /// Assign floating point registers for the instruction at position `iidx`.
+    ///
+    /// This is a convenience function for [Self::assign_regs] when there are no GP registers.
     pub(crate) fn assign_fp_regs<const N: usize>(
         &mut self,
         asm: &mut Assembler,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -456,7 +456,7 @@ impl<'a> Assemble<'a> {
         let mut next = iter.next();
         let mut in_header = true;
         while let Some((iidx, inst)) = next {
-            if self.ra.is_inst_tombstone(iidx) {
+            if self.ra.rev_an.is_inst_tombstone(iidx) {
                 next = iter.next();
                 continue;
             }
@@ -494,7 +494,10 @@ impl<'a> Assemble<'a> {
                             // NOTE: If the value of the condition will be used later, we have to
                             // materialise it.
                             if cond_idx == iidx
-                                && !self.ra.is_inst_var_still_used_after(next_iidx, cond_idx)
+                                && !self
+                                    .ra
+                                    .rev_an
+                                    .is_inst_var_still_used_after(next_iidx, cond_idx)
                             {
                                 self.cg_icmp_guard(iidx, ic_inst, next_iidx, g_inst);
                                 next = iter.next();
@@ -1636,7 +1639,7 @@ impl<'a> Assemble<'a> {
         g_iidx: InstIdx,
         g_inst: jit_ir::GuardInst,
     ) {
-        debug_assert!(!self.ra.is_inst_var_still_used_after(g_iidx, ic_iidx));
+        debug_assert!(!self.ra.rev_an.is_inst_var_still_used_after(g_iidx, ic_iidx));
 
         // Codegen ICmp
         let (lhs, pred, rhs) = (

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1162,12 +1162,12 @@ impl<'a> Assemble<'a> {
                 };
             }
             Ty::Float(fty) => {
-                let [src_reg] =
-                    self.ra
-                        .assign_gp_regs(&mut self.asm, iidx, [RegConstraint::Input(ptr_op)]);
-                let [tgt_reg] =
-                    self.ra
-                        .assign_fp_regs(&mut self.asm, iidx, [RegConstraint::Output]);
+                let ([src_reg], [tgt_reg]) = self.ra.assign_regs(
+                    &mut self.asm,
+                    iidx,
+                    [RegConstraint::Input(ptr_op)],
+                    [RegConstraint::Output],
+                );
                 match fty {
                     FloatTy::Float => {
                         dynasm!(self.asm; movss Rx(tgt_reg.code()), [Rq(src_reg.code()) + off])
@@ -1288,12 +1288,12 @@ impl<'a> Assemble<'a> {
                 }
             }
             Ty::Float(fty) => {
-                let [tgt_reg] =
-                    self.ra
-                        .assign_gp_regs(&mut self.asm, iidx, [RegConstraint::Input(tgt_op)]);
-                let [val_reg] =
-                    self.ra
-                        .assign_fp_regs(&mut self.asm, iidx, [RegConstraint::Input(val)]);
+                let ([tgt_reg], [val_reg]) = self.ra.assign_regs(
+                    &mut self.asm,
+                    iidx,
+                    [RegConstraint::Input(tgt_op)],
+                    [RegConstraint::Input(val)],
+                );
                 match fty {
                     FloatTy::Float => {
                         dynasm!(self.asm ; movss [Rq(tgt_reg.code()) + off], Rx(val_reg.code()));
@@ -1436,9 +1436,7 @@ impl<'a> Assemble<'a> {
         }
 
         // We now have all the FP constraints, so assign those.
-        let _: [Rx; 16] =
-            self.ra
-                .assign_fp_regs(&mut self.asm, iidx, fp_cnstrs.try_into().unwrap());
+        let fp_cnstrs: [_; 16] = fp_cnstrs.try_into().unwrap();
         let num_float_args = i32::try_from(num_float_args).unwrap();
 
         // We now have most of the GP constraints, except the call target. We have to handle that
@@ -1448,9 +1446,12 @@ impl<'a> Assemble<'a> {
                 // Direct call
 
                 if !fty.is_vararg() {
-                    let [_, _, _, _, _, _, _, _, _] =
-                        self.ra
-                            .assign_gp_regs(&mut self.asm, iidx, gp_cnstrs.try_into().unwrap());
+                    let _: ([Rq; CALLER_CLOBBER_REGS.len()], [Rx; 16]) = self.ra.assign_regs(
+                        &mut self.asm,
+                        iidx,
+                        gp_cnstrs.try_into().unwrap(),
+                        fp_cnstrs,
+                    );
                     // rax is considered clobbered, but isn't used to pass an argument, so we can
                     // safely use it for the function pointer.
                     dynasm!(self.asm
@@ -1459,9 +1460,13 @@ impl<'a> Assemble<'a> {
                     );
                 } else {
                     gp_cnstrs.push(RegConstraint::Temporary);
-                    let [_, _, _, _, _, _, _, _, _, tmp_reg] =
-                        self.ra
-                            .assign_gp_regs(&mut self.asm, iidx, gp_cnstrs.try_into().unwrap());
+                    let ([.., tmp_reg], _): ([Rq; CALLER_CLOBBER_REGS.len() + 1], [Rx; 16]) =
+                        self.ra.assign_regs(
+                            &mut self.asm,
+                            iidx,
+                            gp_cnstrs.try_into().unwrap(),
+                            fp_cnstrs,
+                        );
                     dynasm!(self.asm
                         ; mov rax, num_float_args
                         ; mov Rq(tmp_reg.code()), QWORD p as i64
@@ -1472,9 +1477,13 @@ impl<'a> Assemble<'a> {
             (None, Some(op)) => {
                 // Indirect call
                 gp_cnstrs.push(RegConstraint::Input(op));
-                let [_, _, _, _, _, _, _, _, _, op_reg] =
-                    self.ra
-                        .assign_gp_regs(&mut self.asm, iidx, gp_cnstrs.try_into().unwrap());
+                let ([.., op_reg], _): ([Rq; CALLER_CLOBBER_REGS.len() + 1], [Rx; 16]) =
+                    self.ra.assign_regs(
+                        &mut self.asm,
+                        iidx,
+                        gp_cnstrs.try_into().unwrap(),
+                        fp_cnstrs,
+                    );
                 if fty.is_vararg() {
                     dynasm!(self.asm; mov rax, num_float_args); // SysV x64 ABI
                 }
@@ -1732,14 +1741,12 @@ impl<'a> Assemble<'a> {
     fn cg_fcmp(&mut self, iidx: InstIdx, inst: &jit_ir::FCmpInst) {
         let (lhs, pred, rhs) = (inst.lhs(self.m), inst.predicate(), inst.rhs(self.m));
         let size = lhs.byte_size(self.m);
-        let [lhs_reg, rhs_reg] = self.ra.assign_fp_regs(
+        let ([tgt_reg], [lhs_reg, rhs_reg]) = self.ra.assign_regs(
             &mut self.asm,
             iidx,
+            [RegConstraint::Output],
             [RegConstraint::Input(lhs), RegConstraint::Input(rhs)],
         );
-        let [tgt_reg] = self
-            .ra
-            .assign_gp_regs(&mut self.asm, iidx, [RegConstraint::Output]);
 
         match pred.is_ordered() {
             Some(true) => match size {
@@ -1907,12 +1914,15 @@ impl<'a> Assemble<'a> {
             }
         }
 
-        let _: [_; lsregalloc::GP_REGS.len()] =
-            self.ra
-                .assign_gp_regs(&mut self.asm, iidx, gp_regs.try_into().unwrap());
-        let _: [_; lsregalloc::FP_REGS.len()] =
-            self.ra
-                .assign_fp_regs(&mut self.asm, iidx, fp_regs.try_into().unwrap());
+        let _: (
+            [Rq; lsregalloc::GP_REGS.len()],
+            [Rx; lsregalloc::FP_REGS.len()],
+        ) = self.ra.assign_regs(
+            &mut self.asm,
+            iidx,
+            gp_regs.try_into().unwrap(),
+            fp_regs.try_into().unwrap(),
+        );
     }
 
     fn cg_body_end(&mut self, iidx: InstIdx) {
@@ -2126,14 +2136,12 @@ impl<'a> Assemble<'a> {
                 todo!();
             }
             (gp_ty, jit_ir::Ty::Float(_)) => {
-                let [src_reg] = self.ra.assign_gp_regs(
+                let ([src_reg], [tgt_reg]) = self.ra.assign_regs(
                     &mut self.asm,
                     iidx,
                     [RegConstraint::Input(inst.val(self.m))],
+                    [RegConstraint::Output],
                 );
-                let [tgt_reg] =
-                    self.ra
-                        .assign_fp_regs(&mut self.asm, iidx, [RegConstraint::Output]);
                 // unwrap safe: IR would be invalid otherwise.
                 match gp_ty.byte_size().unwrap() {
                     4 => dynasm!(self.asm; cvtsi2ss Rx(tgt_reg.code()), Rd(src_reg.code())),
@@ -2146,14 +2154,12 @@ impl<'a> Assemble<'a> {
     }
 
     fn cg_sitofp(&mut self, iidx: InstIdx, inst: &jit_ir::SIToFPInst) {
-        let [src_reg] = self.ra.assign_gp_regs(
+        let ([src_reg], [tgt_reg]) = self.ra.assign_regs(
             &mut self.asm,
             iidx,
             [RegConstraint::Input(inst.val(self.m))],
+            [RegConstraint::Output],
         );
-        let [tgt_reg] = self
-            .ra
-            .assign_fp_regs(&mut self.asm, iidx, [RegConstraint::Output]);
 
         let src_size = inst.val(self.m).byte_size(self.m);
         match self.m.type_(inst.dest_tyidx()) {
@@ -2177,12 +2183,12 @@ impl<'a> Assemble<'a> {
         let from_size = self.m.type_(from_val.tyidx(self.m)).byte_size().unwrap();
         let to_size = to_ty.byte_size().unwrap();
 
-        let [src_reg] =
-            self.ra
-                .assign_fp_regs(&mut self.asm, iidx, [RegConstraint::Input(from_val)]);
-        let [tgt_reg] = self
-            .ra
-            .assign_gp_regs(&mut self.asm, iidx, [RegConstraint::Output]);
+        let ([tgt_reg], [src_reg]) = self.ra.assign_regs(
+            &mut self.asm,
+            iidx,
+            [RegConstraint::Output],
+            [RegConstraint::Input(from_val)],
+        );
 
         match from_size {
             4 => dynasm!(self.asm; cvttss2si Rq(tgt_reg.code()), Rx(src_reg.code())),
@@ -2309,12 +2315,10 @@ impl<'a> Assemble<'a> {
         // There is no dedicated instruction for negating the value in an XMM register, so we flip
         // the sign bit manually. It's a bit of a dance since you can't XORPS with an immediate
         // float.
-        let [tmpi_reg] = self
-            .ra
-            .assign_gp_regs(&mut self.asm, iidx, [RegConstraint::Temporary]);
-        let [io_reg, tmpf_reg] = self.ra.assign_fp_regs(
+        let ([tmpi_reg], [io_reg, tmpf_reg]) = self.ra.assign_regs(
             &mut self.asm,
             iidx,
+            [RegConstraint::Temporary],
             [RegConstraint::InputOutput(val), RegConstraint::Temporary],
         );
         match ty {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -194,12 +194,17 @@ impl<'a> RevAnalyse<'a> {
 
     /// Is the value produced by instruction `query_iidx` used after (but not including!)
     /// instruction `cur_idx`?
-    pub(crate) fn is_inst_var_still_used_after(
+    pub(super) fn is_inst_var_still_used_after(
         &self,
         cur_iidx: InstIdx,
         query_iidx: InstIdx,
     ) -> bool {
         usize::from(cur_iidx) < usize::from(self.inst_vals_alive_until[usize::from(query_iidx)])
+    }
+
+    /// Is the value produced by instruction `query_iidx` used at or after instruction `cur_idx`?
+    pub(super) fn is_inst_var_still_used_at(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> bool {
+        usize::from(cur_iidx) <= usize::from(self.inst_vals_alive_until[usize::from(query_iidx)])
     }
 
     /// Propagate the hint for the instruction being processed at `iidx` to `op`, if appropriate


### PR DESCRIPTION
This PR tidies up some parts of the register allocator (and those bits that use it) so that future work has a slightly more satisfactory base to work upon. There is still a lot more tidying up that we could do here (and, as is not uncommon, this PR exposes more things we should tackle in the future), but this is better than nothing.