### PR TITLE
Better aim spills

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -556,10 +556,7 @@ impl LSRegAlloc<'_> {
                                 if furthest.is_none() {
                                     furthest = Some((reg, from_iidx));
                                 } else if let Some((_, furthest_iidx)) = furthest {
-                                    if self.rev_an.inst_vals_alive_until[usize::from(from_iidx)]
-                                        >= self.rev_an.inst_vals_alive_until
-                                            [usize::from(furthest_iidx)]
-                                    {
+                                    if self.rev_an.used_later_than(from_iidx, furthest_iidx) {
                                         furthest = Some((reg, from_iidx))
                                     }
                                 }
@@ -1120,10 +1117,7 @@ impl LSRegAlloc<'_> {
                                 if furthest.is_none() {
                                     furthest = Some((reg, from_iidx));
                                 } else if let Some((_, furthest_iidx)) = furthest {
-                                    if self.rev_an.inst_vals_alive_until[usize::from(from_iidx)]
-                                        >= self.rev_an.inst_vals_alive_until
-                                            [usize::from(furthest_iidx)]
-                                    {
+                                    if self.rev_an.used_later_than(from_iidx, furthest_iidx) {
                                         furthest = Some((reg, from_iidx))
                                     }
                                 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -252,11 +252,6 @@ impl<'a> LSRegAlloc<'a> {
         self.stack.size()
     }
 
-    #[cfg(test)]
-    pub(crate) fn inst_vals_alive_until(&self) -> &Vec<InstIdx> {
-        &self.rev_an.inst_vals_alive_until
-    }
-
     /// Return the inline [PtrAddInst] for a load/store, if there is one.
     pub(crate) fn ptradd(&self, iidx: InstIdx) -> Option<PtrAddInst> {
         self.rev_an.ptradds[usize::from(iidx)]

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -258,6 +258,12 @@ impl<'a> RevAnalyse<'a> {
         }
     }
 
+    /// Iterate, in ascending order, over all uses of `iidx`.
+    pub(crate) fn iter_uses(&self, iidx: InstIdx) -> impl Iterator<Item = InstIdx> + '_ {
+        debug_assert!(self.def_use[usize::from(iidx)].iter().rev().is_sorted());
+        self.def_use[usize::from(iidx)].iter().cloned().rev()
+    }
+
     /// Propagate the hint for the instruction being processed at `iidx` to `op`, if appropriate
     /// for `op`.
     fn push_reg_hint(&mut self, iidx: InstIdx, op: Operand) {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -39,7 +39,7 @@ pub(crate) struct RevAnalyse<'a> {
     /// instruction is used. This implicitly enables a layer of dead-code elimination: it doesn't
     /// cause JIT IR instructions to be removed, but it allows a code generator to avoid generating
     /// code for some of them.
-    pub(crate) used_insts: Vob,
+    used_insts: Vob,
     /// What [Register] should an instruction aim to put its output to?
     pub(crate) reg_hints: Vec<Option<Register>>,
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -30,7 +30,7 @@ pub(crate) struct RevAnalyse<'a> {
     /// A `Vec<InstIdx>` with one entry per instruction. Each denotes the last instruction that the
     /// value produced by an instruction is used. By definition this must either be unused (if an
     /// instruction does not produce a value) or `>=` the offset in this vector.
-    pub(crate) inst_vals_alive_until: Vec<InstIdx>,
+    inst_vals_alive_until: Vec<InstIdx>,
     /// A `Vec<Option<PtrAddInst>>` that "inlines" pointer additions into load/stores. The
     /// `PtrAddInst` is not marked as used, for such instructions: note that it might be marked as
     /// used by other instructions!
@@ -211,6 +211,12 @@ impl<'a> RevAnalyse<'a> {
     /// Is the value produced by instruction `query_iidx` used at or after instruction `cur_idx`?
     pub(super) fn is_inst_var_still_used_at(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> bool {
         usize::from(cur_iidx) <= usize::from(self.inst_vals_alive_until[usize::from(query_iidx)])
+    }
+
+    /// Is `query_iidx` used later in the trace than `cur_iidx`?
+    pub(super) fn used_later_than(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> bool {
+        self.inst_vals_alive_until[usize::from(cur_iidx)]
+            >= self.inst_vals_alive_until[usize::from(query_iidx)]
     }
 
     /// Propagate the hint for the instruction being processed at `iidx` to `op`, if appropriate

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -35,10 +35,10 @@ pub(crate) struct RevAnalyse<'a> {
     /// `PtrAddInst` is not marked as used, for such instructions: note that it might be marked as
     /// used by other instructions!
     pub(crate) ptradds: Vec<Option<PtrAddInst>>,
-    /// A `Vob` with one entry per instruction, denoting whether the code generator use its
-    /// value. This is implicitly a layer of dead-code elimination: it doesn't cause JIT IR
-    /// instructions to be removed, but it will stop any code being (directly) generated for
-    /// some of them.
+    /// A `Vob` with one entry per instruction, denoting whether the value resulting from an
+    /// instruction is used. This implicitly enables a layer of dead-code elimination: it doesn't
+    /// cause JIT IR instructions to be removed, but it allows a code generator to avoid generating
+    /// code for some of them.
     pub(crate) used_insts: Vob,
     /// What [Register] should an instruction aim to put its output to?
     pub(crate) reg_hints: Vec<Option<Register>>,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -193,7 +193,10 @@ impl<'a> RevAnalyse<'a> {
                 if self.inst_vals_alive_until[usize::from(x)] < iidx {
                     self.inst_vals_alive_until[usize::from(x)] = iidx;
                 }
-                self.push_def_use(x, iidx);
+                match inst {
+                    Inst::TraceHeaderStart | Inst::TraceBodyStart => (),
+                    _ => self.push_def_use(x, iidx),
+                }
             });
         }
     }

--- a/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/dead_code.rs
@@ -42,25 +42,6 @@ mod test {
             "
           entry:
             %0: i8 = param 0
-            %1: i8 = param 1
-            black_box %1
-        ",
-            |mut m| {
-                m.dead_code_elimination();
-                m
-            },
-            "
-          ...
-          entry:
-            %1: i8 = param ...
-            black_box %1
-        ",
-        );
-
-        Module::assert_ir_transform_eq(
-            "
-          entry:
-            %0: i8 = param 0
             %1: i8 = add %0, %0
             %2: i8 = add %0, %0
             black_box %2
@@ -117,6 +98,7 @@ mod test {
             "
           ...
           entry:
+            %0: i8 = param ...
             %1: i8 = param ...
             %3: i1 = ult %1, %1
             black_box %3
@@ -161,6 +143,7 @@ mod test {
           ...
           entry:
             %0: i8 = param ...
+            %1: i8 = param ...
             call @f(%0)
         ",
         );
@@ -183,6 +166,7 @@ mod test {
           entry:
             %0: ptr = param ...
             %1: i8 = param ...
+            %2: i8 = param ...
             icall %0(%1)
         ",
         );

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1525,6 +1525,7 @@ impl Inst {
                 | Inst::TraceBodyStart
                 | Inst::TraceBodyEnd
                 | Inst::SidetraceEnd
+                | Inst::Param(_)
         )
     }
 

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -765,6 +765,7 @@ mod test {
             "
           ...
           entry:
+            %0: i1 = param ...
         ",
         );
     }
@@ -893,6 +894,7 @@ mod test {
             "
           ...
           entry:
+            %0: i8 = param ...
             black_box 0i8
         ",
         );
@@ -1034,6 +1036,7 @@ mod test {
             "
           ...
           entry:
+            %0: i8 = param ...
             %1: i8 = param ...
             black_box %1
             black_box %1


### PR DESCRIPTION
This PR gradually nudges spilling to a better place: we avoid spillings unnecessarily (https://github.com/ykjit/yk/commit/38419d3498d19f538a7e02ae031994015d9785c0) and we spill things we don't need on the fast (https://github.com/ykjit/yk/commit/d8790939e8732cd07c1967354842e1137cf4681a). Both of these are intended to help with medium to long traces, with the latter potentially significantly reducing pressure on the register allocator. The various other commits are various helpers/cleanups needed to make the main commits possible.