### PR TITLE
Fix bounce

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -19,4 +19,4 @@ RUN useradd -m -u ${CI_UID} ci && chown ${CI_UID}:${CI_UID} .
 ARG CI_RUNNER
 ENV CI_RUNNER=${CI_RUNNER}
 COPY --chown=${CI_UID}:${CI_UID} . .
-CMD sh -x .buildbot.sh
+CMD ["sh", "-x", ".buildbot.sh"]

--- a/hwtracer/src/pt/ykpt/parser.rs
+++ b/hwtracer/src/pt/ykpt/parser.rs
@@ -11,6 +11,8 @@ use super::packets::*;
 
 #[derive(Clone, Copy, Debug)]
 enum PacketParserState {
+    /// Initial state, waiting for a PSB packet.
+    Init,
     /// The "normal" decoding state.
     Normal,
     /// We are decoding a PSB+ sequence.
@@ -27,6 +29,7 @@ impl PacketParserState {
         // OPT: The order below is a rough guess based on what limited traces I've seen. Benchmark
         // and optimise.
         match self {
+            Self::Init => &[PacketKind::PSB, PacketKind::CBR, PacketKind::PAD],
             Self::Normal => &[
                 PacketKind::ShortTNT,
                 PacketKind::PAD,
@@ -60,6 +63,7 @@ impl PacketParserState {
     /// kind of packet.
     fn transition(&mut self, pkt_kind: PacketKind) {
         let new = match (*self, pkt_kind) {
+            (Self::Init, PacketKind::PSB) => Self::PSBPlus,
             (Self::Normal, PacketKind::PSB) => Self::PSBPlus,
             (Self::PSBPlus, PacketKind::PSBEND) => Self::Normal,
             _ => return, // No state transition.
@@ -105,7 +109,7 @@ impl<'t> PacketParser<'t> {
     pub(super) fn new(bytes: &'t [u8]) -> Self {
         Self {
             bits: BitSlice::from_slice(bytes),
-            state: PacketParserState::Normal,
+            state: PacketParserState::Init,
             prev_tip: 0,
         }
     }
@@ -228,7 +232,6 @@ impl Iterator for PacketParser<'_> {
 mod tests {
     use super::{super::packets::*, PacketParser};
     use crate::{trace_closure, work_loop, TracerBuilder, TracerKind};
-    use std::hint::black_box;
 
     /// Parse the packets of a small trace, checking the basic structure of the decoded trace.
     #[test]
@@ -268,22 +271,6 @@ mod tests {
             };
         }
         assert!(matches!(ts, TestState::SawPacketGenDisable));
-    }
-
-    /// Checks PT packet streams make sense when a perf fd is re-used.
-    #[test]
-    fn decode_many() {
-        let tc = TracerBuilder::new()
-            .tracer_kind(TracerKind::PT(crate::perf::PerfCollectorConfig::default()))
-            .build()
-            .unwrap();
-        for _ in 0..50 {
-            let trace = trace_closure(&tc, || work_loop(3));
-            // Force full-decoding of the trace.
-            for p in PacketParser::new(trace.bytes()) {
-                let _ = black_box(p);
-            }
-        }
     }
 
     /// Test target IP decompression when the `IPBytes = 0b000`.


### PR DESCRIPTION
We've been experiencing non-deterministic segfaults, assertion failures
and Lua-level errors in bounce.lua for a while:
https://github.com/ykjit/yk/issues/1544

After a couple of days of systematically narrowing down the cause, it
appears to be something to do with the re-use of the PT resources in
collect.c.

In theory reusing the PT stuff for subsequent tracing sessions on the
same thread *should* be just fine -- I've even found examples on the
internet where people do this -- however, something is wrong with our
implementation, so I'm disabling the caching for now.

This commit does several things related to this:

 - Fixes a bug in the aux buffer read code in the case that the ring
   buffer wraps around. We were incorrectly bumping the length of the
   recorded trace, which would cause trace corruption in the form of
   uninitialised reads when we come to decode the trace:

   ```diff
   -    trace->len += size + head;
   +    trace->len += head;
   ```

   Later changes (not re-using the aux buffer) will actually mean that
   the wraparound case can't happen (since the aux buffer is the same
   size as the allocated copyout buffer), but I'm leaving it in in case
   we ever decide to re-use perf stuff again.

   Sadly this fix alone isn't enough to fix bounce.lua.

 - Removes caching of perf-related mmap buffers and the perf file
   descriptor itself. This basically reverts https://github.com/ykjit/yk/commit/bedafd9259361840d17eb665547b91b4a993b166. This means each
   tracing session now allocates fresh memory and opens a fresh perf fd.
   As part of this change we re-introduce `PacketParserState::Init` and
   add a couple of other permissible packets that I've seen come up when
   using try_repeat on the test suite.

 - Ensures that the collector's resources are freed by calling
   `hwt_perf_free_collector()`, even if collecting a trace is aborted by
   (e.g.) "trace too long". We were failing to do this, meaning that
   resources would potentially leak. Since we no longer cache the perf
   fd, and this is closed in `hwt_perf_free_collector()`, if we don't
   call that, then the thread is effectively blocked from ever tracing
   again: trying to open perf agaiin would give "resource busy".

This appears to fix the original `bounce.lua` and the reduced one that me an Lukas devised.

I did 3 try_ci runs of this and all suceeded! Fingers crossed.