### PR TITLE
Be somewhat clearer about upper bits in the codegen.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1008,7 +1008,7 @@ impl Ty {
     }
 
     /// Returns the size of the type in bits, or `None` if asking the size makes no sense.
-    pub(crate) fn bit_size(&self) -> Option<usize> {
+    pub(crate) fn bitw(&self) -> Option<usize> {
         match self {
             Self::Void => Some(0),
             Self::Integer(bits) => Some(usize::try_from(*bits).unwrap()),
@@ -1165,6 +1165,18 @@ impl Operand {
         match self {
             Self::Var(l) => m.inst_raw(*l).def_byte_size(m),
             Self::Const(cidx) => m.type_(m.const_(*cidx).tyidx(m)).byte_size().unwrap(),
+        }
+    }
+
+    /// Returns the size of the operand in bits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if asking for the size make no sense for this operand.
+    pub(crate) fn bitw(&self, m: &Module) -> usize {
+        match self {
+            Self::Var(l) => m.inst_raw(*l).def_bitw(m),
+            Self::Const(cidx) => m.type_(m.const_(*cidx).tyidx(m)).bitw().unwrap(),
         }
     }
 
@@ -1844,7 +1856,7 @@ impl Inst {
         Ok(inst)
     }
 
-    /// Returns the size of the local variable that this instruction defines (if any).
+    /// Returns the size in bytes of the local variable that this instruction defines (if any).
     ///
     /// # Panics
     ///
@@ -1854,6 +1866,25 @@ impl Inst {
     pub(crate) fn def_byte_size(&self, m: &Module) -> usize {
         if let Some(ty) = self.def_type(m) {
             if let Some(size) = ty.byte_size() {
+                size
+            } else {
+                panic!()
+            }
+        } else {
+            panic!()
+        }
+    }
+
+    /// Returns the bit width of the local variable that this instruction defines (if any).
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    ///  - The instruction defines no local variable.
+    ///  - The instruction defines an unsized local variable.
+    pub(crate) fn def_bitw(&self, m: &Module) -> usize {
+        if let Some(ty) = self.def_type(m) {
+            if let Some(size) = ty.bitw() {
                 size
             } else {
                 panic!()

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -193,7 +193,7 @@ impl Module {
                             self.inst(iidx).display(self, iidx)
                         );
                     }
-                    let val_bitsize = val_ty.bit_size().unwrap();
+                    let val_bitsize = val_ty.bitw().unwrap();
 
                     let dest_ty = self.type_(x.dest_tyidx());
                     if !matches!(dest_ty, Ty::Integer(_)) && !matches!(dest_ty, Ty::Ptr) {
@@ -202,7 +202,7 @@ impl Module {
                             self.inst(iidx).display(self, iidx)
                         );
                     }
-                    let dest_bitsize = dest_ty.bit_size().unwrap();
+                    let dest_bitsize = dest_ty.bitw().unwrap();
 
                     // FIXME: strictly this should be >= to be in line with LLVM semantics, but the
                     // way we lower LLVM `ptrtoint` to `zext` means that pointer to integer
@@ -228,8 +228,8 @@ impl Module {
                     }
                     // LLVM semantics: "The bit sizes of [source] value and the destination type
                     // must be identical"
-                    let val_bitsize = val_ty.bit_size().unwrap();
-                    let dest_bitsize = dest_ty.bit_size().unwrap();
+                    let val_bitsize = val_ty.bitw().unwrap();
+                    let dest_bitsize = dest_ty.bitw().unwrap();
                     if val_bitsize != dest_bitsize {
                         panic!(
                             "Instruction at position {iidx} trying to bitcast to a differently-sized type\n  {}",


### PR DESCRIPTION
This is a bit of a hodgepodge of changes, but there are three major things:

  1. Get rid of all the "weird" sized ints, none of which we see in practise, and which we thus have low confidence are correct.
  2. Simplify some of the zero extension stuff.
  3. Zero extend all values to 64 bits before a call. We do this crudely for now.