### PR TITLE
Change how we store and sign/zero extend integers.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -58,3 +58,4 @@ lazy_static = "1.5.0"
 lrlex = "0.13"
 lrpar = "0.13"
 regex = { version = "1.9", features = ["std"] }
+proptest = "1.6.0"

--- a/ykrt/src/compile/jitc_yk/arbbitint.rs
+++ b/ykrt/src/compile/jitc_yk/arbbitint.rs
@@ -1,0 +1,840 @@
+//! An integer of an arbitrary, dynamic, bit width.
+//!
+//! This hides away the underlying representation, and forces the user to consider whether they
+//! want to zero or sign extend the underlying the integer whenever they want access to a
+//! Rust-level integer.
+//!
+//! Currently only up to 64 bits are supported, though the API is flexible enough to transparently
+//! support greater bit widths in the future.
+
+use super::int_signs::{SignExtend, Truncate};
+use std::{
+    hash::Hash,
+    ops::{BitAnd, BitOr, BitXor},
+};
+
+/// An integer of an arbitrary, dynamic, bit width.
+///
+/// Currently can only represent a max of 64 bits: this could be extended in the future.
+#[derive(Clone, Debug)]
+pub(crate) struct ArbBitInt {
+    bitw: u32,
+    /// The underlying value. Any bits above `self.bitw` have an undefined value: they may be set
+    /// or unset.
+    ///
+    /// Currently we can only store ints that can fit in 64 bits: in the future we could use
+    /// another scheme to e.g `Box` bigger integers.
+    val: u64,
+}
+
+impl ArbBitInt {
+    /// Create a new `ArbBitInt` that is `width` bits wide and has a value `val`. Any bits above
+    /// `width` bits are ignored (i.e. it is safe for those bits to be set or unset when calling
+    /// this function).
+    pub(crate) fn from_u64(bitw: u32, val: u64) -> Self {
+        debug_assert!(bitw <= 64);
+        Self { bitw, val }
+    }
+
+    /// Create a new `ArbBitInt` that is `width` bits wide and has a value `val`. Any bits above
+    /// `width` bits are ignored (i.e. it is safe for those bits to be set or unset when calling
+    /// this function).
+    #[cfg(test)]
+    pub(crate) fn from_i64(bitw: u32, val: i64) -> Self {
+        debug_assert!(bitw <= 64);
+        Self {
+            bitw,
+            val: val as u64,
+        }
+    }
+
+    /// Create a new `ArbBitInt` with all `bitw` bits set. This can be seen as equivalent to
+    /// creating a value of `ubitw::MAX` (when `ubitw` is also a valid Rust type).
+    pub(crate) fn all_bits_set(bitw: u32) -> Self {
+        Self {
+            bitw,
+            val: u64::MAX,
+        }
+    }
+
+    /// How many bits wide is this `ArbBitInt`?
+    pub(crate) fn bitw(&self) -> u32 {
+        self.bitw
+    }
+
+    /// Sign extend this `ArbBitInt` to `to_bitw` bits.
+    ///
+    /// # Panics
+    ///
+    /// If `to_bitw` is smaller than `self.bitw()`.
+    pub(crate) fn sign_extend(&self, to_bitw: u32) -> Self {
+        debug_assert!(to_bitw >= self.bitw && to_bitw <= 64);
+        Self {
+            bitw: to_bitw,
+            val: self.val.sign_extend(self.bitw, to_bitw),
+        }
+    }
+
+    /// Zero extend this `ArbBitInt` to `to_bitw` bits.
+    ///
+    /// # Panics
+    ///
+    /// If `to_bitw` is smaller than `self.bitw()`.
+    pub(crate) fn zero_extend(&self, to_bitw: u32) -> Self {
+        debug_assert!(to_bitw >= self.bitw && to_bitw <= 64);
+        Self {
+            bitw: to_bitw,
+            val: self.val.truncate(self.bitw),
+        }
+    }
+
+    /// Sign extend the underlying value and, if it is representable as an `i8`, return it.
+    pub(crate) fn to_sign_ext_i8(&self) -> Option<i8> {
+        i8::try_from(self.val.sign_extend(self.bitw, 64) as i64).ok()
+    }
+
+    /// Sign extend the underlying value and, if it is representable as an `i16`, return it.
+    #[allow(unused)]
+    pub(crate) fn to_sign_ext_i16(&self) -> Option<i16> {
+        i16::try_from(self.val.sign_extend(self.bitw, 64) as i64).ok()
+    }
+
+    /// Sign extend the underlying value and, if it is representable as an `i32`, return it.
+    pub(crate) fn to_sign_ext_i32(&self) -> Option<i32> {
+        i32::try_from(self.val.sign_extend(self.bitw, 64) as i64).ok()
+    }
+
+    /// Sign extend the underlying value and, if it is representable as an `i64`, return it.
+    pub(crate) fn to_sign_ext_i64(&self) -> Option<i64> {
+        Some(self.val.sign_extend(self.bitw, 64) as i64)
+    }
+
+    /// zero extend the underlying value and, if it is representable as an `u8`, return it.
+    pub(crate) fn to_zero_ext_u8(&self) -> Option<u8> {
+        u8::try_from(self.val.truncate(self.bitw)).ok()
+    }
+
+    /// zero extend the underlying value and, if it is representable as an `u16`, return it.
+    pub(crate) fn to_zero_ext_u16(&self) -> Option<u16> {
+        u16::try_from(self.val.truncate(self.bitw)).ok()
+    }
+
+    /// zero extend the underlying value and, if it is representable as an `u32`, return it.
+    pub(crate) fn to_zero_ext_u32(&self) -> Option<u32> {
+        u32::try_from(self.val.truncate(self.bitw)).ok()
+    }
+
+    /// zero extend the underlying value and, if it is representable as an `u64`, return it.
+    pub(crate) fn to_zero_ext_u64(&self) -> Option<u64> {
+        Some(self.val.truncate(self.bitw))
+    }
+
+    /// Return a new [ArbBitInt] that performs two's complement wrapping addition on `self` and
+    /// `other`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` and `other` are not the same bit width.
+    pub(crate) fn wrapping_add(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.bitw, other.bitw);
+        Self {
+            bitw: self.bitw,
+            val: self.val.wrapping_add(other.val),
+        }
+    }
+
+    /// Return a new [ArbBitInt] that performs two's complement wrapping multiplication on `self` and
+    /// `other`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` and `other` are not the same bit width.
+    pub(crate) fn wrapping_mul(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.bitw, other.bitw);
+        Self {
+            bitw: self.bitw,
+            val: self.val.wrapping_mul(other.val),
+        }
+    }
+
+    /// Return a new [ArbBitInt] that performs two's complement wrapping subtraction on `self` and
+    /// `other`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` and `other` are not the same bit width.
+    pub(crate) fn wrapping_sub(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.bitw, other.bitw);
+        Self {
+            bitw: self.bitw,
+            val: self.val.wrapping_sub(other.val),
+        }
+    }
+
+    /// Return a new [ArbBitInt] that left shifts `self` by `bits`s or `None` if `bits >=
+    /// self.bitw()`.
+    pub(crate) fn checked_shl(&self, bits: u32) -> Option<Self> {
+        if bits < self.bitw {
+            Some(Self {
+                bitw: self.bitw,
+                val: self.val.checked_shl(bits).unwrap(), // unwrap cannot fail
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Return a new [ArbBitInt] that right shifts `self` by `bits` or `None` if `bits >=
+    /// self.bitw()`.
+    pub(crate) fn checked_shr(&self, bits: u32) -> Option<Self> {
+        if bits < self.bitw {
+            Some(Self {
+                bitw: self.bitw,
+                val: self.val.checked_shr(bits).unwrap(), // unwrap cannot fail
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Return a new [ArbBitInt] that performs bitwise `AND` on `self` and `other`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` and `other` are not the same bit width.
+    pub(crate) fn bitand(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.bitw, other.bitw);
+        Self {
+            bitw: self.bitw,
+            val: self.val.bitand(other.val),
+        }
+    }
+
+    /// Return a new [ArbBitInt] that performs bitwise `OR` on `self` and `other`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` and `other` are not the same bit width.
+    pub(crate) fn bitor(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.bitw, other.bitw);
+        Self {
+            bitw: self.bitw,
+            val: self.val.bitor(other.val),
+        }
+    }
+
+    /// Return a new [ArbBitInt] that performs bitwise `XOR` on `self` and `other`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` and `other` are not the same bit width.
+    pub(crate) fn bitxor(&self, other: &Self) -> Self {
+        debug_assert_eq!(self.bitw, other.bitw);
+        Self {
+            bitw: self.bitw,
+            val: self.val.bitxor(other.val),
+        }
+    }
+}
+
+impl Hash for ArbBitInt {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.bitw.hash(state);
+        self.val.truncate(self.bitw).hash(state);
+    }
+}
+
+impl PartialEq for ArbBitInt {
+    fn eq(&self, other: &Self) -> bool {
+        self.bitw == other.bitw && self.val.truncate(self.bitw) == other.val.truncate(self.bitw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn arbbitint_8bit(x in any::<i8>(), y in any::<i8>()) {
+            assert_eq!(ArbBitInt::from_i64(8, x as i64).to_sign_ext_i8(), Some(x));
+
+            // wrapping_add
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_add(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_add(y)).ok()
+            );
+
+            // wrapping_sub
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_sub(y)).ok()
+            );
+
+            // wrapping_mul
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_mul(y)).ok()
+            );
+
+            // bitadd
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .bitand(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitand(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .bitand(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitand(y)).ok()
+            );
+
+            // bitor
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .bitor(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .bitor(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitor(y)).ok()
+            );
+
+            // bitxor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitxor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(8, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(8, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitxor(y)).ok()
+            );
+        }
+
+        #[test]
+        fn arbbitint_16bit(x in any::<i16>(), y in any::<i16>()) {
+            match (i8::try_from(x), ArbBitInt::from_i64(16, x as i64).to_sign_ext_i8()) {
+                (Ok(a), Some(b)) if a == b => (),
+                (Err(_), None) => (),
+                a => panic!("{a:?}")
+            }
+            assert_eq!(ArbBitInt::from_i64(16, x as i64).to_sign_ext_i16(), Some(x));
+
+            // wrapping_add
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_add(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_add(y)).ok()
+            );
+
+            // wrapping_sub
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_sub(y)).ok()
+            );
+
+            // wrapping_mul
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_mul(y)).ok()
+            );
+
+            // bitand
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .bitand(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitand(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .bitand(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitand(y)).ok()
+            );
+
+            // bitor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .bitor(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .bitor(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitor(y)).ok()
+            );
+
+            // bitxor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitxor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(16, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(16, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitxor(y)).ok()
+            );
+        }
+
+        #[test]
+        fn arbbitint_32bit(x in any::<i32>(), y in any::<i32>()) {
+            match (i8::try_from(x), ArbBitInt::from_i64(32, x as i64).to_sign_ext_i8()) {
+                (Ok(a), Some(b)) if a == b => (),
+                (Err(_), None) => (),
+                a => panic!("{a:?}")
+            }
+            match (i16::try_from(x), ArbBitInt::from_i64(32, x as i64).to_sign_ext_i16()) {
+                (Ok(a), Some(b)) if a == b => (),
+                (Err(_), None) => (),
+                a => panic!("{a:?}")
+            }
+            assert_eq!(ArbBitInt::from_i64(32, x as i64).to_sign_ext_i32(), Some(x));
+
+            // wrapping_add
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_add(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_add(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_add(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i32(),
+                i32::try_from(x.wrapping_add(y)).ok()
+            );
+
+            // wrapping_sub
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_sub(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i32(),
+                i32::try_from(x.wrapping_sub(y)).ok()
+            );
+
+            // wrapping_mul
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .wrapping_mul(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i32(),
+                i32::try_from(x.wrapping_mul(y)).ok()
+            );
+
+            // bitand
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitand(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitand(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitand(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitand(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitand(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i32(),
+                i32::try_from(x.bitand(y)).ok()
+            );
+
+            // bitor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitor(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitor(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitor(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitor(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i32(),
+                i32::try_from(x.bitor(y)).ok()
+            );
+
+            // bitxor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i8(),
+                i8::try_from(x.bitxor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i16(),
+                i16::try_from(x.bitxor(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(32, x as i64)
+                    .bitxor(&ArbBitInt::from_i64(32, y as i64)).to_sign_ext_i32(),
+                i32::try_from(x.bitxor(y)).ok()
+            );
+        }
+
+        #[test]
+        fn arbbitint_64bit(x in any::<i64>(), y in any::<i64>()) {
+            match (i8::try_from(x), ArbBitInt::from_i64(64, x).to_sign_ext_i8()) {
+                (Ok(a), Some(b)) if a == b => (),
+                (Err(_), None) => (),
+                a => panic!("{a:?}")
+            }
+            match (i16::try_from(x), ArbBitInt::from_i64(64, x).to_sign_ext_i16()) {
+                (Ok(a), Some(b)) if a == b => (),
+                (Err(_), None) => (),
+                a => panic!("{a:?}")
+            }
+            match (i32::try_from(x), ArbBitInt::from_i64(64, x).to_sign_ext_i32()) {
+                (Ok(a), Some(b)) if a == b => (),
+                (Err(_), None) => (),
+                a => panic!("{a:?}")
+            }
+            assert_eq!(ArbBitInt::from_i64(64, x).to_sign_ext_i64(), Some(x));
+
+            // wrapping_add
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_add(&ArbBitInt::from_i64(64, y)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_add(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_add(&ArbBitInt::from_i64(64, y)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_add(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_add(&ArbBitInt::from_i64(64, y)).to_sign_ext_i32(),
+                i32::try_from(x.wrapping_add(y)).ok()
+            );
+            // i64
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_add(&ArbBitInt::from_i64(64, y)).to_sign_ext_i64(),
+                i64::try_from(x.wrapping_add(y)).ok()
+            );
+
+            // wrapping_sub
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_sub(&ArbBitInt::from_i64(64, y)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_sub(&ArbBitInt::from_i64(64, y)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_sub(&ArbBitInt::from_i64(64, y)).to_sign_ext_i32(),
+                i32::try_from(x.wrapping_sub(y)).ok()
+            );
+            // i64
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_sub(&ArbBitInt::from_i64(64, y)).to_sign_ext_i64(),
+                i64::try_from(x.wrapping_sub(y)).ok()
+            );
+
+            // wrapping_mul
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_mul(&ArbBitInt::from_i64(64, y)).to_sign_ext_i8(),
+                i8::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_mul(&ArbBitInt::from_i64(64, y)).to_sign_ext_i16(),
+                i16::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_mul(&ArbBitInt::from_i64(64, y)).to_sign_ext_i32(),
+                i32::try_from(x.wrapping_mul(y)).ok()
+            );
+            // i64
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .wrapping_mul(&ArbBitInt::from_i64(64, y)).to_sign_ext_i64(),
+                i64::try_from(x.wrapping_mul(y)).ok()
+            );
+
+            // bitand
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitand(&ArbBitInt::from_i64(64, y)).to_sign_ext_i8(),
+                i8::try_from(x.bitand(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitand(&ArbBitInt::from_i64(64, y)).to_sign_ext_i16(),
+                i16::try_from(x.bitand(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitand(&ArbBitInt::from_i64(64, y)).to_sign_ext_i32(),
+                i32::try_from(x.bitand(y)).ok()
+            );
+            // i64
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitand(&ArbBitInt::from_i64(64, y)).to_sign_ext_i64(),
+                i64::try_from(x.bitand(y)).ok()
+            );
+
+            // bitor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i8(),
+                i8::try_from(x.bitor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i16(),
+                i16::try_from(x.bitor(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i32(),
+                i32::try_from(x.bitor(y)).ok()
+            );
+            // i64
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i64(),
+                i64::try_from(x.bitor(y)).ok()
+            );
+
+            // bitxor
+            // i8
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitxor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i8(),
+                i8::try_from(x.bitxor(y)).ok()
+            );
+            // i16
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitxor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i16(),
+                i16::try_from(x.bitxor(y)).ok()
+            );
+            // i32
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitxor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i32(),
+                i32::try_from(x.bitxor(y)).ok()
+            );
+            // i64
+            assert_eq!(
+                ArbBitInt::from_i64(64, x)
+                    .bitxor(&ArbBitInt::from_i64(64, y)).to_sign_ext_i64(),
+                i64::try_from(x.bitxor(y)).ok()
+            );
+        }
+
+        #[test]
+        fn arbbitint_8bit_shl(x in any::<u8>(), y in 0u32..=8) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(8, x as u64).checked_shl(y).map(|x| x.to_zero_ext_u8()),
+                x.checked_shl(y).map(|x| u8::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_16bit_shl(x in any::<u16>(), y in 0u32..=16) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(16, x as u64).checked_shl(y).map(|x| x.to_zero_ext_u16()),
+                x.checked_shl(y).map(|x| u16::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_32bit_shl(x in any::<u32>(), y in 0u32..=32) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(32, x as u64).checked_shl(y).map(|x| x.to_zero_ext_u32()),
+                x.checked_shl(y).map(|x| u32::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_64bit_shl(x in any::<u64>(), y in 0u32..=63) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(64, x).checked_shl(y).map(|x| x.to_zero_ext_u64()),
+                x.checked_shl(y).map(|x| u64::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_8bit_shr(x in any::<u8>(), y in 0u32..=8) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(8, x as u64).checked_shr(y).map(|x| x.to_zero_ext_u8()),
+                x.checked_shr(y).map(|x| u8::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_16bit_shr(x in any::<u16>(), y in 0u32..=16) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(16, x as u64).checked_shr(y).map(|x| x.to_zero_ext_u16()),
+                x.checked_shr(y).map(|x| u16::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_32bit_shr(x in any::<u32>(), y in 0u32..=32) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(32, x as u64).checked_shr(y).map(|x| x.to_zero_ext_u32()),
+                x.checked_shr(y).map(|x| u32::try_from(x).ok())
+            );
+        }
+
+        #[test]
+        fn arbbitint_64bit_shr(x in any::<u64>(), y in 0u32..=63) {
+            // Notice that we deliberately allow y to extend beyond to the shiftable range, to make
+            // sure that we test the "failure" case, while not biasing our testing too-far to
+            // "failure cases only".
+            assert_eq!(
+                ArbBitInt::from_u64(64, x).checked_shr(y).map(|x| x.to_zero_ext_u64()),
+                x.checked_shr(y).map(|x| u64::try_from(x).ok())
+            );
+        }
+    }
+}

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -21,6 +21,7 @@ use ykaddr::addr::symbol_to_ptr;
 use yksmp::Location;
 
 pub mod aot_ir;
+mod arbbitint;
 mod codegen;
 #[cfg(any(debug_assertions, test))]
 mod gdb;

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -56,16 +56,12 @@ impl Analyse {
                     // that allows us to turn it into a constant.
                     if let Inst::ICmp(inst) = m.inst(iidx) {
                         let lhs = self.op_map(m, inst.lhs(m));
-                        let pred = inst.predicate();
                         let rhs = self.op_map(m, inst.rhs(m));
-                        if let (&Operand::Const(lhs_cidx), &Operand::Const(rhs_cidx)) = (&lhs, &rhs)
+                        if let (&Operand::Const(_lhs_cidx), &Operand::Const(_rhs_cidx)) =
+                            (&lhs, &rhs)
                         {
-                            if pred == Predicate::Equal && m.const_(lhs_cidx) == m.const_(rhs_cidx)
-                            {
-                                self.values.borrow_mut()[usize::from(iidx)] =
-                                    Value::Const(m.true_constidx());
-                                return Operand::Const(m.true_constidx());
-                            }
+                            // Can we still hit this case?
+                            todo!();
                         }
                     }
                     op

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -7,7 +7,7 @@
 // in this module; the refinement of values in the [Analyse] module.
 
 use super::{
-    int_signs::{SignExtend, Truncate},
+    arbbitint::ArbBitInt,
     jit_ir::{
         BinOp, BinOpInst, Const, ConstIdx, ICmpInst, Inst, InstIdx, Module, Operand, Predicate,
         PtrAddInst, TraceKind, Ty,
@@ -177,7 +177,7 @@ impl Opt {
                         (Operand::Const(op_cidx), Operand::Var(op_iidx))
                         | (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
                             match self.m.const_(op_cidx) {
-                                Const::Int(_, 0) => {
+                                Const::Int(_, x) if x.to_zero_ext_u64().unwrap() == 0 => {
                                     // Replace `x + 0` with `x`.
                                     self.m.replace(iidx, Inst::Copy(op_iidx));
                                 }
@@ -197,15 +197,13 @@ impl Opt {
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
-                                    debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(_rhs_tyidx, rhs)) => {
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    debug_assert_eq!(lhs_tyidx, _rhs_tyidx);
+                                    let cidx = self.m.insert_const(Const::Int(
                                         *lhs_tyidx,
-                                        (lhs_v.wrapping_add(*rhs_v)).truncate(*bits),
-                                    )?;
+                                        lhs.wrapping_add(rhs),
+                                    ))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => todo!(),
@@ -220,7 +218,7 @@ impl Opt {
                         (Operand::Const(op_cidx), Operand::Var(op_iidx))
                         | (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
                             match self.m.const_(op_cidx) {
-                                Const::Int(_, 0) => {
+                                Const::Int(_, x) if x.to_zero_ext_u64().unwrap() == 0 => {
                                     // Replace `x & 0` with `0`.
                                     self.m.replace(iidx, Inst::Const(op_cidx));
                                 }
@@ -240,15 +238,11 @@ impl Opt {
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(rhs_tyidx, rhs)) => {
                                     debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
-                                        *lhs_tyidx,
-                                        (lhs_v & rhs_v).truncate(*bits),
-                                    )?;
+                                    let cidx = self
+                                        .m
+                                        .insert_const(Const::Int(*lhs_tyidx, lhs.bitand(rhs)))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => panic!(),
@@ -261,29 +255,36 @@ impl Opt {
                         self.an.op_map(&self.m, x.rhs(&self.m)),
                     ) {
                         (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
-                            if let Const::Int(_, 0) = self.m.const_(op_cidx) {
-                                // Replace `x >> 0` with `x`.
-                                self.m.replace(iidx, Inst::Copy(op_iidx));
+                            if let Const::Int(_, y) = self.m.const_(op_cidx) {
+                                if y.to_zero_ext_u64().unwrap() == 0 {
+                                    // Replace `x >> 0` with `x`.
+                                    self.m.replace(iidx, Inst::Copy(op_iidx));
+                                }
                             }
                         }
                         (Operand::Const(op_cidx), Operand::Var(_)) => {
-                            if let Const::Int(tyidx, 0) = self.m.const_(op_cidx) {
-                                // Replace `0 >> x` with `0`.
-                                let new_cidx = self.m.insert_const_int(*tyidx, 0)?;
-                                self.m.replace(iidx, Inst::Const(new_cidx));
+                            if let Const::Int(tyidx, y) = self.m.const_(op_cidx) {
+                                if y.to_zero_ext_u64().unwrap() == 0 {
+                                    // Replace `0 >> x` with `0`.
+                                    let new_cidx = self.m.insert_const(Const::Int(
+                                        *tyidx,
+                                        ArbBitInt::from_u64(y.bitw(), 0),
+                                    ))?;
+                                    self.m.replace(iidx, Inst::Const(new_cidx));
+                                }
                             }
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
-                                    debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
-                                        *lhs_tyidx,
-                                        (lhs_v >> rhs_v).truncate(*bits),
-                                    )?;
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(_rhs_tyidx, rhs)) => {
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    debug_assert_eq!(lhs_tyidx, _rhs_tyidx);
+                                    // If checked_shr fails, we've encountered LLVM poison and can
+                                    // choose any value.
+                                    let shr = lhs
+                                        .checked_shr(rhs.to_zero_ext_u32().unwrap())
+                                        .unwrap_or_else(|| ArbBitInt::all_bits_set(lhs.bitw()));
+                                    let cidx = self.m.insert_const(Const::Int(*lhs_tyidx, shr))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => panic!(),
@@ -298,20 +299,22 @@ impl Opt {
                         (Operand::Const(op_cidx), Operand::Var(op_iidx))
                         | (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
                             match self.m.const_(op_cidx) {
-                                Const::Int(_, 0) => {
+                                Const::Int(_, y) if y.to_zero_ext_u64().unwrap() == 0 => {
                                     // Replace `x * 0` with `0`.
                                     self.m.replace(iidx, Inst::Const(op_cidx));
                                 }
-                                Const::Int(_, 1) => {
+                                Const::Int(_, y) if y.to_zero_ext_u64().unwrap() == 1 => {
                                     // Replace `x * 1` with `x`.
                                     self.m.replace(iidx, Inst::Copy(op_iidx));
                                 }
-                                Const::Int(ty_idx, x) if x.is_power_of_two() => {
+                                Const::Int(tyidx, y)
+                                    if y.to_zero_ext_u64().unwrap().is_power_of_two() =>
+                                {
                                     // Replace `x * y` with `x << ...`.
-                                    let shl = u64::from(x.ilog2());
-                                    let shl_op = Operand::Const(
-                                        self.m.insert_const(Const::Int(*ty_idx, shl))?,
-                                    );
+                                    let shl = u64::from(y.to_zero_ext_u64().unwrap().ilog2());
+                                    let shl_op = Operand::Const(self.m.insert_const(
+                                        Const::Int(*tyidx, ArbBitInt::from_u64(y.bitw(), shl)),
+                                    )?);
                                     let new_inst =
                                         BinOpInst::new(Operand::Var(op_iidx), BinOp::Shl, shl_op)
                                             .into();
@@ -333,15 +336,13 @@ impl Opt {
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
-                                    debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(_rhs_tyidx, rhs)) => {
+                                    debug_assert_eq!(lhs_tyidx, _rhs_tyidx);
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    let cidx = self.m.insert_const(Const::Int(
                                         *lhs_tyidx,
-                                        (lhs_v.wrapping_mul(*rhs_v)).truncate(*bits),
-                                    )?;
+                                        lhs.wrapping_mul(rhs),
+                                    ))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => todo!(),
@@ -356,7 +357,7 @@ impl Opt {
                         (Operand::Const(op_cidx), Operand::Var(op_iidx))
                         | (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
                             match self.m.const_(op_cidx) {
-                                Const::Int(_, 0) => {
+                                Const::Int(_, y) if y.to_zero_ext_u64().unwrap() == 0 => {
                                     // Replace `x | 0` with `x`.
                                     self.m.replace(iidx, Inst::Copy(op_iidx));
                                 }
@@ -376,15 +377,12 @@ impl Opt {
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(rhs_tyidx, rhs)) => {
                                     debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
-                                        *lhs_tyidx,
-                                        (lhs_v | rhs_v).truncate(*bits),
-                                    )?;
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    let cidx = self
+                                        .m
+                                        .insert_const(Const::Int(*lhs_tyidx, lhs.bitor(rhs)))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => panic!(),
@@ -397,38 +395,36 @@ impl Opt {
                         self.an.op_map(&self.m, x.rhs(&self.m)),
                     ) {
                         (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
-                            if let Const::Int(_, 0) = self.m.const_(op_cidx) {
-                                // Replace `x << 0` with `x`.
-                                self.m.replace(iidx, Inst::Copy(op_iidx));
+                            if let Const::Int(_, y) = self.m.const_(op_cidx) {
+                                if y.to_zero_ext_u64().unwrap() == 0 {
+                                    // Replace `x << 0` with `x`.
+                                    self.m.replace(iidx, Inst::Copy(op_iidx));
+                                }
                             }
                         }
                         (Operand::Const(op_cidx), Operand::Var(_)) => {
-                            if let Const::Int(tyidx, 0) = self.m.const_(op_cidx) {
-                                // Replace `0 << x` with `0`.
-                                let new_cidx = self.m.insert_const_int(*tyidx, 0)?;
-                                self.m.replace(iidx, Inst::Const(new_cidx));
+                            if let Const::Int(tyidx, y) = self.m.const_(op_cidx) {
+                                if y.to_zero_ext_u64().unwrap() == 0 {
+                                    // Replace `0 << x` with `0`.
+                                    let new_cidx = self.m.insert_const(Const::Int(
+                                        *tyidx,
+                                        ArbBitInt::from_u64(y.bitw(), 0),
+                                    ))?;
+                                    self.m.replace(iidx, Inst::Const(new_cidx));
+                                }
                             }
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(rhs_tyidx, rhs)) => {
                                     debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    // If checked_shl fails, we've encountered LLVM poison: we can
-                                    // now choose any value (in this case 0) and know that we're
-                                    // respecting LLVM's semantics. In case the user's program then
-                                    // has UB and uses the poison value, we make it `int::MAX`
-                                    // because there is a small chance that will make the UB more
-                                    // obvious to them.
-                                    let cidx = self.m.insert_const_int(
-                                        *lhs_tyidx,
-                                        (lhs_v
-                                            .checked_shl(u32::try_from(*rhs_v).unwrap())
-                                            .unwrap_or(u64::MAX))
-                                        .truncate(*bits),
-                                    )?;
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    // If checked_shl fails, we've encountered LLVM poison and can
+                                    // choose any value.
+                                    let shl = lhs
+                                        .checked_shl(rhs.to_zero_ext_u32().unwrap())
+                                        .unwrap_or_else(|| ArbBitInt::all_bits_set(lhs.bitw()));
+                                    let cidx = self.m.insert_const(Const::Int(*lhs_tyidx, shl))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => panic!(),
@@ -441,22 +437,22 @@ impl Opt {
                         self.an.op_map(&self.m, x.rhs(&self.m)),
                     ) {
                         (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
-                            if let Const::Int(_, 0) = self.m.const_(op_cidx) {
-                                // Replace `x - 0` with `x`.
-                                self.m.replace(iidx, Inst::Copy(op_iidx));
+                            if let Const::Int(_, y) = self.m.const_(op_cidx) {
+                                if y.to_zero_ext_u64().unwrap() == 0 {
+                                    // Replace `x - 0` with `x`.
+                                    self.m.replace(iidx, Inst::Copy(op_iidx));
+                                }
                             }
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(rhs_tyidx, rhs)) => {
                                     debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    let cidx = self.m.insert_const(Const::Int(
                                         *lhs_tyidx,
-                                        (lhs_v.wrapping_sub(*rhs_v)).truncate(*bits),
-                                    )?;
+                                        lhs.wrapping_sub(rhs),
+                                    ))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => todo!(),
@@ -472,7 +468,7 @@ impl Opt {
                         (Operand::Const(op_cidx), Operand::Var(op_iidx))
                         | (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
                             match self.m.const_(op_cidx) {
-                                Const::Int(_, 0) => {
+                                Const::Int(_, y) if y.to_zero_ext_u64().unwrap() == 0 => {
                                     // Replace `x ^ 0` with `x`.
                                     self.m.replace(iidx, Inst::Copy(op_iidx));
                                 }
@@ -492,15 +488,12 @@ impl Opt {
                         }
                         (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
                             match (self.m.const_(lhs_cidx), self.m.const_(rhs_cidx)) {
-                                (Const::Int(lhs_tyidx, lhs_v), Const::Int(rhs_tyidx, rhs_v)) => {
+                                (Const::Int(lhs_tyidx, lhs), Const::Int(rhs_tyidx, rhs)) => {
                                     debug_assert_eq!(lhs_tyidx, rhs_tyidx);
-                                    let Ty::Integer(bits) = self.m.type_(*lhs_tyidx) else {
-                                        panic!()
-                                    };
-                                    let cidx = self.m.insert_const_int(
-                                        *lhs_tyidx,
-                                        (lhs_v ^ rhs_v).truncate(*bits),
-                                    )?;
+                                    debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                    let cidx = self
+                                        .m
+                                        .insert_const(Const::Int(*lhs_tyidx, lhs.bitxor(rhs)))?;
                                     self.m.replace(iidx, Inst::Const(cidx));
                                 }
                                 _ => panic!(),
@@ -525,7 +518,7 @@ impl Opt {
                     };
                     // DynPtrAdd indices are signed, so we have to be careful to interpret the
                     // constant as such.
-                    let v = *v as i64;
+                    let v = v.to_sign_ext_i64().unwrap();
                     // LLVM IR allows `off` to be an `i64` but our IR currently allows only an
                     // `i32`. On that basis, we can hit our limits before the program has
                     // itself hit UB, at which point we can't go any further.
@@ -576,7 +569,8 @@ impl Opt {
                     let Const::Int(_, v) = self.m.const_(cidx) else {
                         panic!()
                     };
-                    let op = match v {
+                    debug_assert_eq!(v.bitw(), 1);
+                    let op = match v.to_zero_ext_u8().unwrap() {
                         0 => sinst.falseval(&self.m),
                         1 => sinst.trueval(&self.m),
                         _ => panic!(),
@@ -591,16 +585,14 @@ impl Opt {
             }
             Inst::SExt(x) => {
                 if let Operand::Const(cidx) = self.an.op_map(&self.m, x.val(&self.m)) {
-                    let Const::Int(src_ty, src_val) = self.m.const_(cidx) else {
+                    let Const::Int(_, src_val) = self.m.const_(cidx) else {
                         unreachable!()
                     };
-                    let src_ty = self.m.type_(*src_ty);
                     let dst_ty = self.m.type_(x.dest_tyidx());
-                    let (Ty::Integer(src_bits), Ty::Integer(dst_bits)) = (src_ty, dst_ty) else {
+                    let Ty::Integer(dst_bits) = dst_ty else {
                         unreachable!()
                     };
-                    let dst_val =
-                        Const::Int(x.dest_tyidx(), src_val.sign_extend(*src_bits, *dst_bits));
+                    let dst_val = Const::Int(x.dest_tyidx(), src_val.sign_extend(*dst_bits));
                     let dst_cidx = self.m.insert_const(dst_val)?;
                     self.m.replace(iidx, Inst::Const(dst_cidx));
                 }
@@ -609,7 +601,15 @@ impl Opt {
                 // FIXME: This feels like it should be handled by trace_builder, but we can't
                 // do so yet because of https://github.com/ykjit/yk/issues/1435.
                 if let yksmp::Location::Constant(v) = self.m.param(x.paramidx()) {
-                    let cidx = self.m.insert_const(Const::Int(x.tyidx(), u64::from(*v)))?;
+                    let Ty::Integer(bitw) = self.m.type_(x.tyidx()) else {
+                        unreachable!()
+                    };
+                    // `Location::Constant` is a u32
+                    assert!(*bitw <= 32);
+                    let cidx = self.m.insert_const(Const::Int(
+                        x.tyidx(),
+                        ArbBitInt::from_u64(*bitw, u64::from(*v)),
+                    ))?;
                     self.an.set_value(&self.m, iidx, Value::Const(cidx));
                 }
             }
@@ -664,7 +664,16 @@ impl Opt {
                         Some(Operand::Var(hv_iidx)) => Operand::Var(hv_iidx) == x.val(&self.m),
                         Some(Operand::Const(hv_cidx)) => match val {
                             Operand::Var(_) => false,
-                            Operand::Const(cidx) => self.m.const_(cidx) == self.m.const_(hv_cidx),
+                            Operand::Const(cidx) => {
+                                match (self.m.const_(cidx), self.m.const_(hv_cidx)) {
+                                    (Const::Int(lhs_tyidx, lhs), Const::Int(rhs_tyidx, rhs)) => {
+                                        debug_assert_eq!(lhs_tyidx, rhs_tyidx);
+                                        debug_assert_eq!(lhs.bitw(), rhs.bitw());
+                                        lhs == rhs
+                                    }
+                                    x => todo!("{x:?}"),
+                                }
+                            }
                         },
                     };
                     if is_dead {
@@ -680,18 +689,14 @@ impl Opt {
                     let Const::Int(_src_ty, src_val) = self.m.const_(cidx) else {
                         unreachable!()
                     };
-                    #[cfg(debug_assertions)]
-                    {
-                        let src_ty = self.m.type_(*_src_ty);
-                        let dst_ty = self.m.type_(x.dest_tyidx());
-                        let (Ty::Integer(src_bits), Ty::Integer(dst_bits)) = (src_ty, dst_ty)
-                        else {
-                            unreachable!()
-                        };
-                        debug_assert!(src_bits <= dst_bits);
-                        debug_assert!(*dst_bits <= 64);
-                    }
-                    let dst_cidx = self.m.insert_const(Const::Int(x.dest_tyidx(), *src_val))?;
+                    let dst_ty = self.m.type_(x.dest_tyidx());
+                    let Ty::Integer(dst_bits) = dst_ty else {
+                        unreachable!()
+                    };
+                    debug_assert!(*dst_bits <= 64);
+                    let dst_cidx = self
+                        .m
+                        .insert_const(Const::Int(x.dest_tyidx(), src_val.zero_extend(*dst_bits)))?;
                     self.m.replace(iidx, Inst::Const(dst_cidx));
                 }
             }
@@ -794,22 +799,40 @@ impl Opt {
         let rhs_c = self.m.const_(rhs);
         match (lhs_c, rhs_c) {
             (Const::Float(..), Const::Float(..)) => (),
-            (Const::Int(lhs_tyidx, x), Const::Int(rhs_tyidx, y)) => {
-                debug_assert_eq!(lhs_tyidx, rhs_tyidx);
+            (Const::Int(_, x), Const::Int(_, y)) => {
+                debug_assert_eq!(x.bitw(), y.bitw());
                 // Constant fold comparisons of simple integers.
-                let x = *x;
-                let y = *y;
                 let r = match pred {
-                    Predicate::Equal => x == y,
-                    Predicate::NotEqual => x != y,
-                    Predicate::UnsignedGreater => x > y,
-                    Predicate::UnsignedGreaterEqual => x >= y,
-                    Predicate::UnsignedLess => x < y,
-                    Predicate::UnsignedLessEqual => x <= y,
-                    Predicate::SignedGreater => (x as i64) > (y as i64),
-                    Predicate::SignedGreaterEqual => (x as i64) >= (y as i64),
-                    Predicate::SignedLess => (x as i64) < (y as i64),
-                    Predicate::SignedLessEqual => (x as i64) <= (y as i64),
+                    Predicate::Equal => {
+                        x.to_zero_ext_u64().unwrap() == y.to_zero_ext_u64().unwrap()
+                    }
+                    Predicate::NotEqual => {
+                        x.to_zero_ext_u64().unwrap() != y.to_zero_ext_u64().unwrap()
+                    }
+                    Predicate::UnsignedGreater => {
+                        x.to_zero_ext_u64().unwrap() > y.to_zero_ext_u64().unwrap()
+                    }
+                    Predicate::UnsignedGreaterEqual => {
+                        x.to_zero_ext_u64().unwrap() >= y.to_zero_ext_u64().unwrap()
+                    }
+                    Predicate::UnsignedLess => {
+                        x.to_zero_ext_u64().unwrap() < y.to_zero_ext_u64().unwrap()
+                    }
+                    Predicate::UnsignedLessEqual => {
+                        x.to_zero_ext_u64().unwrap() <= y.to_zero_ext_u64().unwrap()
+                    }
+                    Predicate::SignedGreater => {
+                        (x.to_sign_ext_i64().unwrap()) > (y.to_sign_ext_i64().unwrap())
+                    }
+                    Predicate::SignedGreaterEqual => {
+                        (x.to_sign_ext_i64().unwrap()) >= (y.to_sign_ext_i64().unwrap())
+                    }
+                    Predicate::SignedLess => {
+                        (x.to_sign_ext_i64().unwrap()) < (y.to_sign_ext_i64().unwrap())
+                    }
+                    Predicate::SignedLessEqual => {
+                        (x.to_sign_ext_i64().unwrap()) <= (y.to_sign_ext_i64().unwrap())
+                    }
                 };
 
                 self.m.replace(

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(test, feature(test))]
 #![feature(assert_matches)]
 #![feature(int_roundings)]
+#![feature(let_chains)]
 #![feature(naked_functions)]
 #![feature(ptr_sub_ptr)]
 #![allow(clippy::type_complexity)]

--- a/ykrt/src/log/stats.rs
+++ b/ykrt/src/log/stats.rs
@@ -71,6 +71,7 @@ impl Stats {
     pub fn new() -> Self {
         Self {
             inner: Some(Mutex::new(StatsInner::new("-".to_string()))),
+            #[cfg(feature = "yk_testing")]
             wait_until_condvar: None,
         }
     }


### PR DESCRIPTION
Previously we stored raw `u64`s and expected the user to remember that they needed to zero/sign extend the underlying integer whenever they wanted to do anything with that. We did not always do this, and we did it incorrectly in a couple of places!

This commit introduces a new struct `ArbBitInt` which is basically a pair `(bit_width: u32, value: u64)` which hides the underlying value. To get a raw Rust-level integer you have to call a method, and those methods have names with `sign_extend` and `zero_extend` in them. While one can, of course, call the wrong one, it is now impossible not to sign/zero extend. This struct is currently rather simple, but the API is flexible enough to extend to beyond-64-bit ints transparently. The (fairly extensive) test suite is a bit overkill right now, but is intended to help give us confidence if/when we support more than 64 bit ints in the future.

This commit also necessarily requires a full audit of everything to do with ints-in-traces. That means a lot of code churn, but it's absolutely necessary, and (a) makes much clearer where we should sign/zero extend (b) catches some places where we didn't do this but should.

This commit isn't perfect. In particular, I'm not very happy that `Const::Int` has both a `TyIdx` that contains a bit width *and* an `ArbBitInt` that separately records a bit width. That feels icky, but doing something neater will require at least some ickiness elsewhere. I'll worry about that another day.