### PR TITLE
Don't allow signed pointer comparison.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -156,6 +156,15 @@ impl Module {
                             self.inst(iidx).display(self, iidx)
                         );
                     }
+
+                    if let Ty::Ptr = self.type_(x.lhs(self).tyidx(self)) {
+                        if x.predicate().signed() {
+                            panic!(
+                                "Instruction at position {iidx} compares pointers using a signed predicate\n  {}",
+                                self.inst(iidx).display(self, iidx)
+                            );
+                        }
+                    }
                 }
                 Inst::Select(x) => {
                     let Ty::Integer(bitsize) = self.type_(x.cond(self).tyidx(self)) else {
@@ -418,6 +427,22 @@ mod tests {
                 %0: i8 = param 0
                 %1: i64 = param 1
                 %2: i1 = eq %0, %1
+            ",
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Instruction at position 2 compares pointers using a signed predicate"
+    )]
+    fn cg_icmp_ptr_signed() {
+        Module::from_str(
+            "
+              entry:
+                %0: ptr = param 0
+                %1: ptr = param 1
+                %2: i1 = slt %0, %1
+                black_box %2
             ",
         );
     }

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -677,10 +677,10 @@ impl Opt {
                     Predicate::UnsignedGreaterEqual => x >= y,
                     Predicate::UnsignedLess => x < y,
                     Predicate::UnsignedLessEqual => x <= y,
-                    Predicate::SignedGreater => (x as i64) > (y as i64),
-                    Predicate::SignedGreaterEqual => (x as i64) >= (y as i64),
-                    Predicate::SignedLess => (x as i64) < (y as i64),
-                    Predicate::SignedLessEqual => (x as i64) <= (y as i64),
+                    Predicate::SignedGreater
+                    | Predicate::SignedGreaterEqual
+                    | Predicate::SignedLess
+                    | Predicate::SignedLessEqual => unreachable!(),
                 };
 
                 self.m.replace(


### PR DESCRIPTION
The LLVM manual is unclear as to whether signed pointer comparisons are allowed. I can't see that they make sense, and I haven't yet encountered such things, so I prefer to `panic` if we do see them: this means that I no longer need to worry about zero/sign extending pointers in the optimiser.

[Note: `ptrdiff_t`-esque things clearly can be signed. But I'm not sure that pointers per se make sense as being signed.]