### PR TITLE
Homogenise names

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1391,7 +1391,7 @@ impl<'a> Assemble<'a> {
     fn cg_store(&mut self, iidx: InstIdx, inst: &jit_ir::StoreInst) {
         let (tgt_op, off) = match self.ra.ptradd(iidx) {
             Some(x) => (x.ptr(self.m), x.off()),
-            None => (inst.tgt(self.m), 0),
+            None => (inst.ptr(self.m), 0),
         };
 
         let val = inst.val(self.m);

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1280,7 +1280,7 @@ impl<'a> Assemble<'a> {
     fn cg_load(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::LoadInst) {
         let (ptr_op, off) = match self.ra.ptradd(iidx) {
             Some(x) => (x.ptr(self.m), x.off()),
-            None => (inst.operand(self.m), 0),
+            None => (inst.ptr(self.m), 0),
         };
 
         match self.m.type_(inst.tyidx()) {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -375,7 +375,7 @@ impl<'a> RevAnalyse<'a> {
     /// Analyse a [StoreInst]. Returns `true` if it has been inlined and should not go through the
     /// normal "calculate `inst_vals_alive_until`" phase.
     fn an_store(&mut self, iidx: InstIdx, inst: StoreInst) -> bool {
-        if let Operand::Var(op_iidx) = inst.tgt(self.m) {
+        if let Operand::Var(op_iidx) = inst.ptr(self.m) {
             if let Inst::PtrAdd(pa_inst) = self.m.inst(op_iidx) {
                 self.ptradds[usize::from(iidx)] = Some(pa_inst);
                 if let Operand::Var(y) = pa_inst.ptr(self.m) {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -355,7 +355,7 @@ impl<'a> RevAnalyse<'a> {
     /// Analyse a [LoadInst]. Returns `true` if it has been inlined and should not go through the
     /// normal "calculate `inst_vals_alive_until`" phase.
     fn an_load(&mut self, iidx: InstIdx, inst: LoadInst) -> bool {
-        if let Operand::Var(op_iidx) = inst.operand(self.m) {
+        if let Operand::Var(op_iidx) = inst.ptr(self.m) {
             if let Inst::PtrAdd(pa_inst) = self.m.inst(op_iidx) {
                 self.ptradds[usize::from(iidx)] = Some(pa_inst);
                 if let Operand::Var(y) = pa_inst.ptr(self.m) {

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1577,7 +1577,7 @@ impl Inst {
                 lhs.unpack(m).map_iidx(f);
                 rhs.unpack(m).map_iidx(f);
             }
-            Inst::Load(LoadInst { op, .. }) => op.unpack(m).map_iidx(f),
+            Inst::Load(LoadInst { ptr: op, .. }) => op.unpack(m).map_iidx(f),
             Inst::LookupGlobal(_) => (),
             Inst::Param(_) => (),
             Inst::Call(x) => {
@@ -1786,11 +1786,11 @@ impl Inst {
                 rhs: mapper(m, rhs),
             }),
             Inst::Load(LoadInst {
-                op,
+                ptr,
                 tyidx,
                 volatile,
             }) => Inst::Load(LoadInst {
-                op: mapper(m, op),
+                ptr: mapper(m, ptr),
                 tyidx: *tyidx,
                 volatile: *volatile,
             }),
@@ -1971,7 +1971,7 @@ impl fmt::Display for DisplayableInst<'_> {
                 lhs.unpack(self.m).display(self.m),
                 rhs.unpack(self.m).display(self.m)
             ),
-            Inst::Load(x) => write!(f, "load {}", x.operand(self.m).display(self.m)),
+            Inst::Load(x) => write!(f, "load {}", x.ptr(self.m).display(self.m)),
             Inst::LookupGlobal(x) => write!(
                 f,
                 "lookup_global @{}",
@@ -2263,7 +2263,7 @@ impl BlackBoxInst {
 #[derive(Clone, Copy, Debug)]
 pub struct LoadInst {
     /// The pointer to load from.
-    op: PackedOperand,
+    ptr: PackedOperand,
     /// The type of the pointee.
     tyidx: TyIdx,
     /// Is this load volatile?
@@ -2272,23 +2272,23 @@ pub struct LoadInst {
 
 impl LoadInst {
     // FIXME: why do we need to provide a type index? Can't we get that from the operand?
-    pub(crate) fn new(op: Operand, tyidx: TyIdx, volatile: bool) -> LoadInst {
+    pub(crate) fn new(ptr: Operand, tyidx: TyIdx, volatile: bool) -> LoadInst {
         LoadInst {
-            op: PackedOperand::new(&op),
+            ptr: PackedOperand::new(&ptr),
             tyidx,
             volatile,
         }
     }
 
     fn decopy_eq(&self, m: &Module, other: Self) -> bool {
-        self.op.unpack(m) == other.op.unpack(m)
+        self.ptr.unpack(m) == other.ptr.unpack(m)
             && self.tyidx == other.tyidx
             && self.volatile == other.volatile
     }
 
     /// Return the pointer operand.
-    pub(crate) fn operand(&self, m: &Module) -> Operand {
-        self.op.unpack(m)
+    pub(crate) fn ptr(&self, m: &Module) -> Operand {
+        self.ptr.unpack(m)
     }
 
     /// Returns the type index of the loaded value.

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -76,7 +76,7 @@ impl Analyse {
     pub(super) fn set_value(&self, m: &Module, iidx: InstIdx, v: Value) {
         self.values.borrow_mut()[usize::from(iidx)] = v.clone();
         if let Some(Inst::Load(linst)) = m.inst_nocopy(iidx) {
-            let addr = Address::from_operand(m, linst.operand(m));
+            let addr = Address::from_operand(m, linst.ptr(m));
             self.heapvalues.borrow_mut().load(m, addr, v.to_operand());
         }
     }

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -789,7 +789,7 @@ impl Opt {
 
     fn opt_store(&mut self, iidx: InstIdx, inst: StoreInst) -> Result<(), CompilationError> {
         if !inst.is_volatile() {
-            let tgt = self.an.op_map(&self.m, inst.tgt(&self.m));
+            let tgt = self.an.op_map(&self.m, inst.ptr(&self.m));
             let val = self.an.op_map(&self.m, inst.val(&self.m));
             let is_dead = match self.an.heapvalue(
                 &self.m,

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -698,7 +698,7 @@ impl Opt {
 
     fn opt_load(&mut self, iidx: InstIdx, inst: LoadInst) -> Result<(), CompilationError> {
         if !inst.is_volatile() {
-            let tgt = self.an.op_map(&self.m, inst.operand(&self.m));
+            let tgt = self.an.op_map(&self.m, inst.ptr(&self.m));
             let bytesize = Inst::Load(inst).def_byte_size(&self.m);
             match self.an.heapvalue(
                 &self.m,


### PR DESCRIPTION
While doing lots of JIT IR work I continually tripped over `LoadInst`'s oddly named `operand` function. This PR fixes that, then homogenises `StoreInst`s equivalent. No functional change.

Fixes #1534.