### PR TITLE
Don't give up on a location the first time compiling fails.

### DIFF
--- a/tests/c/early_return1.c
+++ b/tests/c/early_return1.c
@@ -5,8 +5,9 @@
 //   stderr:
 //     yk-jit-event: start-tracing
 //     early return
-//     5
+//     6
 //     yk-jit-event: tracing-aborted
+//     5
 //     4
 //     yk-jit-event: start-tracing
 //     3
@@ -37,10 +38,10 @@ void loop(YkMT *mt, YkLocation *loc, int i) {
   NOOPT_VAL(i);
   while (i > 0) {
     yk_mt_control_point(mt, loc);
-    if (i == 6) {
+    if (i == 7) {
       loop(mt, loc, i - 1);
       i--;
-    } else if (i == 5) {
+    } else if (i == 6) {
       fprintf(stderr, "early return\n");
       return;
     }
@@ -57,7 +58,7 @@ int main(int argc, char **argv) {
   YkLocation loc = yk_location_new();
 
   NOOPT_VAL(loc);
-  loop(mt, &loc, 6);
+  loop(mt, &loc, 7);
   fprintf(stderr, "exit\n");
   yk_location_drop(loc);
   yk_mt_shutdown(mt);


### PR DESCRIPTION
This comment in the code was partly wrong:

```
// FIXME: We will endless retry tracing this
// [HotLocation]. There should be a `Counting`
// state.
```

In fact, we wouldn't endlessly retry: the `HotLocation` would get stuck in the `Compiling` state. Still, the end effect was the same as the comment suggested!

This commit allows `HotLocation`s to transition back to the `Counting` state so that we can retry. That requires allowing `HotLocations` to also be in the `Counting` state: in other words, we can "count" both with and without a `HotLocation`.