### PR TITLE
Allow longer traces

### DIFF
--- a/tests/c/trace_too_long.c
+++ b/tests/c/trace_too_long.c
@@ -24,14 +24,14 @@ int main(int argc, char **argv) {
   YkLocation loc1 = yk_location_new();
   YkLocation loc2 = yk_location_new();
 
-  int i = 2000;
+  int i = 10000;
   NOOPT_VAL(loc1);
   NOOPT_VAL(loc2);
   NOOPT_VAL(i);
   YkLocation *loc = &loc1;
   while (i > 0) {
     yk_mt_control_point(mt, loc);
-    if (i == 2000)
+    if (i == 10000)
       loc = &loc2;
     else if (i == 2)
       loc = &loc1;

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -50,7 +50,7 @@ pub type AtomicTraceCompilationErrorThreshold = AtomicU16;
 /// slower our compiler, the lower this will have to be in order to give the perception of
 /// reasonable performance.
 /// FIXME: needs to be configurable.
-pub(crate) const DEFAULT_TRACE_TOO_LONG: usize = 5000;
+pub(crate) const DEFAULT_TRACE_TOO_LONG: usize = 20000;
 const DEFAULT_HOT_THRESHOLD: HotThreshold = 50;
 const DEFAULT_SIDETRACE_THRESHOLD: HotThreshold = 5;
 /// How often can a [HotLocation] or [Guard] lead to an error in tracing or compilation before we


### PR DESCRIPTION
This PR is as much a RFC as "let's merge this". Right now, we reject a lot of traces as being "too long". There are two current causes for this:

1. We exceeded the PT buffer.
2. We exceeded yk's willingness to compile the trace.

It's easy to think these two cases are the same, but they're not. With `YK_LOG=3` the first case will be detected as stop-tracing time; the second case at compilation time.

This PR only tackles the second case: it allows yk to compile longer traces. First, I think we should give up on the 16/15-bit `InstIdx`s, at least for now: it's a very small type, and probably too restrictive. https://github.com/ykjit/yk/commit/04d3e8ae22fae3f03917f9da4ad562929088b989 changes this to 32/31 bits. Note: `Inst`s now become two machine words big. I think this is fine for now.

That then allows us to increase the size of traces we'll compile. How high is too high? We don't yet know, but it seems worth it to me to substantially increase the size 20,000 is still, I suspect, a fairly conservative limit https://github.com/ykjit/yk/commit/efad15801d691cb6eb90285947ab0dd8109178ba. But we're going to have to experiment with longer traces in order to know "how long is too long", so perhaps we should go higher, at least temporarily.