### PR TITLE
Fix all clippy lints and update deku.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 byteorder = "1.4.3"
-deku = "0.16.0"
+deku = "0.18.1"
 intervaltree = "0.2.7"
 leb128 = "0.2.5"
 libc = "0.2.148"

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 byteorder = "1.4.3"
-deku = { version = "0.16.0", features = ["std"] }
+deku = { version = "0.18.1", features = ["std"] }
 dynasmrt = "3.0.0"
 indexmap = "2.2.6"
 libc = "0.2.148"

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -29,6 +29,7 @@
 use byteorder::{NativeEndian, ReadBytesExt};
 use deku::prelude::*;
 use std::{
+    borrow::Cow,
     collections::HashMap,
     error::Error,
     ffi::{CString, OsStr},
@@ -363,7 +364,7 @@ fn map_to_string(v: Vec<u8>) -> Result<String, DekuError> {
             return Ok(x);
         }
     }
-    Err(DekuError::Parse("Couldn't map string".to_owned()))
+    Err(DekuError::Parse(Cow::Borrowed("Couldn't map string")))
 }
 
 /// Convert the bytes of a null-terminated string into a PathBuf.
@@ -403,7 +404,7 @@ fn map_to_lineinfo(v: Vec<RawLineInfoRec>) -> Result<HashMap<InstID, LineInfoLoc
 /// A binary operator.
 #[deku_derive(DekuRead)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum BinOp {
     /// The canonicalised form of `Add` in JIT IR is (Var, Var) or (Var, Const).
     Add = 0,
@@ -515,7 +516,7 @@ impl BBlockId {
 /// from there.
 #[deku_derive(DekuRead)]
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum Predicate {
     /// "eq: yields true if the operands are equal, false otherwise. No sign
     /// interpretation is necessary or performed."
@@ -591,7 +592,7 @@ impl Display for Predicate {
 /// Predicates for use in numeric comparisons.
 #[deku_derive(DekuRead)]
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum FloatPredicate {
     // FIXME: eventually remove False/True (always false/always true) predicates. LLVM has them,
     // but we can lower these to constants in our IR.
@@ -671,7 +672,7 @@ impl Display for FloatPredicate {
 /// hierarchy here: https://llvm.org/doxygen/classllvm_1_1CastInst.html
 #[deku_derive(DekuRead)]
 #[derive(Debug, Clone, Copy)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum CastKind {
     SExt = 0,
     ZeroExtend = 1,
@@ -699,7 +700,7 @@ impl Display for CastKind {
 
 #[deku_derive(DekuRead)]
 #[derive(Debug, Clone, Hash)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum Operand {
     #[deku(id = "0")]
     Const(ConstIdx),
@@ -826,7 +827,7 @@ impl fmt::Display for DisplayableDeoptSafepoint<'_> {
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
 #[repr(u8)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum Inst {
     #[deku(id = "0")]
     Nop,
@@ -1702,7 +1703,7 @@ impl fmt::Display for DisplayableFuncTy<'_> {
 /// Floating point types.
 #[deku_derive(DekuRead)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum FloatTy {
     // 32-bit floating point.
     #[deku(id = "0")]
@@ -1781,7 +1782,7 @@ const TYKIND_UNIMPLEMENTED: u8 = 255;
 /// A type.
 #[deku_derive(DekuRead)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum Ty {
     #[deku(id = "TYKIND_VOID")]
     Void,
@@ -1859,7 +1860,7 @@ impl fmt::Display for DisplayableTy<'_> {
 /// Constants not handled by the ykllvm serialiser become `Const::Unimplemented`.
 #[deku_derive(DekuRead)]
 #[derive(Debug)]
-#[deku(type = "u8")]
+#[deku(id_type = "u8")]
 pub(crate) enum Const {
     #[deku(id = "0")]
     Val(ConstVal),

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -95,7 +95,7 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
                 let func = self.aot_mod.funcidx(func_name);
                 Some(aot_ir::BBlockId::new(func, aot_ir::BBlockIdx::new(*bb)))
             }
-            TraceAction::UnmappableBBlock { .. } => None,
+            TraceAction::UnmappableBBlock => None,
             TraceAction::Promotion => todo!(),
         }
     }

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -54,7 +54,7 @@ pub enum Location {
     /// * `u16`: Dwarf register number
     /// * `u16`: size of the value
     /// * `Vec<u16>`: additional locations. >=0  is a DWARF register number. < 0 is a stack offset
-    ///    relative to rbp (and [rbp-0] cannot be expressed, nor do we need to).
+    ///   relative to rbp (and [rbp-0] cannot be expressed, nor do we need to).
     ///
     /// FIXME: We may need more additional locations in the future, which however will require
     /// rewriting the stackmap format (until now we managed to get by with two extra locations).


### PR DESCRIPTION
No functional change.

Many of the lints came from deku macros, so to do a proper job of fixing the lints I had to upgrade deku and the API had changed quite a bit.

Namely certain parts of the API are now byte- (not bit)-centric.

Newer dekus also claim to be more performant:
https://github.com/sharksforarms/deku/blob/master/CHANGELOG.md