### PR TITLE
Remove `root` attribute from `Executing`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -54,7 +54,7 @@ pub(crate) extern "C" fn __yk_guardcheck(
 ///
 /// * gidxs - List of [GuardIdx]'s for previous guard failures.
 fn running_trace(gidxs: &[usize]) -> Arc<X64CompiledTrace> {
-    let (ctr, _) = MTThread::with(|mtt| mtt.running_trace());
+    let ctr = MTThread::with(|mtt| mtt.running_trace());
     let mut ctr = ctr
         .clone()
         .unwrap()


### PR DESCRIPTION
I am not sure if/when this was ever used, but in the current code the attribute is only ever to `None`, and thus has no meaningful effect on behaviour.