### PR TITLE
Catch another case of problematic control flow for tracing.

### DIFF
--- a/tests/c/exit_and_reenter_interploop.c
+++ b/tests/c/exit_and_reenter_interploop.c
@@ -1,0 +1,50 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YK_LOG=4
+//   stderr:
+//     enter
+//     yk-jit-event: start-tracing
+//     1
+//     exit
+//     enter
+//     yk-jit-event: stop-tracing
+//     yk-warning: trace-compilation-aborted: returned from function that started tracing
+//     ...
+
+// Check that returning from the function that started tracing, then
+// re-entering it and stopping tracing, causes the trace to be aborted.
+//
+// This is an interesting case because the frame address of the place we start
+// and stop tracing is the same, so mt.rs cannot catch this.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+#include <stdbool.h>
+
+void f(YkMT *mt, YkLocation *loc, int i) {
+  fprintf(stderr, "enter\n");
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    fprintf(stderr, "%d\n", i);
+    i -= 1;
+  }
+  fprintf(stderr, "exit\n");
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+  int i = 1;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  f(mt, &loc, i);
+  f(mt, &loc, i);
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
This change catches the case where we exit the function that started tracing, but re-enter it later and stop tracing. This is problematic for tracing, as evidenced by trace builder crashing with variable mapping problems (it doesn't know about variables in the parent function).

We already have a check in place that was designed to detect "exiting from the function that started tracing", but it's not sufficient for the above scenario: it checks that the frame addresses at the time we start and stop tracing are the same. Here they are the same.

To fix this, while building the trace, we check if a `Inst::Ret` would cause the trace builder's frame stack to become empty.

It's still worth keeping the old check around, since they detect a subset of the "bad returns" earlier than this new check.