### PR TITLE
Rename `YK_LOG` to `YKD_LOG`.

### DIFF
--- a/docs/src/dev/runtime_config.md
+++ b/docs/src/dev/runtime_config.md
@@ -10,22 +10,6 @@ Variables prefixed with `YK_` allow the user to control aspects of yk's executio
 
 The following environment variables are available:
 
-* `YK_LOG=[<path>:]<level>` specifies where, and how much, general information
-  yk will log during execution.
-
-  If `<path>:` (i.e. a path followed by ":") is specified then output is sent
-  to that path. The special value `-` (i.e. a single dash) can be used for
-  `<path>` to indicate stderr. If not specified, logs to stderr.
-
-  `<level>` specifies the level of logging, each adding to the previous: level
-  0 turns off all yk logging; level 1 shows major errors only; and level 2
-  warnings. Levels above 3 are used for internal yk debugging, and their
-  precise output, and indeed the maximum level may change without warning.
-  Currently: level 3 logs transitions of a `Location` transition; and level 4
-  JIT events such as starting/stopping tracing. Note that some information, at
-  all levels, may or may not be displayed based on compile-time options.
-  Defaults to 1.
-
 * `YK_HOT_THRESHOLD`: an integer from 0..4294967295 (both inclusive) that
   determines how many executions of a hot loop are needed before it is traced.
   Defaults to 50.
@@ -40,5 +24,20 @@ performance down.
 
 The following environment variables are available (some only in certain configurations of yk):
 
+* `YKD_LOG=[<path>:]<level>` specifies where, and how much, general information
+  yk will log during execution.
+
+  If `<path>:` (i.e. a path followed by ":") is specified then output is sent
+  to that path. The special value `-` (i.e. a single dash) can be used for
+  `<path>` to indicate stderr. If not specified, logs to stderr.
+
+  `<level>` specifies the level of logging, each adding to the previous: level
+  0 turns off all yk logging; level 1 shows major errors only; and level 2
+  warnings. Levels above 3 are used for internal yk debugging, and their
+  precise output, and indeed the maximum level may change without warning.
+  Currently: level 3 logs transitions of a `Location` transition; and level 4
+  JIT events such as starting/stopping tracing. Note that some information, at
+  all levels, may or may not be displayed based on compile-time options.
+  Defaults to 1.
 * [`YKD_LOG_IR`](understanding_traces.html#ykd_log_ir) [with the `ykd` feature]
 * [`YKD_LOG_STATS`](profiling.html#jit-statistics)

--- a/tests/c/arg_mapping_callee.c
+++ b/tests/c/arg_mapping_callee.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     3:5

--- a/tests/c/arithmetic.c
+++ b/tests/c/arithmetic.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     add 5

--- a/tests/c/ashr_exact.c
+++ b/tests/c/ashr_exact.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     ashr 4

--- a/tests/c/bf.O0.c
+++ b/tests/c/bf.O0.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/bf.O1.c
+++ b/tests/c/bf.O1.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O1
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/bf.O2.c
+++ b/tests/c/bf.O2.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O2
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/bf.O3.c
+++ b/tests/c/bf.O3.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O3
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/call_args.c
+++ b/tests/c/call_args.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     3: 5

--- a/tests/c/call_ext_in_obj.c
+++ b/tests/c/call_ext_in_obj.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4

--- a/tests/c/calls_double.c
+++ b/tests/c/calls_double.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/choice.c
+++ b/tests/c/choice.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:

--- a/tests/c/conditionals.c
+++ b/tests/c/conditionals.c
@@ -1,5 +1,5 @@
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...

--- a/tests/c/const_global.c
+++ b/tests/c/const_global.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4

--- a/tests/c/constexpr.c
+++ b/tests/c/constexpr.c
@@ -2,7 +2,7 @@
 // ignore-if: true
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...

--- a/tests/c/double.c
+++ b/tests/c/double.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 4.000000

--- a/tests/c/doubleinline.c
+++ b/tests/c/doubleinline.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4

--- a/tests/c/dyn_ptradd_mixed.c
+++ b/tests/c/dyn_ptradd_mixed.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4, y=7

--- a/tests/c/dyn_ptradd_multidim.c
+++ b/tests/c/dyn_ptradd_multidim.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=0, elem=000

--- a/tests/c/dyn_ptradd_simple.c
+++ b/tests/c/dyn_ptradd_simple.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4, elem=14

--- a/tests/c/early_return1.c
+++ b/tests/c/early_return1.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     early return

--- a/tests/c/early_return2.c
+++ b/tests/c/early_return2.c
@@ -2,7 +2,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     b3

--- a/tests/c/exit_and_reenter_interploop.c
+++ b/tests/c/exit_and_reenter_interploop.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     enter
 //     yk-jit-event: start-tracing

--- a/tests/c/fcmp_double.c
+++ b/tests/c/fcmp_double.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     1.100000 == 2.200000: 0

--- a/tests/c/fcmp_float.c
+++ b/tests/c/fcmp_float.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     1.100000 == 2.200000: 0

--- a/tests/c/fib.c
+++ b/tests/c/fib.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4:21

--- a/tests/c/float.c
+++ b/tests/c/float.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 4.000000

--- a/tests/c/float_binop.c
+++ b/tests/c/float_binop.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 4.333300 4.840000

--- a/tests/c/float_consts.c
+++ b/tests/c/float_consts.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 3.350000, 4.500000

--- a/tests/c/float_div.c
+++ b/tests/c/float_div.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 8.000000 20.000000

--- a/tests/c/float_mul.c
+++ b/tests/c/float_mul.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 1.333200 3.360000

--- a/tests/c/float_store.c
+++ b/tests/c/float_store.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 -> 3.252033

--- a/tests/c/fp_in_out.c
+++ b/tests/c/fp_in_out.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     5.100000

--- a/tests/c/fp_to_si.c
+++ b/tests/c/fp_to_si.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4

--- a/tests/c/funcptrarg_hasir.c
+++ b/tests/c/funcptrarg_hasir.c
@@ -2,7 +2,7 @@
 // ignore-if: true
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     FIXME: match the indirect call

--- a/tests/c/funcptrarg_noir.c
+++ b/tests/c/funcptrarg_noir.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     z=3

--- a/tests/c/funcptrarg_pretrace.c
+++ b/tests/c/funcptrarg_pretrace.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin jit-pre-opt ---

--- a/tests/c/icmp_ptr.c
+++ b/tests/c/icmp_ptr.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/indirect_branch.c
+++ b/tests/c/indirect_branch.c
@@ -2,7 +2,7 @@
 // ignore-if: true
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     FIXME: match some IR/output
 //     ...

--- a/tests/c/indirect_call.c
+++ b/tests/c/indirect_call.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     foo 7

--- a/tests/c/indirect_external_function_call.c
+++ b/tests/c/indirect_external_function_call.c
@@ -2,7 +2,7 @@
 // ignore-if: true
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stdout:
 //     205

--- a/tests/c/inline_asm.c
+++ b/tests/c/inline_asm.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   status: error
 
 // Check that we can handle inline asm properly (currently expectely fails

--- a/tests/c/inline_const.c
+++ b/tests/c/inline_const.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     foo 3

--- a/tests/c/inst_type_depends_global.c
+++ b/tests/c/inst_type_depends_global.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/internal_linkage_same_obj.c
+++ b/tests/c/internal_linkage_same_obj.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/intrinsic_noinline.c
+++ b/tests/c/intrinsic_noinline.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     yk-jit-event: stop-tracing

--- a/tests/c/intrinsics.c
+++ b/tests/c/intrinsics.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     yk-jit-event: stop-tracing

--- a/tests/c/many_threads_many_locs.c
+++ b/tests/c/many_threads_many_locs.c
@@ -1,7 +1,7 @@
 // ## Shadow stack isn't thread safe.
 // ignore-if: true
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/many_threads_one_loc.c
+++ b/tests/c/many_threads_one_loc.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/mutable_global.c
+++ b/tests/c/mutable_global.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4, g=1000

--- a/tests/c/neg_ptradd.c
+++ b/tests/c/neg_ptradd.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=9

--- a/tests/c/neg_ptradd_dyn.c
+++ b/tests/c/neg_ptradd_dyn.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=9

--- a/tests/c/neg_ptradd_dyn_ptr.c
+++ b/tests/c/neg_ptradd_dyn_ptr.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=0, deref=9

--- a/tests/c/nested_execution.c
+++ b/tests/c/nested_execution.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     enter
 //     yk-jit-event: start-tracing

--- a/tests/c/nested_sidetrace.c
+++ b/tests/c/nested_sidetrace.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/nested_writetoptr.c
+++ b/tests/c/nested_writetoptr.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     yk-jit-event: stop-tracing

--- a/tests/c/no_trace_annotation.c
+++ b/tests/c/no_trace_annotation.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/no_trace_annotation2.c
+++ b/tests/c/no_trace_annotation2.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/noopts.c
+++ b/tests/c/noopts.c
@@ -1,5 +1,5 @@
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=aot
 //   stderr:

--- a/tests/c/outline.c
+++ b/tests/c/outline.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4, r=10

--- a/tests/c/outline_recursion.c
+++ b/tests/c/outline_recursion.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     0

--- a/tests/c/outline_recursion_indirect.c
+++ b/tests/c/outline_recursion_indirect.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     0

--- a/tests/c/phi1.c
+++ b/tests/c/phi1.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/phi2.c
+++ b/tests/c/phi2.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/phi3.c
+++ b/tests/c/phi3.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/promote.c
+++ b/tests/c/promote.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/promote_expr.c
+++ b/tests/c/promote_expr.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/promote_guard.c
+++ b/tests/c/promote_guard.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     y=100

--- a/tests/c/promote_many.c
+++ b/tests/c/promote_many.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/pt_zero_len_call.c
+++ b/tests/c/pt_zero_len_call.c
@@ -1,7 +1,7 @@
 // ignore-if: test ${YK_ARCH} != "x86_64"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/ptr_global.c
+++ b/tests/c/ptr_global.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     i=12

--- a/tests/c/ptradd.c
+++ b/tests/c/ptradd.c
@@ -2,7 +2,7 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/ptrtoint.c
+++ b/tests/c/ptrtoint.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     ptr: {{ptr}}

--- a/tests/c/qsort.c
+++ b/tests/c/qsort.c
@@ -2,7 +2,7 @@
 // ignore-if: test true
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=2

--- a/tests/c/reentrant.c
+++ b/tests/c/reentrant.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 
 // Check that we can reliably deal with "foreign" (not compiled with ykllvm)
 // code that calls back into "native code".

--- a/tests/c/rel_path.c
+++ b/tests/c/rel_path.c
@@ -1,6 +1,6 @@
 // Compiler:
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:

--- a/tests/c/resume_and_branch.c
+++ b/tests/c/resume_and_branch.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/safepoint_const.c
+++ b/tests/c/safepoint_const.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 
 // Check deopt of constants works.
 

--- a/tests/c/sdiv.c
+++ b/tests/c/sdiv.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     sdiv1 -10922

--- a/tests/c/select.c
+++ b/tests/c/select.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4 1 1

--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     we jumped

--- a/tests/c/shadow_longjmp.c
+++ b/tests/c/shadow_longjmp.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     11
 //     10

--- a/tests/c/shadow_reentrant.c
+++ b/tests/c/shadow_reentrant.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     i=4, x=0, argc=1
 //     i=3, x=0, argc=1

--- a/tests/c/side-trace.c
+++ b/tests/c/side-trace.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=-
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:

--- a/tests/c/sidetrace_phinode.old.c
+++ b/tests/c/sidetrace_phinode.old.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stdout:
 //     exit
 

--- a/tests/c/sidetrace_while.old.c
+++ b/tests/c/sidetrace_while.old.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: execute-side-trace

--- a/tests/c/signextend_negative.c
+++ b/tests/c/signextend_negative.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     neg=-1

--- a/tests/c/signextend_positive.c
+++ b/tests/c/signextend_positive.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     pos=1

--- a/tests/c/simple.c
+++ b/tests/c/simple.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4

--- a/tests/c/simple_binop.c
+++ b/tests/c/simple_binop.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     and 0

--- a/tests/c/simple_fprintf.c
+++ b/tests/c/simple_fprintf.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=4

--- a/tests/c/simple_inline.c
+++ b/tests/c/simple_inline.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     foo 7

--- a/tests/c/simple_interp_loop1.c
+++ b/tests/c/simple_interp_loop1.c
@@ -1,5 +1,5 @@
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/simple_interp_loop2.c
+++ b/tests/c/simple_interp_loop2.c
@@ -1,5 +1,5 @@
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/simple_nested.c
+++ b/tests/c/simple_nested.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=5

--- a/tests/c/simple_non_serialised.c
+++ b/tests/c/simple_non_serialised.c
@@ -1,5 +1,5 @@
 // Run-time:
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
 //     yk-jit-event: start-tracing

--- a/tests/c/simple_peeling.c
+++ b/tests/c/simple_peeling.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin jit-post-opt ---

--- a/tests/c/simplecall.c
+++ b/tests/c/simplecall.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4

--- a/tests/c/smmultisrc.c
+++ b/tests/c/smmultisrc.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stdout:
 //     1 2 3 4 5 6
 //     1 2 3 4 5 6

--- a/tests/c/smmultisrc2.c
+++ b/tests/c/smmultisrc2.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stdout:
 //     1 2 3 4 5 6
 //     1 2 3 4 5 6

--- a/tests/c/srem.c
+++ b/tests/c/srem.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     srem 3

--- a/tests/c/strarray.c
+++ b/tests/c/strarray.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     pepper

--- a/tests/c/struct_simple.c
+++ b/tests/c/struct_simple.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: start-tracing

--- a/tests/c/switch_default.c
+++ b/tests/c/switch_default.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=3

--- a/tests/c/switch_many_guards_failing.c
+++ b/tests/c/switch_many_guards_failing.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stdout:
 //     jihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcbajihgfedcba

--- a/tests/c/switch_non_default.c
+++ b/tests/c/switch_non_default.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=3

--- a/tests/c/trace_too_long.c
+++ b/tests/c/trace_too_long.c
@@ -6,7 +6,7 @@
 // ignore-if: test "$YKB_TRACER" != "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-warning: stop-tracing-aborted: Trace too long

--- a/tests/c/trace_too_long_hwt.c
+++ b/tests/c/trace_too_long_hwt.c
@@ -3,7 +3,7 @@
 // ## on hwt.
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-warning: stop-tracing-aborted: Trace too long

--- a/tests/c/tracing_recursion1.c
+++ b/tests/c/tracing_recursion1.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     6
 //     yk-jit-event: start-tracing

--- a/tests/c/truncate.c
+++ b/tests/c/truncate.c
@@ -1,6 +1,6 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     u64 18446744073709551615

--- a/tests/c/udiv.c
+++ b/tests/c/udiv.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     udiv 21845

--- a/tests/c/unintptr_t_to_ptr.c
+++ b/tests/c/unintptr_t_to_ptr.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     4: 0x4

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -2,7 +2,7 @@
 // ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     set jump point

--- a/tests/c/varargs.c
+++ b/tests/c/varargs.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=6

--- a/tests/c/varargs_inlined.c
+++ b/tests/c/varargs_inlined.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     i=1

--- a/tests/c/void_ret.c
+++ b/tests/c/void_ret.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     yk-jit-event: enter-jit-code

--- a/tests/c/yk_debug_str.c
+++ b/tests/c/yk_debug_str.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/yk_debug_str_outline.c
+++ b/tests/c/yk_debug_str_outline.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     ...
 //     --- Begin aot ---

--- a/tests/c/zext.c
+++ b/tests/c/zext.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YK_LOG=4
+//   env-var: YKD_LOG=4
 //   stderr:
 //     yk-jit-event: start-tracing
 //     int to long 4

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -34,7 +34,7 @@ pub(crate) struct Log {
 
 impl Log {
     pub(crate) fn new() -> Result<Self, Box<dyn Error>> {
-        match env::var("YK_LOG") {
+        match env::var("YKD_LOG") {
             Ok(s) => {
                 let (path, level) = match s.split(':').collect::<Vec<_>>()[..] {
                     [path, level] => {
@@ -49,16 +49,16 @@ impl Log {
                         }
                     }
                     [level] => (None, level),
-                    [..] => return Err("YK_LOG must be of the format `[<path|->:]<level>".into()),
+                    [..] => return Err("YKD_LOG must be of the format `[<path|->:]<level>".into()),
                 };
                 let level = level
                     .parse::<u8>()
-                    .map_err(|e| format!("Invalid YK_LOG level '{s}': {e}"))?;
+                    .map_err(|e| format!("Invalid YKD_LOG level '{s}': {e}"))?;
                 // This unwrap can only fail dynamically if we've got the types wrong statically
                 // (i.e. it'll fail as soon as this code is executed for the first time).
                 let max_level = u8::try_from(Verbosity::COUNT).unwrap() - 1;
                 let level = Verbosity::from_repr(level)
-                    .ok_or_else(|| format!("YK_LOG level {level} exceeds maximum {max_level}"))?;
+                    .ok_or_else(|| format!("YKD_LOG level {level} exceeds maximum {max_level}"))?;
                 Ok(Self { path, level })
             }
             Err(_) => Ok(Self {


### PR DESCRIPTION
This is something we expect interpreter authors might need, which is how we defined `YKD` in the docs:

> Variables prefixed with `YKD_` are intended to help interpreter
> authors debug performance issues.