### PR TITLE
Explicitly flush `stdout`.

### DIFF
--- a/tests/c/call_ext_simple.c
+++ b/tests/c/call_ext_simple.c
@@ -34,6 +34,7 @@ int main(int argc, char **argv) {
     putchar(ch);
     ch++;
   }
+  fflush(stdout);
 
   yk_location_drop(loc);
   yk_mt_shutdown(mt);


### PR DESCRIPTION
Once in a blue moon this test fails because nothing appears on `stdout`. This is technically allowed, I believe, because unless we flush `stdout` explicitly, non-interactive `stdout` is not guaranteed to be flushed, even on (normal or abnormal) program exit.

If the test fails after this change, it suggests there's a "real" problem.