### PR TITLE
Temporarily disable Havlak in CI.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -228,6 +228,7 @@ for tracer in $TRACERS; do
         ln -s ../yklua .
         sed -e 's/executions: \[Lua, YkLua\]/executions: [YkLua]/' \
             -e 's/executable: yklua/executable: lua/' \
+            -e '/Havlak/{N; d;}' \
             rebench.conf > rebench2.conf
         ~/.local/bin/rebench --quick --no-denoise -c rebench2.conf
         cd ..


### PR DESCRIPTION
We know this test fails, and rather than retry PRs, we might as well acknowledge that testing this in CI is currently not the right approach. As soon as we've fixed the underlying bug, we can remove the `sed` line in this commit and easily reenable Havlak.