### PR TITLE
Stop tracing when we start unrolling.

### DIFF
--- a/tests/c/nested_execution.c
+++ b/tests/c/nested_execution.c
@@ -7,30 +7,8 @@
 //     yk-jit-event: start-tracing
 //     6
 //     enter
+//     yk-jit-event: tracing-aborted
 //     5
-//     4
-//     3
-//     2
-//     1
-//     return
-//     yk-jit-event: stop-tracing
-//     --- Begin jit-pre-opt ---
-//       ...
-//       guard true, ...
-//       ...
-//       guard false, ...
-//       ...
-//       guard false, ...
-//       ...
-//       guard false, ...
-//       ...
-//       guard true, ...
-//       ...
-//       guard true, ...
-//       ...
-//     --- End jit-pre-opt ---
-//     5
-//     enter
 //     yk-jit-event: start-tracing
 //     4
 //     yk-jit-event: stop-tracing
@@ -49,35 +27,51 @@
 //     1
 //     yk-jit-event: deoptimise
 //     return
-//     yk-jit-event: enter-jit-code
-//     4
+//     yk-jit-event: start-tracing
+//     5
 //     enter
+//     yk-jit-event: tracing-aborted
+//     4
 //     yk-jit-event: enter-jit-code
 //     3
 //     2
 //     1
 //     yk-jit-event: deoptimise
+//     yk-jit-event: start-side-tracing
 //     return
+//     yk-jit-event: tracing-aborted
+//     4
+//     enter
+//     yk-jit-event: start-tracing
+//     3
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//     ...
+//     --- End jit-pre-opt ---
+//     2
+//     yk-jit-event: enter-jit-code
+//     1
 //     yk-jit-event: deoptimise
+//     return
+//     yk-jit-event: start-tracing
 //     c
 //     3
 //     enter
-//     yk-jit-event: enter-jit-code
+//     yk-jit-event: tracing-aborted
 //     2
+//     yk-jit-event: enter-jit-code
 //     1
 //     yk-jit-event: deoptimise
+//     yk-jit-event: start-side-tracing
 //     return
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-jit-event: tracing-aborted
 //     b
 //     2
 //     enter
-//     yk-jit-event: enter-jit-code
+//     yk-jit-event: start-tracing
 //     1
-//     yk-jit-event: deoptimise
 //     return
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-jit-event: tracing-aborted
 //     a
 //     1
 //     enter
@@ -120,6 +114,7 @@ void f(YkMT *mt, int who, YkLocation *loc1, YkLocation *loc2, int i) {
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
+  yk_mt_sidetrace_threshold_set(mt, 2);
   YkLocation loc1 = yk_location_new();
   YkLocation loc2 = yk_location_new();
   int i = 6;

--- a/tests/c/trace_too_long.c
+++ b/tests/c/trace_too_long.c
@@ -1,8 +1,6 @@
 // ## This tests that traces that generate too many blocks cause "trace too
 // ## long" warnings. This can be very slow (e.g. on swt), so ignore it except
 // ## where we know it'll run fast enough.
-// ##
-// ## FIXME: doesn't trigger "trace too long".
 // ignore-if: test "$YKB_TRACER" != "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
@@ -21,26 +19,28 @@
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
-  YkLocation loc1 = yk_location_new();
-  YkLocation loc2 = yk_location_new();
+  YkLocation loc = yk_location_new();
 
-  int i = 10000;
-  NOOPT_VAL(loc1);
-  NOOPT_VAL(loc2);
+  int i = 10;
+  int t = 0;
+  NOOPT_VAL(loc);
   NOOPT_VAL(i);
-  YkLocation *loc = &loc1;
+  NOOPT_VAL(t);
   while (i > 0) {
-    yk_mt_control_point(mt, loc);
-    if (i == 10000)
-      loc = &loc2;
-    else if (i == 2)
-      loc = &loc1;
-    fprintf(stdout, "i=%d\n", i);
+    yk_mt_control_point(mt, &loc);
+    if (i == 10) {
+      int j = 10000;
+      while (j > 0) {
+        t++;
+        j--;
+      }
+    }
+    NOOPT_VAL(i);
     i--;
   }
+  printf("exit");
   NOOPT_VAL(i);
-  yk_location_drop(loc1);
-  yk_location_drop(loc2);
+  yk_location_drop(loc);
   yk_mt_shutdown(mt);
   return (EXIT_SUCCESS);
 }

--- a/tests/c/trace_too_long_hwt.c
+++ b/tests/c/trace_too_long_hwt.c
@@ -18,27 +18,28 @@
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);
-  YkLocation loc1 = yk_location_new();
-  YkLocation loc2 = yk_location_new();
+  YkLocation loc = yk_location_new();
 
-  int i = 100000;
-  NOOPT_VAL(loc1);
-  NOOPT_VAL(loc2);
+  int i = 10;
+  int t = 0;
+  NOOPT_VAL(loc);
   NOOPT_VAL(i);
-  YkLocation *loc = &loc1;
+  NOOPT_VAL(t);
   while (i > 0) {
-    yk_mt_control_point(mt, loc);
-    if (i == 100000)
-      loc = &loc2;
-    else if (i == 2)
-      loc = &loc1;
+    yk_mt_control_point(mt, &loc);
+    if (i == 10) {
+      int j = 100000000;
+      while (j > 0) {
+        t++;
+        j--;
+      }
+    }
     NOOPT_VAL(i);
     i--;
   }
   printf("exit");
   NOOPT_VAL(i);
-  yk_location_drop(loc1);
-  yk_location_drop(loc2);
+  yk_location_drop(loc);
   yk_mt_shutdown(mt);
   return (EXIT_SUCCESS);
 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -267,9 +267,18 @@ pub(crate) extern "C" fn __yk_deopt(
                                 unsafe { rbp.offset(isize::from(*extra)) }
                             };
                             match size {
-                                8 => unsafe { ptr::write::<u64>(temp as *mut u64, jitval) },
-                                4 => unsafe { ptr::write::<u32>(temp as *mut u32, jitval as u32) },
+                                1 => unsafe { ptr::write::<u16>(temp as *mut u16, jitval as u16) },
                                 2 => unsafe { ptr::write::<u16>(temp as *mut u16, jitval as u16) },
+                                4 => unsafe { ptr::write::<u32>(temp as *mut u32, jitval as u32) },
+                                8 => unsafe { ptr::write::<u64>(temp as *mut u64, jitval) },
+                                16 => {
+                                    // FIXME: This case is clearly not safe in general: it just so
+                                    // happens to work because it the moment the biggest value we
+                                    // handle is 64 bits (be that a pointer, u64, or double). If
+                                    // and when we support values bigger than 64 bits, this line
+                                    // will lead to weird problems.
+                                    unsafe { ptr::write::<u64>(temp as *mut u64, jitval) };
+                                }
                                 _ => todo!("{}", size),
                             }
                         }

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -156,7 +156,11 @@ impl Location {
         }
     }
 
-    /// If `self` is in the `Counting` state, return its count, or `None` otherwise.
+    /// If `self` is:
+    ///   1. in the `Counting` state and
+    ///   2. has not had a `HotLocation` allocated for it
+    ///
+    /// return its count, or `None` otherwise
     #[cfg(test)]
     pub(crate) fn count(&self) -> Option<HotThreshold> {
         let x = self.inner.load(Ordering::Relaxed);


### PR DESCRIPTION
Though it may not be obvious that this is what it's doing, this commit stops us tracing undesirable things, notably when we start unrolling inner loops.

Consider this example program:

```python
for x in range(...):
  if x > ...:
    for y in range(...):
```

The outer loop can get hot before the inner loop, so we start tracing the outer loop -- which is fine. But when we trace, we may go around the inner loop an unbounded number of times, endlessly unrolling the inner loop. This can lead to gigantic, and "unstable" traces -- because we've unrolled a specific number of iterations, there's a very high chance that we'll see a different number of iterations next time and encounter a guard on the first "iteration" of the gigantic-loop. This then leads to us creating large numbers of essentially identical side-traces, hugely bloating the system. Using havlak as an example this (combined with a couple of other things) leads to ~10x more traces being created than we would expect.

To avoid this happening, we have to track what `Location`s we've seen while tracing. There are some potentially cunning things we could do here if/when performance becomes an issue, but for now we force every `Location` we see when tracing to become a `HotTracing`. That gives us a stable ID (the `HotLocation`'s `Mutex`) which we can use as a reliable proxy for "have we seen this `Location` before?"