### PR TITLE
Introduce "null" `YkLocation`s.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,8 +2,11 @@
 
 set -eu
 
-# What git commit hash of yklua will we test in buildbot?
-YKLUA_COMMIT="7ced271cf4f36a78127d0cc745906cc21409ae0d"
+# What git commit hash of yklua & ykcbf will we test in buildbot?
+YKLUA_REPO="https://github.com/ltratt/yklua.git"
+YKLUA_COMMIT="305bef80816b84e0848a6694c87e715c4cd263f5"
+YKCBF_REPO="https://github.com/ltratt/ykcbf.git"
+YKCBF_COMMIT="a7eb0e0dbeef38191c4fe823c5aed50e5768df5c"
 
 TRACERS="hwt swt"
 
@@ -14,7 +17,7 @@ TRACERS="hwt swt"
 #  - YK_BUILD_TYPE must be set.
 test_yklua() {
     if [ ! -e "yklua" ]; then
-        git clone --depth=1 https://github.com/ykjit/yklua
+        git clone --depth=1 "$YKLUA_REPO"
         cd yklua
         git fetch --depth=1 origin "$YKLUA_COMMIT"
         git checkout "$YKLUA_COMMIT"
@@ -244,8 +247,10 @@ for b in collect_and_decode promote; do
 done
 
 # Test some BF programs.
-git clone https://github.com/ykjit/ykcbf.git
+git clone --depth=1 "$YKCBF_REPO"
 cd ykcbf
+git fetch --depth=1 origin "$YKCBF_COMMIT"
+git checkout "$YKCBF_COMMIT"
 PATH=$(pwd)/../bin:${PATH} YK_BUILD_TYPE=debug make
 ./bf_simple_yk lang_tests/bench.bf
 ./bf_simple_yk lang_tests/hanoi-opt.bf

--- a/tests/c/bf.O0.c
+++ b/tests/c/bf.O0.c
@@ -36,10 +36,7 @@ int interp(char *prog, char *prog_end, char *cells, char *cells_end, YkMT *mt,
   char *inst = prog;
   char *cell = cells;
   while (inst < prog_end) {
-    YkLocation *loc = NULL;
-    if (*inst == ']')
-      loc = &yklocs[inst - prog];
-    yk_mt_control_point(mt, loc);
+    yk_mt_control_point(mt, &yklocs[inst - prog]);
     switch (*inst) {
     case '>': {
       if (cell++ == cells_end)
@@ -120,8 +117,12 @@ int main(void) {
   YkLocation *yklocs = calloc(prog_len, sizeof(YkLocation));
   if (yklocs == NULL)
     err(1, "out of memory");
-  for (YkLocation *ykloc = yklocs; ykloc < yklocs + prog_len; ykloc++)
-    *ykloc = yk_location_new();
+  for (size_t i = 0; i < prog_len; i++) {
+    if (INPUT_PROG[i] == ']')
+      yklocs[i] = yk_location_new();
+    else
+      yklocs[i] = yk_location_null();
+  }
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 

--- a/tests/c/bf.O1.c
+++ b/tests/c/bf.O1.c
@@ -36,10 +36,7 @@ int interp(char *prog, char *prog_end, char *cells, char *cells_end, YkMT *mt,
   char *inst = prog;
   char *cell = cells;
   while (inst < prog_end) {
-    YkLocation *loc = NULL;
-    if (*inst == ']')
-      loc = &yklocs[inst - prog];
-    yk_mt_control_point(mt, loc);
+    yk_mt_control_point(mt, &yklocs[inst - prog]);
     switch (*inst) {
     case '>': {
       if (cell++ == cells_end)
@@ -120,8 +117,12 @@ int main(void) {
   YkLocation *yklocs = calloc(prog_len, sizeof(YkLocation));
   if (yklocs == NULL)
     err(1, "out of memory");
-  for (YkLocation *ykloc = yklocs; ykloc < yklocs + prog_len; ykloc++)
-    *ykloc = yk_location_new();
+  for (size_t i = 0; i < prog_len; i++) {
+    if (INPUT_PROG[i] == ']')
+      yklocs[i] = yk_location_new();
+    else
+      yklocs[i] = yk_location_null();
+  }
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 

--- a/tests/c/bf.O2.c
+++ b/tests/c/bf.O2.c
@@ -36,10 +36,7 @@ int interp(char *prog, char *prog_end, char *cells, char *cells_end, YkMT *mt,
   char *inst = prog;
   char *cell = cells;
   while (inst < prog_end) {
-    YkLocation *loc = NULL;
-    if (*inst == ']')
-      loc = &yklocs[inst - prog];
-    yk_mt_control_point(mt, loc);
+    yk_mt_control_point(mt, &yklocs[inst - prog]);
     switch (*inst) {
     case '>': {
       if (cell++ == cells_end)
@@ -120,8 +117,12 @@ int main(void) {
   YkLocation *yklocs = calloc(prog_len, sizeof(YkLocation));
   if (yklocs == NULL)
     err(1, "out of memory");
-  for (YkLocation *ykloc = yklocs; ykloc < yklocs + prog_len; ykloc++)
-    *ykloc = yk_location_new();
+  for (size_t i = 0; i < prog_len; i++) {
+    if (INPUT_PROG[i] == ']')
+      yklocs[i] = yk_location_new();
+    else
+      yklocs[i] = yk_location_null();
+  }
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 

--- a/tests/c/bf.O3.c
+++ b/tests/c/bf.O3.c
@@ -36,10 +36,7 @@ int interp(char *prog, char *prog_end, char *cells, char *cells_end, YkMT *mt,
   char *inst = prog;
   char *cell = cells;
   while (inst < prog_end) {
-    YkLocation *loc = NULL;
-    if (*inst == ']')
-      loc = &yklocs[inst - prog];
-    yk_mt_control_point(mt, loc);
+    yk_mt_control_point(mt, &yklocs[inst - prog]);
     switch (*inst) {
     case '>': {
       if (cell++ == cells_end)
@@ -120,8 +117,12 @@ int main(void) {
   YkLocation *yklocs = calloc(prog_len, sizeof(YkLocation));
   if (yklocs == NULL)
     err(1, "out of memory");
-  for (YkLocation *ykloc = yklocs; ykloc < yklocs + prog_len; ykloc++)
-    *ykloc = yk_location_new();
+  for (size_t i = 0; i < prog_len; i++) {
+    if (INPUT_PROG[i] == ']')
+      yklocs[i] = yk_location_new();
+    else
+      yklocs[i] = yk_location_null();
+  }
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 

--- a/tests/c/control_point_in_nested_loop.c
+++ b/tests/c/control_point_in_nested_loop.c
@@ -12,11 +12,12 @@ int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   int outers = 100;
   int inners = 100;
+  YkLocation loc = yk_location_null();
   NOOPT_VAL(outers);
   NOOPT_VAL(inners);
   for (int i = 0; i < outers; i++) {
     for (int j = 0; j < inners; j++) {
-      yk_mt_control_point(mt, NULL); // In a nested loop!
+      yk_mt_control_point(mt, &loc); // In a nested loop!
     }
   }
   yk_mt_shutdown(mt);

--- a/tests/c/shadow_longjmp.c
+++ b/tests/c/shadow_longjmp.c
@@ -53,10 +53,11 @@ int main(int argc, char **argv) {
   jmp_buf env;
 
   int i = 11;
+  YkLocation loc = yk_location_null();
   NOOPT_VAL(i);
   while (i > 0) {
     // Passing a NULL location. We never JIT. Just checking AOT behaviour.
-    yk_mt_control_point(mt, NULL);
+    yk_mt_control_point(mt, &loc);
     if (setjmp(env) != 0) {
       i -= 3;
     }

--- a/tests/c/simple_interp_loop1.c
+++ b/tests/c/simple_interp_loop1.c
@@ -55,13 +55,12 @@ int main(int argc, char **argv) {
   size_t prog_len = sizeof(prog) / sizeof(prog[0]);
 
   // Create one location for each potential PC value.
-  YkLocation loop_loc = yk_location_new();
-  YkLocation **locs = calloc(prog_len, sizeof(&prog[0]));
+  YkLocation *locs = calloc(prog_len, sizeof(&prog[0]));
   for (int i = 0; i < prog_len; i++)
     if (i == 0)
-      locs[i] = &loop_loc;
+      locs[i] = yk_location_new();
     else
-      locs[i] = NULL;
+      locs[i] = yk_location_null();
 
   // The program counter.
   int pc = 0;
@@ -77,7 +76,7 @@ int main(int argc, char **argv) {
     if (pc >= prog_len) {
       exit(0);
     }
-    yk_mt_control_point(mt, locs[pc]);
+    yk_mt_control_point(mt, &locs[pc]);
     if ((pc == 0) && (mem == 9)) {
       __ykstats_wait_until(mt, test_compiled_event);
     }
@@ -102,7 +101,6 @@ int main(int argc, char **argv) {
   NOOPT_VAL(pc);
 
   free(locs);
-  yk_location_drop(loop_loc);
   yk_mt_shutdown(mt);
 
   return (EXIT_SUCCESS);

--- a/tests/c/simple_interp_loop2.c
+++ b/tests/c/simple_interp_loop2.c
@@ -56,14 +56,13 @@ int main(int argc, char **argv) {
   int prog[] = {NOP, NOP, DEC, RESTART_IF_NOT_ZERO, NOP, EXIT};
   size_t prog_len = sizeof(prog) / sizeof(prog[0]);
 
-  YkLocation loop_loc = yk_location_new();
-  YkLocation **locs = calloc(prog_len, sizeof(&prog[0]));
+  YkLocation *locs = calloc(prog_len, sizeof(&prog[0]));
   assert(locs != NULL);
   for (int i = 0; i < prog_len; i++)
     if (i == 0)
-      locs[i] = &loop_loc;
+      locs[i] = yk_location_new();
     else
-      locs[i] = NULL;
+      locs[i] = yk_location_null();
 
   // The program counter.
   int pc = 0;
@@ -77,7 +76,7 @@ int main(int argc, char **argv) {
   // interpreter loop.
   while (true) {
     assert(pc < prog_len);
-    yk_mt_control_point(mt, locs[pc]);
+    yk_mt_control_point(mt, &locs[pc]);
     if ((pc == 0) && (mem == 3)) {
       __ykstats_wait_until(mt, test_compiled_event);
     }
@@ -107,7 +106,6 @@ done:
   NOOPT_VAL(pc);
 
   free(locs);
-  yk_location_drop(loop_loc);
   yk_mt_shutdown(mt);
 
   return (EXIT_SUCCESS);

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -128,9 +128,9 @@ pub extern "C" fn __ykrt_control_point_real(
     // Frame address of caller.
     frameaddr: *mut c_void,
 ) {
+    let mt = unsafe { &*mt };
+    let loc = unsafe { &*loc };
     if !loc.is_null() {
-        let mt = unsafe { &*mt };
-        let loc = unsafe { &*loc };
         let arc = unsafe { Arc::from_raw(mt) };
         arc.control_point(loc, frameaddr, smid);
         forget(arc);
@@ -154,6 +154,11 @@ pub unsafe extern "C" fn yk_mt_sidetrace_threshold_set(mt: *const MT, hot_thresh
 #[no_mangle]
 pub extern "C" fn yk_location_new() -> Location {
     Location::new()
+}
+
+#[no_mangle]
+pub extern "C" fn yk_location_null() -> Location {
+    Location::null()
 }
 
 #[no_mangle]

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -21,6 +21,8 @@ typedef struct {
   uintptr_t state;
 } YkLocation;
 
+#define YKLOCATION_NULL ((YkLocation) 0 )
+
 #if defined(__x86_64)
 typedef uint32_t YkHotThreshold;
 #else
@@ -43,10 +45,11 @@ YkMT *yk_mt_new(char **err_msg);
 // have observable behaviour.
 void yk_mt_shutdown(YkMT *);
 
-// Notify yk that an iteration of an interpreter loop is about to start. The
-// argument passed uniquely identifies the current location in the user's
-// program. A call to this function may cause yk to start/stop tracing, or to
-// execute JITted code.
+// Notify yk that a given `YkLocation` is about to be executed, allowing yk to
+// determine if a trace for this location exists, or one started or stopped, as
+// appropriate. The `YkLocation *` be a non-NULL pointer, though a
+// `yk_location_null` value causes this function call to be, in essence, a
+// no-op: see the documentation for that function for more details.
 void yk_mt_control_point(YkMT *, YkLocation *);
 
 // Set the threshold at which `YkLocation`'s are considered hot.
@@ -55,12 +58,23 @@ void yk_mt_hot_threshold_set(YkMT *, YkHotThreshold);
 // Set the threshold at which guard failures are considered hot.
 void yk_mt_sidetrace_threshold_set(YkMT *, YkHotThreshold);
 
+// Create a new `YkLocation`.
+//
+// Note that a `YkLocation` created by this call must not simply be discarded:
+// if no longer wanted, it must be passed to `yk_location_drop` to allow
+// appropriate clean-up.
+YkLocation yk_location_new(void);
+
+// Create a new NULL-equivalent `Location`. Such a `YkLocation` denotes a point
+// in a program which can never contribute to a trace.
+YkLocation yk_location_null(void);
+
 // Create a new `Location`.
 //
 // Note that a `Location` created by this call must not simply be discarded:
 // if no longer wanted, it must be passed to `yk_location_drop` to allow
 // appropriate clean-up.
-YkLocation yk_location_new(void);
+YkLocation yk_location_empty(void);
 
 // Clean-up a `Location` previously created by `yk_new_location`. The
 // `Location` must not be further used after this call or undefined behaviour

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -186,11 +186,16 @@ impl VarLocation {
             },
             yksmp::Location::Constant(v) => {
                 let bitw = m.inst(iidx).def_bitw(m);
-                assert!(bitw <= 64);
+                assert!(bitw <= 32);
                 VarLocation::ConstInt {
                     bits: bitw,
                     v: u64::from(*v),
                 }
+            }
+            yksmp::Location::LargeConstant(v) => {
+                let bitw = m.inst(iidx).def_bitw(m);
+                assert!(bitw <= 64);
+                VarLocation::ConstInt { bits: bitw, v: *v }
             }
             e => {
                 todo!("{:?}", e);
@@ -259,6 +264,8 @@ impl From<&VarLocation> for yksmp::Location {
             VarLocation::ConstInt { bits, v } => {
                 if *bits <= 32 {
                     yksmp::Location::Constant(u32::try_from(*v).unwrap())
+                } else if *bits <= 64 {
+                    yksmp::Location::LargeConstant(*v)
                 } else {
                     todo!(">32 bit constant")
                 }


### PR DESCRIPTION
Previously we allowed users to pass `NULL` to `yk_mt_control_point` to signify "there's nothing to trace at this point". However that meant that most interpreters would need to maintain two structures for locations: one to say "is there anything to trace at this point?" and another for "this is the YkLocation for this point, if one is needed". This was messy, and easy to misunderstand.

This commit no longer allows passing `NULL` to `yk_mt_control_point`, and instead introduces "null"-equivalent `YkLocation`s which are created by `Location::null()` or `yk_location_null()`. In essence, these tell `yk_mt_control_point` that there's nothing to do at this point in the high-level program, allowing us to compress the two structures we needed previously into one.

Is this a perfect API? Probably not. We might be able to do better again, but this is a useful improvement already, and has allowed me to meaningfully improve yklua.

Note: because this is a breaking change, I have temporarily had to point `.buildbot.sh` at my yklua fork. As soon as this merges, we can update yklua, and then have `.buildbot.sh` point back to the main yklua repository. [The yklua PR is at https://github.com/ykjit/yklua/pull/101].