### PR TITLE
Use a prime number threshold.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -50,7 +50,7 @@ pub type AtomicTraceCompilationErrorThreshold = AtomicU16;
 /// reasonable performance.
 /// FIXME: needs to be configurable.
 pub(crate) const DEFAULT_TRACE_TOO_LONG: usize = 20000;
-const DEFAULT_HOT_THRESHOLD: HotThreshold = 50;
+const DEFAULT_HOT_THRESHOLD: HotThreshold = 131;
 const DEFAULT_SIDETRACE_THRESHOLD: HotThreshold = 5;
 /// How often can a [HotLocation] or [Guard] lead to an error in tracing or compilation before we
 /// give up trying to trace (or compile...) it?


### PR DESCRIPTION
50 turns out to be a less than ideal threshold: it's quite common -- particularly but not only in benchmarks -- to have loops that run for exactly 50 iterations. With a threshold of 50 we therefore end up with unfortunate traces (specifically those where we trace out of the loop) happening disproportionately often.

There is never going to be a perfect threshold but the choice of 131 in this commit is based on two observations:

  1. Loops of 100 or less are probably quite common and not worth tracing.

  2. A hot threshold that's a prime number makes "falling off the end" traces less likely.