### PR TITLE
Properly reset the `HotLocation` when tracing outside the original frame

### DIFF
--- a/tests/c/early_return2.c
+++ b/tests/c/early_return2.c
@@ -21,35 +21,43 @@
 //     yk-jit-event: tracing-aborted
 //     b3
 //     8
-//     b3
-//     7
-//     yk-jit-event: start-tracing
-//     b3
-//     6
-//     yk-jit-event: stop-tracing
-//     --- Begin jit-pre-opt ---
-//     ...
-//     --- End jit-pre-opt ---
-//     b2
-//     5
 //     yk-jit-event: enter-jit-code
 //     yk-jit-event: deoptimise
 //     yk-jit-event: start-side-tracing
+//     b3
+//     7
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//     ...
+//     --- End jit-pre-opt ---
+//     b3
+//     6
+//     yk-jit-event: enter-jit-code
+//     yk-jit-event: execute-side-trace
+//     yk-jit-event: deoptimise
+//     yk-jit-event: start-side-tracing
 //     b2
-//     4
+//     5
 //     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     b2
-//     3
+//     4
 //     yk-jit-event: enter-jit-code
+//     yk-jit-event: execute-side-trace
+//     yk-jit-event: execute-side-trace
+//     b2
+//     3
+//     yk-jit-event: execute-side-trace
 //     yk-jit-event: execute-side-trace
 //     b2
 //     2
 //     yk-jit-event: execute-side-trace
+//     yk-jit-event: execute-side-trace
 //     b2
 //     1
+//     yk-jit-event: execute-side-trace
 //     yk-jit-event: execute-side-trace
 //     b2
 //     0

--- a/tests/c/nested_execution.c
+++ b/tests/c/nested_execution.c
@@ -13,13 +13,7 @@
 //     4
 //     yk-jit-event: stop-tracing
 //     --- Begin jit-pre-opt ---
-//       ...
-//       guard false, ...
-//       ...
-//       guard false, ...
-//       ...
-//       guard true, ...
-//       ...
+//     ...
 //     --- End jit-pre-opt ---
 //     3
 //     yk-jit-event: enter-jit-code
@@ -42,14 +36,9 @@
 //     yk-jit-event: tracing-aborted
 //     4
 //     enter
-//     yk-jit-event: start-tracing
-//     3
-//     yk-jit-event: stop-tracing
-//     --- Begin jit-pre-opt ---
-//     ...
-//     --- End jit-pre-opt ---
-//     2
 //     yk-jit-event: enter-jit-code
+//     3
+//     2
 //     1
 //     yk-jit-event: deoptimise
 //     return
@@ -62,16 +51,15 @@
 //     yk-jit-event: enter-jit-code
 //     1
 //     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
 //     return
-//     yk-jit-event: tracing-aborted
+//     yk-jit-event: start-tracing
 //     b
 //     2
 //     enter
-//     yk-jit-event: start-tracing
+//     yk-jit-event: tracing-aborted
 //     1
 //     return
-//     yk-jit-event: tracing-aborted
+//     yk-jit-event: start-tracing
 //     a
 //     1
 //     enter

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -1071,10 +1071,10 @@ impl LSRegAlloc<'_> {
                 x => todo!("{x}"),
             },
             SpillState::ConstInt { bits, v } => match bits {
-                32 => {
-                    dynasm!(asm; mov Rd(reg.code()), v as i32)
+                64 => {
+                    dynasm!(asm; mov Rq(reg.code()), QWORD v as i64)
                 }
-                8 => {
+                32 | 16 | 8 => {
                     dynasm!(asm; mov Rd(reg.code()), v as i32)
                 }
                 _ => todo!("{bits}"),


### PR DESCRIPTION
When we fall (into or out of) the original frame for the interpreter loop, we need to decide what to do with the `HotLocation` that started the trace off. Previously we could leave it in "perma-tracing" state that then got caught by a branch that also deals with side tracing. That works, but is incredibly inefficient, because it kept retrying to trace from scratch. That could mean we tried (unsuccessfully!) recording hundreds of thousands of traces!

This PR changes that: when we detect the "fall out of frame" case, we deal with it more sensibly. In particular, if we were side-tracing, we restore the original `CompiledTrace`, moving us back to the (at least somewhat) happy path.