### PR TITLE
Fix and optimise truncation

### DIFF
--- a/ykrt/src/compile/jitc_yk/arbbitint.rs
+++ b/ykrt/src/compile/jitc_yk/arbbitint.rs
@@ -88,6 +88,19 @@ impl ArbBitInt {
         }
     }
 
+    /// Truncate this `ArbBitInt` to `to_bitw` bits.
+    ///
+    /// # Panics
+    ///
+    /// If `to_bitw` is larger than `self.bitw()`.
+    pub(crate) fn truncate(&self, to_bitw: u32) -> Self {
+        debug_assert!(to_bitw <= self.bitw && to_bitw <= 64);
+        Self {
+            bitw: to_bitw,
+            val: self.val,
+        }
+    }
+
     /// Sign extend the underlying value and, if it is representable as an `i8`, return it.
     #[allow(unused)]
     pub(crate) fn to_sign_ext_i8(&self) -> Option<i8> {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -862,7 +862,7 @@ impl LSRegAlloc<'_> {
     /// register.
     ///
     /// `from_bits` must be between 1 and 64.
-    fn force_zero_extend_to_reg64(&self, asm: &mut Assembler, reg: Rq, from_bitw: u32) {
+    pub(super) fn force_zero_extend_to_reg64(&self, asm: &mut Assembler, reg: Rq, from_bitw: u32) {
         debug_assert!(from_bitw > 0 && from_bitw <= 64);
         match from_bitw {
             1..=31 => dynasm!(asm; and Rd(reg.code()), ((1u64 << from_bitw) - 1) as i32),


### PR DESCRIPTION
Codegen for truncation was subtly broken (fixed in https://github.com/ykjit/yk/commit/af0858b3758d3fb231ad6b99fa1f09da2f15193e). While I'm here, optimising truncation in the trace optimiser is an easy win (dcfb0a69e85ed95cc2f71ec33b0792d15a5c910d).