### PR TITLE
Better jump var writing

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -95,7 +95,7 @@ const FP_REGS_LEN: usize = 16;
 
 /// The set of general registers which we will never assign value to. RSP & RBP are reserved by
 /// SysV.
-static RESERVED_GP_REGS: [Rq; 2] = [Rq::RSP, Rq::RBP];
+pub(super) static RESERVED_GP_REGS: [Rq; 2] = [Rq::RSP, Rq::RBP];
 
 /// The set of floating point registers which we will never assign value to.
 static RESERVED_FP_REGS: [Rx; 0] = [];

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2294,10 +2294,6 @@ impl<'a> Assemble<'a> {
     /// Move live values from their source location into the target location when doing a jump back
     /// to the beginning of a trace (or a jump from a side-trace to the beginning of its root
     /// trace).
-    ///
-    /// # Arguments
-    ///
-    /// * `tgt_vars` - The target locations. If `None` use `self.loop_start_locs` instead.
     fn write_jump_vars(&mut self, iidx: InstIdx) {
         let (tgt_vars, src_ops) = match self.m.tracekind() {
             TraceKind::HeaderOnly => (self.header_start_locs.clone(), self.m.trace_header_end()),
@@ -2312,8 +2308,6 @@ impl<'a> Assemble<'a> {
                 self.m.trace_header_end(),
             ),
         };
-        // If we pass in `None` use `self.loop_start_locs` instead. We need to do this since we
-        // can't pass in `&self.loop_start_locs` directly due to borrowing restrictions.
         let mut gp_regs = lsregalloc::GP_REGS
             .iter()
             .map(|_| GPConstraint::None)


### PR DESCRIPTION
This PR optimises the writing of jump vars, in essence getting rid of the (repeated) `push rax; move a spill; pop rax` dance we had before. This is particularly useful for long traces, where we could do a *lot* of this at the end.