### PR TITLE
Belt and braces PROT_READ.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -3018,7 +3018,7 @@ fn patch_address(target: *const u8, val: u64) {
             // Since we are only patching 8-bytes which are aligned, we know we can't span two
             // pages. Passing a size of 1 still marks the entire page which is what we need.
             1,
-            libc::PROT_WRITE | libc::PROT_EXEC,
+            libc::PROT_EXEC | libc::PROT_READ | libc::PROT_WRITE,
         )
     };
     // Check that the target address is 8-byte aligned. This is required so we can patch


### PR DESCRIPTION
In general, `PROT_READ` is necessary for `PROT_EXEC` to work. In some cases, `PROT_WRITE` implies `PROT_READ` (e.g. Linux's mprotect man page says "On some hardware architectures (e.g., i386), PROT_WRITE implies PROT_READ.") but this isn't specified anywhere that I know of. There's no harm in being explicit here and adding `PROT_READ` to the `mprotect` call.