### PR TITLE
Use a definitely-spare register in `write_jump_vars`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -376,6 +376,20 @@ impl LSRegAlloc<'_> {
         self.spills[usize::from(iidx)] = SpillState::ConstInt { bits, v };
     }
 
+    /// Return a currently unused general purpose register, if one exists.
+    ///
+    /// Note: you must be *very* careful in when you use the register that's returned.
+    /// Specifically, if you call this after `assign_regs` and use the register before you have
+    /// generated outputs, undefined behaviour will occur.
+    pub(super) fn find_empty_gp_reg(&self) -> Option<Rq> {
+        for (reg_i, rs) in self.gp_reg_states.iter().enumerate() {
+            if let RegState::Empty = rs {
+                return Some(GP_REGS[reg_i]);
+            }
+        }
+        None
+    }
+
     /// Assign general purpose registers for the instruction at position `iidx`.
     ///
     /// This is a convenience function for [Self::assign_regs] when there are no FP registers.


### PR DESCRIPTION
The way we worked out that we had a spare register was completely incorrect, as it didn't respect the current state of the register allocator (indeed, it always returned `RAX`). In particular, that meant that we could use a "spare register" that still contained a value that we needed to use to write jump vars! This only affected side traces: I spotted this when finding that we could sometimes go wrong after a sidetrace had completed a run, because we would write one random value.

This commit asks the register allocator for an empty register and uses that instead. The `assert` added in this commit is our guarantee that we don't reintroduce this bug in the future.

Note that `find_empty_gp_reg` is necessarily a slightly dangerous function, but there's no better way to do it than this. So far I have not been able to come up with a situation where we don't have an empty register: if we do encounter that, we'll have to go back to the `push`/`pop` dance.