### PR TITLE
Continue splitting the register allocator up into more testable chunks.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -59,5 +59,6 @@ fm = "0.4.0"
 lazy_static = "1.5.0"
 lrlex = "0.13"
 lrpar = "0.13"
+rand = "0.9.0"
 regex = { version = "1.9", features = ["std"] }
 proptest = "1.6.0"

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2016,7 +2016,7 @@ impl<'a> Assemble<'a> {
         g_iidx: InstIdx,
         g_inst: jit_ir::GuardInst,
     ) {
-        debug_assert!(!self.ra.rev_an.is_inst_var_still_used_after(g_iidx, ic_iidx));
+        assert!(!self.ra.rev_an.is_inst_var_still_used_after(g_iidx, ic_iidx));
 
         // Codegen ICmp
         let (lhs, pred, rhs) = (
@@ -3005,8 +3005,8 @@ impl<'a> Assemble<'a> {
                 GPConstraint::Temporary,
             ],
         );
-        self.patch_reg.insert(inst.gidx.into(), patch_reg);
         let fail_label = self.guard_to_deopt(inst);
+        self.patch_reg.insert(inst.gidx.into(), patch_reg);
         dynasm!(self.asm ; bt Rd(reg.code()), 0);
         if inst.expect() {
             dynasm!(self.asm ; jnb =>fail_label);
@@ -4398,8 +4398,8 @@ mod tests {
                 ...
                 ; call @puts(%0, %1, %2, %3)
                 mov rsi, rcx
-                mov rdi, rax
                 mov rcx, rbx
+                mov rdi, rax
                 and ecx, 0x01
                 and esi, 0xffff
                 and edi, 0xff
@@ -4525,9 +4525,9 @@ mod tests {
             "
                ...
                ; call @llvm.memcpy.p0.p0.i64(%0, %1, %2, 0i1)
-               mov rdi, rax
                mov rsi, rcx
                mov rcx, rdx
+               mov rdi, rax
                rep movsb
             ",
             false,


### PR DESCRIPTION
This commit splits the register allocator into two major parts:

  1. A non-mutating part which decides what registers to allocate.
  2. A mutating part which generates code.

Previously these were intermingled together in a way that was hard to understand and impossible to test. Happily the second part is now tiny: all of the hard stuff is in the first part.

This commit also takes a section of that first part -- the bit about which I was least confident -- and makes it entirely stateless in `reg_copies_to_actions` (i.e. it doesn't even read state), making it much more easily testable in a unit test setting.

In essence (and the comments in the code explain this, I hope, in more detail) the register allocator now works in terms of "actions": that is, we gradually build up a sequence of things we will do in the future (i.e. code we will generate), but we don't do them yet.

Happily this commit also makes the allocator simpler overall, despite generating code that is at least as good as we did before.

There is more we need to do here, but this is a meaningful step in the right direction.