### PR TITLE
Remove unused `guards` field.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -5,7 +5,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{jitc_yk::jit_ir::Module, CompiledTrace, GuardIdx},
+    compile::{jitc_yk::jit_ir::Module, CompiledTrace},
     location::HotLocation,
     MT,
 };
@@ -38,7 +38,6 @@ pub(crate) trait CodeGen: Send + Sync {
         hl: Arc<Mutex<HotLocation>>,
         sp_offset: Option<usize>,
         root_offset: Option<usize>,
-        prevguards: Option<Vec<GuardIdx>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 


### PR DESCRIPTION
Since 1d342f1f80727aac4eef6ba2a8f0db35cabe5ea8, we have not tracked the chain of guard indexes. However, because of the convoluted path we take to storing these, rustc couldn't identify this field as being unused. Indeed, it took me a while to realise that we definitely weren't using it!