### PR TITLE
Avoid pointless parameters

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -36,8 +36,6 @@ pub(crate) trait CodeGen: Send + Sync {
         m: Module,
         mt: Arc<MT>,
         hl: Arc<Mutex<HotLocation>>,
-        sp_offset: Option<usize>,
-        root_offset: Option<usize>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -322,13 +322,10 @@ struct Assemble<'a> {
     ///
     /// Each assembly offset can have zero or more comment lines.
     comments: Cell<IndexMap<usize, Vec<String>>>,
-    /// Stack pointer offset from the base pointer of the interpreter frame. If this is a root
-    /// trace it's initialised to the size of the interpreter frame. Otherwise its value is passed
-    /// in via [YkSideTraceInfo::sp_offset].
+    /// Stack pointer offset from the base pointer of the interpreter frame:
+    ///   * For a root trace, this will be the size of the interpreter frame.
+    ///   * For side traces, it will be the parent frame's stack offset.
     sp_offset: usize,
-    /// The stack pointer offset of the root trace's frame from the base pointer of the interpreter
-    /// frame. If this is the root trace, this will be None.
-    root_offset: Option<usize>,
     /// The offset after the trace's prologue. This is the re-entry point when returning from
     /// side-traces.
     prologue_offset: AssemblyOffset,
@@ -343,7 +340,7 @@ impl<'a> Assemble<'a> {
             .map_err(|e| CompilationError::ResourceExhausted(Box::new(e)))?;
         // Since we are executing the trace in the main interpreter frame we need this to
         // initialise the trace's register allocator in order to access local variables.
-        let (sp_offset, root_offset) = match m.tracekind() {
+        let sp_offset = match m.tracekind() {
             TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
                 // This is a normal trace, so we need to retrieve the stack size of the main
                 // interpreter frame.
@@ -361,14 +358,14 @@ impl<'a> Assemble<'a> {
                     } else {
                         rec.size
                     };
-                    (usize::try_from(size).unwrap(), None)
+                    usize::try_from(size).unwrap()
                 } else {
                     // The unit tests in this file don't have AOT code. So if we don't find stackmaps here
                     // that's ok. In real-world programs and our C-tests this shouldn't happen though.
                     #[cfg(not(test))]
                     panic!("Couldn't find AOT stackmaps.");
                     #[cfg(test)]
-                    (0, None)
+                    0
                 }
             }
             TraceKind::Sidetrace(sti) => {
@@ -378,7 +375,7 @@ impl<'a> Assemble<'a> {
                     .as_any()
                     .downcast::<YkSideTraceInfo<Register>>()
                     .unwrap();
-                (sti.sp_offset, Some(sti.root_offset()))
+                sti.sp_offset
             }
         };
 
@@ -392,7 +389,6 @@ impl<'a> Assemble<'a> {
             patch_reg: HashMap::new(),
             comments: Cell::new(IndexMap::new()),
             sp_offset,
-            root_offset,
             prologue_offset: AssemblyOffset(0),
         }))
     }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -290,10 +290,8 @@ impl CodeGen for X64CodeGen {
         m: Module,
         mt: Arc<MT>,
         hl: Arc<Mutex<HotLocation>>,
-        sp_offset: Option<usize>,
-        root_offset: Option<usize>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
-        Assemble::new(&m, sp_offset, root_offset)?.codegen(mt, hl)
+        Assemble::new(&m)?.codegen(mt, hl)
     }
 }
 
@@ -337,11 +335,7 @@ struct Assemble<'a> {
 }
 
 impl<'a> Assemble<'a> {
-    fn new(
-        m: &'a jit_ir::Module,
-        sp_offset: Option<usize>,
-        root_offset: Option<usize>,
-    ) -> Result<Box<Assemble<'a>>, CompilationError> {
+    fn new(m: &'a jit_ir::Module) -> Result<Box<Assemble<'a>>, CompilationError> {
         #[cfg(debug_assertions)]
         m.assert_well_formed();
 
@@ -349,35 +343,42 @@ impl<'a> Assemble<'a> {
             .map_err(|e| CompilationError::ResourceExhausted(Box::new(e)))?;
         // Since we are executing the trace in the main interpreter frame we need this to
         // initialise the trace's register allocator in order to access local variables.
-        let sp_offset = if let Some(off) = sp_offset {
-            // This is a side-trace. Use the passed in stack size to initialise the register
-            // allocator.
-            off
-        } else {
-            // This is a normal trace, so we need to retrieve the stack size of the main
-            // interpreter frame.
-            // FIXME: For now the control point stackmap id is always 0. Though
-            // we likely want to support multiple control points in the future. We can either pass
-            // the correct stackmap id in via the control point, or compute the stack size
-            // dynamically upon entering the control point (e.g. by subtracting the current RBP
-            // from the previous RBP).
-            if let Ok(sm) = AOT_STACKMAPS.as_ref() {
-                let (rec, pinfo) = sm.get(0);
-                let size = if pinfo.hasfp {
-                    // The frame size includes the pushed RBP, but since we only care about the size of
-                    // the local variables we need to subtract it again.
-                    rec.size - u64::try_from(REG64_BYTESIZE).unwrap()
+        let (sp_offset, root_offset) = match m.tracekind() {
+            TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
+                // This is a normal trace, so we need to retrieve the stack size of the main
+                // interpreter frame.
+                // FIXME: For now the control point stackmap id is always 0. Though
+                // we likely want to support multiple control points in the future. We can either pass
+                // the correct stackmap id in via the control point, or compute the stack size
+                // dynamically upon entering the control point (e.g. by subtracting the current RBP
+                // from the previous RBP).
+                if let Ok(sm) = AOT_STACKMAPS.as_ref() {
+                    let (rec, pinfo) = sm.get(0);
+                    let size = if pinfo.hasfp {
+                        // The frame size includes the pushed RBP, but since we only care about the size of
+                        // the local variables we need to subtract it again.
+                        rec.size - u64::try_from(REG64_BYTESIZE).unwrap()
+                    } else {
+                        rec.size
+                    };
+                    (usize::try_from(size).unwrap(), None)
                 } else {
-                    rec.size
-                };
-                usize::try_from(size).unwrap()
-            } else {
-                // The unit tests in this file don't have AOT code. So if we don't find stackmaps here
-                // that's ok. In real-world programs and our C-tests this shouldn't happen though.
-                #[cfg(not(test))]
-                panic!("Couldn't find AOT stackmaps.");
-                #[cfg(test)]
-                0
+                    // The unit tests in this file don't have AOT code. So if we don't find stackmaps here
+                    // that's ok. In real-world programs and our C-tests this shouldn't happen though.
+                    #[cfg(not(test))]
+                    panic!("Couldn't find AOT stackmaps.");
+                    #[cfg(test)]
+                    (0, None)
+                }
+            }
+            TraceKind::Sidetrace(sti) => {
+                // This is a side-trace. Use the passed in stack size to initialise the register
+                // allocator.
+                let sti = Arc::clone(sti)
+                    .as_any()
+                    .downcast::<YkSideTraceInfo<Register>>()
+                    .unwrap();
+                (sti.sp_offset, Some(sti.root_offset()))
             }
         };
 
@@ -3479,7 +3480,7 @@ mod tests {
             tracecompilation_errors: 0,
         };
         match_asm(
-            Assemble::new(&m, None, None)
+            Assemble::new(&m)
                 .unwrap()
                 .codegen(mt, Arc::new(Mutex::new(hl)))
                 .unwrap()
@@ -5633,7 +5634,7 @@ mod tests {
             tracecompilation_errors: 0,
         };
 
-        Assemble::new(&m, None, None)
+        Assemble::new(&m)
             .unwrap()
             .codegen(mt, Arc::new(Mutex::new(hl)))
             .unwrap()

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -144,8 +144,6 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         }
 
         let sti = sti.map(|s| s.as_any().downcast::<YkSideTraceInfo<Register>>().unwrap());
-        let sp_offset = sti.as_ref().map(|x| x.sp_offset);
-        let root_offset = sti.as_ref().map(|x| x.root_offset);
 
         let mut jit_mod =
             trace_builder::build(&mt, aot_mod, aottrace_iter, sti, promotions, debug_strs)?;
@@ -167,9 +165,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         }
 
         // FIXME: This needs to be the combined stacksize of all parent traces.
-        let ct = self
-            .codegen
-            .codegen(jit_mod, mt, hl, sp_offset, root_offset)?;
+        let ct = self.codegen.codegen(jit_mod, mt, hl)?;
 
         if should_log_ir(IRPhase::Asm) {
             log_ir(&format!(


### PR DESCRIPTION
This PR avoids passing around data in parameters that we have available in `YkSideTraceInfo`.