### PR TITLE
Fix prototype and description

### DIFF
--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -96,12 +96,9 @@ long long __yk_promote_c_long_long(long long);
 // Rust defines `usize` to be layout compatible with `uintptr_t`.
 uintptr_t __yk_promote_usize(uintptr_t);
 
-/// Insert a debugging string.
-///
-/// When a call to this function is traced, the dynamic value of `msg` will be
-/// shown when the trace is displayed.
-///
-/// `msg` must be a pointer to a UTF-8 compatible string.
-void yk_debug_str(char *fmt);
+/// Associate a UTF-8 compatible string to the next instruction to be traced.
+/// The string will be copied by this function, so callers can safely reuse the
+/// memory after this call has completed.
+void yk_debug_str(char *);
 
 #endif

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -102,6 +102,6 @@ uintptr_t __yk_promote_usize(uintptr_t);
 /// shown when the trace is displayed.
 ///
 /// `msg` must be a pointer to a UTF-8 compatible string.
-void yk_debug_str(char *fmt, ...);
+void yk_debug_str(char *fmt);
 
 #endif


### PR DESCRIPTION
This PR fixes the `yk_debug_str` prototype and, hopefully, improves its documentation.