### PR TITLE
Implement stuff required to elide instruction loading in yklua.

### DIFF
--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -88,13 +88,15 @@ void yk_location_drop(YkLocation);
                                int: __yk_promote_c_int, \
                                unsigned int: __yk_promote_c_unsigned_int, \
                                long long: __yk_promote_c_long_long, \
-                               uintptr_t: __yk_promote_usize \
+                               uintptr_t: __yk_promote_usize, \
+                               void *: __yk_promote_ptr \
                               )(X)
 int __yk_promote_c_int(int);
 unsigned int __yk_promote_c_unsigned_int(unsigned int);
 long long __yk_promote_c_long_long(long long);
 // Rust defines `usize` to be layout compatible with `uintptr_t`.
 uintptr_t __yk_promote_usize(uintptr_t);
+void *__yk_promote_ptr(void *);
 
 /// Associate a UTF-8 compatible string to the next instruction to be traced.
 /// The string will be copied by this function, so callers can safely reuse the

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -276,6 +276,7 @@ impl From<&VarLocation> for yksmp::Location {
                     todo!(">32 bit constant")
                 }
             }
+            VarLocation::ConstPtr(v) => yksmp::Location::LargeConstant(u64::try_from(*v).unwrap()),
             e => todo!("{:?}", e),
         }
     }
@@ -1271,7 +1272,7 @@ impl<'a> Assemble<'a> {
                     .force_assign_inst_indirect(iidx, i32::try_from(frame_off).unwrap());
             }
             VarLocation::ConstInt { bits, v } => {
-                self.ra.assign_const(iidx, bits, v);
+                self.ra.assign_const_int(iidx, bits, v);
             }
             e => panic!("{:?}", e),
         }
@@ -2465,7 +2466,7 @@ impl<'a> Assemble<'a> {
                     // match. But since the value can't change we can safely ignore this.
                 }
                 VarLocation::Register(_reg) => (), // Handled in the earlier loop
-                _ => todo!(),
+                _ => todo!("{dst:?}"),
             }
         }
 
@@ -2609,7 +2610,10 @@ impl<'a> Assemble<'a> {
                             );
                         }
                         VarLocation::ConstInt { bits, v } => {
-                            self.ra.assign_const(iidx, bits, v);
+                            self.ra.assign_const_int(iidx, bits, v);
+                        }
+                        VarLocation::ConstPtr(v) => {
+                            self.ra.assign_const_ptr(iidx, v);
                         }
                         e => panic!("{:?}", e),
                     }

--- a/ykrt/src/compile/jitc_yk/opt/heapvalues.rs
+++ b/ykrt/src/compile/jitc_yk/opt/heapvalues.rs
@@ -4,7 +4,7 @@
 //!
 //! Broadly speaking, loads add new information; stores tend to remove most old information and add
 //! new information; and barriers remove all information.
-use super::super::jit_ir::{Inst, InstIdx, Module, Operand};
+use super::super::jit_ir::{Const, Inst, InstIdx, Module, Operand};
 use std::collections::HashMap;
 
 /// An abstract "address" representing a location in RAM.
@@ -40,7 +40,12 @@ impl Address {
                 }
                 Address::PtrPlusOff(iidx, off)
             }
-            Operand::Const(_) => todo!(),
+            Operand::Const(cidx) => {
+                let Const::Ptr(v) = m.const_(cidx) else {
+                    panic!();
+                };
+                Address::Const(*v)
+            }
         }
     }
 }

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -1144,7 +1144,17 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
                 self.promote_idx += bytew;
                 Const::Int(tyidx, ArbBitInt::from_u64(*bitw, v))
             }
-            jit_ir::Ty::Ptr => todo!(),
+            jit_ir::Ty::Ptr => {
+                let bytew = ty.byte_size().unwrap();
+                assert_eq!(bytew, std::mem::size_of::<usize>());
+                let v = usize::from_ne_bytes(
+                    self.promotions[self.promote_idx..self.promote_idx + bytew]
+                        .try_into()
+                        .unwrap(),
+                );
+                self.promote_idx += bytew;
+                Const::Ptr(v)
+            }
             jit_ir::Ty::Func(_) => todo!(),
             jit_ir::Ty::Float(_) => todo!(),
             jit_ir::Ty::Unimplemented(_) => todo!(),

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -4,7 +4,7 @@
 //! right method in this module to call.
 
 use crate::mt::MTThread;
-use std::ffi::{c_int, c_longlong, c_uint};
+use std::ffi::{c_int, c_longlong, c_uint, c_void};
 
 /// Promote a `c_int` during trace recording.
 #[no_mangle]
@@ -45,6 +45,16 @@ pub extern "C" fn __yk_promote_usize(val: usize) -> usize {
     MTThread::with_borrow_mut(|mtt| {
         // We ignore the return value as we can't really cancel tracing from this function.
         mtt.promote_usize(val);
+    });
+    val
+}
+
+/// Promote a pointer during trace recording.
+#[no_mangle]
+pub extern "C" fn __yk_promote_ptr(val: *const c_void) -> *const c_void {
+    MTThread::with_borrow_mut(|mtt| {
+        // We ignore the return value as we can't really cancel tracing from this function.
+        mtt.promote_usize(val as usize);
     });
     val
 }


### PR DESCRIPTION
This includes:

 - Promote support for pointers.
 - Implementing various todo! relating to constant pointers.
 - Optimisations for ptr_add upon const pointers.
 - SpillState support for const pointers.