### PR TITLE
Remove register alloctor hacks that impact correctness

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -2640,12 +2640,12 @@ mod test {
             ]
         );
 
-        // Fuzz `moves_to_actions` with lots of random data.
+        // Fuzz `reg_copies_to_actions` with lots of random data.
         let mut rng = rand::rng();
         for _ in 0..10000 {
             let mut moves = Vec::new();
             // Note: if we crank the `10` below any higher, we get into register pressure
-            // situations where we hit a `todo` in `moves_to_actions`. Since I haven't yet seen
+            // situations where we hit a `todo` in `reg_copies_to_actions`. Since I haven't yet seen
             // that case in real life, I'm not hugely inclined to spend a lot of time implementing
             // it yet. If/when we do, the `10` should become a `16`.
             for _ in 0..rng.random_range(1..10) {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2642,11 +2642,9 @@ impl<'a> Assemble<'a> {
         let [_reg] = self.ra.assign_gp_regs(
             &mut self.asm,
             iidx,
-            [GPConstraint::InputOutput {
+            [GPConstraint::AlignExtension {
                 op: sinst.val(self.m),
-                in_ext: RegExtension::SignExtended,
                 out_ext: RegExtension::SignExtended,
-                force_reg: None,
             }],
         );
     }
@@ -2655,11 +2653,9 @@ impl<'a> Assemble<'a> {
         let [_reg] = self.ra.assign_gp_regs(
             &mut self.asm,
             iidx,
-            [GPConstraint::InputOutput {
+            [GPConstraint::AlignExtension {
                 op: zinst.val(self.m),
-                in_ext: RegExtension::ZeroExtended,
                 out_ext: RegExtension::ZeroExtended,
-                force_reg: None,
             }],
         );
     }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -4702,6 +4702,41 @@ mod tests {
                 ",
             false,
         );
+
+        // Check that `zext`ing zero extended things doesn't allocate a new register.
+        codegen_and_test(
+            "
+              entry:
+                %0: i16 = param reg
+                %1: i32 = param reg
+                %2: i64 = param reg
+                %3: i32 = zext %0
+                %4: i64 = zext %0
+                %5: i64 = zext %3
+                %6: i64 = add %4, %5
+                black_box %0
+                black_box %1
+                black_box %2
+                black_box %3
+                black_box %4
+                black_box %5
+                black_box %6
+                ",
+            "
+                ...
+                ; %0: i16 = param ...
+                ; %1: i32 = param ...
+                ; %2: i64 = param ...
+                ; %3: i32 = zext %0
+                and eax, 0xffff
+                ; %4: i64 = zext %0
+                ; %5: i64 = zext %3
+                ; %6: i64 = add %4, %5
+                mov r.64._, rax
+                add rax, rax
+                ",
+            false,
+        );
     }
 
     #[test]

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2387,6 +2387,17 @@ impl<'a> Assemble<'a> {
             if let VarLocation::Register(reg) = dst {
                 match reg {
                     Register::GP(r) => {
+                        if let GPConstraint::Input { op: cur_op, .. } =
+                            &gp_regs[usize::from(r.code())]
+                        {
+                            // Two operands both have to end up in the same register: if our
+                            // existing candidate is already in a register (i.e. is cheaper than
+                            // unspilling), we prefer that, otherwise we hope that the "new" one
+                            // we've seen might be in a register.
+                            if self.ra.find_op_in_gp_reg(cur_op).is_some() {
+                                continue;
+                            }
+                        }
                         gp_regs[usize::from(r.code())] = GPConstraint::Input {
                             op: op.clone(),
                             in_ext: RegExtension::Undefined,


### PR DESCRIPTION
The ultimate aim of this PR is to remove the "dealiasing hack" https://github.com/ykjit/yk/commit/695fda3ff54e36d382597d25a6853480cbffe3c1 (originally introduced in ad9f4254dc64895e2fd3cf9b0f51cedaa6df1c76). I was always a bit queasy about that hack, but I couldn't immediately break it. However it turns out that it causes (in-rare-but-they-can-happen-situations) stack aliasing when jumping back to traces.

Before we can get there, however, we need to make some important changes to the register allocator: in particular, we need to allow a single register to track multiple variables. So the first part of the PR gets the register allocator in shape to remove the dealiasing hack.

While I'm here I also removed the purely performance orientated "meaningful register" hack https://github.com/ykjit/yk/commit/04ae7a60bf8cb783689fd452e4dce7c148e2becc. Ironically, despite this being the same theoretical *cause* of the same incorrectness as the daliasing hack, in practise it also somewhat protected us from it -- by chance!

The exact effects of this PR on performance are a bit hard to predict. https://github.com/ykjit/yk/commit/919b97bc8ceb71f027ec1eddbf8bbea590ed1d27 will (mostly) increase performance but https://github.com/ykjit/yk/commit/04ae7a60bf8cb783689fd452e4dce7c148e2becc will sometimes decrease it (particularly for side traces). My guess is that, overall, any differences will be relatively minor, though individual benchmarks might gain/lose more than that suggests.