### PR TITLE
Revert "sync yklua"

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -4,7 +4,7 @@ set -eu
 
 # What git commit hash of yklua & ykcbf will we test in buildbot?
 YKLUA_REPO="https://github.com/ykjit/yklua.git"
-YKLUA_COMMIT="31435c33e98b2a33b8036fd05d714f2d0cdac0bd"
+YKLUA_COMMIT="8a7a2082d941291de90c8314b52fc2bc91353e0c"
 YKCBF_REPO="https://github.com/ykjit/ykcbf.git"
 YKCBF_COMMIT="431b92593180e1e376d08ecf383c4a1ab8473b3d"
 


### PR DESCRIPTION
This reverts commit 1087b06c89b70c3266aa02341ce7e4f7ea7fc2d0.

yklua's main branch is currently broken because of an incorrect idempotency optimisation. Although we think we might have fixed that, we then seem to bump into another unrelated error. How long that will take is unclear, so we need to make sure yk isn't blocked by that.