### PR TITLE
We need to tell the register allocator which registers to keep.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2376,13 +2376,7 @@ impl<'a> Assemble<'a> {
             .collect::<Vec<_>>();
         for (i, op) in src_ops.iter().enumerate() {
             let op = op.unpack(self.m);
-            let src = self.op_to_var_location(op.clone());
-            let dst = tgt_vars[i];
-            if dst == src {
-                // The value is already in the correct place.
-                continue;
-            }
-            if let VarLocation::Register(reg) = dst {
+            if let VarLocation::Register(reg) = tgt_vars[i] {
                 match reg {
                     Register::GP(r) => {
                         gp_regs[usize::from(r.code())] = GPConstraint::Input {


### PR DESCRIPTION
When the register allocator is shuffling registers around, it needs to know which registers need to keep their value maintained. The `if dst == src` check elided that information, which meant that the register allocator could -- if you were very unlucky! -- use an active register as a temporary register. Simply removing the check allows the register allocator to do the right thing.

[This bug has been present for a while; #1648 just got unlucky enough to trigger it. But since it's not exactly related to that PR, fixing it in master is a good idea.]