### PR TITLE
Tidy up some tests.

### DIFF
--- a/tests/c/arithmetic.c
+++ b/tests/c/arithmetic.c
@@ -40,8 +40,6 @@
 #include <yk.h>
 #include <yk_testing.h>
 
-__attribute__((noinline)) int foo(int i) { return i + 3; }
-
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);

--- a/tests/c/ashr_exact.c
+++ b/tests/c/ashr_exact.c
@@ -30,8 +30,6 @@
 #include <yk.h>
 #include <yk_testing.h>
 
-__attribute__((noinline)) int foo(int i) { return i + 3; }
-
 struct P {
   int *yklocs;
   int *code;

--- a/tests/c/inline_const.c
+++ b/tests/c/inline_const.c
@@ -20,7 +20,8 @@
 //     yk-jit-event: deoptimise
 //     exit
 
-// Check that constant return values of inlined functions are properly mapped.
+// Check that constant return values of functions inlined into a trace are
+// properly mapped.
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/c/qsort.c
+++ b/tests/c/qsort.c
@@ -40,7 +40,7 @@ int cmp(const void *a, const void *b) {
     return 1;
 }
 
-__attribute__((noinline)) void print_elems(int elems[]) {
+void print_elems(int elems[]) {
   for (int i = 0; i < N_ELEMS; i++)
     fprintf(stderr, "%d ", elems[i]);
   fprintf(stderr, "end\n");

--- a/tests/c/simple_binop.c
+++ b/tests/c/simple_binop.c
@@ -59,8 +59,6 @@
 #include <yk.h>
 #include <yk_testing.h>
 
-__attribute__((noinline)) int foo(int i) { return i + 3; }
-
 int main(int argc, char **argv) {
   YkMT *mt = yk_mt_new(NULL);
   yk_mt_hot_threshold_set(mt, 0);

--- a/tests/c/simple_inline.c
+++ b/tests/c/simple_inline.c
@@ -22,7 +22,8 @@
 //     yk-jit-event: deoptimise
 //     exit
 
-// Check that return values of inlined functions are properly mapped.
+// Check that return values of fucntions inlined into the trace are properly
+// mapped.
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/c/void_ret.c
+++ b/tests/c/void_ret.c
@@ -10,7 +10,7 @@
 //     yk-jit-event: deoptimise
 //     ...
 
-// Check that inlining a function with a void return type works.
+// Check inlining a function into the trace that has a void return type.
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/c/yk_debug_str_outline.c
+++ b/tests/c/yk_debug_str_outline.c
@@ -46,7 +46,7 @@
 
 #define MAX_MSG 128
 
-__attribute__((yk_outline,noinline))
+__attribute__((yk_outline))
 void f() {
   yk_debug_str("inside f");
 }


### PR DESCRIPTION
All of these found when auditing use of __attribute__((noinline)) in tests. Most uses are legit.