### PR TITLE
Deal with tracing starting in nested interpreter frames.

### DIFF
--- a/tests/c/trace_while_executing1.c
+++ b/tests/c/trace_while_executing1.c
@@ -1,0 +1,72 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   stderr:
+//     yk-jit-event: start-tracing
+//     0: 5
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//       ...
+//       call @indirect(%17, %18, %19, %20, %21)
+//       ...
+//     --- End jit-pre-opt ---
+//     0: 4
+//     yk-jit-event: enter-jit-code
+//     0: 3
+//     yk-jit-event: start-tracing
+//     1: 3
+//     0: 2
+//     0: 1
+//     yk-jit-event: tracing-aborted
+//     yk-jit-event: deoptimise
+//     exit
+
+// Test that we don't record a successful trace if we started tracing in an
+// inner control point, fall back to executing JIT code, and then deopt.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+void indirect(YkMT *, YkLocation *, YkLocation *, int, int);
+
+void loop(YkMT *mt, YkLocation *loc1, YkLocation *loc2, int i, int depth) {
+  YkLocation *loc = loc1;
+  if (depth == 1)
+    loc = loc2;
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    fprintf(stderr, "%d: %d\n", depth, i);
+    if (depth == 1 && i == 3)
+      return;
+    indirect(mt, loc1, loc2, i, depth);
+    i--;
+  }
+}
+
+__attribute__((yk_outline))
+void indirect(YkMT *mt, YkLocation *loc1, YkLocation *loc2, int i, int depth) {
+  // for (int j = 0; j < i; j++)
+  //   printf(".");
+  // printf("\n");
+  if (depth == 0 && i == 3)
+    loop(mt, loc1, loc2, i, 1);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc1 = yk_location_new();
+  YkLocation loc2 = yk_location_new();
+
+  loop(mt, &loc1, &loc2, 5, 0);
+  fprintf(stderr, "exit\n");
+  yk_location_drop(loc1);
+  yk_location_drop(loc2);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/trace_while_executing2.c
+++ b/tests/c/trace_while_executing2.c
@@ -1,0 +1,76 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   stderr:
+//     yk-jit-event: start-tracing
+//     0: 5
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//       ...
+//       call @indirect(%17, %18, %19, %20, %21)
+//       ...
+//     --- End jit-pre-opt ---
+//     0: 4
+//     yk-jit-event: enter-jit-code
+//     0: 3
+//     yk-jit-event: deoptimise
+//     yk-jit-event: start-tracing
+//     1: 3
+//     yk-jit-event: tracing-aborted
+//     0: 2
+//     yk-jit-event: start-tracing
+//     0: 1
+//     exit
+
+// Test that we don't record a successful trace if we started tracing in an inner control point.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+void indirect(YkMT *, YkLocation *, YkLocation *, int, int);
+
+void loop(YkMT *mt, YkLocation *loc1, YkLocation *loc2, int i, int depth) {
+  YkLocation *loc = loc1;
+  if (depth == 1)
+    loc = loc2;
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    fprintf(stderr, "%d: %d\n", depth, i);
+    if (i == 3) {
+      if (depth == 0)
+        loc = loc2;
+      else
+        return;
+    }
+    indirect(mt, loc1, loc2, i, depth);
+    i--;
+  }
+}
+
+__attribute__((yk_outline))
+void indirect(YkMT *mt, YkLocation *loc1, YkLocation *loc2, int i, int depth) {
+  // for (int j = 0; j < i; j++)
+  //   printf(".");
+  // printf("\n");
+  if (depth == 0 && i == 3)
+    loop(mt, loc1, loc2, i, 1);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc1 = yk_location_new();
+  YkLocation loc2 = yk_location_new();
+
+  loop(mt, &loc1, &loc2, 5, 0);
+  fprintf(stderr, "exit\n");
+  yk_location_drop(loc1);
+  yk_location_drop(loc2);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
The "main" test here is `trace_while_executing1.c`, which models a failure we see occasionally in yklua: a JIT frame ends up calling an interpreter frame, which starts tracing, and tracing doesn't falls back into the JIT frame, which then happens to deopt. It took me quite a while to convince myself that's what happening, but it really is!

`trace_while_executing2.c` is a sort-of variant test of something similar that we happened to already deal with correctly, but which no test captured.