### PR TITLE
Better reverse hinting

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -630,7 +630,7 @@ impl LSRegAlloc<'_> {
                 GPConstraint::Output { .. }
                 | GPConstraint::InputOutput { .. }
                 | GPConstraint::AlignExtension { .. } => {
-                    if let Some(Register::GP(reg)) = self.rev_an.reg_hints[usize::from(iidx)] {
+                    if let Some(Register::GP(reg)) = self.rev_an.reg_hint(iidx) {
                         if !asgn_regs.is_set(reg) {
                             cnstr_regs[i] = Some(reg);
                             asgn_regs.set(reg);
@@ -1408,7 +1408,7 @@ impl LSRegAlloc<'_> {
                 RegConstraint::Output
                 | RegConstraint::OutputCanBeSameAsInput(_)
                 | RegConstraint::InputOutput(_) => {
-                    if let Some(Register::FP(reg)) = self.rev_an.reg_hints[usize::from(iidx)] {
+                    if let Some(Register::FP(reg)) = self.rev_an.reg_hint(iidx) {
                         if !avoid.is_set(reg) {
                             *cnstr = match cnstr {
                                 RegConstraint::Output => RegConstraint::OutputFromReg(reg),

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -45,7 +45,7 @@ pub(crate) struct RevAnalyse<'a> {
     /// `[[2, 1], [], [4, 3]]` but `[[1, 2], ..]` is invalid.
     def_use: Vec<Vec<InstIdx>>,
     /// What [Register] should an instruction aim to put its output to?
-    pub(crate) reg_hints: Vec<Option<Register>>,
+    reg_hints: Vec<Option<Register>>,
 }
 
 impl<'a> RevAnalyse<'a> {
@@ -226,6 +226,12 @@ impl<'a> RevAnalyse<'a> {
     pub(super) fn used_later_than(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> bool {
         self.inst_vals_alive_until[usize::from(cur_iidx)]
             >= self.inst_vals_alive_until[usize::from(query_iidx)]
+    }
+
+    /// Which register should the output of `cur_iidx` ideally be put into? Note: this is a hint,
+    /// not a demand, and not following it does not affect correctness!
+    pub(super) fn reg_hint(&self, cur_iidx: InstIdx) -> Option<Register> {
+        self.reg_hints[usize::from(cur_iidx)]
     }
 
     /// Record that `use_iidx` is used at instruction `def_iidx`.

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -16,9 +16,9 @@ use super::{Register, VarLocation};
 use crate::compile::jitc_yk::{
     codegen::x64::{ARG_FP_REGS, ARG_GP_REGS},
     jit_ir::{
-        BinOp, BinOpInst, DirectCallInst, DynPtrAddInst, ICmpInst, IndirectCallInst, Inst, InstIdx,
-        LoadInst, Module, Operand, PtrAddInst, SExtInst, SelectInst, StoreInst, TraceKind,
-        TruncInst, Ty, ZExtInst,
+        BinOp, BinOpInst, DirectCallInst, DynPtrAddInst, GuardInst, ICmpInst, IndirectCallInst,
+        Inst, InstIdx, LoadInst, Module, Operand, PtrAddInst, SExtInst, SelectInst, StoreInst,
+        TraceKind, TruncInst, Ty, ZExtInst,
     },
     YkSideTraceInfo,
 };
@@ -184,6 +184,7 @@ impl<'a> RevAnalyse<'a> {
                 }
                 Inst::BinOp(x) => self.an_binop(iidx, x),
                 Inst::Call(x) => self.an_call(iidx, x),
+                Inst::Guard(x) => self.an_guard(iidx, x),
                 Inst::ICmp(x) => self.an_icmp(iidx, x),
                 Inst::IndirectCall(x) => self.an_indirect_call(iidx, self.m.indirect_call(x)),
                 Inst::DynPtrAdd(x) => self.an_dynptradd(iidx, x),
@@ -408,6 +409,10 @@ impl<'a> RevAnalyse<'a> {
 
     fn an_dynptradd(&mut self, iidx: InstIdx, dpainst: DynPtrAddInst) {
         self.push_reg_hint(iidx, dpainst.num_elems(self.m));
+    }
+
+    fn an_guard(&mut self, iidx: InstIdx, ginst: GuardInst) {
+        self.push_reg_hint(iidx, ginst.cond(self.m));
     }
 
     /// Analyse a [LoadInst]. Returns `true` if it has been inlined and should not go through the


### PR DESCRIPTION
This PR improves reverse register hinting, in particular allowing instructions to be "hinted" in different registers as the trace evolves. This helps us generate slightly better code on long traces.