### PR TITLE
Add the ability to compile inner loops discovered during tracing an outer loop.

### DIFF
--- a/tests/c/compile_inner_loop_simple.c
+++ b/tests/c/compile_inner_loop_simple.c
@@ -1,0 +1,70 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   stderr:
+//     ...
+//     yk-jit-event: start-tracing
+//     i=0, loc0
+//     i=1, loc1
+//     yk-jit-event: stop-tracing (inner loop detected)
+//     i=2, loc1
+//     yk-jit-event: enter-jit-code
+//     i=3, loc1
+//     i=4, loc1
+//     yk-jit-event: deoptimise
+//     i=5, loc0
+//     ...
+
+// Check that we can switch to compiling an inner loop that we discover when
+// tracing an outer loop.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define NUM_LOCS 3
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+
+  YkLocation locs[NUM_LOCS];
+  for (int i = 0; i < NUM_LOCS; i++) {
+    locs[i] = yk_location_new();
+  }
+
+  // The locations we will encounter (in order) in the loop below.
+  // We will start tracing at locs[0], but there is an inner loop starting
+  // at locs[1], and it is the inner loop we should compile.
+  YkLocation *loc_seq[] = {
+    &locs[0], &locs[1], &locs[1], &locs[1], &locs[1], &locs[0], &locs[2] };
+
+  int i = 0;
+  NOOPT_VAL(i);
+  for (; i < 7; i++) {
+    YkLocation *loc = loc_seq[i];
+    /* yk_debug_str("control point"); */
+    yk_mt_control_point(mt, loc);
+
+    char *s = NULL;
+    if (loc == &locs[0]) {
+      s = "loc0";
+    } else if (loc == &locs[1]) {
+      s = "loc1";
+    } else if (loc == &locs[2]) {
+      s = "loc2";
+    } else {
+      abort(); // unreachable
+    }
+    fprintf(stderr, "i=%d, %s\n", i, s);
+  }
+
+  for (int i = 0; i < NUM_LOCS; i++) {
+    yk_location_drop(locs[i]);
+  }
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -130,6 +130,14 @@ pub extern "C" fn __ykrt_control_point_real(
 ) {
     let mt = unsafe { &*mt };
     let loc = unsafe { &*loc };
+
+    // If this thread is tracing, count how many times we've seen the control point since starting.
+    //
+    // This has to happen before the `loc.is_null()` check below because we have to include calls
+    // to the control point with null locations.
+    use ykrt::MTThread;
+    MTThread::inc_cp_idx();
+
     if !loc.is_null() {
         let arc = unsafe { Arc::from_raw(mt) };
         arc.control_point(loc, frameaddr, smid);

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -132,6 +132,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
+        start_cp_idx: usize,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         // If either `unwrap` fails, there is no chance of the system working correctly.
         let aot_mod = &*AOT_MOD;
@@ -145,8 +146,15 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
 
         let sti = sti.map(|s| s.as_any().downcast::<YkSideTraceInfo<Register>>().unwrap());
 
-        let mut jit_mod =
-            trace_builder::build(&mt, aot_mod, aottrace_iter, sti, promotions, debug_strs)?;
+        let mut jit_mod = trace_builder::build(
+            &mt,
+            aot_mod,
+            aottrace_iter,
+            sti,
+            promotions,
+            debug_strs,
+            start_cp_idx,
+        )?;
 
         if should_log_ir(IRPhase::PreOpt) {
             log_ir(&format!(
@@ -192,8 +200,17 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
+        start_cp_idx: usize,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
-        self.compile(mt, aottrace_iter, None, hl, promotions, debug_strs)
+        self.compile(
+            mt,
+            aottrace_iter,
+            None,
+            hl,
+            promotions,
+            debug_strs,
+            start_cp_idx,
+        )
     }
 
     fn sidetrace_compile(
@@ -205,7 +222,7 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
-        self.compile(mt, aottrace_iter, Some(sti), hl, promotions, debug_strs)
+        self.compile(mt, aottrace_iter, Some(sti), hl, promotions, debug_strs, 0)
     }
 }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -54,6 +54,7 @@ pub(crate) trait Compiler: Send + Sync {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
+        start_cp_idx: usize,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 
     /// Compile a mapped root trace into machine code.


### PR DESCRIPTION
Please critique this approach to compiling inner loops found when tracing an outer loop.

It works by counting how many times we encounter the control point since starting tracing, and chopping a prefix (of that many control points) off the mapped trace before the trace builder starts proper.

All yk tests pass. Not tried on Lua tests or benchmarks yet.

Showing this now only to get an idea as to whether this is worth continuing. This is woefully untested and unpolished. Don't review the code too carefully, just the overarching approach for now.