### PR TITLE
Silence Clippy errors on nightly.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -598,7 +598,7 @@ impl MT {
                         } = mtt.peek_mut_tstate()
                         {
                             let mut akind = None;
-                            if frameaddr != *tracing_frameaddr {
+                            if !std::ptr::eq(frameaddr, *tracing_frameaddr) {
                                 // We're tracing but no longer in the frame we started in, so we
                                 // need to stop tracing and report the original [HotLocation] as
                                 // having failed to trace properly.
@@ -811,7 +811,7 @@ impl MT {
                             else {
                                 panic!()
                             };
-                            if frameaddr != *tracing_frameaddr {
+                            if !std::ptr::eq(frameaddr, *tracing_frameaddr) {
                                 // We're tracing but no longer in the frame we started in, so we
                                 // need to stop tracing and report the original [HotLocation] as
                                 // having failed to trace properly.


### PR DESCRIPTION
Since pointer comparison is uncommon, I think that bringing it out explicitly like this is a good thing (i.e. that's why I haven't silenced the warnings).