### PR TITLE
Give `icmp_guard` a better way of assigning registers.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2068,24 +2068,20 @@ impl<'a> Assemble<'a> {
         if bitw == 32 || bitw == 64 {
             in_ext = RegExtension::Undefined;
         }
-        let patch_reg = if let Some(v) = imm {
-            let [lhs_reg, patch_reg] = self.ra.assign_gp_regs(
+        if let Some(v) = imm {
+            let [lhs_reg] = self.ra.assign_gp_regs(
                 &mut self.asm,
                 ic_iidx,
-                [
-                    GPConstraint::Input {
-                        op: lhs,
-                        in_ext,
-                        force_reg: None,
-                        clobber_reg: false,
-                    },
-                    GPConstraint::Temporary,
-                ],
+                [GPConstraint::Input {
+                    op: lhs,
+                    in_ext,
+                    force_reg: None,
+                    clobber_reg: false,
+                }],
             );
             self.cg_cmp_const(bitw, lhs_reg, v);
-            patch_reg
         } else {
-            let [lhs_reg, rhs_reg, patch_reg] = self.ra.assign_gp_regs(
+            let [lhs_reg, rhs_reg] = self.ra.assign_gp_regs(
                 &mut self.asm,
                 ic_iidx,
                 [
@@ -2101,14 +2097,16 @@ impl<'a> Assemble<'a> {
                         force_reg: None,
                         clobber_reg: false,
                     },
-                    GPConstraint::Temporary,
                 ],
             );
             self.cg_cmp_regs(bitw, lhs_reg, rhs_reg);
-            patch_reg
         };
 
         // Codegen guard
+        self.ra.expire_regs(g_iidx);
+        let [patch_reg] =
+            self.ra
+                .assign_gp_regs_no_cpu_flags(&mut self.asm, g_iidx, [GPConstraint::Temporary]);
         self.patch_reg.insert(g_inst.gidx.into(), patch_reg);
         let fail_label = self.guard_to_deopt(&g_inst);
         self.comment(Inst::Guard(g_inst).display(self.m, g_iidx).to_string());


### PR DESCRIPTION
Previously we allocated registers for both the `icmp` and the `guard` in one go, but that causes unspilling issues (and also caused us to generate slightly worse code than necessary, because we needed 3 registers in a combined icmp/guard rather than than 2 and then 1 registers separately). To work around that, however, seems tricky, because `assign_reg`s can set CPU flags.

This commit offers an alternative mechanism (which, currently, we don't need, but we probably will soon so it's `todo`ed) where in the worst case we will need to `push`/`pop` if we encounter a non-zero-extended `i1` that we need to spill.