### PR TITLE
Give `icmp_guard` a better way of assigning registers.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2068,24 +2068,20 @@ impl<'a> Assemble<'a> {
         if bitw == 32 || bitw == 64 {
             in_ext = RegExtension::Undefined;
         }
-        let patch_reg = if let Some(v) = imm {
-            let [lhs_reg, patch_reg] = self.ra.assign_gp_regs(
+        if let Some(v) = imm {
+            let [lhs_reg] = self.ra.assign_gp_regs(
                 &mut self.asm,
                 ic_iidx,
-                [
-                    GPConstraint::Input {
-                        op: lhs,
-                        in_ext,
-                        force_reg: None,
-                        clobber_reg: false,
-                    },
-                    GPConstraint::Temporary,
-                ],
+                [GPConstraint::Input {
+                    op: lhs,
+                    in_ext,
+                    force_reg: None,
+                    clobber_reg: false,
+                }],
             );
             self.cg_cmp_const(bitw, lhs_reg, v);
-            patch_reg
         } else {
-            let [lhs_reg, rhs_reg, patch_reg] = self.ra.assign_gp_regs(
+            let [lhs_reg, rhs_reg] = self.ra.assign_gp_regs(
                 &mut self.asm,
                 ic_iidx,
                 [
@@ -2101,14 +2097,14 @@ impl<'a> Assemble<'a> {
                         force_reg: None,
                         clobber_reg: false,
                     },
-                    GPConstraint::Temporary,
                 ],
             );
             self.cg_cmp_regs(bitw, lhs_reg, rhs_reg);
-            patch_reg
         };
 
         // Codegen guard
+        self.ra.expire_regs(g_iidx);
+        let patch_reg = self.ra.tmp_register_for_icmp_guard(&mut self.asm, g_iidx);
         self.patch_reg.insert(g_inst.gidx.into(), patch_reg);
         let fail_label = self.guard_to_deopt(&g_inst);
         self.comment(Inst::Guard(g_inst).display(self.m, g_iidx).to_string());


### PR DESCRIPTION
Previously we allocated registers for both the `icmp` and the `guard` in one go, but that:

  1. causes unspilling issues
  2. also caused us to generate slightly worse code than necessary, because we needed 3 registers in a combined icmp/guard rather than than 2 and then 1 registers separately)

It turns out that I really undercooked this on my first attempt! `icmp_guard` is actually more special than it first appears: we want to get a temporary register *but* unlike other instructions we don't want to put all possible inputs into registers (if nothing else, in general there are far more live variables than there are registers!). So our previous "give me a `GPConstraint::Temporary`" went wrong when all the registers contained values the guard needed: we hadn't told `assign_gp_regs` what we really wanted.

This commit is a pragmatic approach: we create a special function for `icmp_guard` that finds (or forces) an empty register, but doesn't remove information about values in registers (though it might spill one register). It also does that in a way that doesn't touch CPU flags.