### PR TITLE
When tracing, treat a compiling trace as a compiled trace.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -697,7 +697,15 @@ impl MT {
                                 TransitionControlPoint::Execute(Arc::clone(ctr))
                             }
                         }
-                        HotLocationKind::Compiling => TransitionControlPoint::NoAction,
+                        HotLocationKind::Compiling => {
+                            if is_tracing {
+                                TransitionControlPoint::AbortTracing(
+                                    AbortKind::EncounteredCompiledTrace,
+                                )
+                            } else {
+                                TransitionControlPoint::NoAction
+                            }
+                        }
                         HotLocationKind::Counting(c) => {
                             if is_tracing {
                                 // This thread is tracing something, so bail out as quickly as possible


### PR DESCRIPTION
In the long term we want to do much better than "abort", but for now, this makes things symmetric, and immediately stops us from creating some very silly traces.