### PR TITLE
Connector traces.

### DIFF
--- a/tests/c/connector_trace.c
+++ b/tests/c/connector_trace.c
@@ -1,0 +1,69 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   env-var: YKD_LOG=4
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   stderr:
+//     yk-jit-event: start-tracing
+//     6
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//       ...
+//       header_end ...
+//     --- End jit-pre-opt ---
+//     5
+//     yk-jit-event: start-tracing
+//     4
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//       ...
+//       connector ...
+//     --- End jit-pre-opt ---
+//     3
+//     yk-jit-event: enter-jit-code
+//     2
+//     yk-jit-event: deoptimise
+//     yk-jit-event: start-side-tracing
+//     yk-jit-event: stop-tracing
+//     --- Begin jit-pre-opt ---
+//       ...
+//       sidetrace_end ...
+//     --- End jit-pre-opt ---
+//     1
+//     exit
+
+// Test connector trace creation.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  yk_mt_sidetrace_threshold_set(mt, 0);
+  YkLocation loc1 = yk_location_new();
+  YkLocation loc2 = yk_location_new();
+
+  int i = 6;
+  NOOPT_VAL(loc1);
+  NOOPT_VAL(loc2);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    YkLocation *loc;
+    if (i > 4 || i == 3)
+      loc = &loc1;
+    else
+      loc = &loc2;
+    yk_mt_control_point(mt, loc);
+    fprintf(stderr, "%d\n", i);
+    i--;
+  }
+  fprintf(stderr, "exit");
+  yk_location_drop(loc1);
+  yk_location_drop(loc2);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -758,7 +758,7 @@ impl fmt::Display for DisplayableOperand<'_> {
 }
 
 #[deku_derive(DekuRead)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct DeoptSafepoint {
     pub(crate) id: u64,
     #[deku(temp)]

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -3,7 +3,7 @@ use crate::{
     aotsmp::AOT_STACKMAPS,
     compile::GuardIdx,
     log::Verbosity,
-    mt::{CompiledTraceId, MTThread},
+    mt::{MTThread, TraceId},
 };
 use dynasmrt::Register as _;
 use libc::c_void;
@@ -46,7 +46,7 @@ pub(crate) extern "C" fn __yk_deopt(
     fp_regs: &[u64; 16],
     ctrid: u64,
 ) -> *const libc::c_void {
-    let ctr = MTThread::with_borrow(|mtt| mtt.running_trace(CompiledTraceId::from_u64(ctrid)))
+    let ctr = MTThread::with_borrow(|mtt| mtt.running_trace(TraceId::from_u64(ctrid)))
         .as_any()
         .downcast::<X64CompiledTrace>()
         .unwrap();

--- a/ykrt/src/compile/jitc_yk/gdb.rs
+++ b/ykrt/src/compile/jitc_yk/gdb.rs
@@ -5,7 +5,7 @@
 //! (than just raw asm) displayed when debugging traces.
 
 use super::CompilationError;
-use crate::mt::CompiledTraceId;
+use crate::mt::TraceId;
 use deku::prelude::*;
 use indexmap::IndexMap;
 use std::{
@@ -175,7 +175,7 @@ impl Drop for GdbCtx {
 
 /// Inform gdb of newly-compiled JITted code.
 pub(crate) fn register_jitted_code(
-    ctr_id: CompiledTraceId,
+    ctr_id: TraceId,
     jitted_code: *const u8,
     jitted_code_size: usize,
     comments: &IndexMap<usize, Vec<String>>,

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -466,7 +466,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                             let op = self.process_operand(op)?;
                             self.m.trace_header_end.push(PackedOperand::new(&op));
                         }
-                        self.m.push(Inst::TraceHeaderEnd).unwrap();
+                        self.m.push(Inst::TraceHeaderEnd(false)).unwrap();
                     }
                     ASTInst::Trunc {
                         assign,

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -38,7 +38,7 @@ impl Module {
                     );
                 }
             }
-            super::TraceKind::Sidetrace(_) => (),
+            super::TraceKind::Sidetrace(_) | super::TraceKind::Connector(_) => (),
         }
 
         let mut last_inst = None;
@@ -313,7 +313,7 @@ impl Module {
                 }
                 Inst::Param(_) => {
                     if let Some(i) = last_inst {
-                        if !matches!(i, Inst::Param(_) | Inst::TraceHeaderEnd) {
+                        if !matches!(i, Inst::Param(_) | Inst::TraceHeaderEnd(_)) {
                             panic!("Param instruction may only appear at the beginning of a trace or after another Param instruction, or after the trace header jump\n  {}",
                                 self.inst(iidx).display(self, iidx));
                         }
@@ -332,7 +332,7 @@ mod tests {
         super::{ArbBitInt, TraceKind},
         BinOp, BinOpInst, Const, Inst, Module, Operand,
     };
-    use crate::mt::CompiledTraceId;
+    use crate::mt::TraceId;
 
     #[should_panic(expected = "Instruction at position 0 passing too few arguments")]
     #[test]
@@ -403,7 +403,7 @@ mod tests {
     fn cg_add_wrong_types() {
         // The parser will reject a binop with a result type different from either operand, so to
         // get the test we want, we can't use the parser.
-        let mut m = Module::new(TraceKind::HeaderOnly, CompiledTraceId::testing(), 0).unwrap();
+        let mut m = Module::new(TraceKind::HeaderOnly, TraceId::testing(), 0).unwrap();
         let c1 = m
             .insert_const(Const::Int(m.int1_tyidx(), ArbBitInt::from_u64(1, 0)))
             .unwrap();

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -11,9 +11,9 @@ use super::{
 };
 use crate::{
     aotsmp::AOT_STACKMAPS,
-    compile::CompilationError,
+    compile::{CompilationError, CompiledTrace},
     log::stats::TimingState,
-    mt::MT,
+    mt::{TraceId, MT},
     trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction},
 };
 use std::{collections::HashMap, ffi::CString, marker::PhantomData, sync::Arc};
@@ -62,19 +62,16 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
     ///  - `promotions`: Values promoted to constants during runtime.
     ///  - `debug_archors`: Debug strs recorded during runtime.
     fn new(
-        mt: &Arc<MT>,
+        _mt: &Arc<MT>,
         tracekind: TraceKind,
         aot_mod: &'static Module,
+        ctrid: TraceId,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
     ) -> Result<Self, CompilationError> {
         Ok(Self {
             aot_mod,
-            jit_mod: jit_ir::Module::new(
-                tracekind,
-                mt.next_compiled_trace_id(),
-                aot_mod.global_decls_len(),
-            )?,
+            jit_mod: jit_ir::Module::new(tracekind, ctrid, aot_mod.global_decls_len())?,
             local_map: HashMap::new(),
             cp_block: None,
             // We have to insert a placeholder frame to represent the place we started tracing, as
@@ -114,21 +111,26 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
         blk: &'static aot_ir::BBlock,
     ) -> Result<(), CompilationError> {
         // Find the control point call to retrieve the live variables from its safepoint.
-        //
-        // FIXME: Stash the location at IR lowering time, instead of searching at runtime.
-        let mut safepoint = None;
-        let mut inst_iter = blk.insts.iter().enumerate().rev();
-        for (_, inst) in inst_iter.by_ref() {
-            // Is it a call to the control point, then insert loads for the trace inputs. These
-            // directly reference registers or stack slots in the parent frame and thus don't
-            // necessarily result in machine code during codegen.
-            if inst.is_control_point(self.aot_mod) {
-                safepoint = Some(inst.safepoint().unwrap());
-                break;
+        let safepoint = match self.jit_mod.tracekind() {
+            TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
+                let mut inst_iter = blk.insts.iter().enumerate().rev();
+                let mut safepoint = None;
+                for (_, inst) in inst_iter.by_ref() {
+                    // Is it a call to the control point, then insert loads for the trace inputs. These
+                    // directly reference registers or stack slots in the parent frame and thus don't
+                    // necessarily result in machine code during codegen.
+                    if inst.is_control_point(self.aot_mod) {
+                        safepoint = Some(inst.safepoint().unwrap());
+                        break;
+                    }
+                }
+                // If we don't find a safepoint here something has gone wrong with the AOT IR.
+                safepoint.unwrap().clone()
             }
-        }
-        // If we don't find a safepoint here something has gone wrong with the AOT IR.
-        let safepoint = safepoint.unwrap();
+            TraceKind::Sidetrace(_) => unreachable!(),
+            TraceKind::Connector(ctr) => ctr.safepoint().as_ref().unwrap().clone(),
+        };
+        self.jit_mod.safepoint = Some(safepoint.clone());
         let (rec, _) = AOT_STACKMAPS
             .as_ref()
             .unwrap()
@@ -272,7 +274,13 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
                     incoming_vals,
                     ..
                 } => {
-                    debug_assert_eq!(prevbb.as_ref().unwrap().funcidx(), bid.funcidx());
+                    assert_eq!(
+                        prevbb.as_ref().map(|x| x.funcidx()),
+                        Some(bid.funcidx()),
+                        "{:?} {:?}",
+                        self.jit_mod.ctrid(),
+                        self.jit_mod.insts_len()
+                    );
                     self.handle_phi(
                         bid,
                         iidx,
@@ -1364,7 +1372,7 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
         }
 
         match self.jit_mod.tracekind() {
-            TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
+            TraceKind::HeaderOnly | TraceKind::HeaderAndBody | TraceKind::Connector(_) => {
                 // Find the block containing the control point call. This is the (sole) predecessor of the
                 // first (guaranteed mappable) block in the trace. Note that empty traces are handled in
                 // the tracing phase so the `unwrap` is safe.
@@ -1501,26 +1509,21 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
         let blk = self.aot_mod.bblock(self.cp_block.as_ref().unwrap());
         let cpcall = blk.insts.iter().rev().nth(1).unwrap();
         debug_assert!(cpcall.is_control_point(self.aot_mod));
+        let safepoint = cpcall.safepoint().unwrap();
+        for idx in 0..safepoint.lives.len() {
+            let aot_op = &safepoint.lives[idx];
+            let jit_op = &self.local_map[&aot_op.to_inst_id()];
+            self.jit_mod.push_header_end_var(jit_op.clone());
+        }
         match self.jit_mod.tracekind() {
-            TraceKind::Sidetrace(_) => {
-                // This is the end of a side-trace. Create a jump back to the root trace.
-                let safepoint = cpcall.safepoint().unwrap();
-                for idx in 0..safepoint.lives.len() {
-                    let aot_op = &safepoint.lives[idx];
-                    let jit_op = &self.local_map[&aot_op.to_inst_id()];
-                    self.jit_mod.push_header_end_var(jit_op.clone());
-                }
-                self.jit_mod.push(jit_ir::Inst::SidetraceEnd)?;
+            TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
+                self.jit_mod.push(jit_ir::Inst::TraceHeaderEnd(false))?;
             }
-            TraceKind::HeaderAndBody | TraceKind::HeaderOnly => {
-                // For normal traces insert a jump back to the loop start.
-                let safepoint = cpcall.safepoint().unwrap();
-                for idx in 0..safepoint.lives.len() {
-                    let aot_op = &safepoint.lives[idx];
-                    let jit_op = &self.local_map[&aot_op.to_inst_id()];
-                    self.jit_mod.push_header_end_var(jit_op.clone());
-                }
-                self.jit_mod.push(jit_ir::Inst::TraceHeaderEnd)?;
+            TraceKind::Connector(_) => {
+                self.jit_mod.push(jit_ir::Inst::TraceHeaderEnd(true))?;
+            }
+            TraceKind::Sidetrace(_) => {
+                self.jit_mod.push(jit_ir::Inst::SidetraceEnd)?;
             }
         }
 
@@ -1542,16 +1545,20 @@ struct InlinedFrame {
 pub(super) fn build<Register: Send + Sync + 'static>(
     mt: &Arc<MT>,
     aot_mod: &'static Module,
+    ctrid: TraceId,
     ta_iter: Box<dyn AOTTraceIterator>,
     sti: Option<Arc<YkSideTraceInfo<Register>>>,
     promotions: Box<[u8]>,
     debug_strs: Vec<String>,
+    connector_tid: Option<Arc<dyn CompiledTrace>>,
 ) -> Result<jit_ir::Module, CompilationError> {
     let tracekind = if let Some(x) = sti {
         TraceKind::Sidetrace(x)
+    } else if let Some(connector_tid) = connector_tid {
+        TraceKind::Connector(connector_tid)
     } else {
         TraceKind::HeaderOnly
     };
-    TraceBuilder::<Register>::new(mt, tracekind, aot_mod, promotions, debug_strs)?
+    TraceBuilder::<Register>::new(mt, tracekind, aot_mod, ctrid, promotions, debug_strs)?
         .build(mt, ta_iter)
 }

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(int_roundings)]
 #![feature(let_chains)]
 #![feature(naked_functions)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::upper_case_acronyms)]
 

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::{
     compile::{CompiledTrace, GuardIdx},
-    mt::{HotThreshold, TraceCompilationErrorThreshold, MT},
+    mt::{HotThreshold, TraceCompilationErrorThreshold, TraceId, MT},
 };
 use parking_lot::Mutex;
 
@@ -317,7 +317,7 @@ pub(crate) enum HotLocationKind {
     Compiled(Arc<dyn CompiledTrace>),
     /// A trace for this HotLocation is being compiled in another trace. When compilation is
     /// complete, the compiling thread will update the state of this HotLocation.
-    Compiling,
+    Compiling(TraceId),
     /// Because of a failure in compiling / tracing, we have reentered the `Counting` state. This
     /// can be seen as a way of implementing back-off in the face of errors.
     Counting(HotThreshold),
@@ -345,7 +345,7 @@ impl std::fmt::Debug for HotLocationKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Compiled(_) => write!(f, "Compiled"),
-            Self::Compiling => write!(f, "Compiling"),
+            Self::Compiling(_) => write!(f, "Compiling"),
             Self::Counting(_) => write!(f, "Counting"),
             Self::DontTrace => write!(f, "DontTrace"),
             Self::Tracing => write!(f, "Tracing"),


### PR DESCRIPTION
Connector traces are non-looping traces that end by jumping to an existing `CompiledTrace`. They allow us to "stay within machine code" much more often: not only is that faster than the interpreter, but it also means that we sidestep deopt costs. RPython calls this kind of traces "bridges", but for some reason that name never gave me the right intuition, so I'm tentatively trying "connector" instead (I've previously tried "link", and "jump_to", but those weren't improvements). I suggest we don't get hung up on the name yet, because the semantic and performance change is what this commit is all about!

The most obvious use for connector traces is when you have inner/outer loops e.g.:

```
for x in .. {
  for y in .. { }
}
```

In most cases the inner loop will get hot first, and lead to a `CompiledTrace`. When we later trace the outer loop, what should we do?

  * We could unroll the inner loop, but that's nearly always a bad idea (we once did this!).
  * We could abort compilation (which is what we did before this commit).
  * We can create a connector trace from the start of the outer loop to the inner loop's `CompiledTrace`.

That's what this commit does -- and more!

It also alters sidetraces so that they no longer have to end in a root trace. In other words, sidetraces can (optionally) be a kind of connector trace. In the example above, we will end up with a "connector sidetrace" from the end of the inner loop to the outerloop's connector trace.

It also makes all of this play well with parallel compilation: compilation jobs can now have a dependency on a yet-to-be-compiled trace (hence the `CompiledTraceId` -> `TraceId` renaming). This means that we can trace the outer loop while the inner trace is still compiling, and put the outer trace on the compilation queue: we won't start compiling it until the inner trace has been compiled.

This commit doesn't tie up every possible loose end (e.g. we can now end up with "dead" compilation jobs if a compiling trace fails to compile and there are dependent traces waiting upon it), but it's already sufficiently big and complex that I think trying to do more will be overwhelming.

This commit doesn't help every benchmark, but when it does, it can be very helpful e.g.: deltablue is improved by a smidgen under 2x; richards by 1.15x. On deltablue this is because we previously compiled about 13 traces successfully and aborted 48: with this commit we successfully compile 104 traces and abort none. On richards we also successfully compile many more traces, but deopt time goes down by 10x.