### PR TITLE
Fix a bug where we asked the wrong thing for its size.

### DIFF
--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -2400,7 +2400,6 @@ mod test {
             *%1 = 1i64
             *%2 = 1i64
             *%1 = 1i64
-            black_box %1
         ",
             |m| opt(m).unwrap(),
             "
@@ -2411,7 +2410,6 @@ mod test {
             %2: ptr = ptr_add %0, 16
             *%1 = 1i64
             *%2 = 1i64
-            black_box %1
         ",
         );
 
@@ -2419,24 +2417,42 @@ mod test {
             "
           entry:
             %0: ptr = param reg
-            %1: ptr = ptr_add %0, 1
+            %1: ptr = ptr_add %0, 7
             %2: ptr = ptr_add %0, 8
             *%1 = 1i8
             *%2 = 1i64
             *%1 = 1i8
-            black_box %1
         ",
             |m| opt(m).unwrap(),
             "
           ...
           entry:
             %0: ptr = param ...
-            %1: ptr = ptr_add %0, 1
+            %1: ptr = ptr_add %0, 7
             %2: ptr = ptr_add %0, 8
             *%1 = 1i8
             *%2 = 1i64
-            *%1 = 1i8
-            black_box %1
+        ",
+        );
+
+        Module::assert_ir_transform_eq(
+            "
+          entry:
+            %0: ptr = param reg
+            %1: ptr = ptr_add %0, 4
+            *%1 = 1i32
+            *%0 = 1i64
+            *%1 = 1i32
+        ",
+            |m| opt(m).unwrap(),
+            "
+          ...
+          entry:
+            %0: ptr = param ...
+            %1: ptr = ptr_add %0, 4
+            *%1 = 1i32
+            *%0 = 1i64
+            *%1 = 1i32
         ",
         );
     }


### PR DESCRIPTION
We previously nearly always checked that stores didn't overlap by 8 bytes, rather than the actual bytewidth of the value in question. Since we don't support more than 64 bit values currently, this wasn't a potential crashing bug, but it made the analysis unnecessarily pessimistic.