### PR TITLE
Propagate constant heapvalues

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -283,7 +283,7 @@ impl<'a> RevAnalyse<'a> {
 
     /// Record that `use_iidx` is used at instruction `def_iidx`.
     fn push_def_use(&mut self, def_iidx: InstIdx, use_iidx: InstIdx) {
-        debug_assert!(def_iidx < use_iidx);
+        assert!(def_iidx < use_iidx);
         self.def_use[usize::from(def_iidx)].push(use_iidx);
     }
 

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -46,6 +46,13 @@ impl Analyse {
         }
     }
 
+    /// Propagate relevant analysis from the trace header to body. This must only be called at the
+    /// end of analysing the trace header; doing otherwise leads to undefined behaviour. `map` is a
+    /// 1:1 mapping of "header [InstIdx] to body [InstIdx]".
+    pub(super) fn propagate_header_to_body(&self, map: &[InstIdx]) {
+        self.heapvalues.borrow_mut().propagate_header_to_body(map);
+    }
+
     /// Map `op` based on our analysis so far. In some cases this will return `op` unchanged, but
     /// in others it may be able to turn what looks like a variable reference into a constant.
     pub(super) fn op_map(&self, m: &Module, op: Operand) -> Operand {

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -2134,36 +2134,6 @@ mod test {
         );
     }
 
-    #[ignore]
-    #[test]
-    fn opt_peeling_hoist() {
-        Module::assert_ir_transform_eq(
-            "
-          entry:
-            %0: i8 = param reg
-            %1: i8 = param reg
-            body_start [%0, %1]
-            %2: i8 = add %0, 1i8
-            %3: i8 = add %1, %2
-            body_end [%0, %3]
-        ",
-            |m| opt(m).unwrap(),
-            "
-          ...
-          entry:
-            %0: i8 = param ...
-            %1: i8 = param ...
-            head_start [%0, %1]
-            %3: i8 = add %0, 1i8
-            %4: i8 = add %1, %3
-            head_end [%0, %4, %3]
-            body_start [%0, %4, %3]
-            %10: i8 = add %4, %3
-            body_end [%0, %10, %3]
-        ",
-        );
-    }
-
     #[test]
     fn opt_dead_load() {
         Module::assert_ir_transform_eq(


### PR DESCRIPTION
After a couple of warmup commits, the main part of this PR is https://github.com/ykjit/yk/commit/6e555c361dd43481b48be19357ae52dcbfd9fce7 which propagates knowledge of "constants stored in the heap" across peeling. It's probably easiest to see what this is doing from the new `opt_peeling_heap` test. This is simple, conservative, and also surprisingly effective on yklua: on a couple of tight loop benchmarks (e.g. bigloop, nbody) this gives a 3-5% boost.