### PR TITLE
Only propagate heap information for unchanging pointers.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -643,12 +643,26 @@ impl Module {
         GuardInfoIdx::try_from(self.guard_info.len()).inspect(|_| self.guard_info.push(info))
     }
 
+    pub(crate) fn trace_header_start(&self) -> &[PackedOperand] {
+        &self.trace_header_start
+    }
+
+    /// Return the position in the list of live variables at the trace header start, if any, of
+    /// `op`.
+    pub(crate) fn trace_header_start_position(&self, op: Operand) -> Option<usize> {
+        let pop = PackedOperand::new(&op);
+        self.trace_header_start.iter().position(|x| x == &pop)
+    }
+
     pub(crate) fn trace_header_end(&self) -> &[PackedOperand] {
         &self.trace_header_end
     }
 
-    pub(crate) fn trace_header_start(&self) -> &[PackedOperand] {
-        &self.trace_header_start
+    /// Return the position in the list of live variables at the trace header end, if any, of
+    /// `op`.
+    pub(crate) fn trace_header_end_position(&self, op: Operand) -> Option<usize> {
+        let pop = PackedOperand::new(&op);
+        self.trace_header_end.iter().position(|x| x == &pop)
     }
 
     pub(crate) fn trace_body_start(&self) -> &[PackedOperand] {

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -49,8 +49,10 @@ impl Analyse {
     /// Propagate relevant analysis from the trace header to body. This must only be called at the
     /// end of analysing the trace header; doing otherwise leads to undefined behaviour. `map` is a
     /// 1:1 mapping of "header [InstIdx] to body [InstIdx]".
-    pub(super) fn propagate_header_to_body(&self, map: &[InstIdx]) {
-        self.heapvalues.borrow_mut().propagate_header_to_body(map);
+    pub(super) fn propagate_header_to_body(&self, m: &Module, map: &[InstIdx]) {
+        self.heapvalues
+            .borrow_mut()
+            .propagate_header_to_body(m, map);
     }
 
     /// Map `op` based on our analysis so far. In some cases this will return `op` unchanged, but


### PR DESCRIPTION
The very simple new test captures something that I didn't get right before. In essence, it's a "zero all memory" trace but before we didn't notice that the pointer increments on each iteration of the trace.

This commit checks that we only propagate knowledge of pointers that are truly loop invariant. We do that by checking that the same SSA value that was an input to the trace header is passed to the trace end.