### PR TITLE
Fix idempotent promotes.

### DIFF
--- a/tests/c/yk_outline_dynamic_with_promote.c
+++ b/tests/c/yk_outline_dynamic_with_promote.c
@@ -1,0 +1,59 @@
+// Compiler:
+//   env-var: YKB_EXTRA_CC_FLAGS=-O2
+// Run-time:
+//   env-var: YKD_LOG_IR=aot
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   stderr:
+//     ...
+//     --- Begin aot ---
+//     ...
+//     func f(...
+//     ...
+//     %{{_}}: i{{size}} = icall %{{_}}(%{{_}})
+//     ...
+//     }
+//     ...
+//     --- End aot ---
+//     ...
+
+// Check that promotes in indirect callees of outlined functions are consumed
+// properly during outlining. If we failed to consume them, an assertion would
+// fail in the trace builder.
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+__attribute__((noinline))
+uintptr_t g(uintptr_t x) {
+  return yk_promote(x) + 1;
+}
+
+__attribute__((yk_outline))
+uintptr_t f(uintptr_t x) {
+  // force an indirect call.
+  uintptr_t (*fptr)(uintptr_t) = g;
+  NOOPT_VAL(fptr);
+  return fptr(x);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  size_t i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "%" PRIuPTR ": %" PRIuPTR "\n", i, f(1));
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
We were immediately consuming the return value from the promote buffer upon encountering a call to an idempotent function. If the callee calls functions that then promote their own values, then this means we consume the promote buffer in the wrong order.

This change ensures we only consume the return value from the promote buffer *after* we have returned from the idempotent function, and thus all inner promotions will already have been handled.

We achieve this by introducing a "pending" state for idempotent constants. When the trace builder encounters a call to an idempotent function it sets the `idem_const` field to `IdemConst::Pending`. When the trace builder has finishes outlining, it checks if it just emitted a call instruction with a pending `idem_const`, and if so it replaces it with `IdemConst::Const(cidx)`.