### PR TITLE
Fix yklua submodule uninitialised error message.

### DIFF
--- a/tests/langtest_lua.rs
+++ b/tests/langtest_lua.rs
@@ -20,7 +20,7 @@ const COMMENT_PREFIX: &str = "##";
 fn build() {
     // Build yklua for testing purposes.
 
-    if !Path::new(YKLUA_SUBMODULE_PATH).is_dir() {
+    if !Path::new(&format!("{}/Makefile", YKLUA_SUBMODULE_PATH)).is_file() {
         panic!(
             "yklua submodule not found. To checkout:\n  git submodule update --init --recursive"
         );


### PR DESCRIPTION
The error message that informs us if the yklua submodule hasn't been initialised yet isn't showing. The condition checks if the `tests/yklua` folder exists, which is always true. We need to instead check whether it contains any files to determine if the submodule has been initialised.

Which file to check for is a bit tricky as the yklua repo might change in the future, but checking for the `Makefile` is probably good enough for now. The proper fix would be to use `git submodule status` but that change is a bit more involved.