### PR TITLE
Better debug string tests

### DIFF
--- a/tests/langtest_lua.rs
+++ b/tests/langtest_lua.rs
@@ -91,7 +91,11 @@ fn build() {
     // there's nothing to do, it'll finish quicker than we can notice!
     let mut make_cmd = Command::new("make");
     make_cmd
-        .args(["-j".into(), num_cpus::get().to_string()])
+        .args([
+            "-j".into(),
+            num_cpus::get().to_string(),
+            "MYCFLAGS=-DYKLUA_DEBUG_STRS=2".into(),
+        ])
         .env(
             "PATH",
             format!(

--- a/tests/langtest_lua.rs
+++ b/tests/langtest_lua.rs
@@ -1,189 +1,205 @@
 #![feature(exit_status_error)]
 
-use fs4::fs_std::FileExt;
-use lang_tester::LangTester;
-use regex::Regex;
-use std::{
-    env,
-    fs::{canonicalize, create_dir_all, read_to_string, write, File},
-    path::Path,
-    process::{exit, Command},
-};
-use ykbuild::{target_dir, ykllvm_bin_dir};
+use inner::main;
 
-const YKLUA_SUBMODULE_PATH: &str = "yklua";
-const YKLLLVM_SUBMODULE_PATH: &str = "../ykllvm";
+#[cfg(cargo_profile = "debug")]
+mod inner {
+    pub(super) fn main() {
+        // Right now, these tests tend to cause "trace too long" too often to be usable in debug
+        // mode.
+        println!("<Lua tests are not run in debug mode>");
+    }
+}
 
-const COMMENT: &str = "--";
-const COMMENT_PREFIX: &str = "##";
+#[cfg(cargo_profile = "release")]
+mod inner {
+    use fs4::fs_std::FileExt;
+    use lang_tester::LangTester;
+    use regex::Regex;
+    use std::{
+        env,
+        fs::{canonicalize, create_dir_all, read_to_string, write, File},
+        path::Path,
+        process::{exit, Command},
+    };
+    use ykbuild::{target_dir, ykllvm_bin_dir};
 
-fn build() {
-    // Build yklua for testing purposes.
+    const YKLUA_SUBMODULE_PATH: &str = "yklua";
+    const YKLLLVM_SUBMODULE_PATH: &str = "../ykllvm";
 
-    if !Path::new(&format!("{}/Makefile", YKLUA_SUBMODULE_PATH)).is_file() {
-        panic!(
+    const COMMENT: &str = "--";
+    const COMMENT_PREFIX: &str = "##";
+
+    fn build() {
+        // Build yklua for testing purposes.
+
+        if !Path::new(&format!("{}/Makefile", YKLUA_SUBMODULE_PATH)).is_file() {
+            panic!(
             "yklua submodule not found. To checkout:\n  git submodule update --init --recursive"
         );
-    }
+        }
 
-    // Set variables for tests `ignore-if`s.
-    #[cfg(cargo_profile = "debug")]
-    let profile = "debug";
-    #[cfg(cargo_profile = "release")]
-    let profile = "release";
-    let mut yklua_tgt_dir = target_dir();
-    yklua_tgt_dir.push("yklua");
-    create_dir_all(&yklua_tgt_dir).unwrap();
+        // Set variables for tests `ignore-if`s.
+        #[cfg(cargo_profile = "debug")]
+        let profile = "debug";
+        #[cfg(cargo_profile = "release")]
+        let profile = "release";
+        let mut yklua_tgt_dir = target_dir();
+        yklua_tgt_dir.push("yklua");
+        create_dir_all(&yklua_tgt_dir).unwrap();
 
-    // We use `rsync` to copy from the submodule to the target dir. This means that we can
-    // transparently build multiple copies of yklua without the user having to know that there is
-    // more than one copy.
-    let mut rsync_cmd = Command::new("rsync");
-    rsync_cmd.args(["-a", YKLUA_SUBMODULE_PATH, yklua_tgt_dir.to_str().unwrap()]);
-    rsync_cmd.status().unwrap().exit_ok().unwrap();
+        // We use `rsync` to copy from the submodule to the target dir. This means that we can
+        // transparently build multiple copies of yklua without the user having to know that there is
+        // more than one copy.
+        let mut rsync_cmd = Command::new("rsync");
+        rsync_cmd.args(["-a", YKLUA_SUBMODULE_PATH, yklua_tgt_dir.to_str().unwrap()]);
+        rsync_cmd.status().unwrap().exit_ok().unwrap();
 
-    // cargo can sometimes run multiple builds in parallel. At the moment that's probably only
-    // build scripts, though that doesn't seem to be precisely specified and might change in the
-    // future. To avoid tripping us up, we use the same trick as `ykbuild/build.rs` and use a
-    // `build_lock` so that we don't have two builds trampling on each other.
-    let mut lock_path = yklua_tgt_dir.clone();
-    lock_path.push("build_lock");
-    let lock_file = File::create(lock_path).unwrap();
-    lock_file.lock_exclusive().unwrap();
+        // cargo can sometimes run multiple builds in parallel. At the moment that's probably only
+        // build scripts, though that doesn't seem to be precisely specified and might change in the
+        // future. To avoid tripping us up, we use the same trick as `ykbuild/build.rs` and use a
+        // `build_lock` so that we don't have two builds trampling on each other.
+        let mut lock_path = yklua_tgt_dir.clone();
+        lock_path.push("build_lock");
+        let lock_file = File::create(lock_path).unwrap();
+        lock_file.lock_exclusive().unwrap();
 
-    let mut build_dir = yklua_tgt_dir.clone();
-    build_dir.push("yklua");
-    build_dir.push("src");
+        let mut build_dir = yklua_tgt_dir.clone();
+        build_dir.push("yklua");
+        build_dir.push("src");
 
-    // If ykllvm changes, we need to rebuild yklua from scratch. There isn't a perfect way to do
-    // this, because we can't easily distinguish dirty changes so:
-    //   1. If the commit hash changes, we `make clean`.
-    //   2. If the commit hash is suffixed with `-dirty`, we `make clean`.
-    // The second clause means that if you have local changes in the yklua submodule, you'll pay a
-    // rebuild penalty every time you run `cargo`.
-    let mut ykllvm_git_hash_path = yklua_tgt_dir.clone();
-    ykllvm_git_hash_path.push("ykllvm_hash");
-    let ykllvm_hash = String::from_utf8(
-        Command::new("git")
-            .current_dir(YKLLLVM_SUBMODULE_PATH)
-            .args(["describe", "--always", "--dirty", "--no-abbrev"])
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
-    let do_make_clean = if ykllvm_hash.trim().ends_with("-dirty") {
-        true
-    } else if let Ok(x) = read_to_string(&ykllvm_git_hash_path) {
-        x.trim() != ykllvm_hash.trim()
-    } else {
-        true
-    };
-    write(ykllvm_git_hash_path, ykllvm_hash).unwrap();
-    if do_make_clean {
-        let mut cmd = Command::new("make");
-        cmd.arg("clean")
-            .current_dir(build_dir.as_os_str().to_str().unwrap());
-        supuner(cmd);
-    }
-
-    // Because `make` is so quick, we can afford to run it every time this file is run -- if
-    // there's nothing to do, it'll finish quicker than we can notice!
-    let mut make_cmd = Command::new("make");
-    make_cmd
-        .args([
-            "-j".into(),
-            num_cpus::get().to_string(),
-            "MYCFLAGS=-DYKLUA_DEBUG_STRS=2".into(),
-        ])
-        .env(
-            "PATH",
-            format!(
-                "{}:{}:{}",
-                canonicalize("../bin/").unwrap().to_str().unwrap(),
-                ykllvm_bin_dir().to_str().unwrap(),
-                env::var("PATH").unwrap()
-            ),
-        )
-        .env("YK_BUILD_TYPE", profile)
-        .current_dir(build_dir.as_os_str().to_str().unwrap());
-    supuner(make_cmd);
-
-    FileExt::unlock(&lock_file).unwrap();
-}
-
-/// Run `cmd` without outputting anything to the terminal unless it fails. Failure will also cause
-/// this process to terminate.
-fn supuner(mut cmd: Command) {
-    let output = cmd.output().unwrap();
-    if !output.status.success() {
-        eprint!(
-            "{cmd:?} failed with error code {}.\n\n",
-            output
-                .status
-                .code()
-                .map_or_else(|| "<unknown>".to_string(), |x| x.to_string())
-        );
-        eprint!(
-            "--- begin stdout ---\n{}\n--- end stdout ---\n\n",
-            String::from_utf8_lossy(&output.stdout)
-        );
-        eprint!(
-            "--- begin stderr ---\n{}\n--- end stderr ---\n\n",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        exit(1);
-    }
-}
-
-fn main() {
-    build();
-
-    println!("Running Lua tests...");
-
-    // Set variables for tests `ignore-if`s.
-    #[cfg(cargo_profile = "debug")]
-    env::set_var("YK_CARGO_PROFILE", "debug");
-    #[cfg(cargo_profile = "release")]
-    env::set_var("YK_CARGO_PROFILE", "release");
-
-    #[cfg(target_arch = "x86_64")]
-    env::set_var("YK_ARCH", "x86_64");
-    #[cfg(not(target_arch = "x86_64"))]
-    panic!("Unknown target_arch");
-
-    LangTester::new()
-        .comment_prefix(COMMENT_PREFIX)
-        .test_dir("lua")
-        .test_path_filter(|p: &Path| p.extension().as_ref().and_then(|p| p.to_str()) == Some("lua"))
-        .test_extract(move |p| {
-            read_to_string(p)
+        // If ykllvm changes, we need to rebuild yklua from scratch. There isn't a perfect way to do
+        // this, because we can't easily distinguish dirty changes so:
+        //   1. If the commit hash changes, we `make clean`.
+        //   2. If the commit hash is suffixed with `-dirty`, we `make clean`.
+        // The second clause means that if you have local changes in the yklua submodule, you'll pay a
+        // rebuild penalty every time you run `cargo`.
+        let mut ykllvm_git_hash_path = yklua_tgt_dir.clone();
+        ykllvm_git_hash_path.push("ykllvm_hash");
+        let ykllvm_hash = String::from_utf8(
+            Command::new("git")
+                .current_dir(YKLLLVM_SUBMODULE_PATH)
+                .args(["describe", "--always", "--dirty", "--no-abbrev"])
+                .output()
                 .unwrap()
-                .lines()
-                .skip_while(|l| !l.starts_with(COMMENT))
-                .take_while(|l| l.starts_with(COMMENT))
-                .map(|l| &l[COMMENT.len()..])
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-        .test_cmds(move |p| {
-            let mut yklua_exe = target_dir();
-            yklua_exe.push("yklua");
-            yklua_exe.push("yklua");
-            yklua_exe.push("src");
-            yklua_exe.push("lua");
-            let mut cmd = Command::new(yklua_exe);
-            cmd.arg(p);
-            vec![("Run-time", cmd)]
-        })
-        .fm_options(|_, _, fmb| {
-            // Use `{{}}` to match non-literal strings in tests.
-            // E.g. use `%{{var}}` to capture the name of a variable.
-            let ptn_re = Regex::new(r"\{\{.+?\}\}").unwrap();
-            let ptn_re_ignore = Regex::new(r"\{\{_}\}").unwrap();
-            let text_re = Regex::new(r"[a-zA-Z0-9\._]+").unwrap();
-            fmb.name_matcher_ignore(ptn_re_ignore, text_re.clone())
-                .name_matcher(ptn_re, text_re)
-        })
-        .run();
+                .stdout,
+        )
+        .unwrap();
+        let do_make_clean = if ykllvm_hash.trim().ends_with("-dirty") {
+            true
+        } else if let Ok(x) = read_to_string(&ykllvm_git_hash_path) {
+            x.trim() != ykllvm_hash.trim()
+        } else {
+            true
+        };
+        write(ykllvm_git_hash_path, ykllvm_hash).unwrap();
+        if do_make_clean {
+            let mut cmd = Command::new("make");
+            cmd.arg("clean")
+                .current_dir(build_dir.as_os_str().to_str().unwrap());
+            supuner(cmd);
+        }
+
+        // Because `make` is so quick, we can afford to run it every time this file is run -- if
+        // there's nothing to do, it'll finish quicker than we can notice!
+        let mut make_cmd = Command::new("make");
+        make_cmd
+            .args([
+                "-j".into(),
+                num_cpus::get().to_string(),
+                "MYCFLAGS=-DYKLUA_DEBUG_STRS=2".into(),
+            ])
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}:{}",
+                    canonicalize("../bin/").unwrap().to_str().unwrap(),
+                    ykllvm_bin_dir().to_str().unwrap(),
+                    env::var("PATH").unwrap()
+                ),
+            )
+            .env("YK_BUILD_TYPE", profile)
+            .current_dir(build_dir.as_os_str().to_str().unwrap());
+        supuner(make_cmd);
+
+        FileExt::unlock(&lock_file).unwrap();
+    }
+
+    /// Run `cmd` without outputting anything to the terminal unless it fails. Failure will also cause
+    /// this process to terminate.
+    fn supuner(mut cmd: Command) {
+        let output = cmd.output().unwrap();
+        if !output.status.success() {
+            eprint!(
+                "{cmd:?} failed with error code {}.\n\n",
+                output
+                    .status
+                    .code()
+                    .map_or_else(|| "<unknown>".to_string(), |x| x.to_string())
+            );
+            eprint!(
+                "--- begin stdout ---\n{}\n--- end stdout ---\n\n",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            eprint!(
+                "--- begin stderr ---\n{}\n--- end stderr ---\n\n",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            exit(1);
+        }
+    }
+
+    pub(super) fn main() {
+        build();
+
+        println!("Running Lua tests...");
+
+        // Set variables for tests `ignore-if`s.
+        #[cfg(cargo_profile = "debug")]
+        env::set_var("YK_CARGO_PROFILE", "debug");
+        #[cfg(cargo_profile = "release")]
+        env::set_var("YK_CARGO_PROFILE", "release");
+
+        #[cfg(target_arch = "x86_64")]
+        env::set_var("YK_ARCH", "x86_64");
+        #[cfg(not(target_arch = "x86_64"))]
+        panic!("Unknown target_arch");
+
+        LangTester::new()
+            .comment_prefix(COMMENT_PREFIX)
+            .test_dir("lua")
+            .test_path_filter(|p: &Path| {
+                p.extension().as_ref().and_then(|p| p.to_str()) == Some("lua")
+            })
+            .test_extract(move |p| {
+                read_to_string(p)
+                    .unwrap()
+                    .lines()
+                    .skip_while(|l| !l.starts_with(COMMENT))
+                    .take_while(|l| l.starts_with(COMMENT))
+                    .map(|l| &l[COMMENT.len()..])
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .test_cmds(move |p| {
+                let mut yklua_exe = target_dir();
+                yklua_exe.push("yklua");
+                yklua_exe.push("yklua");
+                yklua_exe.push("src");
+                yklua_exe.push("lua");
+                let mut cmd = Command::new(yklua_exe);
+                cmd.arg(p);
+                vec![("Run-time", cmd)]
+            })
+            .fm_options(|_, _, fmb| {
+                // Use `{{}}` to match non-literal strings in tests.
+                // E.g. use `%{{var}}` to capture the name of a variable.
+                let ptn_re = Regex::new(r"\{\{.+?\}\}").unwrap();
+                let ptn_re_ignore = Regex::new(r"\{\{_}\}").unwrap();
+                let text_re = Regex::new(r"[a-zA-Z0-9\._]+").unwrap();
+                fmb.name_matcher_ignore(ptn_re_ignore, text_re.clone())
+                    .name_matcher(ptn_re, text_re)
+            })
+            .run();
+    }
 }

--- a/tests/lua/for_loop.lua
+++ b/tests/lua/for_loop.lua
@@ -2,18 +2,29 @@
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YKD_LOG=4
---   env-var: YKD_LOG_IR=trace-kind
+--   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     0
 --     1
 --     2
---     yk-jit-event: start-tracing: for_loop.lua:23: FORLOOP
+--     yk-jit-event: start-tracing: for_loop.lua:35: GETTABUP
 --     3
 --     yk-jit-event: stop-tracing: ...
---     --- trace-kind header ---
+--     --- Begin debugstrs: header: for_loop.lua:35: GETTABUP ---
+--       for_loop.lua:35: GETFIELD
+--       for_loop.lua:35: SELF
+--       for_loop.lua:35: GETTABUP
+--       for_loop.lua:35: MOVE
+--       for_loop.lua:35: CALL
+--       for_loop.lua:35: LOADK
+--       for_loop.lua:35: CALL
+--       for_loop.lua:36: ADDI
+--       for_loop.lua:34: FORLOOP
+--       for_loop.lua:35: GETTABUP
+--     --- End debugstrs ---
 --     4
---     yk-jit-event: enter-jit-code: for_loop.lua:23: FORLOOP
+--     yk-jit-event: enter-jit-code: for_loop.lua:35: GETTABUP
 --     5
 --     6
 --     yk-jit-event: deoptimise

--- a/tests/lua/for_loop.lua
+++ b/tests/lua/for_loop.lua
@@ -8,12 +8,12 @@
 --     0
 --     1
 --     2
---     yk-jit-event: start-tracing
+--     yk-jit-event: start-tracing: for_loop.lua:23: FORLOOP
 --     3
---     yk-jit-event: stop-tracing
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind header ---
 --     4
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: for_loop.lua:23: FORLOOP
 --     5
 --     6
 --     yk-jit-event: deoptimise

--- a/tests/lua/nested_loops.lua
+++ b/tests/lua/nested_loops.lua
@@ -4,23 +4,23 @@
 --   env-var: YKD_LOG_IR=trace-kind
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
---     yk-jit-event: start-tracing
---     yk-jit-event: stop-tracing
+--     yk-jit-event: start-tracing: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind header ---
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
 --     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing
---     yk-jit-event: stop-tracing
+--     yk-jit-event: start-side-tracing: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind side-trace ---
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
 --     yk-jit-event: deoptimise
 --   stdout:
 --     251502

--- a/tests/lua/nested_loops.lua
+++ b/tests/lua/nested_loops.lua
@@ -1,28 +1,38 @@
 -- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YKD_LOG=4
---   env-var: YKD_LOG_IR=trace-kind
+--   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
---     yk-jit-event: start-tracing: nested_loops.lua:31: FORLOOP
---     yk-jit-event: stop-tracing: ...
---     --- trace-kind header ---
---     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: start-tracing: nested_loops.lua:42: ADDI
+--     yk-jit-event: stop-tracing: nested_loops.lua:42: ADDI
+--     --- Begin debugstrs: header: nested_loops.lua:42: ADDI ---
+--       nested_loops.lua:41: FORLOOP
+--       nested_loops.lua:42: ADDI
+--     --- End debugstrs ---
+--     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
 --     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
 --     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing: nested_loops.lua:31: FORLOOP
---     yk-jit-event: stop-tracing: ...
---     --- trace-kind side-trace ---
---     yk-jit-event: enter-jit-code: nested_loops.lua:31: FORLOOP
+--     yk-jit-event: start-side-tracing: nested_loops.lua:42: ADDI
+--     yk-jit-event: stop-tracing: nested_loops.lua:42: ADDI
+--     --- Begin debugstrs: side-trace: nested_loops.lua:42: ADDI ---
+--       nested_loops.lua:39: FORLOOP
+--       nested_loops.lua:40: ADDI
+--       nested_loops.lua:41: LOADI
+--       nested_loops.lua:41: LOADI
+--       nested_loops.lua:41: LOADI
+--       nested_loops.lua:41: FORPREP
+--       nested_loops.lua:42: ADDI
+--     --- End debugstrs ---
+--     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
 --     yk-jit-event: deoptimise
---   stdout:
 --     251502
 
 local x = 0
@@ -32,4 +42,4 @@ for _ = 0, 500 do
     x = x + 1
   end
 end
-print(x)
+io.stderr:write(x)

--- a/tests/lua/recursive_function.lua
+++ b/tests/lua/recursive_function.lua
@@ -2,18 +2,31 @@
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YKD_LOG=4
---   env-var: YKD_LOG_IR=trace-kind
+--   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     6
 --     5
 --     4
---     yk-jit-event: start-tracing: recursive_function.lua:23: GETTABUP
+--     yk-jit-event: start-tracing: recursive_function.lua:36: GETTABUP
 --     3
 --     yk-jit-event: stop-tracing: ...
---     --- trace-kind header ---
+--     --- Begin debugstrs: header: recursive_function.lua:36: GETTABUP ---
+--       recursive_function.lua:36: GETFIELD
+--       recursive_function.lua:36: SELF
+--       recursive_function.lua:36: GETTABUP
+--       recursive_function.lua:36: MOVE
+--       recursive_function.lua:36: CALL
+--       recursive_function.lua:36: LOADK
+--       recursive_function.lua:36: CALL
+--       recursive_function.lua:37: GTI
+--       recursive_function.lua:38: GETTABUP
+--       recursive_function.lua:38: ADDI
+--       recursive_function.lua:38: CALL
+--       recursive_function.lua:36: GETTABUP
+--     --- End debugstrs ---
 --     2
---     yk-jit-event: enter-jit-code: recursive_function.lua:23: GETTABUP
+--     yk-jit-event: enter-jit-code: recursive_function.lua:36: GETTABUP
 --     1
 --     0
 --     yk-jit-event: deoptimise

--- a/tests/lua/recursive_function.lua
+++ b/tests/lua/recursive_function.lua
@@ -8,12 +8,12 @@
 --     6
 --     5
 --     4
---     yk-jit-event: start-tracing
+--     yk-jit-event: start-tracing: recursive_function.lua:23: GETTABUP
 --     3
---     yk-jit-event: stop-tracing
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind header ---
 --     2
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: recursive_function.lua:23: GETTABUP
 --     1
 --     0
 --     yk-jit-event: deoptimise

--- a/tests/lua/sidetrace.lua
+++ b/tests/lua/sidetrace.lua
@@ -9,22 +9,22 @@
 --     <0
 --     <1
 --     <2
---     yk-jit-event: start-tracing
+--     yk-jit-event: start-tracing: sidetrace.lua:34: FORLOOP
 --     <3
---     yk-jit-event: stop-tracing
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind header ---
 --     <4
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: sidetrace.lua:34: FORLOOP
 --     yk-jit-event: deoptimise
 --     >=5
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: sidetrace.lua:34: FORLOOP
 --     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing
+--     yk-jit-event: start-side-tracing: sidetrace.lua:34: FORLOOP
 --     >=6
---     yk-jit-event: stop-tracing
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind side-trace ---
 --     >=7
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: sidetrace.lua:34: FORLOOP
 --     >=8
 --     >=9
 --     >=10

--- a/tests/lua/sidetrace.lua
+++ b/tests/lua/sidetrace.lua
@@ -3,28 +3,53 @@
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YK_SIDETRACE_THRESHOLD=2
 --   env-var: YKD_LOG=4
---   env-var: YKD_LOG_IR=trace-kind
+--   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     <0
 --     <1
 --     <2
---     yk-jit-event: start-tracing: sidetrace.lua:34: FORLOOP
+--     yk-jit-event: start-tracing: sidetrace.lua:60: LTI
 --     <3
 --     yk-jit-event: stop-tracing: ...
---     --- trace-kind header ---
+--     --- Begin debugstrs: header: sidetrace.lua:60: LTI ---
+--       sidetrace.lua:61: GETTABUP
+--       sidetrace.lua:61: GETFIELD
+--       sidetrace.lua:61: SELF
+--       sidetrace.lua:61: LOADK
+--       sidetrace.lua:61: GETTABUP
+--       sidetrace.lua:61: MOVE
+--       sidetrace.lua:61: CALL
+--       sidetrace.lua:61: LOADK
+--       sidetrace.lua:61: CALL
+--       sidetrace.lua:61: JMP
+--       sidetrace.lua:59: FORLOOP
+--       sidetrace.lua:60: LTI
+--     --- End debugstrs ---
 --     <4
---     yk-jit-event: enter-jit-code: sidetrace.lua:34: FORLOOP
+--     yk-jit-event: enter-jit-code: sidetrace.lua:60: LTI
 --     yk-jit-event: deoptimise
 --     >=5
---     yk-jit-event: enter-jit-code: sidetrace.lua:34: FORLOOP
+--     yk-jit-event: enter-jit-code: sidetrace.lua:60: LTI
 --     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing: sidetrace.lua:34: FORLOOP
+--     yk-jit-event: start-side-tracing: sidetrace.lua:60: LTI
 --     >=6
 --     yk-jit-event: stop-tracing: ...
---     --- trace-kind side-trace ---
+--     --- Begin debugstrs: side-trace: sidetrace.lua:60: LTI ---
+--       sidetrace.lua:63: GETTABUP
+--       sidetrace.lua:63: GETFIELD
+--       sidetrace.lua:63: SELF
+--       sidetrace.lua:63: LOADK
+--       sidetrace.lua:63: GETTABUP
+--       sidetrace.lua:63: MOVE
+--       sidetrace.lua:63: CALL
+--       sidetrace.lua:63: LOADK
+--       sidetrace.lua:63: CALL
+--       sidetrace.lua:59: FORLOOP
+--       sidetrace.lua:60: LTI
+--     --- End debugstrs ---
 --     >=7
---     yk-jit-event: enter-jit-code: sidetrace.lua:34: FORLOOP
+--     yk-jit-event: enter-jit-code: sidetrace.lua:60: LTI
 --     >=8
 --     >=9
 --     >=10

--- a/tests/lua/while_loop.lua
+++ b/tests/lua/while_loop.lua
@@ -8,12 +8,12 @@
 --     0
 --     1
 --     2
---     yk-jit-event: start-tracing
+--     yk-jit-event: start-tracing: while_loop.lua:25: JMP
 --     3
---     yk-jit-event: stop-tracing
+--     yk-jit-event: stop-tracing: ...
 --     --- trace-kind header ---
 --     4
---     yk-jit-event: enter-jit-code
+--     yk-jit-event: enter-jit-code: while_loop.lua:25: JMP
 --     5
 --     6
 --     yk-jit-event: deoptimise

--- a/tests/lua/while_loop.lua
+++ b/tests/lua/while_loop.lua
@@ -2,18 +2,30 @@
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YKD_LOG=4
---   env-var: YKD_LOG_IR=trace-kind
+--   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     0
 --     1
 --     2
---     yk-jit-event: start-tracing: while_loop.lua:25: JMP
+--     yk-jit-event: start-tracing: while_loop.lua:35: LEI
 --     3
 --     yk-jit-event: stop-tracing: ...
---     --- trace-kind header ---
+--     --- Begin debugstrs: header: while_loop.lua:35: LEI ---
+--       while_loop.lua:36: GETTABUP
+--       while_loop.lua:36: GETFIELD
+--       while_loop.lua:36: SELF
+--       while_loop.lua:36: GETTABUP
+--       while_loop.lua:36: MOVE
+--       while_loop.lua:36: CALL
+--       while_loop.lua:36: LOADK
+--       while_loop.lua:36: CALL
+--       while_loop.lua:37: ADDI
+--       while_loop.lua:37: JMP
+--       while_loop.lua:35: LEI
+--     --- End debugstrs ---
 --     4
---     yk-jit-event: enter-jit-code: while_loop.lua:25: JMP
+--     yk-jit-event: enter-jit-code: while_loop.lua:35: LEI
 --     5
 --     6
 --     yk-jit-event: deoptimise

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -709,7 +709,7 @@ impl fmt::Display for Module {
         }
         write!(f, "\nentry:")?;
         for (iidx, inst) in self.iter_skipping_insts() {
-            write!(f, "\n    {}", inst.display(self, iidx))?
+            write!(f, "\n  {}", inst.display(self, iidx))?
         }
 
         Ok(())
@@ -3547,7 +3547,7 @@ mod tests {
             "global_decl tls @some_thread_local",
             "",
             "entry:",
-            "    %0: i8 = param Register(3, 1, [])",
+            "  %0: i8 = param Register(3, 1, [])",
         ]
         .join("\n");
         assert_eq!(m.to_string(), expect);

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -144,14 +144,26 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
             connector_tid,
         )?;
 
-        if should_log_ir(IRPhase::TraceKind) {
+        if should_log_ir(IRPhase::DebugStrs) {
             let kind = match jit_mod.tracekind() {
                 jit_ir::TraceKind::HeaderOnly => "header",
                 jit_ir::TraceKind::HeaderAndBody => unreachable!(),
                 jit_ir::TraceKind::Connector(_) => "connector",
                 jit_ir::TraceKind::Sidetrace(_) => "side-trace",
             };
-            log_ir(&format!("--- trace-kind {kind} ---\n"));
+            let mut out = String::new();
+            if let Some(x) = &hl.lock().debug_str {
+                out.push_str(&format!("--- Begin debugstrs: {kind}: {x} ---\n"));
+            } else {
+                out.push_str(&format!("--- Begin debugstrs: {kind} ---\n"));
+            }
+            for (_, inst) in jit_mod.iter_skipping_insts() {
+                if let jit_ir::Inst::DebugStr(x) = inst {
+                    out.push_str(&format!("  {}\n", x.msg(&jit_mod)));
+                }
+            }
+            out.push_str("--- End debugstrs ---\n");
+            log_ir(&out);
         }
 
         if should_log_ir(IRPhase::PreOpt) {

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -179,7 +179,6 @@ impl Location {
     ///   2. has not had a `HotLocation` allocated for it
     ///
     /// return its count, or `None` otherwise
-    #[cfg(feature = "ykd")]
     pub(crate) fn count(&self) -> Option<HotThreshold> {
         let x = self.inner.load(Ordering::Relaxed);
         if x & STATE_TAG_MASK == STATE_NOT_HOT {
@@ -218,7 +217,6 @@ impl Location {
         }
     }
 
-    #[cfg(feature = "ykd")]
     pub fn set_hl_debug_str(&self, s: String) {
         match self.hot_location() {
             Some(hl) => {
@@ -293,7 +291,6 @@ pub(crate) struct HotLocation {
     /// error?
     pub(crate) tracecompilation_errors: TraceCompilationErrorThreshold,
     /// An optional debug string for this hot location.
-    #[cfg(feature = "ykd")]
     pub(crate) debug_str: Option<String>,
 }
 

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -120,8 +120,8 @@ impl Log {
 pub(crate) enum IRPhase {
     /// The AOT IR.
     AOT,
-    /// The trace kind only (i.e. without IR instructions).
-    TraceKind,
+    /// Debug strings only
+    DebugStrs,
     /// The JIT IR before it has been optimised.
     PreOpt,
     /// The JIT IR after it has been optimised.
@@ -175,7 +175,7 @@ mod internals {
         fn from_str(s: &str) -> Result<Self, Box<dyn Error>> {
             match s {
                 "aot" => Ok(Self::AOT),
-                "trace-kind" => Ok(Self::TraceKind),
+                "debugstrs" => Ok(Self::DebugStrs),
                 "jit-pre-opt" => Ok(Self::PreOpt),
                 "jit-post-opt" => Ok(Self::PostOpt),
                 "jit-asm" => Ok(Self::Asm),

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -777,7 +777,6 @@ impl MT {
                             let hl = HotLocation {
                                 kind: HotLocationKind::Tracing,
                                 tracecompilation_errors: 0,
-                                #[cfg(feature = "ykd")]
                                 debug_str: None,
                             };
                             if let Some(hl) = loc.count_to_hot_location(x, hl) {
@@ -938,7 +937,6 @@ impl MT {
                         let hl = HotLocation {
                             kind: HotLocationKind::Counting(count),
                             tracecompilation_errors: 0,
-                            #[cfg(feature = "ykd")]
                             debug_str: None,
                         };
                         loc.count_to_hot_location(count, hl)


### PR DESCRIPTION
The heart of this PR is 03eb753879117c3882c7a48207ad3aecc8d0078c, which allows us to much more accurately test what we're tracing.

There *may* be an issue with this PR: for me `cargo test` fairly frequently fails on these tests on b16 with "Trace too long". I have a small hope that this is just a weird quirk of b16 or my setup there, but it may well be that yklua in debug mode really is creating traces that (at least at the moment!) are too long because we're tracing quite a bit of Rust code. Possible remedies include:

* Only run these tests in release mode (i.e. `cargo test --release`).
* Wait for "exclude stuff from PT traces so we only trace stuff with IR".