### PR TITLE
Reenable the `OutsideYk` timing state.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -481,6 +481,7 @@ impl MT {
                     &format!("tracing-aborted: {ak}"),
                     loc.hot_location()
                 );
+                self.stats.timing_state(TimingState::OutsideYk);
             }
             TransitionControlPoint::Execute(ctr) => {
                 yklog!(
@@ -608,6 +609,7 @@ impl MT {
                         );
                     }
                 }
+                self.stats.timing_state(TimingState::OutsideYk);
             }
             TransitionControlPoint::StopSideTracing {
                 gidx: guardid,
@@ -662,6 +664,7 @@ impl MT {
                         );
                     }
                 }
+                self.stats.timing_state(TimingState::OutsideYk);
             }
         }
     }


### PR DESCRIPTION
When using `YKD_STATS` I noticed that the `OutsideYk` time wasn't reporting correctly. This was because this state was only set after deopting, but not after tracing, compiling, etc. Setting this state at the end of the controlpoint, which is just before we return to the interpreter, will measure the time we spent outside of yk correctly again.