### PR TITLE
Various clippy fixes.

### DIFF
--- a/hwtracer/src/block.rs
+++ b/hwtracer/src/block.rs
@@ -31,7 +31,7 @@ impl fmt::Debug for Block {
                 first_inst,
                 last_inst,
             } => {
-                write!(f, "Block({:x}..={:x})", first_inst, last_inst)
+                write!(f, "Block({first_inst:x}..={last_inst:x})")
             }
             Self::Unknown => {
                 write!(f, "UnknownBlock")

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -137,7 +137,7 @@ where
     let tt = Arc::clone(tc).start_collector().unwrap();
     let res = f();
     let trace = tt.stop_collector().unwrap();
-    println!("traced closure with result: {}", res); // To avoid over-optimisation.
+    println!("traced closure with result: {res}"); // To avoid over-optimisation.
     trace
 }
 

--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -244,7 +244,7 @@ mod tests {
         let res = work_loop(10000);
         let trace = tt.stop_collector().unwrap();
 
-        println!("res: {}", res); // Stop over-optimisation.
+        println!("res: {res}"); // Stop over-optimisation.
         assert!(trace.capacity() > start_bufsize);
     }
 

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -136,10 +136,10 @@ enum ObjLoc {
 impl Debug for ObjLoc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::MainObj(v) => write!(f, "ObjLoc::MainObj(0x{:x})", v),
+            Self::MainObj(v) => write!(f, "ObjLoc::MainObj(0x{v:x})"),
             Self::OtherObjOrUnknown(e) => {
                 if let Some(e) = e {
-                    write!(f, "ObjLoc::OtherObjOrUnknown(0x{:x})", e)
+                    write!(f, "ObjLoc::OtherObjOrUnknown(0x{e:x})")
                 } else {
                     write!(f, "ObjLoc::OtherObjOrUnknown(???)")
                 }

--- a/tests/benches/collect_and_decode.rs
+++ b/tests/benches/collect_and_decode.rs
@@ -37,8 +37,8 @@ fn compile_runner(tempdir: &TempDir) -> PathBuf {
 
 fn collect_and_decode_trace(runner: &Path, benchmark: usize, param: usize) {
     let out = Command::new(runner)
-        .arg(format!("{}", benchmark))
-        .arg(format!("{}", param))
+        .arg(format!("{benchmark}"))
+        .arg(format!("{param}"))
         .output()
         .unwrap();
     check_output(&out);
@@ -65,7 +65,7 @@ fn bench_native(c: &mut Criterion) {
     let (_tempdir, runner, mut group) = setup(c, "trace-decode-native");
 
     for param in [1000, 10000, 100000] {
-        group.bench_function(BenchmarkId::new("YkPT", format!("{}", param)), |b| {
+        group.bench_function(BenchmarkId::new("YkPT", format!("{param}")), |b| {
             b.iter(|| collect_and_decode_trace(&runner, 0, param))
         });
     }
@@ -77,7 +77,7 @@ fn bench_disasm(c: &mut Criterion) {
     let (_tempdir, runner, mut group) = setup(c, "trace-decode-disasm");
 
     for param in [10, 30, 50] {
-        group.bench_function(BenchmarkId::new("YkPT", format!("{}", param)), |b| {
+        group.bench_function(BenchmarkId::new("YkPT", format!("{param}")), |b| {
             b.iter(|| collect_and_decode_trace(&runner, 1, param))
         });
     }

--- a/tests/benches/promote.rs
+++ b/tests/benches/promote.rs
@@ -55,7 +55,7 @@ fn setup<'c, M: Measurement>(
 fn run_bench(bench_bin: &Path, param: usize) {
     assert!(bench_bin.exists());
     let out = Command::new(bench_bin)
-        .arg(format!("{}", param))
+        .arg(format!("{param}"))
         .env("YKD_SERIALISE_COMPILATION", "1")
         .env("YKD_LOG_JITSTATE", "1")
         .output()
@@ -69,14 +69,13 @@ fn bench_promote(c: &mut Criterion) {
     let reps = 100000;
     // Benchmark a simple loop *without* promotion.
     group.bench_function(
-        BenchmarkId::new("without promotes", format!("{}", reps)),
+        BenchmarkId::new("without promotes", format!("{reps}")),
         |b| b.iter(|| run_bench(&bin_np, reps)),
     );
     // Benchmark a simple loop *with* promotion.
-    group.bench_function(
-        BenchmarkId::new("with promotes", format!("{}", reps)),
-        |b| b.iter(|| run_bench(&bin_p, reps)),
-    );
+    group.bench_function(BenchmarkId::new("with promotes", format!("{reps}")), |b| {
+        b.iter(|| run_bench(&bin_p, reps))
+    });
 }
 
 criterion_group!(promote_benchmarks, bench_promote);

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -17,7 +17,7 @@ pub fn main() {
 
     // Expose the cargo profile to run.rs so that it can set the right link flags.
     let profile = env::var("PROFILE").unwrap();
-    println!("cargo::rustc-cfg=cargo_profile=\"{}\"", profile);
+    println!("cargo::rustc-cfg=cargo_profile=\"{profile}\"");
     println!(
         r#"cargo::rustc-check-cfg=cfg(cargo_profile, values("debug", "release", "release-with-debug"))"#
     );

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -88,7 +88,7 @@ impl<'a> ExtraLinkage<'a> {
         }
         let out = match cmd.output() {
             Ok(x) => x,
-            Err(e) => panic!("Error when running {:?} {:?}", cmd, e),
+            Err(e) => panic!("Error when running {cmd:?} {e:?}"),
         };
         assert!(tempdir.exists());
         if !out.status.success() {

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -32,7 +32,7 @@ const YKLLVM_SUBMODULE_PATH: &str = "../ykllvm/llvm";
 
 fn main() {
     for k in ENV_VARS_RERUN {
-        println!("cargo::rerun-if-env-changed={}", k);
+        println!("cargo::rerun-if-env-changed={k}");
     }
 
     // If the user defines YKB_YKLLVM_BIN_DIR then we don't try to build ykllvm ourselves.

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -13,7 +13,6 @@
 // stuff in `ykrt`, so perhaps the latter?
 
 #![allow(clippy::missing_safety_doc)]
-#![feature(naked_functions)]
 
 #[cfg(feature = "ykd")]
 use std::ffi::CStr;

--- a/ykrt/src/aotsmp.rs
+++ b/ykrt/src/aotsmp.rs
@@ -24,7 +24,7 @@ impl AOTStackmapInfo {
 
 pub(crate) static AOT_STACKMAPS: LazyLock<Result<AOTStackmapInfo, String>> = LazyLock::new(|| {
     fn errstr(msg: &str) -> String {
-        format!("failed to load stackmaps: {}", msg)
+        format!("failed to load stackmaps: {msg}")
     }
 
     // We use an inner function so that we can use the `?` operator for errors.

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -449,7 +449,7 @@ impl<'a> Assemble<'a> {
             let deopt_label = self.asm.new_dynamic_label();
             let guardcheck_label = self.asm.new_dynamic_label();
             for (deoptid, fail_label) in infos {
-                self.comment(format!("Deopt ID and patch point for guard {:?}", deoptid));
+                self.comment(format!("Deopt ID and patch point for guard {deoptid:?}"));
                 self.ra
                     .get_ready_for_deopt(&mut self.asm, &self.deoptinfo[&deoptid].0);
                 // FIXME: Why are `deoptid`s 64 bit? We're not going to have that many guards!
@@ -632,20 +632,20 @@ impl<'a> Assemble<'a> {
                     next = iter.next();
                     // We have a special optimisation for `ICmp`s iff they're immediately followed
                     // by a `Guard`.
-                    if let Some((next_iidx, Inst::Guard(g_inst))) = next {
-                        if let Operand::Var(cond_idx) = g_inst.cond(self.m) {
-                            // NOTE: If the value of the condition will be used later, we have to
-                            // materialise it.
-                            if cond_idx == iidx
-                                && !self
-                                    .ra
-                                    .rev_an
-                                    .is_inst_var_still_used_after(next_iidx, cond_idx)
-                            {
-                                self.cg_icmp_guard(iidx, ic_inst, next_iidx, g_inst);
-                                next = iter.next();
-                                continue;
-                            }
+                    if let Some((next_iidx, Inst::Guard(g_inst))) = next
+                        && let Operand::Var(cond_idx) = g_inst.cond(self.m)
+                    {
+                        // NOTE: If the value of the condition will be used later, we have to
+                        // materialise it.
+                        if cond_idx == iidx
+                            && !self
+                                .ra
+                                .rev_an
+                                .is_inst_var_still_used_after(next_iidx, cond_idx)
+                        {
+                            self.cg_icmp_guard(iidx, ic_inst, next_iidx, g_inst);
+                            next = iter.next();
+                            continue;
                         }
                     }
                     self.cg_icmp(iidx, ic_inst);
@@ -1282,7 +1282,7 @@ impl<'a> Assemble<'a> {
             VarLocation::ConstInt { bits, v } => {
                 self.ra.assign_const_int(iidx, bits, v);
             }
-            e => panic!("{:?}", e),
+            e => panic!("{e:?}"),
         }
     }
 
@@ -2070,10 +2070,10 @@ impl<'a> Assemble<'a> {
     /// If an `Operand` refers to a constant integer that can be represented as an `i32`, return it
     /// sign-extended to 32 bits, otherwise return `None`.
     fn op_to_sign_ext_i32(&self, op: &Operand) -> Option<i32> {
-        if let Operand::Const(cidx) = op {
-            if let Const::Int(_, x) = self.m.const_(*cidx) {
-                return x.to_sign_ext_i32();
-            }
+        if let Operand::Const(cidx) = op
+            && let Const::Int(_, x) = self.m.const_(*cidx)
+        {
+            return x.to_sign_ext_i32();
         }
         None
     }
@@ -2081,10 +2081,10 @@ impl<'a> Assemble<'a> {
     /// If an `Operand` refers to a constant integer that can be represented as an `i8`, return
     /// it zero-extended to 8 bits, otherwise return `None`.
     fn op_to_zero_ext_i8(&self, op: &Operand) -> Option<i8> {
-        if let Operand::Const(cidx) = op {
-            if let Const::Int(_, x) = self.m.const_(*cidx) {
-                return x.to_zero_ext_u8().map(|x| x as i8);
-            }
+        if let Operand::Const(cidx) = op
+            && let Const::Int(_, x) = self.m.const_(*cidx)
+        {
+            return x.to_zero_ext_u8().map(|x| x as i8);
         }
         None
     }
@@ -2092,10 +2092,10 @@ impl<'a> Assemble<'a> {
     /// If an `Operand` refers to a constant integer that can be represented as an `i8`, return
     /// it zero-extended to 8 bits, otherwise return `None`.
     fn op_to_zero_ext_i16(&self, op: &Operand) -> Option<i16> {
-        if let Operand::Const(cidx) = op {
-            if let Const::Int(_, x) = self.m.const_(*cidx) {
-                return x.to_zero_ext_u16().map(|x| x as i16);
-            }
+        if let Operand::Const(cidx) = op
+            && let Const::Int(_, x) = self.m.const_(*cidx)
+        {
+            return x.to_zero_ext_u16().map(|x| x as i16);
         }
         None
     }
@@ -2763,7 +2763,7 @@ impl<'a> Assemble<'a> {
                         VarLocation::ConstPtr(v) => {
                             self.ra.assign_const_ptr(iidx, v);
                         }
-                        e => panic!("{:?}", e),
+                        e => panic!("{e:?}"),
                     }
                 }
             }
@@ -3458,7 +3458,7 @@ impl<'a> AsmPrinter<'a> {
             }
             let istr = fmt.format(Some(ip), &insn).unwrap();
             if self.with_addrs {
-                out.push(format!("{:016x} {:08x}: {}", ip, off, istr));
+                out.push(format!("{ip:016x} {off:08x}: {istr}"));
             } else {
                 out.push(istr.to_string());
             }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -331,10 +331,10 @@ impl<'a> RevAnalyse<'a> {
     /// Propagate the hint for the instruction being processed at `iidx` to `op`, if appropriate
     /// for `op`.
     fn push_reg_hint(&mut self, iidx: InstIdx, op: Operand) {
-        if let Operand::Var(op_iidx) = op {
-            if let Some(reg) = self.reg_hint(iidx, iidx) {
-                self.reg_hints[usize::from(op_iidx)].push((iidx, reg));
-            }
+        if let Operand::Var(op_iidx) = op
+            && let Some(reg) = self.reg_hint(iidx, iidx)
+        {
+            self.reg_hints[usize::from(op_iidx)].push((iidx, reg));
         }
     }
 
@@ -447,19 +447,19 @@ impl<'a> RevAnalyse<'a> {
     /// Analyse a [LoadInst]. Returns `true` if it has been inlined and should not go through the
     /// normal "calculate `inst_vals_alive_until`" phase.
     fn an_load(&mut self, iidx: InstIdx, inst: LoadInst) -> bool {
-        if let Operand::Var(op_iidx) = inst.ptr(self.m) {
-            if let Inst::PtrAdd(pa_inst) = self.m.inst(op_iidx) {
-                self.ptradds[usize::from(iidx)] = Some(pa_inst);
-                if let Operand::Var(y) = pa_inst.ptr(self.m) {
-                    if self.inst_vals_alive_until[usize::from(y)] < iidx {
-                        self.inst_vals_alive_until[usize::from(y)] = iidx;
-                        self.push_reg_hint_outputcanbesameasinput(iidx, pa_inst.ptr(self.m));
-                    }
-                    self.used_insts.set(usize::from(y), true);
-                    self.push_def_use(y, iidx);
+        if let Operand::Var(op_iidx) = inst.ptr(self.m)
+            && let Inst::PtrAdd(pa_inst) = self.m.inst(op_iidx)
+        {
+            self.ptradds[usize::from(iidx)] = Some(pa_inst);
+            if let Operand::Var(y) = pa_inst.ptr(self.m) {
+                if self.inst_vals_alive_until[usize::from(y)] < iidx {
+                    self.inst_vals_alive_until[usize::from(y)] = iidx;
+                    self.push_reg_hint_outputcanbesameasinput(iidx, pa_inst.ptr(self.m));
                 }
-                return true;
+                self.used_insts.set(usize::from(y), true);
+                self.push_def_use(y, iidx);
             }
+            return true;
         }
         false
     }
@@ -467,25 +467,25 @@ impl<'a> RevAnalyse<'a> {
     /// Analyse a [StoreInst]. Returns `true` if it has been inlined and should not go through the
     /// normal "calculate `inst_vals_alive_until`" phase.
     fn an_store(&mut self, iidx: InstIdx, inst: StoreInst) -> bool {
-        if let Operand::Var(op_iidx) = inst.ptr(self.m) {
-            if let Inst::PtrAdd(pa_inst) = self.m.inst(op_iidx) {
-                self.ptradds[usize::from(iidx)] = Some(pa_inst);
-                if let Operand::Var(y) = pa_inst.ptr(self.m) {
-                    if self.inst_vals_alive_until[usize::from(y)] < iidx {
-                        self.inst_vals_alive_until[usize::from(y)] = iidx;
-                    }
-                    self.used_insts.set(usize::from(y), true);
-                    self.push_def_use(y, iidx);
+        if let Operand::Var(op_iidx) = inst.ptr(self.m)
+            && let Inst::PtrAdd(pa_inst) = self.m.inst(op_iidx)
+        {
+            self.ptradds[usize::from(iidx)] = Some(pa_inst);
+            if let Operand::Var(y) = pa_inst.ptr(self.m) {
+                if self.inst_vals_alive_until[usize::from(y)] < iidx {
+                    self.inst_vals_alive_until[usize::from(y)] = iidx;
                 }
-                if let Operand::Var(y) = inst.val(self.m) {
-                    if self.inst_vals_alive_until[usize::from(y)] < iidx {
-                        self.inst_vals_alive_until[usize::from(y)] = iidx;
-                    }
-                    self.used_insts.set(usize::from(y), true);
-                    self.push_def_use(y, iidx);
-                }
-                return true;
+                self.used_insts.set(usize::from(y), true);
+                self.push_def_use(y, iidx);
             }
+            if let Operand::Var(y) = inst.val(self.m) {
+                if self.inst_vals_alive_until[usize::from(y)] < iidx {
+                    self.inst_vals_alive_until[usize::from(y)] = iidx;
+                }
+                self.used_insts.set(usize::from(y), true);
+                self.push_def_use(y, iidx);
+            }
+            return true;
         }
         false
     }

--- a/ykrt/src/compile/jitc_yk/gdb.rs
+++ b/ykrt/src/compile/jitc_yk/gdb.rs
@@ -193,7 +193,7 @@ pub(crate) fn register_jitted_code(
             vaddr: code_vaddr + off,
         });
         for line in lines {
-            writeln!(src_file, "{}", line).map_err(|_| {
+            writeln!(src_file, "{line}").map_err(|_| {
                 CompilationError::InternalError("failed to write into gdb src_file".into())
             })?;
             line_num += 1;
@@ -207,7 +207,7 @@ pub(crate) fn register_jitted_code(
     // Build the symbol file we are going to give to gdb.
     //
     // unwrap safe: string cannot contain internal zero bytes.
-    let sym_name = CString::new(format!("{}{}", TRACE_SYM_PREFIX, ctr_id)).unwrap();
+    let sym_name = CString::new(format!("{TRACE_SYM_PREFIX}{ctr_id}")).unwrap();
     // unwrap safe: path is valid UTF-8 and  cannot contain internal zero bytes.
     let src_path = CString::new(src_file.path().to_str().unwrap()).unwrap();
     // Support for more lineinfos could be added if required.

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -809,7 +809,7 @@ impl From<U24> for usize {
 ///
 /// FIXME: all of these should be checked at compile time.
 fn index_overflow(typ: &str) -> CompilationError {
-    CompilationError::LimitExceeded(format!("index overflow: {}", typ))
+    CompilationError::LimitExceeded(format!("index overflow: {typ}"))
 }
 
 // Generate common methods for 24-bit index types.
@@ -1156,7 +1156,7 @@ impl fmt::Display for DisplayableTy<'_> {
                     )
                 }
             }
-            Ty::Float(ft) => write!(f, "{}", ft),
+            Ty::Float(ft) => write!(f, "{ft}"),
             Ty::Unimplemented(_) => write!(f, "?type"),
         }
     }
@@ -1357,7 +1357,7 @@ impl fmt::Display for DisplayableConst<'_> {
         match self.const_ {
             Const::Float(tyidx, v) => match self.m.type_(*tyidx) {
                 Ty::Float(FloatTy::Float) => write!(f, "{}float", *v as f32),
-                Ty::Float(FloatTy::Double) => write!(f, "{}double", v),
+                Ty::Float(FloatTy::Double) => write!(f, "{v}double"),
                 _ => unreachable!(),
             },
             Const::Int(_, x) => {

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -145,13 +145,13 @@ impl Module {
                         );
                     }
 
-                    if let Ty::Ptr = self.type_(x.lhs(self).tyidx(self)) {
-                        if x.predicate().signed() {
-                            panic!(
+                    if let Ty::Ptr = self.type_(x.lhs(self).tyidx(self))
+                        && x.predicate().signed()
+                    {
+                        panic!(
                                 "Instruction at position {iidx} compares pointers using a signed predicate\n  {}",
                                 self.inst(iidx).display(self, iidx)
                             );
-                        }
                     }
                 }
                 Inst::Select(x) => {
@@ -300,11 +300,11 @@ impl Module {
                     }
                 }
                 Inst::Param(_) => {
-                    if let Some(i) = last_inst {
-                        if !matches!(i, Inst::Param(_) | Inst::TraceHeaderEnd(_)) {
-                            panic!("Param instruction may only appear at the beginning of a trace or after another Param instruction, or after the trace header jump\n  {}",
+                    if let Some(i) = last_inst
+                        && !matches!(i, Inst::Param(_) | Inst::TraceHeaderEnd(_))
+                    {
+                        panic!("Param instruction may only appear at the beginning of a trace or after another Param instruction, or after the trace header jump\n  {}",
                                 self.inst(iidx).display(self, iidx));
-                        }
                     }
                 }
                 _ => (),

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -125,10 +125,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         let aot_mod = &*AOT_MOD;
 
         if should_log_ir(IRPhase::AOT) {
-            log_ir(&format!(
-                "--- Begin aot ---\n{}\n--- End aot ---\n",
-                aot_mod
-            ));
+            log_ir(&format!("--- Begin aot ---\n{aot_mod}\n--- End aot ---\n"));
         }
 
         let sti = sti.map(|s| s.as_any().downcast::<YkSideTraceInfo<Register>>().unwrap());

--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -112,26 +112,26 @@ impl Analyse {
 
     /// Use the guard `inst` to update our knowledge about the variable used as its condition.
     pub(super) fn guard(&self, m: &Module, g_inst: GuardInst) {
-        if let Operand::Var(iidx) = g_inst.cond(m) {
-            if let Inst::ICmp(ic_inst) = m.inst(iidx) {
-                let lhs = self.op_map(m, ic_inst.lhs(m));
-                let pred = ic_inst.predicate();
-                let rhs = self.op_map(m, ic_inst.rhs(m));
-                match (&lhs, &rhs) {
-                    (&Operand::Const(_), &Operand::Const(_)) => {
-                        // This will have been handled by icmp/guard optimisations.
-                        unreachable!();
-                    }
-                    (&Operand::Var(iidx), &Operand::Const(cidx))
-                    | (&Operand::Const(cidx), &Operand::Var(iidx)) => {
-                        if (g_inst.expect && pred == Predicate::Equal)
-                            || (!g_inst.expect && pred == Predicate::NotEqual)
-                        {
-                            self.set_value(m, iidx, Value::Const(cidx));
-                        }
-                    }
-                    (&Operand::Var(_), &Operand::Var(_)) => (),
+        if let Operand::Var(iidx) = g_inst.cond(m)
+            && let Inst::ICmp(ic_inst) = m.inst(iidx)
+        {
+            let lhs = self.op_map(m, ic_inst.lhs(m));
+            let pred = ic_inst.predicate();
+            let rhs = self.op_map(m, ic_inst.rhs(m));
+            match (&lhs, &rhs) {
+                (&Operand::Const(_), &Operand::Const(_)) => {
+                    // This will have been handled by icmp/guard optimisations.
+                    unreachable!();
                 }
+                (&Operand::Var(iidx), &Operand::Const(cidx))
+                | (&Operand::Const(cidx), &Operand::Var(iidx)) => {
+                    if (g_inst.expect && pred == Predicate::Equal)
+                        || (!g_inst.expect && pred == Predicate::NotEqual)
+                    {
+                        self.set_value(m, iidx, Value::Const(cidx));
+                    }
+                }
+                (&Operand::Var(_), &Operand::Var(_)) => (),
             }
         }
     }

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -342,23 +342,22 @@ impl Opt {
                 self.an.op_map(&self.m, inst.rhs(&self.m)),
             ) {
                 (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
-                    if let Const::Int(_, y) = self.m.const_(op_cidx) {
-                        if y.to_zero_ext_u64().unwrap() == 0 {
-                            // Replace `x >> 0` with `x`.
-                            self.m.replace(iidx, Inst::Copy(op_iidx));
-                        }
+                    if let Const::Int(_, y) = self.m.const_(op_cidx)
+                        && y.to_zero_ext_u64().unwrap() == 0
+                    {
+                        // Replace `x >> 0` with `x`.
+                        self.m.replace(iidx, Inst::Copy(op_iidx));
                     }
                 }
                 (Operand::Const(op_cidx), Operand::Var(_)) => {
-                    if let Const::Int(tyidx, y) = self.m.const_(op_cidx) {
-                        if y.to_zero_ext_u64().unwrap() == 0 {
-                            // Replace `0 >> x` with `0`.
-                            let new_cidx = self.m.insert_const(Const::Int(
-                                *tyidx,
-                                ArbBitInt::from_u64(y.bitw(), 0),
-                            ))?;
-                            self.m.replace(iidx, Inst::Const(new_cidx));
-                        }
+                    if let Const::Int(tyidx, y) = self.m.const_(op_cidx)
+                        && y.to_zero_ext_u64().unwrap() == 0
+                    {
+                        // Replace `0 >> x` with `0`.
+                        let new_cidx = self
+                            .m
+                            .insert_const(Const::Int(*tyidx, ArbBitInt::from_u64(y.bitw(), 0)))?;
+                        self.m.replace(iidx, Inst::Const(new_cidx));
                     }
                 }
                 (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
@@ -485,23 +484,22 @@ impl Opt {
                 self.an.op_map(&self.m, inst.rhs(&self.m)),
             ) {
                 (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
-                    if let Const::Int(_, y) = self.m.const_(op_cidx) {
-                        if y.to_zero_ext_u64().unwrap() == 0 {
-                            // Replace `x << 0` with `x`.
-                            self.m.replace(iidx, Inst::Copy(op_iidx));
-                        }
+                    if let Const::Int(_, y) = self.m.const_(op_cidx)
+                        && y.to_zero_ext_u64().unwrap() == 0
+                    {
+                        // Replace `x << 0` with `x`.
+                        self.m.replace(iidx, Inst::Copy(op_iidx));
                     }
                 }
                 (Operand::Const(op_cidx), Operand::Var(_)) => {
-                    if let Const::Int(tyidx, y) = self.m.const_(op_cidx) {
-                        if y.to_zero_ext_u64().unwrap() == 0 {
-                            // Replace `0 << x` with `0`.
-                            let new_cidx = self.m.insert_const(Const::Int(
-                                *tyidx,
-                                ArbBitInt::from_u64(y.bitw(), 0),
-                            ))?;
-                            self.m.replace(iidx, Inst::Const(new_cidx));
-                        }
+                    if let Const::Int(tyidx, y) = self.m.const_(op_cidx)
+                        && y.to_zero_ext_u64().unwrap() == 0
+                    {
+                        // Replace `0 << x` with `0`.
+                        let new_cidx = self
+                            .m
+                            .insert_const(Const::Int(*tyidx, ArbBitInt::from_u64(y.bitw(), 0)))?;
+                        self.m.replace(iidx, Inst::Const(new_cidx));
                     }
                 }
                 (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
@@ -527,11 +525,11 @@ impl Opt {
                 self.an.op_map(&self.m, inst.rhs(&self.m)),
             ) {
                 (Operand::Var(op_iidx), Operand::Const(op_cidx)) => {
-                    if let Const::Int(_, y) = self.m.const_(op_cidx) {
-                        if y.to_zero_ext_u64().unwrap() == 0 {
-                            // Replace `x - 0` with `x`.
-                            self.m.replace(iidx, Inst::Copy(op_iidx));
-                        }
+                    if let Const::Int(_, y) = self.m.const_(op_cidx)
+                        && y.to_zero_ext_u64().unwrap() == 0
+                    {
+                        // Replace `x - 0` with `x`.
+                        self.m.replace(iidx, Inst::Copy(op_iidx));
                     }
                 }
                 (Operand::Const(lhs_cidx), Operand::Const(rhs_cidx)) => {
@@ -1051,13 +1049,12 @@ impl Opt {
             Some(Inst::Const(_)) | Some(Inst::Tombstone) => return,
             Some(inst @ Inst::Guard(ginst)) => {
                 for (_, back_inst) in instll.rev_iter(&self.m, inst) {
-                    if let Inst::Guard(back_ginst) = back_inst {
-                        if ginst.cond(&self.m) == back_ginst.cond(&self.m)
-                            && ginst.expect() == back_ginst.expect()
-                        {
-                            self.m.replace(iidx, Inst::Tombstone);
-                            return;
-                        }
+                    if let Inst::Guard(back_ginst) = back_inst
+                        && ginst.cond(&self.m) == back_ginst.cond(&self.m)
+                        && ginst.expect() == back_ginst.expect()
+                    {
+                        self.m.replace(iidx, Inst::Tombstone);
+                        return;
                     }
                 }
                 inst

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(assert_matches)]
 #![feature(int_roundings)]
 #![feature(let_chains)]
-#![feature(naked_functions)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::upper_case_acronyms)]

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -77,7 +77,7 @@ impl Log {
     pub(crate) fn log_with_hl_debug(&self, level: Verbosity, msg: &str, hl: &Mutex<HotLocation>) {
         // If the hot location has a debug string, append it to the log message.
         let msg = if let Some(dstr) = hl.lock().debug_str.as_ref() {
-            &format!("{}: {}", msg, dstr)
+            &format!("{msg}: {dstr}")
         } else {
             msg
         };
@@ -194,7 +194,7 @@ mod internals {
 
     pub(crate) fn log_ir(s: &str) {
         match LOG_IR.as_ref().map(|(p, _)| p.as_str()) {
-            Some("-") => eprint!("{}", s),
+            Some("-") => eprint!("{s}"),
             Some(x) => {
                 File::options()
                     .append(true)

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -174,12 +174,12 @@ impl MT {
             self.stats.output();
             let mut lk = self.active_worker_threads.lock();
             for hdl in lk.drain(..) {
-                if hdl.is_finished() {
-                    if let Err(e) = hdl.join() {
-                        // Despite the name `resume_unwind` will abort if the unwind strategy in
-                        // Rust is set to `abort`.
-                        std::panic::resume_unwind(e);
-                    }
+                if hdl.is_finished()
+                    && let Err(e) = hdl.join()
+                {
+                    // Despite the name `resume_unwind` will abort if the unwind strategy in
+                    // Rust is set to `abort`.
+                    std::panic::resume_unwind(e);
                 }
             }
         }
@@ -820,10 +820,10 @@ impl MT {
                     akind = Some(AbortKind::OutOfFrame);
                 }
 
-                if let Some(x) = loc.hot_location().map(|x| x as *const Mutex<HotLocation>) {
-                    if !seen_hls.insert(x) {
-                        akind = Some(AbortKind::Unrolled);
-                    }
+                if let Some(x) = loc.hot_location().map(|x| x as *const Mutex<HotLocation>)
+                    && !seen_hls.insert(x)
+                {
+                    akind = Some(AbortKind::Unrolled);
                 }
 
                 if let Some(akind) = akind {


### PR DESCRIPTION
With the recent rust update clippy is complaining about a lot of code. There's two main fixes I can see:

1) Inlining variables into the format string.
2) Combining the conditions of nested `if`s via `&&`.

I can agree with number 1), however I'm not fully sold on 2) yet. I don't really mind having nested `if`s, and fixing all of them changes our code **a lot**, because it also results in reformatting of those if statements. Have a look at the diff and see what you think @vext01 @ltratt.