### PR TITLE
Avoid intermediate spills

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -1332,9 +1332,20 @@ impl LSRegAlloc<'_> {
                         .map(|x| self.m.inst(**x).def_byte_size(self.m))
                         .max()
                         .unwrap();
-                    self.stack.align(bytew);
-                    let frame_off = self.stack.grow(bytew);
-                    let off = i32::try_from(frame_off).unwrap();
+                    let mut off = None;
+                    if need_spilling.len() == 1 {
+                        off = self
+                            .rev_an
+                            .spill_to(*need_spilling[0])
+                            .map(|x| i32::try_from(x).unwrap());
+                    }
+                    let off = match off {
+                        Some(x) => x,
+                        None => {
+                            self.stack.align(bytew);
+                            i32::try_from(self.stack.grow(bytew)).unwrap()
+                        }
+                    };
                     match bitw {
                         1 => {
                             if *ext == RegExtension::ZeroExtended {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -870,12 +870,14 @@ impl LSRegAlloc<'_> {
     fn sort_clobber_regs(&self, iidx: InstIdx, clobber_regs: &mut [Rq]) {
         // Our heuristic is (in order):
         // 1. Prefer to clobber registers whose values are unused in the future.
-        // 2. Prefer to clobber constants.
-        // 3. Prefer to clobber a register that is used further away in the trace.
-        // 4. Prefer to clobber a register that is already spilled.
-        // 5. Prefer to clobber a register whose value(s) are used the fewest subsequent times in
+        // 2. Prefer to clobber registers whose values will be spilled anyway (i.e. because they're
+        //    only referenced in the trace end and need to be spilled then).
+        // 3. Prefer to clobber constants.
+        // 4. Prefer to clobber a register that is used further away in the trace.
+        // 5. Prefer to clobber a register that is already spilled.
+        // 6. Prefer to clobber a register whose value(s) are used the fewest subsequent times in
         //    the trace.
-        // 6. Prefer to clobber a register that contains fewer variables.
+        // 7. Prefer to clobber a register that contains fewer variables.
         clobber_regs.sort_unstable_by(|lhs_reg, rhs_reg| {
             match (
                 &self.gp_reg_states[usize::from(lhs_reg.code())],
@@ -907,26 +909,36 @@ impl LSRegAlloc<'_> {
                         Ordering::Less
                     } else if lhs_next.is_some() && rhs_next.is_none() {
                         Ordering::Greater
-                    } else if lhs_next != rhs_next {
-                        lhs_next.cmp(rhs_next).reverse()
                     } else {
-                        let lhs_spilled = lhs_iidxs
-                            .iter()
-                            .all(|x| !matches!(self.spills[usize::from(*x)], SpillState::Empty));
-                        let rhs_spilled = rhs_iidxs
-                            .iter()
-                            .all(|x| !matches!(self.spills[usize::from(*x)], SpillState::Empty));
-
-                        if lhs_spilled && !rhs_spilled {
+                        let lhs_spill =
+                            lhs_iidxs.len() == 1 && self.rev_an.spill_to(lhs_iidxs[0]).is_some();
+                        let rhs_spill =
+                            rhs_iidxs.len() == 1 && self.rev_an.spill_to(rhs_iidxs[0]).is_some();
+                        if lhs_spill && !rhs_spill {
                             Ordering::Less
-                        } else if !lhs_spilled && rhs_spilled {
+                        } else if !lhs_spill && rhs_spill {
                             Ordering::Greater
+                        } else if lhs_next != rhs_next {
+                            lhs_next.cmp(rhs_next).reverse()
                         } else {
-                            let lhs_count = lhs.iter().map(|(count, _)| count).max().unwrap();
-                            let rhs_count = rhs.iter().map(|(count, _)| count).max().unwrap();
-                            lhs_count
-                                .cmp(rhs_count)
-                                .then(lhs_iidxs.len().cmp(&rhs_iidxs.len()))
+                            let lhs_spilled = lhs_iidxs.iter().all(|x| {
+                                !matches!(self.spills[usize::from(*x)], SpillState::Empty)
+                            });
+                            let rhs_spilled = rhs_iidxs.iter().all(|x| {
+                                !matches!(self.spills[usize::from(*x)], SpillState::Empty)
+                            });
+
+                            if lhs_spilled && !rhs_spilled {
+                                Ordering::Less
+                            } else if !lhs_spilled && rhs_spilled {
+                                Ordering::Greater
+                            } else {
+                                let lhs_count = lhs.iter().map(|(count, _)| count).max().unwrap();
+                                let rhs_count = rhs.iter().map(|(count, _)| count).max().unwrap();
+                                lhs_count
+                                    .cmp(rhs_count)
+                                    .then(lhs_iidxs.len().cmp(&rhs_iidxs.len()))
+                            }
                         }
                     }
                 }

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -50,6 +50,11 @@ pub(crate) struct RevAnalyse<'a> {
     /// instruction %1, we would like %0 to already be in rax; when generating code for instruction
     /// %2, we would like %) to already be in rdi".
     reg_hints: Vec<Vec<(InstIdx, Register)>>,
+    /// For each instruction, record whether we know whether it should spill to in advance.
+    /// Currently this only happens for instructions referenced in the header/body end, where we
+    /// have to put the value in a specific place on the stack before we loop/jump. `u32::MAX` is
+    /// used to record "there is no predetermined spill for this instruction".
+    spill_to: Vec<u32>,
 }
 
 impl<'a> RevAnalyse<'a> {
@@ -61,6 +66,7 @@ impl<'a> RevAnalyse<'a> {
             used_insts: Vob::from_elem(false, usize::from(m.last_inst_idx()) + 1),
             def_use: vec![vec![]; m.insts_len()],
             reg_hints: vec![vec![]; m.insts_len()],
+            spill_to: vec![u32::MAX; m.insts_len()],
         }
     }
 
@@ -97,6 +103,22 @@ impl<'a> RevAnalyse<'a> {
                             _ => break,
                         }
                     }
+
+                    assert_eq!(
+                        self.m.trace_header_start().len(),
+                        self.m.trace_header_end().len()
+                    );
+                    for i in 0..self.m.trace_header_start().len() {
+                        let Inst::Param(pinst) = self.m.inst(InstIdx::unchecked_from(i)) else {
+                            panic!()
+                        };
+                        if let yksmp::Location::Indirect(_, off, _) = self.m.param(pinst.paramidx())
+                            && let Operand::Var(iidx) = self.m.trace_header_end()[i].unpack(self.m)
+                        {
+                            assert_eq!(self.spill_to[usize::from(iidx)], u32::MAX);
+                            self.spill_to[usize::from(iidx)] = u32::try_from(*off).unwrap();
+                        }
+                    }
                 }
             }
             TraceKind::HeaderAndBody => {
@@ -109,7 +131,7 @@ impl<'a> RevAnalyse<'a> {
                     .downcast::<X64CompiledTrace>()
                     .unwrap();
                 let vlocs = ctr.entry_vars();
-                // Side-traces don't have a trace body since we don't apply loop peeling and thus use
+                // Connector traces don't have a trace body since we don't apply loop peeling and thus use
                 // `trace_header_end` to store the jump variables.
                 debug_assert_eq!(vlocs.len(), self.m.trace_header_end().len());
 
@@ -118,6 +140,22 @@ impl<'a> RevAnalyse<'a> {
                 for (vloc, jump_op) in vlocs.iter().zip(self.m.trace_header_end()) {
                     if let VarLocation::Register(reg) = *vloc {
                         self.push_reg_hint_fixed(jtend_iidx, jump_op.unpack(self.m), reg);
+                    }
+                }
+
+                assert_eq!(
+                    self.m.trace_header_start().len(),
+                    self.m.trace_header_end().len()
+                );
+                for i in 0..self.m.trace_header_start().len() {
+                    let Inst::Param(pinst) = self.m.inst(InstIdx::unchecked_from(i)) else {
+                        panic!()
+                    };
+                    if let yksmp::Location::Indirect(_, off, _) = self.m.param(pinst.paramidx())
+                        && let Operand::Var(iidx) = self.m.trace_header_end()[i].unpack(self.m)
+                    {
+                        assert_eq!(self.spill_to[usize::from(iidx)], u32::MAX);
+                        self.spill_to[usize::from(iidx)] = u32::try_from(-*off).unwrap();
                     }
                 }
             }
@@ -136,6 +174,16 @@ impl<'a> RevAnalyse<'a> {
                 for (vloc, jump_op) in vlocs.iter().zip(self.m.trace_header_end()) {
                     if let VarLocation::Register(reg) = *vloc {
                         self.push_reg_hint_fixed(stend_iidx, jump_op.unpack(self.m), reg);
+                    }
+                }
+
+                assert_eq!(vlocs.len(), self.m.trace_header_end().len());
+                for (i, vloc) in vlocs.iter().enumerate() {
+                    if let VarLocation::Stack { frame_off, .. } = vloc
+                        && let Operand::Var(iidx) = self.m.trace_header_end()[i].unpack(self.m)
+                    {
+                        assert_eq!(self.spill_to[usize::from(iidx)], u32::MAX);
+                        self.spill_to[usize::from(iidx)] = *frame_off;
                     }
                 }
             }
@@ -185,6 +233,16 @@ impl<'a> RevAnalyse<'a> {
                 break;
             }
             self.analyse(iidx, inst);
+        }
+
+        assert_eq!(self.m.trace_body_end().len(), header_end_vlocs.len());
+        for (i, vloc) in header_end_vlocs.iter().enumerate() {
+            if let VarLocation::Stack { frame_off, .. } = vloc
+                && let Operand::Var(iidx) = self.m.trace_body_end()[i].unpack(self.m)
+            {
+                assert_eq!(self.spill_to[usize::from(iidx)], u32::MAX);
+                self.spill_to[usize::from(iidx)] = *frame_off;
+            }
         }
     }
 
@@ -279,6 +337,16 @@ impl<'a> RevAnalyse<'a> {
         self.reg_hints[usize::from(query_iidx)]
             .last()
             .map(|(_, y)| *y)
+    }
+
+    /// Return the predetermined stack location for `iidx` to be spilled to, if one is known.
+    pub(super) fn spill_to(&self, iidx: InstIdx) -> Option<u32> {
+        let x = self.spill_to[usize::from(iidx)];
+        if x == u32::MAX {
+            None
+        } else {
+            Some(x)
+        }
     }
 
     /// Record that `use_iidx` is used at instruction `def_iidx`.


### PR DESCRIPTION
This PR optimises the (relatively frequent) case that a variable *will* be spilled at the end of a trace but we spill it earlier to a different place. We then end up shuffling spill locations around before jumping, which is slow and pointless.

The main part of this PR is https://github.com/ykjit/yk/commit/9460d699710bf332049a929a25dfcdafe11466e8, but that enables a very simple second optimisation in https://github.com/ykjit/yk/commit/a35326569979e6b3d591003a665f248a5baa5a24.

This is a small speedup, on a few examples I tried perhaps of the order of 1%. Better than nothing, though.