### PR TITLE
PT trace only the executable segment of the main object.

### DIFF
--- a/hwtracer/src/perf/mod.rs
+++ b/hwtracer/src/perf/mod.rs
@@ -1,4 +1,5 @@
 use libc::size_t;
+use std::fs;
 
 pub(crate) mod collect;
 
@@ -23,14 +24,20 @@ pub struct PerfCollectorConfig {
     /// The size of the final memory returned, measured in bytes. There are no constraints on size
     /// or alignment but it needs to big enough to contain the AUX buffers.
     pub trace_result_size: size_t,
+    /// Whether or not to use PT IP filtering.
+    pub use_pt_filtering: bool,
 }
 
 impl Default for PerfCollectorConfig {
     fn default() -> Self {
+        // PT IP filtering doesn't work inside docker.
+        // https://lore.kernel.org/linux-perf-users/aBCwoq7w8ohBRQCh@fremen.lan/
+        let use_pt_filtering = !fs::exists("/.dockerenv").unwrap();
         Self {
             data_bufsize: PERF_DFLT_DATA_BUFSIZE,
             aux_bufsize: PERF_DFLT_AUX_BUFSIZE,
             trace_result_size: TRACE_RESULT_SIZE,
+            use_pt_filtering,
         }
     }
 }

--- a/hwtracer/src/pt/mod.rs
+++ b/hwtracer/src/pt/mod.rs
@@ -5,6 +5,13 @@ use core::arch::x86_64::__cpuid_count;
 
 /// Checks if the CPU supports Intel Processor Trace.
 pub(crate) fn pt_supported() -> bool {
-    let res = unsafe { __cpuid_count(0x7, 0x0) };
-    (res.ebx & (1 << 25)) != 0
+    // Check that the chip has PT capabilities.
+    let cpuid1 = unsafe { __cpuid_count(0x7, 0x0) };
+    let res1 = (cpuid1.ebx & (1 << 25)) != 0;
+
+    // Check that the chip supports at least one PT IP filtering range.
+    let cpuid2 = unsafe { __cpuid_count(0x14, 0x0) };
+    let res2 = (cpuid2.ebx & (1 << 2)) != 0;
+
+    res1 && res2
 }

--- a/tests/c/longjmp_from_foreign_into_trace1.c
+++ b/tests/c/longjmp_from_foreign_into_trace1.c
@@ -1,0 +1,54 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=3
+//   stderr:
+//     yk-tracing: start-tracing
+//     we jumped
+//     yk-tracing: stop-tracing
+//     yk-warning: trace-compilation-aborted: irregular control flow detected
+//     ...
+
+// Tests that we can deal with setjmp/longjmp when we jump from foreign code
+// into a different place in the function that started outlining.
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+jmp_buf buf;
+
+// By annotating this `yk_outline` we don't serialise its IR and therefore
+// can't see the `longjmp` inside. The tracebuilder is expected to notice the
+// "odd" control flow that results.
+__attribute__((noinline, yk_outline))
+void ljmp() {
+  longjmp(buf, 1);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 2;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  if (setjmp(buf) != 0) {
+    fprintf(stderr, "we jumped\n");
+  }
+  while (i > 0) {
+    i--;
+    yk_mt_control_point(mt, &loc);
+    ljmp();
+    fprintf(stderr, "i=%d\n", i);
+  }
+  printf("exit");
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/longjmp_from_foreign_into_trace2.c
+++ b/tests/c/longjmp_from_foreign_into_trace2.c
@@ -1,0 +1,60 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=3
+//   stderr:
+//     yk-tracing: start-tracing
+//     we jumped
+//     yk-tracing: stop-tracing
+//     yk-warning: trace-compilation-aborted: irregular control flow detected
+//     we jumped
+//     exit
+//     ...
+
+// Tests that we can deal with setjmp/longjmp when we jump from foreign code
+// into a different function than started outlining.
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+jmp_buf buf;
+
+// By annotating this `yk_outline` we don't serialise its IR and therefore
+// can't see the `longjmp` inside. The tracebuilder is expected to notice the
+// "odd" control flow that results.
+__attribute__((noinline, yk_outline))
+void ljmp() {
+  longjmp(buf, 1);
+}
+
+__attribute__((noinline))
+void inner() {
+    ljmp();
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 2;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  if (setjmp(buf) != 0) {
+    fprintf(stderr, "we jumped\n");
+  }
+  while (i > 0) {
+    i--;
+    yk_mt_control_point(mt, &loc);
+    inner();
+    fprintf(stderr, "unreachable\n");
+  }
+  fprintf(stderr, "exit");
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/signal_handler_interrupts_trace.c
+++ b/tests/c/signal_handler_interrupts_trace.c
@@ -1,0 +1,66 @@
+// ## FIXME: currently we can't distinguish a signal handler from a regular
+// ## call (or call back from unmappable code). In this test the signal handler
+// ## is INLINED into trace!
+// ignore-if: true
+// Run-time:
+//   env-var: YKD_LOG_IR=jit-pre-opt,aot
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=3
+//   stderr:
+//     i=3
+//     yk-tracing: start-tracing
+//     i=2
+//     yk-tracing: stop-tracing
+//     yk-warning: trace-compilation-aborted: irregular control flow detected
+//     i=1
+//     exit
+
+// Check that something sensible happens when a signal handler interrupts
+// execution during tracing.
+
+#include <assert.h>
+#include <err.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int flag = 0;
+
+__attribute__((yk_outline))
+void handler(int sig) {
+  flag = 1;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 1);
+  YkLocation loc = yk_location_new();
+
+  signal(SIGUSR1, handler);
+  pid_t self = getpid();
+
+  int i = 3;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "i=%d\n", i);
+
+    flag = 0;
+    if (kill(self, SIGUSR1) != 0) {
+      errx(EXIT_FAILURE, "kill");
+    }
+    while (flag == 0) {
+      usleep(1000); // attempt to not blow the trace buffer.
+    }
+
+    i--;
+  }
+  fprintf(stderr, "exit");
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -1,5 +1,7 @@
+// ## FIXME: PT IP filtering means we can't reliably detect longjmp() in
+// ##        external code.
 // ## FIXME: Implement setjmp/longjmp detection for swt.
-// ignore-if: test "$YKB_TRACER" = "swt"
+// ignore-if: true || test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=3


### PR DESCRIPTION
deltablue (benchmark that spends a lot of time mapping):
  - time spent mapping reduced in the order of ~10x
  - overall performance improved about 15%

This change means that we can no longer spot longjmp in code outside of
the traced range. Whereas before, we'd spot calls to longjmp when the PT
decoder was disassembling foreign code, now what we do is do some basic
"control flow integrity" checking in the trace builder, checking that
each mappable block is either: the entry block of a function, a return
block from a function, or a static successor of the last mappable block
we processed.

(Annoyingly this means we have to keep track of the previous block ID
(which may be unmappable) *and* the previous mappable block ID
separately -- although Lukas and I think we could probably do away with
unmappable blocks and thus also the former, but that's another story)

Although to detect longjmp this way we would only need to check this
property when we return from a function, it turns out to be simpler to
implement for every mappable block (return or not) and arguably it's a
really good sanity check that we should probably have had in place from
the start.

An added bonus is that this approach is tracer-agnostic, so the longjmp
tests work for software tracing too.

I had hoped to detect signal handlers this way too, but unfortunately I
can't see an universally unambiguous way to distinguish them from
regular calls. Since signal handlers weren't really the aim of this PR,
I won't let this hold us up. For now I've added an ignored test showing
the issue: currently signal handlers that have IR get inlined.