### PR TITLE
Introduce a `tracing` timing state.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -314,8 +314,6 @@ pub(crate) extern "C" fn __yk_deopt(
     }
 
     mt.guard_failure(ctr, gidx, frameaddr);
-    mt.stats
-        .timing_state(crate::log::stats::TimingState::OutsideYk);
 
     // Now overwrite the existing stack with our newly recreated one.
     unsafe { replace_stack(newframedst, newstack, memsize) };

--- a/ykrt/src/log/stats.rs
+++ b/ykrt/src/log/stats.rs
@@ -254,6 +254,9 @@ pub(crate) enum TimingState {
     /// counted towards anything and is not displayed to the user.
     #[strum(to_string = "")]
     None,
+    /// This thread is tracing.
+    #[strum(to_string = "duration_tracing")]
+    Tracing,
     /// This thread is compiling a mapped trace.
     #[strum(to_string = "duration_compiling")]
     Compiling,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -518,6 +518,8 @@ impl MT {
                 unsafe { __yk_exec_trace(frameaddr, rsp, trace_addr) };
             }
             TransitionControlPoint::StartTracing(hl) => {
+                self.stats
+                    .timing_state(crate::log::stats::TimingState::Tracing);
                 yklog!(
                     self.log,
                     Verbosity::JITEvent,
@@ -1062,8 +1064,13 @@ impl MT {
         frameaddr: *mut c_void,
     ) {
         match self.transition_guard_failure(parent, gidx) {
-            TransitionGuardFailure::NoAction => (),
+            TransitionGuardFailure::NoAction => {
+                self.stats
+                    .timing_state(crate::log::stats::TimingState::OutsideYk);
+            }
             TransitionGuardFailure::StartSideTracing(hl) => {
+                self.stats
+                    .timing_state(crate::log::stats::TimingState::Tracing);
                 yklog!(
                     self.log,
                     Verbosity::JITEvent,


### PR DESCRIPTION
For quite a while the `deopt` timing state has shown very large values, but when I investigated the code carefully there was nothing which could possibly account for this. It turns out that most of the time we've thought is "deopting" is when `mt.guard_failure` calls `start_recorder`, which is nothing to do with deopting per se.

This commit thus introduces a new timing state `tracing` (used for both "normal" and "side" tracing) which gives us a much better sense of what costs we're incurring where. Deopting itself turns out to be a minor performance overhead (one that it would be nice to improve, but it wouldn't be a massive factor); tracing (which is "start tracing, actually trace a loop, stop tracing") is an order of magnitude more expensive.