### PR TITLE
Allow writing of 64-bit constant ints.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -4,7 +4,7 @@ set -eu
 
 # What git commit hash of yklua & ykcbf will we test in buildbot?
 YKLUA_REPO="https://github.com/ykjit/yklua.git"
-YKLUA_COMMIT="e620be710154b064d0e25f432110968460149b58"
+YKLUA_COMMIT="484deee46c9a26ca32434f7fc0b992b97cbcd855"
 YKCBF_REPO="https://github.com/ykjit/ykcbf.git"
 YKCBF_COMMIT="431b92593180e1e376d08ecf383c4a1ab8473b3d"
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2574,6 +2574,10 @@ impl<'a> Assemble<'a> {
                             }
                         }
                         VarLocation::ConstInt { bits, v } => match bits {
+                            64 => dynasm!(self.asm
+                                ; mov Rq(spare_reg.code()), QWORD v.cast_signed()
+                                ; mov QWORD [rbp - off_dst], Rq(spare_reg.code())
+                            ),
                             32 => dynasm!(self.asm;
                                 mov DWORD [rbp - off_dst], v as i32
                             ),


### PR DESCRIPTION
A recent yklua change means that we do now see this case in the wild.