### PR TITLE
Cache perf fd and mmapped data structures.

### DIFF
--- a/hwtracer/src/perf/collect.rs
+++ b/hwtracer/src/perf/collect.rs
@@ -93,8 +93,7 @@ impl ThreadTracer for PerfThreadTracer {
         let stop_rc = unsafe { hwt_perf_stop_collector(self.ctx, &mut stop_cerr) };
 
         // Even if stopping the collecor fails, we still have to free the collector to ensure that
-        // no resources leak. Critically, we must ensure that the perf fd is closed so that this
-        // thread is able to trace again!
+        // no resources leak.
         let mut free_cerr = PerfPTCError::new();
         let free_rc = unsafe { hwt_perf_free_collector(self.ctx, &mut free_cerr) };
 

--- a/hwtracer/src/pt/ykpt/parser.rs
+++ b/hwtracer/src/pt/ykpt/parser.rs
@@ -8,8 +8,6 @@ use super::packets::*;
 
 #[derive(Clone, Copy, Debug)]
 enum PacketParserState {
-    /// Initial state, waiting for a PSB packet.
-    Init,
     /// The "normal" decoding state.
     Normal,
     /// We are decoding a PSB+ sequence.
@@ -26,7 +24,6 @@ impl PacketParserState {
         // OPT: The order below is a rough guess based on what limited traces I've seen. Benchmark
         // and optimise.
         match self {
-            Self::Init => &[PacketKind::PSB, PacketKind::CBR, PacketKind::PAD],
             Self::Normal => &[
                 PacketKind::ShortTNT,
                 PacketKind::PAD,
@@ -60,7 +57,6 @@ impl PacketParserState {
     /// kind of packet.
     fn transition(&mut self, pkt_kind: PacketKind) {
         let new = match (*self, pkt_kind) {
-            (Self::Init, PacketKind::PSB) => Self::PSBPlus,
             (Self::Normal, PacketKind::PSB) => Self::PSBPlus,
             (Self::PSBPlus, PacketKind::PSBEND) => Self::Normal,
             _ => return, // No state transition.
@@ -107,7 +103,7 @@ impl<'t> PacketParser<'t> {
     pub(super) fn new(bytes: &'t [u8]) -> Self {
         Self {
             pt_bytes: bytes,
-            state: PacketParserState::Init,
+            state: PacketParserState::Normal,
             prev_tip: 0,
         }
     }


### PR DESCRIPTION
This is similar to a revert of 3345db18, but I did it manually to force me to think about what I was doing. I also put all the cached bits into a struct.

(Note that I also didn't revert the bugfix hidden in 3345db18)

Improves the time spent tracing (as reported by YKD_LOG_STATS) and overall performance a bit too.

# Deltablue before

```
1: lua harness.lua deltablue 5 12000
            Mean        Std.Dev.    Min         Median      Max
real        9.625       0.388       8.963       9.837       10.017
user        17.971      1.021       16.339      18.067      19.258
sys         19.923      2.485       15.222      20.640      22.107
```

# Deltablue after

```
1: lua harness.lua deltablue 5 12000
            Mean        Std.Dev.    Min         Median      Max
real        8.043       0.653       6.817       8.158       8.762
user        15.019      1.727       11.609      15.702      16.391
sys         17.363      4.113       10.052      20.088      20.619
```

# Richards before

```
1: lua harness.lua richards 5 100
            Mean        Std.Dev.    Min         Median      Max
real        29.138      0.216       28.959      29.076      29.549
user        33.300      0.592       32.619      33.152      34.096
sys         8.249       0.966       6.370       8.631       9.119
```

# Richards after

```
1: lua harness.lua richards 5 100
            Mean        Std.Dev.    Min         Median      Max
real        28.939      0.238       28.598      28.942      29.274
user        32.733      0.570       32.084      32.682      33.408
sys         6.776       1.321       5.266       6.307       8.970
```