### PR TITLE
Fix the "skip the initial block" logic in the trace builder.

### DIFF
--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -183,20 +183,10 @@ impl Iterator for HWTTraceIterator {
             // multiple machine blocks, which are not all removed here. Since we don't have enough
             // information at this level to remove all of them, there's a workaround in the trace
             // builder.
-            //
-            // As a rough proxy for "check that we removed only the thing we want to remove", we know
-            // that the control point will be contained in a single mappable block. The `unwrap` can
-            // only fail if our assumption about the block is incorrect (i.e. some part of the system
-            // doesn't work as expected).
             match self.hwt_iter.next() {
                 Some(Ok(x)) => {
                     self.map_block(&x);
-                    match self.upcoming.as_slice() {
-                        &[TraceAction::MappedAOTBBlock { .. }] => {
-                            self.upcoming.pop();
-                        }
-                        _ => panic!(),
-                    }
+                    self.upcoming.pop();
                 }
                 Some(Err(BlockIteratorError::HWTracerError(HWTracerError::Temporary(
                     TemporaryErrorKind::TraceBufferOverflow,


### PR DESCRIPTION
The way the pattern is matched, assumes that the block mapped to exactly one IR block, but this appears to not be the case.

Whereas before I could get this to crash relatively quickly, now it takes much longer, and when it does crash, it's for a different reason:

```
thread '<unnamed>' panicked at hwtracer/src/pt/ykpt/mod.rs:449:13:
internal error: entered unreachable code: compressed returns are disabled in collect.c
```

(this after 245 try_repeats)

As it happens, I'm already investigating this crash, as it's the same one that stops us from not emitting stackmaps into outlined functions. I *think* this is a separate issue.