### PR TITLE
Canonicalise `const predicate val` to `val predicate const` for `ICmp`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -2092,6 +2092,12 @@ impl<'a> Assemble<'a> {
                     ; cmovl Rq(lhs_reg.code()), Rq(rhs_reg.code())
                 );
             }
+            32 => {
+                dynasm!(self.asm
+                    ; cmp Rd(lhs_reg.code()), Rd(rhs_reg.code())
+                    ; cmovl Rd(lhs_reg.code()), Rd(rhs_reg.code())
+                );
+            }
             x => todo!("{x}"),
         }
     }


### PR DESCRIPTION
This makes codegen simpler (at the moment we only handle `val predicate const` so canonicalising here saves us having to implement the other case).