### PR TITLE
Implement `todo!` in `force_spill_gp`.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -1374,6 +1374,11 @@ impl LSRegAlloc<'_> {
                                     ; bt Rd(reg.code()), 0
                                     ; setc BYTE [rbp - off]
                                 );
+                            } else if *ext == RegExtension::Undefined {
+                                dynasm!(asm
+                                    ; and Rd(reg.code()), 0x01
+                                    ; mov BYTE [rbp - off], Rb(reg.code())
+                                );
                             } else {
                                 todo!();
                             }


### PR DESCRIPTION
This is required for the new benchmarks added in https://github.com/ykjit/yk-benchmarks/pull/22.