### PR TITLE
`Indirect`s always have a negative offset.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -118,7 +118,7 @@ impl<'a> RevAnalyse<'a> {
                         {
                             assert!(self.spill_to[usize::from(iidx)].is_none());
                             self.spill_to[usize::from(iidx)] =
-                                Some((InstIdx::unchecked_from(i), u32::try_from(*off).unwrap()));
+                                Some((InstIdx::unchecked_from(i), u32::try_from(-*off).unwrap()));
                         }
                     }
                 }


### PR DESCRIPTION
This matches code elsewhere: the reason we hadn't noticed this before is that one can only encounter this code with `YKD_OPT=0`.