### PR TITLE
Lessen overhead

### DIFF
--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -10,10 +10,12 @@ use std::ffi::{c_int, c_longlong, c_uint, c_void};
 #[no_mangle]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_i32(val);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_i32(val);
+        });
+    }
     val
 }
 
@@ -21,10 +23,12 @@ pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
 #[no_mangle]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_unsigned_int(val: c_uint) -> c_uint {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_u32(val);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_u32(val);
+        });
+    }
     val
 }
 
@@ -32,49 +36,59 @@ pub extern "C" fn __yk_promote_c_unsigned_int(val: c_uint) -> c_uint {
 #[no_mangle]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_long_long(val: c_longlong) -> c_longlong {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_i64(val);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_i64(val);
+        });
+    }
     val
 }
 
 /// Promote a `usize` during trace recording.
 #[no_mangle]
 pub extern "C" fn __yk_promote_usize(val: usize) -> usize {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_usize(val);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_usize(val);
+        });
+    }
     val
 }
 
 /// Promote a pointer during trace recording.
 #[no_mangle]
 pub extern "C" fn __yk_promote_ptr(val: *const c_void) -> *const c_void {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_usize(val as usize);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_usize(val as usize);
+        });
+    }
     val
 }
 
 /// Records a 64-bit return value of an idempotent function during trace recording.
 #[no_mangle]
 pub extern "C" fn __yk_idempotent_promote_i64(val: i64) -> i64 {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_i64(val);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_i64(val);
+        });
+    }
     val
 }
 
 /// Records a 32-bit return value of an idempotent function during trace recording.
 #[no_mangle]
 pub extern "C" fn __yk_idempotent_promote_i32(val: i32) -> i32 {
-    MTThread::with_borrow_mut(|mtt| {
-        // We ignore the return value as we can't really cancel tracing from this function.
-        mtt.promote_i32(val);
-    });
+    if MTThread::is_tracing() {
+        MTThread::with_borrow_mut(|mtt| {
+            // We ignore the return value as we can't really cancel tracing from this function.
+            mtt.promote_i32(val);
+        });
+    }
     val
 }

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -52,16 +52,14 @@ thread_local! {
 #[cfg(tracer_swt)]
 #[no_mangle]
 pub extern "C" fn __yk_trace_basicblock(function_index: usize, block_index: usize) {
-    MTThread::with_borrow(|mtt| {
-        if mtt.is_tracing() {
-            BASIC_BLOCKS.with(|v| {
-                v.borrow_mut().push(TracingBBlock {
-                    function_index,
-                    block_index,
-                });
-            })
-        }
-    });
+    if MTThread::is_tracing() {
+        BASIC_BLOCKS.with(|v| {
+            v.borrow_mut().push(TracingBBlock {
+                function_index,
+                block_index,
+            });
+        })
+    }
 }
 
 pub(crate) struct SWTracer {}


### PR DESCRIPTION
These are two slightly separate commits: the first tries to reduce the quantity of non-IR code that PT will have to disassemble; and the second tries to speed up functions like `yk_promote`. The latter is probably the more important of the two (though it depends on the first).