### PR TITLE
Retry errors.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -21,7 +21,7 @@ use parking_lot_core::SpinWait;
 use crate::{
     aotsmp::{load_aot_stackmaps, AOT_STACKMAPS},
     compile::{default_compiler, CompilationError, CompiledTrace, Compiler, GuardIdx},
-    job_queue::JobQueue,
+    job_queue::{Job, JobQueue},
     location::{HotLocation, HotLocationKind, Location, TraceFailed},
     log::{
         stats::{Stats, TimingState},
@@ -237,8 +237,10 @@ impl MT {
         connector_tid: Option<TraceId>,
     ) {
         self.stats.trace_recorded_ok();
+
+        let hl_arc_cl = Arc::clone(&hl_arc);
         let mt = Arc::clone(self);
-        let do_compile = move || {
+        let main = move || {
             let compiler = {
                 let lk = mt.compiler.lock();
                 Arc::clone(&*lk)
@@ -262,6 +264,7 @@ impl MT {
                     debug_assert_matches!(hl.kind, HotLocationKind::Compiling(_));
                     hl.kind = HotLocationKind::Compiled(ctr);
                     mt.stats.trace_compiled_ok();
+                    mt.job_queue.notify_success(ctrid);
                 }
                 Err(e) => {
                     mt.stats.trace_compiled_err();
@@ -295,15 +298,29 @@ impl MT {
                                 .log(Verbosity::Error, &format!("trace-compilation-aborted: {e}"));
                         }
                     }
+                    mt.job_queue.notify_failure(&mt, ctrid);
                 }
             }
 
-            mt.job_queue.notify_success(ctrid);
             mt.stats.timing_state(TimingState::None);
         };
 
-        self.job_queue
-            .push(self, connector_tid, Box::new(do_compile));
+        let mt = Arc::clone(self);
+        let failure = move || {
+            let mut hl = hl_arc_cl.lock();
+            debug_assert_matches!(hl.kind, HotLocationKind::Compiling(_));
+            if let TraceFailed::DontTrace = hl.tracecompilation_error(&mt) {
+                hl.kind = HotLocationKind::DontTrace;
+            } else {
+                hl.kind = HotLocationKind::Counting(0);
+            }
+            mt.job_queue.notify_failure(&mt, ctrid);
+        };
+
+        self.job_queue.push(
+            self,
+            Job::new(Box::new(main), connector_tid, Box::new(failure)),
+        );
     }
 
     /// Add a compilation job for a sidetrace where: `hl_arc` is the [HotLocation] this compilation
@@ -326,7 +343,8 @@ impl MT {
     ) {
         self.stats.trace_recorded_ok();
         let mt = Arc::clone(self);
-        let do_compile = move || {
+        let parent_ctr_cl = Arc::clone(&parent_ctr);
+        let main = move || {
             let compiler = {
                 let lk = mt.compiler.lock();
                 Arc::clone(&*lk)
@@ -355,13 +373,13 @@ impl MT {
                     mt.stats.trace_compiled_ok();
                 }
                 Err(e) => {
-                    // FIXME: We need to track how often compiling a guard fails.
+                    parent_ctr.guard(guardid).trace_or_compile_failed(&mt);
                     mt.stats.trace_compiled_err();
                     match e {
                         CompilationError::General(e) | CompilationError::LimitExceeded(e) => {
                             mt.log.log(
                                 Verbosity::Warning,
-                                &format!("trace-compilation-aborted: {e}"),
+                                &format!("sidetrace-compilation-aborted: {e}"),
                             );
                         }
                         CompilationError::InternalError(e) => {
@@ -371,13 +389,15 @@ impl MT {
                             {
                                 mt.log.log(
                                     Verbosity::Error,
-                                    &format!("trace-compilation-aborted: {e}"),
+                                    &format!("sidetrace-compilation-aborted: {e}"),
                                 );
                             }
                         }
                         CompilationError::ResourceExhausted(e) => {
-                            mt.log
-                                .log(Verbosity::Error, &format!("trace-compilation-aborted: {e}"));
+                            mt.log.log(
+                                Verbosity::Error,
+                                &format!("sidetrace-compilation-aborted: {e}"),
+                            );
                         }
                     }
                 }
@@ -386,8 +406,14 @@ impl MT {
             mt.stats.timing_state(TimingState::None);
         };
 
-        self.job_queue
-            .push(self, connector_tid, Box::new(do_compile));
+        let mt = Arc::clone(self);
+        let failure = move || {
+            parent_ctr_cl.guard(guardid).trace_or_compile_failed(&mt);
+        };
+        self.job_queue.push(
+            self,
+            Job::new(Box::new(main), connector_tid, Box::new(failure)),
+        );
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -548,7 +574,7 @@ impl MT {
                 self.stats.timing_state(TimingState::OutsideYk);
             }
             TransitionControlPoint::StopSideTracing {
-                gidx: guardid,
+                gidx,
                 parent_ctr,
                 root_ctr,
                 connector_tid,
@@ -586,13 +612,13 @@ impl MT {
                             hl,
                             root_ctr,
                             parent_ctr,
-                            guardid,
+                            gidx,
                             connector_tid,
                         );
                     }
                     Err(e) => {
                         MTThread::set_not_tracing();
-                        self.stats.timing_state(TimingState::None);
+                        parent_ctr.guard(gidx).trace_or_compile_failed(self);
                         self.stats.trace_recorded_err();
                         yklog!(
                             self.log,
@@ -600,6 +626,7 @@ impl MT {
                             &format!("stop-tracing-aborted: {e}"),
                             loc.hot_location()
                         );
+                        self.stats.timing_state(TimingState::None);
                     }
                 }
                 self.stats.timing_state(TimingState::OutsideYk);


### PR DESCRIPTION
This commit does several related things (which is how they all got jumbled together):

  1. It gives queue jobs their own `struct`. Jobs now have a "main" function and a "connector_failed" function.
  2. If a job is waiting on a connector trace and that fails, the "connector_failed" function is called and the job is removed from the queue.
  3. When a trace fails to compile, we now mark that as an error; when the threshold (for `Location`s and `Guard`s) is exceeded, that place will no longer try to trace again.
  4. Guards now track how often tracing/compiling have led to errors.

Put another way: when tracing / compilation goes wrong, locations and guards can no longer get "stuck". Before this commit, guards could get stuck in a "we tried tracing once and it didn't work" state forever and locations could get stuck in a "we're waiting for a connector trace, but it's failed and will never be available" state forever.

Tiny benchmarks tend not to encounter these things, but larger benchmarks are more likely to. LuLPeg and Storage both benefit by 8%, Towers by 3%, and DeltaBlue by 2%. I was expecting CD to slow down (long story), but it doesn't seem to be meaningfully effected.