### PR TITLE
Differentiate two kinds of "trace too long"

### DIFF
--- a/tests/c/trace_too_long.c
+++ b/tests/c/trace_too_long.c
@@ -7,7 +7,7 @@
 //   env-var: YKD_LOG=4
 //   stderr:
 //     ...
-//     yk-warning: stop-tracing-aborted: Trace too long
+//     yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/c/trace_too_long_hwt.c
+++ b/tests/c/trace_too_long_hwt.c
@@ -6,7 +6,7 @@
 //   env-var: YKD_LOG=4
 //   stderr:
 //     ...
-//     yk-warning: stop-tracing-aborted: Trace too long
+//     yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
 
 #include <assert.h>
 #include <stdio.h>

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -14,7 +14,7 @@ use crate::{
     compile::{CompilationError, CompiledTrace},
     log::stats::TimingState,
     mt::{TraceId, MT},
-    trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction},
+    trace::{AOTTraceIterator, TraceAction},
 };
 use std::{collections::HashMap, ffi::CString, marker::PhantomData, sync::Arc};
 
@@ -1279,14 +1279,7 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
         // don't have to do this.
         mt.stats.timing_state(TimingState::TraceMapping);
         let tas = ta_iter
-            .map(|x| {
-                x.map_err(|e| match e {
-                    AOTTraceIteratorError::TraceTooLong => {
-                        CompilationError::LimitExceeded("Trace too long.".into())
-                    }
-                    x => CompilationError::General(x.to_string()),
-                })
-            })
+            .map(|x| x.map_err(|e| CompilationError::General(e.to_string())))
             .collect::<Result<Vec<_>, _>>()?;
 
         // Peek to the last block (needed for side-tracing).

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -1276,8 +1276,7 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
         // FIXME: This is a workaround so we can peek at the last block in a trace in order to
         // extract information from the control point when we are side-tracing. Ideally, we extract
         // this information at AOT compile time and serialise it into the module (or block), so we
-        // don't have to do this. Note, we also can't use `collect` here since that won't catch the
-        // `TraceTooLong` error early enough and we run out of memory.
+        // don't have to do this.
         mt.stats.timing_state(TimingState::TraceMapping);
         let tas = ta_iter
             .map(|x| {

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -237,7 +237,7 @@ impl Iterator for HWTTraceIterator {
         }
 
         if self.tas_generated > crate::mt::DEFAULT_TRACE_TOO_LONG {
-            return Some(Err(AOTTraceIteratorError::RecorderOverflow));
+            return Some(Err(AOTTraceIteratorError::TooManyIrElements));
         }
 
         // The `remove` cannot panic because upcoming.len > 1 is guaranteed by the `while` loop

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -191,7 +191,7 @@ impl Iterator for HWTTraceIterator {
                 Some(Err(BlockIteratorError::HWTracerError(HWTracerError::Temporary(
                     TemporaryErrorKind::TraceBufferOverflow,
                 )))) => {
-                    return Some(Err(AOTTraceIteratorError::TraceTooLong));
+                    return Some(Err(AOTTraceIteratorError::RecorderOverflow));
                 }
                 Some(Err(e)) => return Some(Err(AOTTraceIteratorError::Other(e.to_string()))),
                 None => return Some(Err(AOTTraceIteratorError::PrematureEnd)),
@@ -215,7 +215,7 @@ impl Iterator for HWTTraceIterator {
                 Some(Err(BlockIteratorError::HWTracerError(HWTracerError::Temporary(
                     TemporaryErrorKind::TraceBufferOverflow,
                 )))) => {
-                    return Some(Err(AOTTraceIteratorError::TraceTooLong));
+                    return Some(Err(AOTTraceIteratorError::RecorderOverflow));
                 }
                 Some(Err(e)) => return Some(Err(AOTTraceIteratorError::Other(e.to_string()))),
                 None => {
@@ -237,7 +237,7 @@ impl Iterator for HWTTraceIterator {
         }
 
         if self.tas_generated > crate::mt::DEFAULT_TRACE_TOO_LONG {
-            return Some(Err(AOTTraceIteratorError::TraceTooLong));
+            return Some(Err(AOTTraceIteratorError::RecorderOverflow));
         }
 
         // The `remove` cannot panic because upcoming.len > 1 is guaranteed by the `while` loop

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -62,8 +62,8 @@ pub enum TraceRecorderError {
     #[error("Trace empty")]
     #[allow(dead_code)]
     TraceEmpty,
-    /// The trace being recorded was too long and tracing was aborted.
-    #[error("Trace too long")]
+    /// The trace being recorded was too long.
+    #[error("Trace overflowed recorder's storage")]
     #[allow(dead_code)]
     TraceTooLong,
 }
@@ -90,9 +90,10 @@ pub(crate) enum AOTTraceIteratorError {
     #[error("Trace ended prematurely")]
     #[allow(dead_code)]
     PrematureEnd,
-    #[error("Trace too long")]
+    /// The trace being recorded exceeded the tracing recorder's storage.
+    #[error("Trace overflowed recorder's storage")]
     #[allow(dead_code)]
-    TraceTooLong,
+    RecorderOverflow,
     #[error("longjmp encountered")]
     #[allow(dead_code)]
     LongJmpEncountered,

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -94,6 +94,10 @@ pub(crate) enum AOTTraceIteratorError {
     #[error("Trace overflowed recorder's storage")]
     #[allow(dead_code)]
     RecorderOverflow,
+    /// The trace exceeds yk's limit for IR instructions.
+    #[error("Trace would contain too many IR elements")]
+    #[allow(dead_code)]
+    TooManyIrElements,
     #[error("longjmp encountered")]
     #[allow(dead_code)]
     LongJmpEncountered,


### PR DESCRIPTION
Previously we used "trace too long" to mean both:

1. The recorder overflowed its storage.
2. The JIT IR trace we're going to create will be too long.

This PR splits these two concepts apart, which immediately makes clear that we see both kinds in real benchmarks:

```
$ YKD_LOG=3 ~/yklua/src/lua harness.lua deltablue 10 12000
Starting deltablue benchmark ...
deltablue: iterations=1 runtime: 2799356us
deltablue: iterations=1 runtime: 1035879us
deltablue: iterations=1 runtime: 940342us
deltablue: iterations=1 runtime: 1049129us
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
deltablue: iterations=1 runtime: 1127518us
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
deltablue: iterations=1 runtime: 1294389us
yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
deltablue: iterations=1 runtime: 1127559us
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
deltablue: iterations=1 runtime: 948320us
yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: stop-tracing-aborted: Trace overflowed recorder's storage
deltablue: iterations=1 runtime: 918816us
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
yk-warning: trace-compilation-aborted: Trace would contain too many IR elements
deltablue: iterations=1 runtime: 930562us
deltablue: iterations=10 average: 1217187us total: 12171869us

Total Runtime: 12171869us
```

The good news is that, for hwt, PT address filtering should solve most of the "Trace overflowed recorder's storage" errors.

It's also now clear that our "Trace would contain too many IR elements" check is completely bogus: we use PT "TA's generated" as a proxy. That means that the 20K limit in `mt.rs` is completely meaningless across tracing backends. Fixing that is something for a future PR.