### PR TITLE
Make `TraceId` copyable.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -3421,7 +3421,7 @@ impl X64CompiledTrace {
 
 impl CompiledTrace for X64CompiledTrace {
     fn ctrid(&self) -> TraceId {
-        self.ctrid.clone()
+        self.ctrid
     }
 
     fn safepoint(&self) -> &Option<DeoptSafepoint> {

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -251,7 +251,7 @@ impl Module {
 
     /// Returns the ID the module will have when it is compiled into a trace.
     pub(crate) fn ctrid(&self) -> TraceId {
-        self.ctr_id.clone()
+        self.ctr_id
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Since it's just wrapping an integer -- and that's likely to remain the case -- there's no point pretending we need to go through the `clone` rigmarole.