### PR TITLE
Split `YKD_LOG=4` into two levels.

### DIFF
--- a/tests/c/arg_mapping_callee.c
+++ b/tests/c/arg_mapping_callee.c
@@ -1,18 +1,18 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     3:5
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     2:5
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1:5
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that using an argument (of a non-main() function) in a trace works.

--- a/tests/c/arithmetic.c
+++ b/tests/c/arithmetic.c
@@ -3,13 +3,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     add 5
 //     sub 3
 //     mul 12
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{1}}: i32 = add %{{2}}, %{{argc}}
@@ -21,14 +21,14 @@
 //     add 4
 //     sub 2
 //     mul 9
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     add 3
 //     sub 1
 //     mul 6
 //     add 2
 //     sub 0
 //     mul 3
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test some binary operations.

--- a/tests/c/ashr_exact.c
+++ b/tests/c/ashr_exact.c
@@ -3,21 +3,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     ashr 4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{result}}: i64 = ashr %{{1}}, 2i64
 //     ...
 //     --- End jit-pre-opt ---
 //     ashr 3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ashr 2
 //     ashr 1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test ashr instructions with the exact keyword.

--- a/tests/c/bf.O0.c
+++ b/tests/c/bf.O0.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //   stdout:
 //     Hello World!

--- a/tests/c/bf.O1.c
+++ b/tests/c/bf.O1.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O1
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //   stdout:
 //     Hello World!

--- a/tests/c/bf.O2.c
+++ b/tests/c/bf.O2.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O2
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //   stdout:
 //     Hello World!

--- a/tests/c/bf.O3.c
+++ b/tests/c/bf.O3.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O3
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //   stdout:
 //     Hello World!

--- a/tests/c/call_args.c
+++ b/tests/c/call_args.c
@@ -1,20 +1,20 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     3: 5
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{20}}: i32 = add %{{13}}, %{{14}}
 //     ...
 //     --- End jit-pre-opt ---
 //     2: 5
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1: 5
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that function calls with arguments do the right thing

--- a/tests/c/call_ext_in_obj.c
+++ b/tests/c/call_ext_in_obj.c
@@ -1,18 +1,18 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that we can call a function without IR from another object (.o) file.

--- a/tests/c/calls_double.c
+++ b/tests/c/calls_double.c
@@ -1,9 +1,9 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     res=3
 //     ...
 

--- a/tests/c/choice.c
+++ b/tests/c/choice.c
@@ -1,20 +1,20 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     3: 47
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     2: 47
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1: 47
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that tracing a cascading "if...else if...else" works.

--- a/tests/c/conditionals.c
+++ b/tests/c/conditionals.c
@@ -1,9 +1,9 @@
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     res=2
 //     ...
 

--- a/tests/c/connector_trace.c
+++ b/tests/c/connector_trace.c
@@ -1,29 +1,29 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     6
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //       ...
 //       header_end ...
 //     --- End jit-pre-opt ---
 //     5
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //       ...
 //       connector ...
 //     --- End jit-pre-opt ---
 //     3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
-//     yk-jit-event: stop-tracing
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //       ...
 //       sidetrace_end ...

--- a/tests/c/const_global.c
+++ b/tests/c/const_global.c
@@ -1,21 +1,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{12}}: i32 = add %{{11}}, 2i32
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2
 //     i=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that using a global constant works.

--- a/tests/c/constexpr.c
+++ b/tests/c/constexpr.c
@@ -2,7 +2,7 @@
 // ignore-if: true
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...
@@ -16,7 +16,7 @@
 //       ...
 //     --- End jit-pre-opt ---
 //     2:97
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1:97
 //     ...
 

--- a/tests/c/double.c
+++ b/tests/c/double.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 4.000000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -25,10 +25,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 3.000000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 2.000000
 //     1 -> 1.000000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check basic 64-bit float (double) support.
 

--- a/tests/c/doubleinline.c
+++ b/tests/c/doubleinline.c
@@ -3,13 +3,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4
 //     foo-if
 //     bar
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -25,12 +25,12 @@
 //     3
 //     foo-if
 //     bar
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2
 //     foo-if
 //     bar
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     foo-else
 //     bar
 //     0

--- a/tests/c/dyn_ptradd_mixed.c
+++ b/tests/c/dyn_ptradd_mixed.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, y=7
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{9_4}}: ptr = ptr_add @line, 4 + (%{{9_3}} * 8)
@@ -20,10 +20,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, y=6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, y=5
 //     i=1, y=4
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check dynamic ptradd instructions work.
 

--- a/tests/c/dyn_ptradd_multidim.c
+++ b/tests/c/dyn_ptradd_multidim.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=0, elem=000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{10_13}}: ptr = ptr_add %{{0_5}}, 0 + (%{{10_8}} * 64) + (%{{10_10}} * 16) + (%{{%10_12}} * 4)
@@ -21,10 +21,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=1, elem=111
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, elem=222
 //     i=3, elem=333
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check dynamic ptradd instructions work.
 

--- a/tests/c/dyn_ptradd_simple.c
+++ b/tests/c/dyn_ptradd_simple.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, elem=14
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{9_4}}: ptr = ptr_add @array, 0 + (%{{9_3}} * 4)
@@ -17,10 +17,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, elem=13
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, elem=12
 //     i=1, elem=11
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check dynamic ptradd instructions work.
 

--- a/tests/c/early_return1.c
+++ b/tests/c/early_return1.c
@@ -1,24 +1,24 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     early return
 //     6
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     5
 //     4
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     return
 //     exit
 

--- a/tests/c/early_return2.c
+++ b/tests/c/early_return2.c
@@ -1,49 +1,49 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     b3
 //     8
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     b1
 //     7
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     b1
 //     ret1
 //     9
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     b3
 //     8
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     b3
 //     7
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     b3
 //     6
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     b2
 //     5
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     b2
 //     4
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     b2
 //     3
 //     b2
@@ -52,8 +52,8 @@
 //     1
 //     b2
 //     0
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     ret2
 //     exit
 

--- a/tests/c/exit_and_reenter_interploop.c
+++ b/tests/c/exit_and_reenter_interploop.c
@@ -3,11 +3,11 @@
 //   env-var: YKD_LOG=4
 //   stderr:
 //     enter
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     1
 //     exit
 //     enter
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     yk-warning: trace-compilation-aborted: returned from function that started tracing
 //     ...
 

--- a/tests/c/fcmp_double.c
+++ b/tests/c/fcmp_double.c
@@ -1,9 +1,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -17,9 +17,9 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -33,7 +33,7 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that double comparisons work.
 

--- a/tests/c/fcmp_float.c
+++ b/tests/c/fcmp_float.c
@@ -1,9 +1,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-asm
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -17,9 +17,9 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1.100000 == 2.200000: 0
 //     1.100000 == 1.100000: 1
 //     1.100000 != 2.200000: 1
@@ -33,7 +33,7 @@
 //     nan == nan: 0
 //     nan != nan: 1
 //     0.000000 == -0.000000: 1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that 32-bit float comparisons work.
 

--- a/tests/c/fcmp_float_unordered.c
+++ b/tests/c/fcmp_float_unordered.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     --- Begin aot ---
@@ -46,7 +46,7 @@
 //     ...
 //     --- End aot ---
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1.000000 < 1.000000: 0
 //     2.000000 < 2.000000: 0
 //     1.000000 < 2.000000: 1
@@ -95,7 +95,7 @@
 //     nan != 1.000000: 1
 //     nan != nan: 1
 //     ---
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check unordered comparisons are JITted correctly.
 

--- a/tests/c/fib.c
+++ b/tests/c/fib.c
@@ -1,19 +1,19 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4:21
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     3:21
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2:21
 //     1:21
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 #include <stdio.h>

--- a/tests/c/float.c
+++ b/tests/c/float.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 4.000000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -27,10 +27,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 3.000000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 2.000000
 //     1 -> 1.000000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check basic 32-bit float support.
 

--- a/tests/c/float_binop.c
+++ b/tests/c/float_binop.c
@@ -3,12 +3,12 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 4.333300 4.840000
 //     4 -> 3.666700 3.160000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -37,12 +37,12 @@
 //     --- End jit-pre-opt ---
 //     3 -> 3.333300 3.840000
 //     3 -> 2.666700 2.160000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 2.333300 2.840000
 //     2 -> 1.666700 1.160000
 //     1 -> 1.333300 1.840000
 //     1 -> 0.666700 0.160000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check floating point addition works.
 

--- a/tests/c/float_consts.c
+++ b/tests/c/float_consts.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 3.350000, 4.500000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -19,10 +19,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 3.350000, 4.500000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 3.350000, 4.500000
 //     1 -> 3.350000, 4.500000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check 32- and 64-bit float constants work properly.
 

--- a/tests/c/float_div.c
+++ b/tests/c/float_div.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 8.000000 20.000000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -31,10 +31,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 6.000000 15.000000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 4.000000 10.000000
 //     1 -> 2.000000 5.000000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check floating point division works.
 

--- a/tests/c/float_mul.c
+++ b/tests/c/float_mul.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 1.333200 3.360000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -31,10 +31,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3 -> 0.999900 2.520000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 0.666600 1.680000
 //     1 -> 0.333300 0.840000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check floating point multiplication works.
 

--- a/tests/c/float_store.c
+++ b/tests/c/float_store.c
@@ -1,15 +1,15 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 -> 3.252033
 //     4 -> 3.252033
 //     4 -> 3.252033
 //     4 -> 3.252033
 //     4 -> 3.252033
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -29,7 +29,7 @@
 //     3 -> 2.439024
 //     3 -> 2.439024
 //     3 -> 2.439024
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 -> 1.626016
 //     2 -> 1.626016
 //     2 -> 1.626016
@@ -40,7 +40,7 @@
 //     1 -> 0.813008
 //     1 -> 0.813008
 //     1 -> 0.813008
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check basic 32-bit float support.
 

--- a/tests/c/fp_in_out.c
+++ b/tests/c/fp_in_out.c
@@ -1,19 +1,19 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     5.100000
 //     5.200000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     4.100000
 //     4.200000
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     3.100000
 //     3.200000
 //     2.100000
 //     2.200000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that passing floats to/from a function works correctly.
 

--- a/tests/c/fp_to_si.c
+++ b/tests/c/fp_to_si.c
@@ -1,13 +1,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -27,14 +27,14 @@
 //     i=3
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
 //     i=1
 //     f32->int: 5, 4, -1
 //     f64->int: 2, 3, -1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check float to signed integer conversions.
 

--- a/tests/c/funcptrarg_hasir.c
+++ b/tests/c/funcptrarg_hasir.c
@@ -2,11 +2,11 @@
 // ignore-if: true
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     FIXME: match the indirect call
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     z=4
 //     ...
 

--- a/tests/c/funcptrarg_noir.c
+++ b/tests/c/funcptrarg_noir.c
@@ -1,20 +1,20 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     z=3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{17}}: i64 = icall %{{8}}(%{{16}})
 //     ...
 //     --- End jit-pre-opt ---
 //     z=3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     z=3
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Test indirect calls where we don't have IR for the callee.
 

--- a/tests/c/hl_debug.c
+++ b/tests/c/hl_debug.c
@@ -2,12 +2,12 @@
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=4
 //   stderr:
-//     yk-jit-event: start-tracing: somefile.lua:1234: for i = 0, 10 do
+//     yk-tracing: start-tracing: somefile.lua:1234: for i = 0, 10 do
 //     4
 //     3
-//     yk-jit-event: stop-tracing: somefile.lua:1234: for i = 0, 10 do
+//     yk-tracing: stop-tracing: somefile.lua:1234: for i = 0, 10 do
 //     2
-//     yk-jit-event: start-tracing: someotherfile.lua:5678: while j < 1000
+//     yk-tracing: start-tracing: someotherfile.lua:5678: while j < 1000
 //     1
 //     exit
 

--- a/tests/c/icmp_ptr.c
+++ b/tests/c/icmp_ptr.c
@@ -1,12 +1,12 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     p1==p2: 1, p2==p3: 0
 //     p1==p2: 1, p2==p3: 0
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //
 

--- a/tests/c/idempotent.c
+++ b/tests/c/idempotent.c
@@ -3,13 +3,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4: 39 39
 //     4: 41 41
 //     4: 43 43
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     ...
 //     --- Begin aot ---
 //     ...
@@ -60,14 +60,14 @@
 //     3: 39 39
 //     3: 41 41
 //     3: 43 43
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2: 39 39
 //     2: 41 41
 //     2: 43 43
 //     1: 39 39
 //     1: 41 41
 //     1: 43 43
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that idempotent functions work.
 

--- a/tests/c/idempotent_outline.c
+++ b/tests/c/idempotent_outline.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4: 28
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     ...
 //     --- Begin aot ---
 //     ...
@@ -30,11 +30,11 @@
 //     ...
 //     --- End jit-post-opt ---
 //     3: 24
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     2: 20
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     1: 16
 
 // Check that idempotent functions work when they call functions that

--- a/tests/c/idempotent_outline_simple.c
+++ b/tests/c/idempotent_outline_simple.c
@@ -5,9 +5,9 @@
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=4
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4: {{val}}
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     ...
 //     --- Begin aot ---
 //     ...

--- a/tests/c/indirect_call.c
+++ b/tests/c/indirect_call.c
@@ -1,21 +1,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     foo 7
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{1}}: i32 = icall %{{2}}(%{{3}})
 //     ...
 //     --- End jit-pre-opt ---
 //     foo 6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     foo 5
 //     foo 4
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that indirect calls work.

--- a/tests/c/inline_const.c
+++ b/tests/c/inline_const.c
@@ -3,21 +3,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     foo 3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{2}}: i32 = call @fprintf(%{{3}}, %{{4}}, 3i32)
 //     ...
 //     --- End jit-pre-opt ---
 //     foo 3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     foo 3
 //     foo 3
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that constant return values of functions inlined into a trace are

--- a/tests/c/internal_linkage_same_obj.c
+++ b/tests/c/internal_linkage_same_obj.c
@@ -1,21 +1,21 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     x=0
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{12}}: i32 = call @call_me(%{{8}})
 //     ...
 //     --- End jit-pre-opt ---
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     x=0
 //     x=0
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that we can call a static function with internal linkage from the same
 // compilation unit.

--- a/tests/c/intrinsic_noinline.c
+++ b/tests/c/intrinsic_noinline.c
@@ -3,10 +3,10 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
-//     yk-jit-event: stop-tracing
+//     yk-tracing: start-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     define ptr @__yk_compiled_trace_0(ptr %0, ptr %1...
@@ -16,9 +16,9 @@
 //     }
 //     ...
 //     --- End jit-pre-opt ---
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //   stdout:
 //     3

--- a/tests/c/intrinsics.c
+++ b/tests/c/intrinsics.c
@@ -3,16 +3,16 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
-//     yk-jit-event: stop-tracing
+//     yk-tracing: start-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //   stdout:
 //     998

--- a/tests/c/many_threads_many_locs.c
+++ b/tests/c/many_threads_many_locs.c
@@ -1,11 +1,11 @@
 // ## FIXME: SWT can't handle control points not in main.
 // ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
 
 // Check that compiling and running traces in parallel works.

--- a/tests/c/many_threads_one_loc.c
+++ b/tests/c/many_threads_one_loc.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     --- Begin aot ---
@@ -15,7 +15,7 @@
 //     }
 //     ...
 //     --- End aot ---
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
 
 // Check that compiling and running traces in parallel works.

--- a/tests/c/mutable_global.c
+++ b/tests/c/mutable_global.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, g=1000
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ..~
 //     %{{14}}: ptr = lookup_global @g
@@ -14,10 +14,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, g=1005
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, g=1010
 //     i=1, g=1015
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that mutating a global works.

--- a/tests/c/neg_ptradd.c
+++ b/tests/c/neg_ptradd.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=9
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{14_2}}: ptr = ptr_add %{{14_1}}, -{{4}}
@@ -17,10 +17,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=9
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=9
 //     i=9
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that basic trace compilation works.
 

--- a/tests/c/neg_ptradd_dyn.c
+++ b/tests/c/neg_ptradd_dyn.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=9
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{15_4}}: ptr = ptr_add %{{15_1}}, 0 + (%{{15_3}} * {{4}})
@@ -17,10 +17,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=9
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=9
 //     i=9
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that basic trace compilation works.
 

--- a/tests/c/neg_ptradd_dyn_ptr.c
+++ b/tests/c/neg_ptradd_dyn_ptr.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=0, deref=9
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{15_3}}: ptr = ptr_add %{{15_1}}, 0 + (%{{15_2}} * {{4}})
@@ -17,10 +17,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=1, deref=8
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, deref=7
 //     i=3, deref=6
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that basic trace compilation works.
 

--- a/tests/c/nested_execution.c
+++ b/tests/c/nested_execution.c
@@ -1,65 +1,65 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     enter
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     6
 //     enter
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     5
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     return
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     5
 //     enter
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     4
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     3
 //     2
 //     1
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     return
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     4
 //     enter
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     3
 //     2
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     return
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     c
 //     3
 //     enter
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     return
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     b
 //     2
 //     enter
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     1
 //     return
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     a
 //     1
 //     enter

--- a/tests/c/nested_sidetrace.c
+++ b/tests/c/nested_sidetrace.c
@@ -1,16 +1,16 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     3
 //     4
 //     5
@@ -19,54 +19,54 @@
 //     8
 //     9
 //     10
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     12
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     14
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     16
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     18
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     20
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     22
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     24
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     26
 //     28
 //     30
 //     ...
 //     36
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     ...
 //     42
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     45
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     48
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     51
 //     54
 //     57
 //     60
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //   stdout:
 //     exit
 

--- a/tests/c/nested_writetoptr.c
+++ b/tests/c/nested_writetoptr.c
@@ -3,8 +3,8 @@
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=4
 //   stderr:
-//     yk-jit-event: start-tracing
-//     yk-jit-event: stop-tracing
+//     yk-tracing: start-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func foo(...

--- a/tests/c/no_trace_annotation.c
+++ b/tests/c/no_trace_annotation.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     --- Begin aot ---
@@ -17,11 +17,11 @@
 //     --- End jit-pre-opt ---
 //     ...
 //     Can't JIT this!
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     Can't JIT this!
 //     Can't JIT this!
 //     Can't JIT this!
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that the `yk_outline` annotation works.

--- a/tests/c/no_trace_annotation2.c
+++ b/tests/c/no_trace_annotation2.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt,jit-post-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     --- Begin aot ---
@@ -18,14 +18,14 @@
 //     ...
 //     Can't JIT this!
 //     Or this!
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     Can't JIT this!
 //     Or this!
 //     Can't JIT this!
 //     Or this!
 //     Can't JIT this!
 //     Or this!
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that the `yk_outline` annotation works when a `yk_outline` annotated

--- a/tests/c/outline.c
+++ b/tests/c/outline.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, r=10
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     #[yk_outline]
@@ -18,10 +18,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, r=6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, r=3
 //     i=1, r=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     0
 //     exit
 

--- a/tests/c/outline_promoted_ptr.c
+++ b/tests/c/outline_promoted_ptr.c
@@ -1,15 +1,15 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4: 0x...
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     3: 0x...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2: 0x...
 //     1: 0x...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that outlining over a promoted pointer works.

--- a/tests/c/outline_recursion.c
+++ b/tests/c/outline_recursion.c
@@ -1,15 +1,15 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     0
 //     1
 //     2
 //     3
 //     4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -24,13 +24,13 @@
 //     1
 //     2
 //     3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     0
 //     1
 //     2
 //     0
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     0
 //     exit
 

--- a/tests/c/outline_recursion_indirect.c
+++ b/tests/c/outline_recursion_indirect.c
@@ -1,15 +1,15 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     0
 //     1
 //     2
 //     3
 //     4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -24,13 +24,13 @@
 //     1
 //     2
 //     3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     0
 //     1
 //     2
 //     0
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     0
 //     exit
 

--- a/tests/c/phi1.c
+++ b/tests/c/phi1.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, val=1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{_}}: i32 = phi bb{{_}} -> 2i32, bb{{_}} -> 1i32
@@ -19,10 +19,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=1
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, val=1
 //     i=1, val=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that PHI nodes JIT properly.
 

--- a/tests/c/phi2.c
+++ b/tests/c/phi2.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, val=6
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{23_0}}: i32 = phi bb{{bb22}} -> 100i32, bb{{bb21}} -> 6i32
@@ -25,10 +25,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, val=6
 //     i=1, val=6
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that PHI nodes JIT properly.
 

--- a/tests/c/phi3.c
+++ b/tests/c/phi3.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, val=3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{13_2}}: i32 = call f() ...
@@ -25,10 +25,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, val=3
 //     i=1, val=3
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that PHI nodes JIT properly.
 

--- a/tests/c/promote.c
+++ b/tests/c/promote.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     a=99 b=765 y=100
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{_}}: i64 = promote %{{_}} ...
@@ -18,11 +18,11 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     a=99 b=765 y=200
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     a=99 b=765 y=300
 //     a=99 b=765 y=400
 //     a=99 b=765 y=500
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that promotion works in traces.
 

--- a/tests/c/promote_expr.c
+++ b/tests/c/promote_expr.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     y=50
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{16}}: i1 = eq %{{_}}, 50i64
@@ -13,11 +13,11 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     y=100
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     y=150
 //     y=200
 //     y=250
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that expression promotion works in traces.
 //

--- a/tests/c/promote_guard.c
+++ b/tests/c/promote_guard.c
@@ -1,22 +1,22 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     y=100
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     y=200
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     y=300
 //     y=400
 //     y=500
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     y=700
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     y=800
 //     y=900
 //     y=1000
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     y=1999
 
 // Check that promotions are guarded correctly.

--- a/tests/c/promote_many.c
+++ b/tests/c/promote_many.c
@@ -1,10 +1,10 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   stderr:
-//     yk-jit-event: start-tracing
-//     yk-jit-event: stop-tracing
+//     yk-tracing: start-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{_}}: i64 = promote %{{_}} [safepoint: ...
@@ -31,8 +31,8 @@
 //     guard true, %{{5}}, ...
 //     ...
 //     --- End jit-pre-opt ---
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 
 // Check that promotion works in traces.
 

--- a/tests/c/pt_zero_len_call.c
+++ b/tests/c/pt_zero_len_call.c
@@ -1,10 +1,10 @@
 // ignore-if: test ${YK_ARCH} != "x86_64"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
 //  stdout:
 //     exit

--- a/tests/c/ptr_global.c
+++ b/tests/c/ptr_global.c
@@ -1,12 +1,12 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     i=12
 //     i=13
 //     i=14
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that tracing mutation of a global pointer works.

--- a/tests/c/ptradd.c
+++ b/tests/c/ptradd.c
@@ -2,12 +2,12 @@
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0 -Xclang -disable-O0-optnone -Xlinker --lto-newpm-passes=instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4, val=3, p=4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{13_2}}: i32 = call f() ...
@@ -29,10 +29,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3, val=3, p=8
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2, val=3, p=12
 //     i=1, val=3, p=16
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that ptr addition in C input leads to the expected AOT and JIT IR.
 

--- a/tests/c/ptrtoint.c
+++ b/tests/c/ptrtoint.c
@@ -1,21 +1,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     ptr: {{ptr}}
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{1}}: i64 = ptr_to_int %{{2}}
 //     ...
 //     --- End jit-pre-opt ---
 //     ptr: {{ptr}}
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ptr: {{ptr}}
 //     ptr: {{ptr}}
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that pointer to integer conversion works.

--- a/tests/c/qsort.c
+++ b/tests/c/qsort.c
@@ -2,20 +2,20 @@
 // ignore-if: test true
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=2
 //     4 6 1 3 2 5 end
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     i=3
 //     1 4 6 3 2 5 end
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=4
 //     1 3 4 6 2 5 end
 //     i=5
 //     1 2 3 4 6 5 end
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that foreign code calling back to "native" code works.
 

--- a/tests/c/rel_path.c
+++ b/tests/c/rel_path.c
@@ -1,11 +1,11 @@
 // Compiler:
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     ...
 
 // Check that running a traced binary via a relative path works.

--- a/tests/c/resume_and_branch.c
+++ b/tests/c/resume_and_branch.c
@@ -1,10 +1,10 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     x=2
 //     ...
 

--- a/tests/c/sdiv.c
+++ b/tests/c/sdiv.c
@@ -3,9 +3,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     sdiv1 -10922
 //     sdiv2 -715827882
 //     sdiv3 -3074457345618258602
@@ -14,7 +14,7 @@
 //     sdiv6 -715827882
 //     sdiv7 -3074457345618258602
 //     sdiv8 -42
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{_}}: i16 = sdiv %{{_}}, 3i16
@@ -34,7 +34,7 @@
 //     sdiv6 -715827882
 //     sdiv7 -3074457345618258602
 //     sdiv8 -42
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     sdiv1 -10922
 //     sdiv2 -715827882
 //     sdiv3 -3074457345618258602
@@ -51,7 +51,7 @@
 //     sdiv6 -715827882
 //     sdiv7 -3074457345618258602
 //     sdiv8 -42
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test signed division.

--- a/tests/c/select.c
+++ b/tests/c/select.c
@@ -1,21 +1,21 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4 1 1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{13}}: i32 = %{{12}} ? 1i32 : 2i32
 //     ...
 //     --- End jit-pre-opt ---
 //     3 2 3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2 1 4
 //     1 2 6
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that select instructions work.

--- a/tests/c/setlongjmp.c
+++ b/tests/c/setlongjmp.c
@@ -5,9 +5,9 @@
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=4
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     we jumped
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     yk-warning: trace-compilation-aborted: longjmp encountered
 //     ...
 

--- a/tests/c/side-trace.c
+++ b/tests/c/side-trace.c
@@ -1,17 +1,17 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=-
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     3
 //     4
 //     5
@@ -20,32 +20,32 @@
 //     8
 //     9
 //     10
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     12
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     14
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     16
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
 //     18
-//     yk-jit-event: enter-jit-code
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-side-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise
+//     yk-tracing: start-side-tracing
 //     20
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     22
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     24
 //     26
 //     28
 //     30
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     {
 //         ...
 //         "trace_executions": 6,

--- a/tests/c/sidetrace_while.old.c
+++ b/tests/c/sidetrace_while.old.c
@@ -1,7 +1,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     yk-jit-event: execute-side-trace

--- a/tests/c/signextend_negative.c
+++ b/tests/c/signextend_negative.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     neg=-1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     ... = sext ...
@@ -17,10 +17,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     neg=-2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     neg=-3
 //     neg=-4
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that sign extending a negative value works.
 

--- a/tests/c/signextend_positive.c
+++ b/tests/c/signextend_positive.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     pos=1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     ... = sext ...
@@ -17,10 +17,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     pos=2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     pos=3
 //     pos=4
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that sign extending with a positive value works.
 

--- a/tests/c/simple.c
+++ b/tests/c/simple.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -15,10 +15,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2
 //     1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that basic trace compilation works.

--- a/tests/c/simple_binop.c
+++ b/tests/c/simple_binop.c
@@ -1,9 +1,9 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     and 0
 //     or 5
 //     lshr 2
@@ -13,7 +13,7 @@
 //     xor2 -5
 //     shl 8
 //     ---
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{result}}: i32 = and %{{1}}, 1i32
@@ -28,7 +28,7 @@
 //     xor2 -4
 //     shl 6
 //     ---
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     and 0
 //     or 3
 //     lshr 1
@@ -47,7 +47,7 @@
 //     xor2 -2
 //     shl 2
 //     ---
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test some binary operations.

--- a/tests/c/simple_fprintf.c
+++ b/tests/c/simple_fprintf.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -17,11 +17,11 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2
 //     i=1
 //     ...
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 //     exit
 

--- a/tests/c/simple_inline.c
+++ b/tests/c/simple_inline.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     foo 7
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{result}}: i32 = add %{{1}}, 3i32
@@ -16,10 +16,10 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     foo 6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     foo 5
 //     foo 4
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Check that return values of fucntions inlined into the trace are properly

--- a/tests/c/simple_interp_loop1.c
+++ b/tests/c/simple_interp_loop1.c
@@ -1,18 +1,18 @@
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     pc=0, mem=12
 //     pc=1, mem=11
 //     pc=2, mem=10
 //     pc=3, mem=9
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     pc=0, mem=9
 //     pc=1, mem=8
 //     pc=2, mem=7
 //     pc=3, mem=6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     pc=0, mem=6
 //     pc=1, mem=5
 //     pc=2, mem=4
@@ -21,7 +21,7 @@
 //     pc=1, mem=2
 //     pc=2, mem=1
 //     pc=3, mem=0
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     pc=4, mem=0
 //     pc=5, mem=-1
 

--- a/tests/c/simple_interp_loop2.c
+++ b/tests/c/simple_interp_loop2.c
@@ -1,18 +1,18 @@
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     pc=0, mem=4
 //     pc=1, mem=4
 //     pc=2, mem=4
 //     pc=3, mem=3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     pc=0, mem=3
 //     pc=1, mem=3
 //     pc=2, mem=3
 //     pc=3, mem=2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     pc=0, mem=2
 //     pc=1, mem=2
 //     pc=2, mem=2
@@ -21,7 +21,7 @@
 //     pc=1, mem=1
 //     pc=2, mem=1
 //     pc=3, mem=0
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     pc=4, mem=0
 //     pc=5, mem=0
 

--- a/tests/c/simple_nested.c
+++ b/tests/c/simple_nested.c
@@ -1,15 +1,15 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=5
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     i=4
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=3
 //     i=2
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that basic trace compilation works with nested calls.

--- a/tests/c/simple_non_serialised.c
+++ b/tests/c/simple_non_serialised.c
@@ -1,15 +1,15 @@
 // Run-time:
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_STATS=/dev/null
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     i=3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=2
 //     i=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that basic trace compilation in a thread works.
 

--- a/tests/c/simplecall.c
+++ b/tests/c/simplecall.c
@@ -3,12 +3,12 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4
 //     foo
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -23,12 +23,12 @@
 //     --- End jit-pre-opt ---
 //     3
 //     foo
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2
 //     foo
 //     1
 //     bar
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     0
 //     exit
 

--- a/tests/c/srem.c
+++ b/tests/c/srem.c
@@ -1,14 +1,14 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     srem 3
 //     srem2 3
 //     srem3 2
 //     srem4 3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{_}}: i32 = srem %{{_}}, %{{_}}
@@ -24,7 +24,7 @@
 //     srem2 1
 //     srem3 2
 //     srem4 1
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     srem 1
 //     srem2 1
 //     srem3 0
@@ -33,7 +33,7 @@
 //     srem2 0
 //     srem3 0
 //     srem4 0
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test signed division.

--- a/tests/c/strarray.c
+++ b/tests/c/strarray.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     pepper
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     global_decl @fruits
@@ -14,10 +14,10 @@
 //     ...
 //     --- End aot ---
 //     cucumber
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     tomato
 //     banana
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //   stdout:
 //     exit
 

--- a/tests/c/struct_simple.c
+++ b/tests/c/struct_simple.c
@@ -1,19 +1,19 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     3:1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     --- End jit-pre-opt ---
 //     2:1
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     1:1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that we can handle struct field accesses.

--- a/tests/c/switch_default.c
+++ b/tests/c/switch_default.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     switch %{{10_1}}, bb{{bb15}}, [299 -> bb{{bb11}}, 298 -> bb{{bb13}}]...
@@ -20,9 +20,9 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that tracing the default arm of a switch works correctly.

--- a/tests/c/switch_non_default.c
+++ b/tests/c/switch_non_default.c
@@ -1,11 +1,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     switch %{{10_1}}, bb{{bb14}}, [300 -> bb{{bb11}}, 299 -> bb{{bb12}}]...
@@ -18,9 +18,9 @@
 //     ...
 //     --- End jit-pre-opt ---
 //     i=2
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check that tracing a non-default switch arm works correctly.

--- a/tests/c/thread_local_in_trace.c
+++ b/tests/c/thread_local_in_trace.c
@@ -3,7 +3,7 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
 //     %{{8}}: ptr = lookup_global @shadowstack_0
@@ -18,7 +18,7 @@
 //     Run trace in a thread.
 //     ...
 //     res: {{thread_ptr}} 2
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     res: {{thread_ptr}} 2
 //     ...
 

--- a/tests/c/trace_while_executing1.c
+++ b/tests/c/trace_while_executing1.c
@@ -1,25 +1,25 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     0: 5
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //       ...
 //       call @indirect(%17, %18, %19, %20, %21)
 //       ...
 //     --- End jit-pre-opt ---
 //     0: 4
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     0: 3
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     1: 3
 //     0: 2
 //     0: 1
 //     yk-warning: tracing-aborted: tracing continued into a JIT frame
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test that we don't record a successful trace if we started tracing in an

--- a/tests/c/trace_while_executing2.c
+++ b/tests/c/trace_while_executing2.c
@@ -1,25 +1,25 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     0: 5
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //       ...
 //       call @indirect(%17, %18, %19, %20, %21)
 //       ...
 //     --- End jit-pre-opt ---
 //     0: 4
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     0: 3
-//     yk-jit-event: deoptimise
-//     yk-jit-event: start-tracing
+//     yk-execution: deoptimise
+//     yk-tracing: start-tracing
 //     1: 3
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     0: 2
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     0: 1
 //     exit
 

--- a/tests/c/tracing_recursion1.c
+++ b/tests/c/tracing_recursion1.c
@@ -4,7 +4,7 @@
 //   env-var: YKD_LOG=4
 //   stderr:
 //     6
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     5
 //     yk-warning: tracing-aborted: tracing went outside of starting frame
 //     ...

--- a/tests/c/truncate.c
+++ b/tests/c/truncate.c
@@ -1,23 +1,23 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     u64 18446744073709551615
 //     u32 4294967295
 //     u16 65535
 //     u8 255
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     u64 18446744073709551615
 //     u32 4294967295
 //     u16 65535
 //     u8 255
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     u64 18446744073709551615
 //     u32 4294967295
 //     u16 65535
 //     u8 255
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test truncation.

--- a/tests/c/udiv.c
+++ b/tests/c/udiv.c
@@ -3,14 +3,14 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     udiv 21845
 //     udiv2 715827882
 //     udiv3 1431655764
 //     udiv4 42
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
 //     %{{_}}: i16 = udiv %{{_}}, 3i16
@@ -26,7 +26,7 @@
 //     udiv2 715827882
 //     udiv3 1431655764
 //     udiv4 42
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     udiv 21845
 //     udiv2 715827882
 //     udiv3 1431655764
@@ -35,7 +35,7 @@
 //     udiv2 715827882
 //     udiv3 1431655764
 //     udiv4 42
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test unsigned division.

--- a/tests/c/unintptr_t_to_ptr.c
+++ b/tests/c/unintptr_t_to_ptr.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     4: 0x4
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     %{{11_2}}: ptr = int_to_ptr %{{11_1}}, ptr
@@ -16,10 +16,10 @@
 //     ...
 //     --- End aot ---
 //     3: 0x3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     2: 0x2
 //     1: 0x1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that converting an integer to a pointer works.
 

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -4,10 +4,10 @@
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=4
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     set jump point
 //     jumped!
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     yk-warning: trace-compilation-aborted: longjmp encountered
 //     ...
 

--- a/tests/c/varargs.c
+++ b/tests/c/varargs.c
@@ -1,15 +1,15 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=6
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     i=6
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=6
 //     i=6
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check varargs calls work.
 

--- a/tests/c/varargs_inlined.c
+++ b/tests/c/varargs_inlined.c
@@ -3,11 +3,11 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     i=1
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     call llvm.va_start...
@@ -16,10 +16,10 @@
 //     ...
 //     --- End aot ---
 //     i=1
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     i=1
 //     i=1
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 
 // Check that inlining works when the function is vararg.
 

--- a/tests/c/void_ret.c
+++ b/tests/c/void_ret.c
@@ -1,13 +1,13 @@
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG_IR=jit-pre-opt
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
 //     ...
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     inside f
 //     inside f
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     ...
 
 // Check inlining a function into the trace that has a void return type.

--- a/tests/c/zext.c
+++ b/tests/c/zext.c
@@ -1,13 +1,13 @@
 // Run-time:
 //   env-var: YKD_LOG_IR=aot,jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
-//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG=5
 //   stderr:
-//     yk-jit-event: start-tracing
+//     yk-tracing: start-tracing
 //     int to long 4
 //     long to long long 4
 //     uint8_t to uint32_t 3
-//     yk-jit-event: stop-tracing
+//     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
 //     func main(%arg0: i32, %arg1: ptr) -> i32 {
@@ -19,14 +19,14 @@
 //     int to long 3
 //     long to long long 3
 //     uint8_t to uint32_t 3
-//     yk-jit-event: enter-jit-code
+//     yk-execution: enter-jit-code
 //     int to long 2
 //     long to long long 2
 //     uint8_t to uint32_t 3
 //     int to long 1
 //     long to long long 1
 //     uint8_t to uint32_t 3
-//     yk-jit-event: deoptimise
+//     yk-execution: deoptimise
 //     exit
 
 // Test zero extend.

--- a/tests/lua/for_loop.lua
+++ b/tests/lua/for_loop.lua
@@ -1,16 +1,16 @@
 -- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     0
 --     1
 --     2
---     yk-jit-event: start-tracing: for_loop.lua:35: GETTABUP
+--     yk-tracing: start-tracing: for_loop.lua:35: GETTABUP
 --     3
---     yk-jit-event: stop-tracing: ...
+--     yk-tracing: stop-tracing: ...
 --     --- Begin debugstrs: header: for_loop.lua:35: GETTABUP ---
 --       for_loop.lua:35: GETFIELD
 --       for_loop.lua:35: SELF
@@ -24,10 +24,10 @@
 --       for_loop.lua:35: GETTABUP
 --     --- End debugstrs ---
 --     4
---     yk-jit-event: enter-jit-code: for_loop.lua:35: GETTABUP
+--     yk-execution: enter-jit-code: for_loop.lua:35: GETTABUP
 --     5
 --     6
---     yk-jit-event: deoptimise
+--     yk-execution: deoptimise
 --     exit
 
 local x = 0

--- a/tests/lua/nested_loops.lua
+++ b/tests/lua/nested_loops.lua
@@ -1,27 +1,27 @@
 -- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
---     yk-jit-event: start-tracing: nested_loops.lua:42: ADDI
---     yk-jit-event: stop-tracing: nested_loops.lua:42: ADDI
+--     yk-tracing: start-tracing: nested_loops.lua:42: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:42: ADDI
 --     --- Begin debugstrs: header: nested_loops.lua:42: ADDI ---
 --       nested_loops.lua:41: FORLOOP
 --       nested_loops.lua:42: ADDI
 --     --- End debugstrs ---
---     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
---     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
---     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
---     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
---     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
---     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing: nested_loops.lua:42: ADDI
---     yk-jit-event: stop-tracing: nested_loops.lua:42: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: deoptimise
+--     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: deoptimise
+--     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: deoptimise
+--     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: deoptimise
+--     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: deoptimise
+--     yk-tracing: start-side-tracing: nested_loops.lua:42: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:42: ADDI
 --     --- Begin debugstrs: side-trace: nested_loops.lua:42: ADDI ---
 --       nested_loops.lua:39: FORLOOP
 --       nested_loops.lua:40: ADDI
@@ -31,8 +31,8 @@
 --       nested_loops.lua:41: FORPREP
 --       nested_loops.lua:42: ADDI
 --     --- End debugstrs ---
---     yk-jit-event: enter-jit-code: nested_loops.lua:42: ADDI
---     yk-jit-event: deoptimise
+--     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: deoptimise
 --     251502
 
 local x = 0

--- a/tests/lua/recursive_function.lua
+++ b/tests/lua/recursive_function.lua
@@ -1,16 +1,16 @@
 -- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=2
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     6
 --     5
 --     4
---     yk-jit-event: start-tracing: recursive_function.lua:36: GETTABUP
+--     yk-tracing: start-tracing: recursive_function.lua:36: GETTABUP
 --     3
---     yk-jit-event: stop-tracing: ...
+--     yk-tracing: stop-tracing: ...
 --     --- Begin debugstrs: header: recursive_function.lua:36: GETTABUP ---
 --       recursive_function.lua:36: GETFIELD
 --       recursive_function.lua:36: SELF
@@ -26,10 +26,10 @@
 --       recursive_function.lua:36: GETTABUP
 --     --- End debugstrs ---
 --     2
---     yk-jit-event: enter-jit-code: recursive_function.lua:36: GETTABUP
+--     yk-execution: enter-jit-code: recursive_function.lua:36: GETTABUP
 --     1
 --     0
---     yk-jit-event: deoptimise
+--     yk-execution: deoptimise
 --     exit
 
 function f(x)

--- a/tests/lua/recursive_function_indirect.lua
+++ b/tests/lua/recursive_function_indirect.lua
@@ -1,16 +1,16 @@
 -- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=2
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     8
 --     7
 --     6
---     yk-jit-event: start-tracing: recursive_function_indirect.lua:48: GETTABUP
+--     yk-tracing: start-tracing: recursive_function_indirect.lua:48: GETTABUP
 --     5
---     yk-jit-event: stop-tracing: ...
+--     yk-tracing: stop-tracing: ...
 --     --- Begin debugstrs: header: recursive_function_indirect.lua:48: GETTABUP ---
 --       recursive_function_indirect.lua:48: GETFIELD
 --       recursive_function_indirect.lua:48: SELF
@@ -29,19 +29,19 @@
 --       recursive_function_indirect.lua:48: GETTABUP
 --     --- End debugstrs ---
 --     4
---     yk-jit-event: start-tracing: recursive_function_indirect.lua:55: GETTABUP
---     yk-jit-event: stop-tracing: recursive_function_indirect.lua:48: GETTABUP
+--     yk-tracing: start-tracing: recursive_function_indirect.lua:55: GETTABUP
+--     yk-tracing: stop-tracing: recursive_function_indirect.lua:48: GETTABUP
 --     --- Begin debugstrs: connector: recursive_function_indirect.lua:55: GETTABUP ---
 --       recursive_function_indirect.lua:55: MOVE
 --       recursive_function_indirect.lua:55: TAILCALL
 --       recursive_function_indirect.lua:48: GETTABUP
 --     --- End debugstrs ---
 --     3
---     yk-jit-event: enter-jit-code: recursive_function_indirect.lua:55: GETTABUP
+--     yk-execution: enter-jit-code: recursive_function_indirect.lua:55: GETTABUP
 --     2
 --     1
 --     0
---     yk-jit-event: deoptimise
+--     yk-execution: deoptimise
 --     exit
 
 function f(x)

--- a/tests/lua/sidetrace.lua
+++ b/tests/lua/sidetrace.lua
@@ -2,16 +2,16 @@
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YK_SIDETRACE_THRESHOLD=2
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     <0
 --     <1
 --     <2
---     yk-jit-event: start-tracing: sidetrace.lua:60: LTI
+--     yk-tracing: start-tracing: sidetrace.lua:60: LTI
 --     <3
---     yk-jit-event: stop-tracing: ...
+--     yk-tracing: stop-tracing: ...
 --     --- Begin debugstrs: header: sidetrace.lua:60: LTI ---
 --       sidetrace.lua:61: GETTABUP
 --       sidetrace.lua:61: GETFIELD
@@ -27,14 +27,14 @@
 --       sidetrace.lua:60: LTI
 --     --- End debugstrs ---
 --     <4
---     yk-jit-event: enter-jit-code: sidetrace.lua:60: LTI
---     yk-jit-event: deoptimise
+--     yk-execution: enter-jit-code: sidetrace.lua:60: LTI
+--     yk-execution: deoptimise
 --     >=5
---     yk-jit-event: enter-jit-code: sidetrace.lua:60: LTI
---     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing: sidetrace.lua:60: LTI
+--     yk-execution: enter-jit-code: sidetrace.lua:60: LTI
+--     yk-execution: deoptimise
+--     yk-tracing: start-side-tracing: sidetrace.lua:60: LTI
 --     >=6
---     yk-jit-event: stop-tracing: ...
+--     yk-tracing: stop-tracing: ...
 --     --- Begin debugstrs: side-trace: sidetrace.lua:60: LTI ---
 --       sidetrace.lua:63: GETTABUP
 --       sidetrace.lua:63: GETFIELD
@@ -49,11 +49,11 @@
 --       sidetrace.lua:60: LTI
 --     --- End debugstrs ---
 --     >=7
---     yk-jit-event: enter-jit-code: sidetrace.lua:60: LTI
+--     yk-execution: enter-jit-code: sidetrace.lua:60: LTI
 --     >=8
 --     >=9
 --     >=10
---     yk-jit-event: deoptimise
+--     yk-execution: deoptimise
 --     exit
 
 for i = 0, 10 do

--- a/tests/lua/sidetrace_to_loop.lua
+++ b/tests/lua/sidetrace_to_loop.lua
@@ -2,13 +2,13 @@
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=2
 --   env-var: YK_SIDETRACE_THRESHOLD=2
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     h1
---     yk-jit-event: start-tracing: sidetrace_to_loop.lua:35: GTI
---     yk-jit-event: stop-tracing: sidetrace_to_loop.lua:35: GTI
+--     yk-tracing: start-tracing: sidetrace_to_loop.lua:35: GTI
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:35: GTI
 --     --- Begin debugstrs: header: sidetrace_to_loop.lua:35: GTI ---
 --       sidetrace_to_loop.lua:36: TEST
 --       sidetrace_to_loop.lua:36: JMP
@@ -17,18 +17,18 @@
 --       sidetrace_to_loop.lua:35: GTI
 --     --- End debugstrs ---
 --     h2
---     yk-jit-event: enter-jit-code: sidetrace_to_loop.lua:35: GTI
---     yk-jit-event: deoptimise
---     yk-jit-event: enter-jit-code: sidetrace_to_loop.lua:35: GTI
---     yk-jit-event: deoptimise
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: deoptimise
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: deoptimise
 --     h3
---     yk-jit-event: enter-jit-code: sidetrace_to_loop.lua:35: GTI
---     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: deoptimise
+--     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:35: GTI
 --     yk-warning: tracing-aborted: tracing unrolled a loop: sidetrace_to_loop.lua:40: FORLOOP
---     yk-jit-event: enter-jit-code: sidetrace_to_loop.lua:35: GTI
---     yk-jit-event: deoptimise
---     yk-jit-event: start-side-tracing: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: deoptimise
+--     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:35: GTI
 --     exit
 
 function h(i, b1, b2)

--- a/tests/lua/while_loop.lua
+++ b/tests/lua/while_loop.lua
@@ -1,16 +1,16 @@
 -- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
---   env-var: YKD_LOG=4
+--   env-var: YKD_LOG=5
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     0
 --     1
 --     2
---     yk-jit-event: start-tracing: while_loop.lua:35: LEI
+--     yk-tracing: start-tracing: while_loop.lua:35: LEI
 --     3
---     yk-jit-event: stop-tracing: ...
+--     yk-tracing: stop-tracing: ...
 --     --- Begin debugstrs: header: while_loop.lua:35: LEI ---
 --       while_loop.lua:36: GETTABUP
 --       while_loop.lua:36: GETFIELD
@@ -25,10 +25,10 @@
 --       while_loop.lua:35: LEI
 --     --- End debugstrs ---
 --     4
---     yk-jit-event: enter-jit-code: while_loop.lua:35: LEI
+--     yk-execution: enter-jit-code: while_loop.lua:35: LEI
 --     5
 --     6
---     yk-jit-event: deoptimise
+--     yk-execution: deoptimise
 --     exit
 
 local x = 0

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -58,7 +58,7 @@ pub(crate) extern "C" fn __yk_deopt(
     mt.deopt();
     mt.stats
         .timing_state(crate::log::stats::TimingState::Deopting);
-    mt.log.log(Verbosity::JITEvent, "deoptimise");
+    mt.log.log(Verbosity::Execution, "deoptimise");
 
     // Calculate space required for the new stack.
     // Add space for live register values which we'll be adding at the end.

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -25,8 +25,10 @@ pub(crate) enum Verbosity {
     Warning,
     /// Log transitions of a [Location].
     LocationTransition,
-    /// Log JIT events (e.g. start/stop tracing).
-    JITEvent,
+    /// Log tracing events (start/stop tracing etc.).
+    Tracing,
+    /// Log execution events (execute trace / deopt etc.).
+    Execution,
 }
 
 pub(crate) struct Log {
@@ -95,8 +97,9 @@ impl Log {
                 Verbosity::Disabled => panic!(),
                 Verbosity::Error => "yk-error",
                 Verbosity::Warning => "yk-warning",
-                Verbosity::JITEvent => "yk-jit-event",
                 Verbosity::LocationTransition => "yk-location-transition",
+                Verbosity::Tracing => "yk-tracing",
+                Verbosity::Execution => "yk-execution",
             };
             match &self.path {
                 Some(p) => {

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -412,7 +412,7 @@ impl MT {
             TransitionControlPoint::Execute(ctr) => {
                 yklog!(
                     self.log,
-                    Verbosity::JITEvent,
+                    Verbosity::Execution,
                     "enter-jit-code",
                     loc.hot_location()
                 );
@@ -444,7 +444,7 @@ impl MT {
                     .timing_state(crate::log::stats::TimingState::Tracing);
                 yklog!(
                     self.log,
-                    Verbosity::JITEvent,
+                    Verbosity::Tracing,
                     "start-tracing",
                     loc.hot_location()
                 );
@@ -522,7 +522,7 @@ impl MT {
                         self.stats.timing_state(TimingState::None);
                         yklog!(
                             self.log,
-                            Verbosity::JITEvent,
+                            Verbosity::Tracing,
                             "stop-tracing",
                             loc.hot_location()
                         );
@@ -577,7 +577,7 @@ impl MT {
                         self.stats.timing_state(TimingState::None);
                         yklog!(
                             self.log,
-                            Verbosity::JITEvent,
+                            Verbosity::Tracing,
                             "stop-tracing",
                             loc.hot_location()
                         );
@@ -1002,7 +1002,7 @@ impl MT {
                     .timing_state(crate::log::stats::TimingState::Tracing);
                 yklog!(
                     self.log,
-                    Verbosity::JITEvent,
+                    Verbosity::Tracing,
                     "start-side-tracing",
                     Some(&*hl)
                 );


### PR DESCRIPTION
I often want to know when tracing has started and stopped but, outside of tests, I almost never want to know when a trace has executed. Before this commit `YKD_LOG=4` bundled those two classes of things into one.

This commit splits them into two. `YKD_LOG=4` now captures start/stop tracing and `YKD_LOG=5` captures trace execution / deopt.

@vext01 Separately, in the past you were -- I think! -- adamant that we needed all these different `yk-` prefixes even though the RHS part of the message always differentiates things. I *think* we should just have a `yk_log:` prefix (or `ykd_log:`?) for consistency. If you agree, that would be a sensible follow-up PR IMHO.