### PR TITLE
Terminate guard traces at the first `Location` encountered

### DIFF
--- a/tests/lua/nested_loops.lua
+++ b/tests/lua/nested_loops.lua
@@ -4,34 +4,38 @@
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
---     yk-tracing: start-tracing: nested_loops.lua:42: ADDI
---     yk-tracing: stop-tracing: nested_loops.lua:42: ADDI
---     --- Begin debugstrs: header: nested_loops.lua:42: ADDI ---
---       nested_loops.lua:41: FORLOOP
---       nested_loops.lua:42: ADDI
+--     yk-tracing: start-tracing: nested_loops.lua:46: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:46: ADDI
+--     --- Begin debugstrs: header: nested_loops.lua:46: ADDI ---
+--       nested_loops.lua:45: FORLOOP
+--       nested_loops.lua:46: ADDI
 --     --- End debugstrs ---
---     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:46: ADDI
 --     yk-execution: deoptimise
---     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:46: ADDI
 --     yk-execution: deoptimise
---     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:46: ADDI
 --     yk-execution: deoptimise
---     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:46: ADDI
 --     yk-execution: deoptimise
---     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:46: ADDI
 --     yk-execution: deoptimise
---     yk-tracing: start-side-tracing: nested_loops.lua:42: ADDI
---     yk-tracing: stop-tracing: nested_loops.lua:42: ADDI
---     --- Begin debugstrs: side-trace: nested_loops.lua:42: ADDI ---
---       nested_loops.lua:39: FORLOOP
---       nested_loops.lua:40: ADDI
---       nested_loops.lua:41: LOADI
---       nested_loops.lua:41: LOADI
---       nested_loops.lua:41: LOADI
---       nested_loops.lua:41: FORPREP
---       nested_loops.lua:42: ADDI
+--     yk-tracing: start-side-tracing: nested_loops.lua:46: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:44: ADDI
+--     yk-tracing: start-tracing: nested_loops.lua:44: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:46: ADDI
+--     --- Begin debugstrs: connector: nested_loops.lua:44: ADDI ---
+--       nested_loops.lua:45: LOADI
+--       nested_loops.lua:45: LOADI
+--       nested_loops.lua:45: LOADI
+--       nested_loops.lua:45: FORPREP
+--       nested_loops.lua:46: ADDI
 --     --- End debugstrs ---
---     yk-execution: enter-jit-code: nested_loops.lua:42: ADDI
+--     --- Begin debugstrs: side-trace: nested_loops.lua:46: ADDI ---
+--       nested_loops.lua:43: FORLOOP
+--       nested_loops.lua:44: ADDI
+--     --- End debugstrs ---
+--     yk-execution: enter-jit-code: nested_loops.lua:46: ADDI
 --     yk-execution: deoptimise
 --     251502
 

--- a/tests/lua/sidetrace_to_loop.lua
+++ b/tests/lua/sidetrace_to_loop.lua
@@ -7,28 +7,43 @@
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     h1
---     yk-tracing: start-tracing: sidetrace_to_loop.lua:35: GTI
---     yk-tracing: stop-tracing: sidetrace_to_loop.lua:35: GTI
---     --- Begin debugstrs: header: sidetrace_to_loop.lua:35: GTI ---
---       sidetrace_to_loop.lua:36: TEST
---       sidetrace_to_loop.lua:36: JMP
---       sidetrace_to_loop.lua:45: ADDI
---       sidetrace_to_loop.lua:45: JMP
---       sidetrace_to_loop.lua:35: GTI
+--     yk-tracing: start-tracing: sidetrace_to_loop.lua:50: GTI
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:50: GTI
+--     --- Begin debugstrs: header: sidetrace_to_loop.lua:50: GTI ---
+--       sidetrace_to_loop.lua:51: TEST
+--       sidetrace_to_loop.lua:51: JMP
+--       sidetrace_to_loop.lua:60: ADDI
+--       sidetrace_to_loop.lua:60: JMP
+--       sidetrace_to_loop.lua:50: GTI
 --     --- End debugstrs ---
 --     h2
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:50: GTI
 --     yk-execution: deoptimise
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:50: GTI
 --     yk-execution: deoptimise
 --     h3
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:50: GTI
 --     yk-execution: deoptimise
---     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:35: GTI
---     yk-warning: tracing-aborted: tracing unrolled a loop: sidetrace_to_loop.lua:40: FORLOOP
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:35: GTI
+--     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:50: GTI
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:55: FORLOOP
+--     yk-tracing: start-tracing: sidetrace_to_loop.lua:55: FORLOOP
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:55: FORLOOP
+--     --- Begin debugstrs: header: sidetrace_to_loop.lua:55: FORLOOP ---
+--       sidetrace_to_loop.lua:55: FORLOOP
+--     --- End debugstrs ---
+--     --- Begin debugstrs: side-trace: sidetrace_to_loop.lua:50: GTI ---
+--       sidetrace_to_loop.lua:54: TEST
+--       sidetrace_to_loop.lua:55: LOADI
+--       sidetrace_to_loop.lua:55: LOADI
+--       sidetrace_to_loop.lua:55: LOADI
+--       sidetrace_to_loop.lua:55: FORPREP
+--       sidetrace_to_loop.lua:55: FORLOOP
+--     --- End debugstrs ---
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:55: FORLOOP
 --     yk-execution: deoptimise
---     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:35: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:50: GTI
+--     yk-execution: deoptimise
+--     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:50: GTI
 --     exit
 
 function h(i, b1, b2)

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
+atomic_enum = "0.3.0"
 byteorder = "1.4.3"
 deku = { version = "0.18.1", features = ["std"] }
 dynasmrt = "3.0.0"

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -3928,7 +3928,7 @@ mod tests {
         let m = Module::from_str(mod_str);
         let mt = MT::new().unwrap();
         let hl = HotLocation {
-            kind: HotLocationKind::Tracing,
+            kind: HotLocationKind::Tracing(mt.next_trace_id()),
             tracecompilation_errors: 0,
             #[cfg(feature = "ykd")]
             debug_str: None,
@@ -6565,7 +6565,7 @@ mod tests {
 
         let mt = MT::new().unwrap();
         let hl = HotLocation {
-            kind: HotLocationKind::Tracing,
+            kind: HotLocationKind::Tracing(mt.next_trace_id()),
             tracecompilation_errors: 0,
             #[cfg(feature = "ykd")]
             debug_str: None,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -3536,11 +3536,10 @@ impl CompiledTrace for X64CompiledTrace {
 
     fn sidetraceinfo(
         &self,
-        root_ctr: Arc<dyn CompiledTrace>,
         gidx: GuardIdx,
-        connect_ctr: Option<Arc<dyn CompiledTrace>>,
+        target_ctr: Arc<dyn CompiledTrace>,
     ) -> Arc<dyn SideTraceInfo> {
-        let root_ctr = root_ctr.as_any().downcast::<X64CompiledTrace>().unwrap();
+        let target_ctr = target_ctr.as_any().downcast::<X64CompiledTrace>().unwrap();
         // FIXME: Can we reference these instead of copying them, e.g. by passing in a reference to
         // the `CompiledTrace` and `gidx` or better a reference to `DeoptInfo`?
         let deoptinfo = &self.deoptinfo[&usize::from(gidx)];
@@ -3555,9 +3554,9 @@ impl CompiledTrace for X64CompiledTrace {
             bid: deoptinfo.bid.clone(),
             lives,
             callframes,
-            entry_vars: root_ctr.entry_vars().to_vec(),
+            entry_vars: target_ctr.entry_vars().to_vec(),
             sp_offset: self.sp_offset,
-            target_ctr: connect_ctr.unwrap_or(root_ctr),
+            target_ctr,
         })
     }
 

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -119,7 +119,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
-        connector_tid: Option<Arc<dyn CompiledTrace>>,
+        connector_ctr: Option<Arc<dyn CompiledTrace>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         // If either `unwrap` fails, there is no chance of the system working correctly.
         let aot_mod = &*AOT_MOD;
@@ -138,7 +138,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
             sti,
             promotions,
             debug_strs,
-            connector_tid,
+            connector_ctr,
         )?;
 
         let ds = if let Some(x) = &hl.lock().debug_str {
@@ -210,7 +210,7 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
-        connector_tid: Option<Arc<dyn CompiledTrace>>,
+        connector_ctr: Option<Arc<dyn CompiledTrace>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         self.compile(
             mt,
@@ -220,7 +220,7 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
             hl,
             promotions,
             debug_strs,
-            connector_tid,
+            connector_ctr,
         )
     }
 
@@ -233,7 +233,6 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
-        connector_tid: Option<Arc<dyn CompiledTrace>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
         self.compile(
             mt,
@@ -243,7 +242,7 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
             hl,
             promotions,
             debug_strs,
-            connector_tid,
+            None,
         )
     }
 }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -56,7 +56,7 @@ pub(crate) trait Compiler: Send + Sync {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
-        connector_tid: Option<Arc<dyn CompiledTrace>>,
+        connector_ctr: Option<Arc<dyn CompiledTrace>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 
     /// Compile a mapped root trace into machine code.
@@ -69,7 +69,6 @@ pub(crate) trait Compiler: Send + Sync {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
-        connector_tid: Option<Arc<dyn CompiledTrace>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 
@@ -95,9 +94,8 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
 
     fn sidetraceinfo(
         &self,
-        root_ctr: Arc<dyn CompiledTrace>,
         gidx: GuardIdx,
-        connect_ctr: Option<Arc<dyn CompiledTrace>>,
+        target_ctr: Arc<dyn CompiledTrace>,
     ) -> Arc<dyn SideTraceInfo>;
 
     /// Return a reference to the guard `id`.
@@ -165,9 +163,8 @@ mod compiled_trace_testing {
 
         fn sidetraceinfo(
             &self,
-            _root_ctr: Arc<dyn CompiledTrace>,
             _gidx: GuardIdx,
-            _connect_ctr: Option<Arc<dyn CompiledTrace>>,
+            _target_ctr: Arc<dyn CompiledTrace>,
         ) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
@@ -229,9 +226,8 @@ mod compiled_trace_testing {
 
         fn sidetraceinfo(
             &self,
-            _root_ctr: Arc<dyn CompiledTrace>,
             _gidx: GuardIdx,
-            _connect_ctr: Option<Arc<dyn CompiledTrace>>,
+            _target_ctr: Arc<dyn CompiledTrace>,
         ) -> Arc<dyn SideTraceInfo> {
             panic!();
         }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -216,7 +216,7 @@ mod compiled_trace_testing {
 
     impl CompiledTrace for CompiledTraceTestingBasicTransitions {
         fn ctrid(&self) -> TraceId {
-            panic!();
+            TraceId::testing()
         }
 
         fn safepoint(&self) -> &Option<DeoptSafepoint> {

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -322,10 +322,11 @@ pub(crate) enum HotLocationKind {
     /// traced again.
     DontTrace,
     /// This HotLocation started a trace which is ongoing.
-    Tracing,
+    Tracing(TraceId),
     /// While executing JIT compiled code, a guard failed often enough for us to want to generate a
     /// side trace starting at this HotLocation.
     SideTracing {
+        trid: TraceId,
         /// The root [CompiledTrace]: while one thread is side tracing a (possibly many levels
         /// deep) side trace that ultimately relates to this [CompiledTrace], other threads can
         /// execute this compiled trace.
@@ -345,7 +346,7 @@ impl std::fmt::Debug for HotLocationKind {
             Self::Compiling(_) => write!(f, "Compiling"),
             Self::Counting(_) => write!(f, "Counting"),
             Self::DontTrace => write!(f, "DontTrace"),
-            Self::Tracing => write!(f, "Tracing"),
+            Self::Tracing(_) => write!(f, "Tracing"),
             Self::SideTracing { .. } => write!(f, "SideTracing"),
         }
     }

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -326,7 +326,6 @@ pub(crate) enum HotLocationKind {
     /// While executing JIT compiled code, a guard failed often enough for us to want to generate a
     /// side trace starting at this HotLocation.
     SideTracing {
-        trid: TraceId,
         /// The root [CompiledTrace]: while one thread is side tracing a (possibly many levels
         /// deep) side trace that ultimately relates to this [CompiledTrace], other threads can
         /// execute this compiled trace.

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    compile::{CompiledTrace, GuardIdx},
+    compile::CompiledTrace,
     mt::{HotThreshold, TraceCompilationErrorThreshold, TraceId, MT},
 };
 use parking_lot::Mutex;
@@ -46,38 +46,33 @@ pub struct Location {
     /// operate operate as follows (where Counting is the start state):
     ///
     /// ```text
+    ///                                           ★
     ///                                           │
     ///                                           │
     ///                                           ▼
-    ///                                         ┌─────────────────────────────────────────────────────────────────────────────────────┐   increment count
-    ///                                         │                                                                                     │ ──────────────────┐
-    ///                                         │                                      Counting                                       │                   │
-    ///                                         │                                                                                     │ ◀─────────────────┘
-    ///                                         └─────────────────────────────────────────────────────────────────────────────────────┘
-    ///                                           │                                ▲                          ▲
-    ///                                           │ start tracing                  │ failed below threshold   │ failed below threshold
-    ///                                           ▼                                │                          │
-    /// ┌───────────┐  failed above threshold   ┌───────────────────────────────┐  │                          │
-    /// │ DontTrace │ ◀──────────────────────── │            Tracing            │ ─┘                          │
-    /// └───────────┘                           └───────────────────────────────┘                             │
-    ///   ▲                                       │                                                           │
-    ///   │                                       │                                                           │
-    ///   │                                       ▼                                                           │
-    ///   │           failed above threshold    ┌───────────────────────────────┐                             │
-    ///   └──────────────────────────────────── │           Compiling           │ ────────────────────────────┘
-    ///                                         └───────────────────────────────┘
+    ///                                         ┌──────────────────────────────────────────────────────────────────────┐   increment count
+    ///                                         │                                                                      │ ──────────────────┐
+    ///                                         │                               Counting                               │                   │
+    ///                                         │                                                                      │ ◀─────────────────┘
+    ///                                         └──────────────────────────────────────────────────────────────────────┘
+    ///                                           │                 ▲                          ▲
+    ///                                           │ start tracing   │ failed below threshold   │ failed below threshold
+    ///                                           ▼                 │                          │
+    /// ┌───────────┐  failed above threshold   ┌────────────────┐  │                          │
+    /// │ DontTrace │ ◀──────────────────────── │    Tracing     │ ─┘                          │
+    /// └───────────┘                           └────────────────┘                             │
+    ///   ▲                                       │                                            │
+    ///   │                                       │                                            │
+    ///   │                                       ▼                                            │
+    ///   │           failed above threshold    ┌────────────────┐                             │
+    ///   └──────────────────────────────────── │   Compiling    │ ────────────────────────────┘
+    ///                                         └────────────────┘
     ///                                           │
     ///                                           │
     ///                                           ▼
-    ///                                         ┌───────────────────────────────┐
-    ///                                         │           Compiled            │ ◀┐
-    ///                                         └───────────────────────────────┘  │
-    ///                                           │                                │
-    ///                                           │ guard failed above threshold   │ sidetracing completed
-    ///                                           ▼                                │
-    ///                                         ┌───────────────────────────────┐  │
-    ///                                         │          SideTracing          │ ─┘
-    ///                                         └───────────────────────────────┘
+    ///                                         ┌────────────────┐
+    ///                                         │    Compiled    │
+    ///                                         └────────────────┘
     /// ```
     ///
     /// This diagram was created with [this tool](https://dot-to-ascii.ggerganov.com/) using this
@@ -95,8 +90,6 @@ pub struct Location {
     ///   Compiling -> Compiled;
     ///   Compiling -> Counting [label="failed below threshold"];
     ///   Compiling -> DontTrace [label="failed above threshold"];
-    ///   Compiled -> SideTracing [label="guard failed above threshold"];
-    ///   SideTracing -> Compiled [label="sidetracing completed"];
     /// }
     /// ```
     ///
@@ -323,19 +316,6 @@ pub(crate) enum HotLocationKind {
     DontTrace,
     /// This HotLocation started a trace which is ongoing.
     Tracing(TraceId),
-    /// While executing JIT compiled code, a guard failed often enough for us to want to generate a
-    /// side trace starting at this HotLocation.
-    SideTracing {
-        /// The root [CompiledTrace]: while one thread is side tracing a (possibly many levels
-        /// deep) side trace that ultimately relates to this [CompiledTrace], other threads can
-        /// execute this compiled trace.
-        root_ctr: Arc<dyn CompiledTrace>,
-        /// The ID of the guard that failed (inside `parent`).
-        gidx: GuardIdx,
-        /// The [CompiledTrace] that the guard failed in. This will either be `root_ctr` or a
-        /// descendent of `root_ctr`.
-        parent_ctr: Arc<dyn CompiledTrace>,
-    },
 }
 
 impl std::fmt::Debug for HotLocationKind {
@@ -346,7 +326,6 @@ impl std::fmt::Debug for HotLocationKind {
             Self::Counting(_) => write!(f, "Counting"),
             Self::DontTrace => write!(f, "DontTrace"),
             Self::Tracing(_) => write!(f, "Tracing"),
-            Self::SideTracing { .. } => write!(f, "SideTracing"),
         }
     }
 }


### PR DESCRIPTION
The main aim of this PR is best described in https://github.com/ykjit/yk/commit/8764a1074a28e0e6fed1266c3eea806920bc1b73: terminate guard traces at the first non-null-`Location` encountered. To get there, we have to do a lot of preparation, but there are various rewards along the way: overall, the code ends up cleaner. Notably, all of this work eventually lets us remove `HotLocation::SideTracing` entirely.