### PR TITLE
A spare register isn't always available.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -493,6 +493,13 @@ impl LSRegAlloc<'_> {
         self.force_tmp_register(asm, RegSet::with_gp_reserved())
     }
 
+    /// Return a temporary register suitable for `write_vars`. Note: this might cause the value
+    /// originally in the returned value to be spilled.
+    pub(super) fn tmp_register_for_write_vars(&mut self, asm: &mut Assembler) -> Rq {
+        self.find_empty_gp_reg()
+            .unwrap_or_else(|| self.force_tmp_register(asm, RegSet::with_gp_reserved()))
+    }
+
     /// Assign general purpose registers for the instruction at position `iidx`.
     ///
     /// This is a convenience function for [Self::assign_regs] when there are no FP registers.


### PR DESCRIPTION
Previously we had -- as the comment said -- normally been lucky in `write_jump_vars` and not needed to spill a register. I've now encountered situations where that isn't true and we need to spill a register.

This commit handles that case --- but it does try very hard not to spill! In order to do that, we have to sort-of duplicate a `match`: this does allow us to escape a spill in a small but notable number of cases (enough that I can just about measure it in a small benchmark).