### PR TITLE
Guard tidyups

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -52,7 +52,7 @@ pub(crate) extern "C" fn __yk_deopt(
         .unwrap();
     let gidx = GuardIdx::from(usize::try_from(gidx).unwrap());
     let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
-    let info = &ctr.deoptinfo[&usize::from(gidx)];
+    let info = &ctr.deoptinfo[usize::from(gidx)];
     let mt = Arc::clone(&ctr.mt);
 
     mt.deopt();

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -52,7 +52,7 @@ pub(crate) extern "C" fn __yk_deopt(
         .unwrap();
     let gidx = GuardIdx::from(usize::try_from(gidx).unwrap());
     let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
-    let info = &ctr.deoptinfo[usize::from(gidx)];
+    let cgd = &ctr.compiled_guard(gidx);
     let mt = Arc::clone(&ctr.mt);
 
     mt.deopt();
@@ -64,7 +64,7 @@ pub(crate) extern "C" fn __yk_deopt(
     // Add space for live register values which we'll be adding at the end.
     let mut memsize = RECOVER_REG.len() * REG64_BYTESIZE;
     // Calculate amount of space we need to allocate for each stack frame.
-    for (i, iframe) in info.inlined_frames.iter().enumerate() {
+    for (i, iframe) in cgd.inlined_frames.iter().enumerate() {
         let (rec, _) = aot_smaps.get(usize::try_from(iframe.safepoint.id).unwrap());
         debug_assert!(rec.size != u64::MAX);
         // The controlpoint frame (i == 0) doesn't need to be recreated.
@@ -90,7 +90,7 @@ pub(crate) extern "C" fn __yk_deopt(
     // Live register values that we need to write back into AOT registers.
     let mut registers = [0; REGISTER_NUM];
     let mut varidx = 0;
-    for (i, iframe) in info.inlined_frames.iter().enumerate() {
+    for (i, iframe) in cgd.inlined_frames.iter().enumerate() {
         let (rec, pinfo) = aot_smaps.get(usize::try_from(iframe.safepoint.id).unwrap());
 
         // WRITE RBP
@@ -160,7 +160,7 @@ pub(crate) extern "C" fn __yk_deopt(
         // stackmap.
         for aotvar in rec.live_vars.iter() {
             // Read live JIT values from the trace's stack frame.
-            let jitval = match info.live_vars[varidx].1 {
+            let jitval = match cgd.live_vars[varidx].1 {
                 VarLocation::Stack { frame_off, size } => {
                     // rbp-0 can't contain a variable.
                     // [rbp-0] points to either the return address or the previous frame's rbp
@@ -305,7 +305,7 @@ pub(crate) extern "C" fn __yk_deopt(
 
     // Compute the address to which we want to write the new stack. This is immediately after the
     // frame containing the control point.
-    let (rec, pinfo) = aot_smaps.get(usize::try_from(info.inlined_frames[0].safepoint.id).unwrap());
+    let (rec, pinfo) = aot_smaps.get(usize::try_from(cgd.inlined_frames[0].safepoint.id).unwrap());
     let mut newframedst = unsafe { frameaddr.byte_sub(usize::try_from(rec.size).unwrap()) };
     if pinfo.hasfp {
         // `frameaddr` is the RBP value of the bottom frame after pushing the previous frame's RBP.

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -2180,6 +2180,7 @@ impl<R: dynasmrt::Register> RegConstraint<R> {
 
 /// The information the register allocator records at the point of a guard's code generation that
 /// it later needs to get a failing guard ready for deopt.
+#[derive(Debug)]
 pub(super) struct GuardSnapshot {
     /// The registers we need to zero extend: the `u32` is the `from_bitw` that is passed to
     /// `force_zero_extend_to_reg64`.

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -14,26 +14,21 @@
 //!   * When a value is in a register, we make no guarantees about what the upper bits are set to.
 //!     You must sign or zero extend at all points that these values are important.
 
-use super::{
-    super::{
-        aot_ir::DeoptSafepoint,
-        arbbitint::ArbBitInt,
-        jit_ir::{self, BinOp, FloatTy, Inst, InstIdx, Module, Operand, TraceKind, Ty},
-        CompilationError,
-    },
-    CodeGen,
-};
 #[cfg(any(debug_assertions, test))]
 use crate::compile::jitc_yk::gdb::{self, GdbCtx};
 use crate::{
     aotsmp::AOT_STACKMAPS,
     compile::{
         jitc_yk::{
-            aot_ir,
-            jit_ir::{Const, IndirectCallIdx, InlinedFrame},
-            YkSideTraceInfo,
+            aot_ir::{self, DeoptSafepoint},
+            arbbitint::ArbBitInt,
+            jit_ir::{
+                self, BinOp, Const, FloatTy, IndirectCallIdx, InlinedFrame, Inst, InstIdx, Module,
+                Operand, TraceKind, Ty,
+            },
+            CodeGen, YkSideTraceInfo,
         },
-        CompiledTrace, Guard, GuardIdx, SideTraceInfo,
+        CompilationError, CompiledTrace, Guard, GuardIdx, SideTraceInfo,
     },
     location::HotLocation,
     mt::{TraceId, MT},


### PR DESCRIPTION
This PR somewhat tidies up guards (what use to be called `DeoptInfo`). After first converting a `HashMap` to a `Vec`, https://github.com/ykjit/yk/commit/947c664717bdc27fc32b58c416f6b59ac3fda82e is really the main part of this PR: it recognises that we need to store different info while we're compiling a trace than after we've compiled a trace. Overall, there's only a mild functional change here, but this PR is a stepping stone towards making these parts of the system easier to work on.