### PR TITLE
Update deopt function documentation.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -36,8 +36,8 @@ const REGISTER_NUM: usize = RECOVER_REG.len() + 2;
 /// * `gidx` - the [GuardIdx] of the current failing guard
 /// * `gp_regs` - a pointer to the saved values of the 16 general purpose registers in the same
 ///   order as [crate::compile::jitc_yk::codegen::x64::lsregalloc::GP_REGS]
-/// * gptr - Pointer to a list of previous [GuardIdx]'s leading up to the current guard failure.
-/// * glen - Length for list in `gptr`.
+/// * `fp_regs` - a pointer to the saved values of the 16 floating point registers
+/// * `ctrid` - the ID of the compiled trace that is being deoptimized
 #[no_mangle]
 pub(crate) extern "C" fn __yk_deopt(
     frameaddr: *mut c_void,


### PR DESCRIPTION
Update deopt function docs to include new parameters for floating point registers and compiled trace id.