### PR TITLE
Push `SideTraceInfo` into jitc_yk

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -21,7 +21,6 @@ use crate::compile::jitc_yk::{
         PtrToIntInst, SExtInst, SIToFPInst, SelectInst, StoreInst, TraceKind, TruncInst, Ty,
         ZExtInst,
     },
-    YkSideTraceInfo,
 };
 use dynasmrt::x64::Rq;
 use std::{assert_matches::assert_matches, sync::Arc};
@@ -123,10 +122,6 @@ impl<'a> RevAnalyse<'a> {
                 }
             }
             TraceKind::Sidetrace(sti) => {
-                let sti = Arc::clone(sti)
-                    .as_any()
-                    .downcast::<YkSideTraceInfo<Register>>()
-                    .unwrap();
                 let vlocs = &sti.entry_vars;
                 // Side-traces don't have a trace body since we don't apply loop peeling and thus use
                 // `trace_header_end` to store the jump variables.

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -97,9 +97,9 @@ mod parser;
 #[cfg(any(debug_assertions, test))]
 mod well_formed;
 
-use super::aot_ir;
+use super::{aot_ir, codegen::x64::Register, YkSideTraceInfo};
 use crate::{
-    compile::{jitc_yk::arbbitint::ArbBitInt, CompilationError, CompiledTrace, SideTraceInfo},
+    compile::{jitc_yk::arbbitint::ArbBitInt, CompilationError, CompiledTrace},
     mt::TraceId,
 };
 use indexmap::IndexSet;
@@ -128,7 +128,7 @@ pub(crate) enum TraceKind {
     Connector(Arc<dyn CompiledTrace>),
     /// A sidetrace: this will start at the point of a guard and will jump to
     /// [SideTraceInfo::target_ctr].
-    Sidetrace(Arc<dyn SideTraceInfo>),
+    Sidetrace(Arc<YkSideTraceInfo<Register>>),
 }
 
 impl std::fmt::Debug for TraceKind {

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,7 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, GuardIdx, SideTraceInfo},
+    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, GuardIdx},
     location::HotLocation,
     log::{log_ir, should_log_ir, IRPhase},
     mt::{TraceId, MT},
@@ -45,7 +45,7 @@ pub(crate) static AOT_MOD: LazyLock<aot_ir::Module> = LazyLock::new(|| {
 });
 
 /// Contains information required for side-tracing.
-struct YkSideTraceInfo<Register: Send + Sync> {
+pub(crate) struct YkSideTraceInfo<Register: Send + Sync> {
     /// The AOT IR block the failing guard originated from.
     bid: aot_ir::BBlockId,
     /// Inlined calls tracked by [trace_builder] during processing of a trace. Required for
@@ -63,16 +63,6 @@ struct YkSideTraceInfo<Register: Send + Sync> {
     sp_offset: usize,
     /// The trace to jump to at the end of this sidetrace.
     target_ctr: Arc<dyn CompiledTrace>,
-}
-
-impl<Register: Send + Sync + 'static> SideTraceInfo for YkSideTraceInfo<Register> {
-    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
-        self
-    }
-
-    fn target_ctr(&self) -> Arc<dyn CompiledTrace> {
-        Arc::clone(&self.target_ctr)
-    }
 }
 
 impl<Register: Send + Sync> YkSideTraceInfo<Register> {
@@ -115,7 +105,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         mt: Arc<MT>,
         aottrace_iter: Box<dyn AOTTraceIterator>,
         ctrid: TraceId,
-        sti: Option<Arc<dyn SideTraceInfo>>,
+        sti: Option<Arc<YkSideTraceInfo<codegen::x64::Register>>>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
@@ -127,8 +117,6 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
         if should_log_ir(IRPhase::AOT) {
             log_ir(&format!("--- Begin aot ---\n{aot_mod}\n--- End aot ---\n"));
         }
-
-        let sti = sti.map(|s| s.as_any().downcast::<YkSideTraceInfo<Register>>().unwrap());
 
         let mut jit_mod = trace_builder::build(
             &mt,
@@ -236,6 +224,10 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
+        let parent_ctr = parent_ctr
+            .as_any()
+            .downcast::<codegen::x64::X64CompiledTrace>()
+            .unwrap();
         let sti = parent_ctr.sidetraceinfo(gidx, Arc::clone(&target_ctr));
         self.compile(
             mt,

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,7 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, SideTraceInfo},
+    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, GuardIdx, SideTraceInfo},
     location::HotLocation,
     log::{log_ir, should_log_ir, IRPhase},
     mt::{TraceId, MT},
@@ -229,11 +229,14 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         mt: Arc<MT>,
         aottrace_iter: Box<dyn AOTTraceIterator>,
         ctrid: TraceId,
-        sti: Arc<dyn SideTraceInfo>,
+        parent_ctr: Arc<dyn CompiledTrace>,
+        gidx: GuardIdx,
+        target_ctr: Arc<dyn CompiledTrace>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError> {
+        let sti = parent_ctr.sidetraceinfo(gidx, Arc::clone(&target_ctr));
         self.compile(
             mt,
             aottrace_iter,

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -16,11 +16,11 @@ use crate::{
     mt::{TraceId, MT},
     trace::{AOTTraceIterator, TraceAction},
 };
-use std::{collections::HashMap, ffi::CString, marker::PhantomData, sync::Arc};
+use std::{collections::HashMap, ffi::CString, sync::Arc};
 use ykaddr::addr::symbol_to_ptr;
 
 /// Given an execution trace and AOT IR, creates a JIT IR trace.
-pub(crate) struct TraceBuilder<Register: Send + Sync> {
+pub(crate) struct TraceBuilder {
     /// The AOT IR.
     aot_mod: &'static Module,
     /// The JIT IR this struct builds.
@@ -46,7 +46,6 @@ pub(crate) struct TraceBuilder<Register: Send + Sync> {
     promotions: Box<[u8]>,
     /// The trace's current position in the promotions array.
     promote_idx: usize,
-    phantom: PhantomData<Register>,
     /// The dynamically recorded debug strings, in the order that the corresponding
     /// `yk_debug_str()` calls were encountered in the trace.
     debug_strs: Vec<String>,
@@ -56,7 +55,7 @@ pub(crate) struct TraceBuilder<Register: Send + Sync> {
     inferred_consts: HashMap<jit_ir::InstIdx, jit_ir::ConstIdx>,
 }
 
-impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
+impl TraceBuilder {
     /// Create a trace builder.
     ///
     /// Arguments:
@@ -89,7 +88,6 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
             recursion_count: 0,
             promotions,
             promote_idx: 0,
-            phantom: PhantomData,
             debug_strs,
             debug_str_idx: 0,
             inferred_consts: HashMap::new(),
@@ -1392,10 +1390,7 @@ impl<Register: Send + Sync + 'static> TraceBuilder<Register> {
         let mut prev_mappable_bid: Option<BBlockId> = None;
 
         if let TraceKind::Sidetrace(sti) = self.jit_mod.tracekind() {
-            let sti = Arc::clone(sti)
-                .as_any()
-                .downcast::<YkSideTraceInfo<Register>>()
-                .unwrap();
+            let sti = Arc::clone(sti);
             // Set the previous block to the last block in the parent trace. Required in order to
             // process phi nodes.
             prev_bid = Some(sti.bid.clone());
@@ -1656,12 +1651,12 @@ struct InlinedFrame {
 }
 
 /// Create JIT IR from the (`aot_mod`, `ta_iter`) tuple.
-pub(super) fn build<Register: Send + Sync + 'static>(
+pub(super) fn build(
     mt: &Arc<MT>,
     aot_mod: &'static Module,
     ctrid: TraceId,
     ta_iter: Box<dyn AOTTraceIterator>,
-    sti: Option<Arc<YkSideTraceInfo<Register>>>,
+    sti: Option<Arc<YkSideTraceInfo<super::codegen::x64::Register>>>,
     promotions: Box<[u8]>,
     debug_strs: Vec<String>,
     connector_tid: Option<Arc<dyn CompiledTrace>>,
@@ -1673,6 +1668,5 @@ pub(super) fn build<Register: Send + Sync + 'static>(
     } else {
         TraceKind::HeaderOnly
     };
-    TraceBuilder::<Register>::new(mt, tracekind, aot_mod, ctrid, promotions, debug_strs)?
-        .build(mt, ta_iter)
+    TraceBuilder::new(mt, tracekind, aot_mod, ctrid, promotions, debug_strs)?.build(mt, ta_iter)
 }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -94,12 +94,6 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     /// upcasting in Rust is incomplete.
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static>;
 
-    fn sidetraceinfo(
-        &self,
-        gidx: GuardIdx,
-        target_ctr: Arc<dyn CompiledTrace>,
-    ) -> Arc<dyn SideTraceInfo>;
-
     /// Return a reference to the guard `id`.
     fn guard(&self, gidx: GuardIdx) -> &Guard;
 
@@ -118,18 +112,6 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
 
     /// Disassemble the JITted code into a string, for testing and deubgging.
     fn disassemble(&self, with_addrs: bool) -> Result<String, Box<dyn Error>>;
-}
-
-/// Stores information required for compiling a side-trace. Passed down from a (parent) trace
-/// during deoptimisation.
-pub(crate) trait SideTraceInfo: fmt::Debug {
-    /// Upcast this [SideTraceInfo] to `Any`. This method is a hack that's only needed since trait
-    /// upcasting in Rust is incomplete.
-    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static>;
-
-    /// Return the [CompiledTrace] this side-trace should jump to at its end. Note: this may be the
-    /// "root" trace of a trace tree, or a completely different trace altogether.
-    fn target_ctr(&self) -> Arc<dyn CompiledTrace>;
 }
 
 #[cfg(test)]
@@ -160,14 +142,6 @@ mod compiled_trace_testing {
         }
 
         fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
-            panic!();
-        }
-
-        fn sidetraceinfo(
-            &self,
-            _gidx: GuardIdx,
-            _target_ctr: Arc<dyn CompiledTrace>,
-        ) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
 
@@ -223,14 +197,6 @@ mod compiled_trace_testing {
         }
 
         fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
-            panic!();
-        }
-
-        fn sidetraceinfo(
-            &self,
-            _gidx: GuardIdx,
-            _target_ctr: Arc<dyn CompiledTrace>,
-        ) -> Arc<dyn SideTraceInfo> {
             panic!();
         }
 

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -59,13 +59,15 @@ pub(crate) trait Compiler: Send + Sync {
         connector_ctr: Option<Arc<dyn CompiledTrace>>,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 
-    /// Compile a mapped root trace into machine code.
+    /// Compile a guard trace into machine code.
     fn sidetrace_compile(
         &self,
         mt: Arc<MT>,
         aottrace_iter: Box<dyn AOTTraceIterator>,
         ctrid: TraceId,
-        sti: Arc<dyn SideTraceInfo>,
+        parent_ctr: Arc<dyn CompiledTrace>,
+        gidx: GuardIdx,
+        target_ctr: Arc<dyn CompiledTrace>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -340,7 +340,7 @@ impl MT {
         hl_arc: Arc<Mutex<HotLocation>>,
         trid: TraceId,
         parent_ctr: Arc<dyn CompiledTrace>,
-        guardid: GuardIdx,
+        gidx: GuardIdx,
         connector_tid: TraceId,
     ) {
         self.stats.trace_recorded_ok();
@@ -353,7 +353,6 @@ impl MT {
             };
             mt.stats.timing_state(TimingState::Compiling);
             let target_ctr = Arc::clone(&mt.compiled_traces.lock()[&connector_tid]);
-            let sti = parent_ctr.sidetraceinfo(guardid, Arc::clone(&target_ctr));
             // FIXME: Can we pass in the root trace address, root trace entry variable locations,
             // and the base stack-size from here, rather than spreading them out via
             // DeoptInfo/SideTraceInfo, and CompiledTrace?
@@ -361,7 +360,9 @@ impl MT {
                 Arc::clone(&mt),
                 trace_iter.0,
                 trid,
-                sti,
+                Arc::clone(&parent_ctr),
+                gidx,
+                target_ctr,
                 Arc::clone(&hl_arc),
                 trace_iter.1,
                 trace_iter.2,
@@ -371,11 +372,11 @@ impl MT {
                     mt.compiled_traces
                         .lock()
                         .insert(ctr.ctrid(), Arc::clone(&ctr));
-                    parent_ctr.guard(guardid).set_ctr(ctr, &parent_ctr, guardid);
+                    parent_ctr.guard(gidx).set_ctr(ctr, &parent_ctr, gidx);
                     mt.stats.trace_compiled_ok();
                 }
                 Err(e) => {
-                    parent_ctr.guard(guardid).trace_or_compile_failed(&mt);
+                    parent_ctr.guard(gidx).trace_or_compile_failed(&mt);
                     mt.stats.trace_compiled_err();
                     match e {
                         CompilationError::General(e) | CompilationError::LimitExceeded(e) => {
@@ -410,7 +411,7 @@ impl MT {
 
         let mt = Arc::clone(self);
         let failure = move || {
-            parent_ctr_cl.guard(guardid).trace_or_compile_failed(&mt);
+            parent_ctr_cl.guard(gidx).trace_or_compile_failed(&mt);
         };
         self.job_queue.push(
             self,


### PR DESCRIPTION
This PR pushes `SideTraceInfo` into jitc_yk, in two stages. Ultimately, although we tried to make this somewhat abstract, it's now very obvious that it's intimately tied to jitc_yk's view of the world, in a way that no other backend could share without unpleasant contortions. The second commit makes explicit something that's been implicit for ages: jitc_yk's current design is x64 only, and trying to pretend it isn't just makes things confusing. Biting the bullet on that clears up quite a few things, and gives us a better guide for what we need to do next time.