### PR TITLE
Fix incorrect integer formatting in filter string.

### DIFF
--- a/hwtracer/src/perf/collect.c
+++ b/hwtracer/src/perf/collect.c
@@ -472,7 +472,7 @@ static int open_perf(size_t aux_bufsize, bool filter, struct hwt_cerror *err) {
     get_tracing_extent(&fltr_obj, &fltr_base_off, &fltr_size);
 
     char f_str[512];
-    if ((size_t) snprintf(f_str, sizeof(f_str), "filter 0x%zu/%zu@%s",
+    if ((size_t) snprintf(f_str, sizeof(f_str), "filter 0x%zx/%zu@%s",
           fltr_base_off, fltr_size, fltr_obj) >= sizeof(f_str))
     {
       hwt_set_cerr(err, hwt_cerror_unknown, 0);


### PR DESCRIPTION
Due to blind luck, I don't expect this to make any difference just now.

Because we disable PIE, the executable segment always starts at offset zero. Decimal 0 and hexidecimal 0x0 are the same number.