### PR TITLE
Calculate the transitively reachable set of "guard body" instructions.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -249,7 +249,19 @@ impl<'a> RevAnalyse<'a> {
                     Inst::TraceHeaderStart | Inst::TraceBodyStart => (),
                     Inst::Guard(_) => (),
                     _ => {
-                        self.used_only_by_guards.set(usize::from(x), false);
+                        if inst.is_internal_inst()
+                            || inst.is_guard()
+                            || inst.has_load_effect(self.m)
+                            || inst.has_store_effect(self.m)
+                            || !self.used_only_by_guards[usize::from(iidx)]
+                        {
+                            self.used_only_by_guards.set(usize::from(x), false);
+                        } else {
+                            let cnd = self.inst_vals_alive_until[usize::from(iidx)];
+                            if self.inst_vals_alive_until[usize::from(x)] < cnd {
+                                self.inst_vals_alive_until[usize::from(x)] = cnd;
+                            }
+                        }
                         self.push_def_use(x, iidx);
                     }
                 }


### PR DESCRIPTION
This means that we now pull even "indirect" instructions into guard bodies. Because the register allocator does quite a bad job inside guard bodies, this isn't as big a win as the previous PR, but it's still useful. The winners are:

```
DeltaBlue/YkLua/12000     6.72% faster
Havlak/YkLua/1500         3.83% faster
NBody/YkLua/250000        3.25% faster
```