### PR TITLE
Tweak yksmp a bit.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -19,6 +19,7 @@ page_size = "0.6.0"
 cache-size = "0.7.0"
 parking_lot = "0.12.0"
 parking_lot_core = "0.9.1"
+smallvec = { version = "1.15.1", features = ["union"] }
 static_assertions = "1.1.0"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -214,7 +214,7 @@ pub(crate) extern "C" fn __yk_deopt(
                 VarLocation::Direct { frame_off, size } => {
                     // See comment below: this case never needs to do anything.
                     debug_assert_eq!(
-                        *aotvar.get(0).unwrap(),
+                        aotvar[0],
                         SMLocation::Direct(6, frame_off, u16::try_from(size).unwrap())
                     );
                     varidx += 1;
@@ -224,7 +224,7 @@ pub(crate) extern "C" fn __yk_deopt(
             varidx += 1;
 
             let aotloc = if aotvar.len() == 1 {
-                aotvar.get(0).unwrap()
+                &aotvar[0]
             } else {
                 todo!("Deal with multi register locations");
             };

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -187,7 +187,7 @@ pub(crate) extern "C" fn __yk_deopt(
 
         // Now write all live variables to the new stack in the order they are listed in the AOT
         // stackmap.
-        for aotvar in rec.live_vars.iter() {
+        for aotvar in rec.live_vals.iter() {
             // Read live JIT values from the trace's stack frame.
             let jitval = match cgd.live_vars[varidx].1 {
                 VarLocation::Stack { frame_off, size } => {

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -43,6 +43,7 @@ use dynasmrt::{
 use indexmap::IndexMap;
 use page_size;
 use parking_lot::Mutex;
+use smallvec::SmallVec;
 use std::{
     assert_matches::debug_assert_matches,
     cell::Cell,
@@ -284,7 +285,7 @@ impl From<&VarLocation> for yksmp::Location {
                 };
                 // We currently only use 8 byte registers, so the size is constant. Since these are
                 // JIT values there are no extra locations we need to worry about.
-                yksmp::Location::Register(dwarf, 8, Vec::new())
+                yksmp::Location::Register(dwarf, 8, SmallVec::new())
             }
             VarLocation::ConstInt { bits, v } => {
                 if *bits <= 32 {
@@ -3924,6 +3925,7 @@ mod tests {
     use lazy_static::lazy_static;
     use parking_lot::Mutex;
     use regex::{Regex, RegexBuilder};
+    use smallvec::smallvec;
     use std::{
         collections::{HashMap, HashSet},
         sync::Arc,
@@ -7030,7 +7032,7 @@ mod tests {
         let mut m = jit_ir::Module::new(TraceKind::HeaderOnly, TraceId::testing(), 0).unwrap();
 
         // Create two trace paramaters whose locations alias.
-        let loc = yksmp::Location::Register(13, 1, [].into());
+        let loc = yksmp::Location::Register(13, 1, smallvec![]);
         m.push_param(loc.clone());
         let pinst1: Inst =
             jit_ir::ParamInst::new(ParamIdx::try_from(0).unwrap(), m.int8_tyidx()).into();

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -3401,6 +3401,7 @@ impl FPExtInst {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use smallvec::smallvec;
 
     #[test]
     fn use_case_update_inst() {
@@ -3599,7 +3600,7 @@ mod tests {
     #[test]
     fn print_module() {
         let mut m = Module::new_testing();
-        m.push_param(yksmp::Location::Register(3, 1, vec![]));
+        m.push_param(yksmp::Location::Register(3, 1, smallvec![]));
         m.push(ParamInst::new(ParamIdx::try_from(0).unwrap(), m.int8_tyidx()).into())
             .unwrap();
         m.insert_global_decl(GlobalDecl::new(

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -28,6 +28,7 @@ use fm::FMBuilder;
 use lrlex::{lrlex_mod, DefaultLexerTypes, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, NonStreamingLexer, Span};
 use regex::Regex;
+use smallvec::smallvec;
 use std::{collections::HashMap, convert::TryFrom, error::Error, sync::OnceLock};
 use yksmp;
 
@@ -335,13 +336,13 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                 self.m.push_param(yksmp::Location::Register(
                                     dwarf_reg,
                                     u16::try_from(size).unwrap(),
-                                    vec![],
+                                    smallvec![],
                                 ))
                             }
                             Ty::Float(_) => self.m.push_param(yksmp::Location::Register(
                                 fp_reg_iter.next().expect("Out of FP registers"),
                                 u16::try_from(size).unwrap(),
-                                vec![],
+                                smallvec![],
                             )),
                             Ty::Unimplemented(_) => todo!(),
                         };
@@ -944,8 +945,8 @@ mod tests {
         let mut m = Module::new_testing();
         let i16_tyidx = m.insert_ty(Ty::Integer(16)).unwrap();
 
-        m.push_param(yksmp::Location::Register(3, 1, vec![]));
-        m.push_param(yksmp::Location::Register(3, 1, vec![]));
+        m.push_param(yksmp::Location::Register(3, 1, smallvec![]));
+        m.push_param(yksmp::Location::Register(3, 1, smallvec![]));
         let op1 = m
             .push_and_make_operand(ParamInst::new(ParamIdx::try_from(0).unwrap(), i16_tyidx).into())
             .unwrap();

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -155,7 +155,7 @@ impl TraceBuilder {
             }
             let param_inst = jit_ir::ParamInst::new(ParamIdx::try_from(idx)?, input_tyidx).into();
             self.jit_mod.push(param_inst)?;
-            self.jit_mod.push_param(var.get(0).unwrap().clone());
+            self.jit_mod.push_param(var[0].clone());
             self.local_map.insert(
                 aot_op.to_inst_id(),
                 jit_ir::Operand::Var(self.jit_mod.last_inst_idx()),

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -143,13 +143,13 @@ impl TraceBuilder {
             .unwrap()
             .get(usize::try_from(safepoint.id).unwrap());
 
-        debug_assert!(safepoint.lives.len() == rec.live_vars.len());
+        debug_assert!(safepoint.lives.len() == rec.live_vals.len());
         for idx in 0..safepoint.lives.len() {
             let aot_op = &safepoint.lives[idx];
             let input_tyidx = self.handle_type(aot_op.type_(self.aot_mod))?;
 
             // Get the location for this input variable.
-            let var = &rec.live_vars[idx];
+            let var = &rec.live_vals[idx];
             if var.len() > 1 {
                 todo!("Deal with multi register locations");
             }

--- a/yksmp/Cargo.toml
+++ b/yksmp/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Yk Developers"]
 license = "Apache-2.0 OR MIT"
+
+[dependencies]
+smallvec = { version="1.15.1", features=["union"] }

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -9,6 +9,7 @@
 #[cfg(not(target_arch = "x86_64"))]
 compile_error!("The stackmap parser currently only supports x64.");
 
+use smallvec::SmallVec;
 use std::error;
 
 struct Function {
@@ -28,7 +29,7 @@ pub struct Record {
     /// The absolute offset in bytes of this record in the binary.
     pub offset: u64,
     /// The list of live values recorded at this point.
-    pub live_vals: Vec<Vec<Location>>,
+    pub live_vals: Vec<SmallVec<[Location; 1]>>,
     /// The stack size of the function this record is contained in.
     pub size: u64,
 }
@@ -231,7 +232,7 @@ impl StackMapParser<'_> {
         v
     }
 
-    fn read_live_vals(&mut self, num: u16, consts: &[u64]) -> Vec<Vec<Location>> {
+    fn read_live_vals(&mut self, num: u16, consts: &[u64]) -> Vec<SmallVec<[Location; 1]>> {
         let mut v = Vec::with_capacity(usize::from(num));
         for _ in 0..num {
             let num_locs = self.read_u8();
@@ -240,8 +241,8 @@ impl StackMapParser<'_> {
         v
     }
 
-    fn read_locations(&mut self, num: u8, consts: &[u64]) -> Vec<Location> {
-        let mut v = Vec::new();
+    fn read_locations(&mut self, num: u8, consts: &[u64]) -> SmallVec<[Location; 1]> {
+        let mut v = SmallVec::new();
         for _ in 0..num {
             let kind = self.read_u8();
             self.read_u8();

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -59,7 +59,7 @@ pub enum Location {
     ///
     /// FIXME: We may need more additional locations in the future, which however will require
     /// rewriting the stackmap format (until now we managed to get by with two extra locations).
-    Register(u16, u16, Vec<i16>),
+    Register(u16, u16, SmallVec<[i16; 1]>),
     /// The live variable lives on the stack, because it was either put there directly via an
     /// `alloca` or it was spilled. The location is encoded as an offset relative to the base
     /// pointer. To get the value, we first need to compute the pointer via `rbp - offset` and then
@@ -249,7 +249,7 @@ impl StackMapParser<'_> {
             let size = self.read_u16();
             let dwreg = self.read_u16();
             self.read_u16();
-            let mut extras = Vec::new();
+            let mut extras = SmallVec::new();
             for _ in 0..self.read_u16() {
                 extras.push(self.read_i16());
             }

--- a/yksmp/src/lib.rs
+++ b/yksmp/src/lib.rs
@@ -27,8 +27,8 @@ pub struct Record {
     pub id: u64,
     /// The absolute offset in bytes of this record in the binary.
     pub offset: u64,
-    /// The list of live variables recorded at this point.
-    pub live_vars: Vec<LiveVar>,
+    /// The list of live values recorded at this point.
+    pub live_vals: Vec<LiveVal>,
     /// The stack size of the function this record is contained in.
     pub size: u64,
 }
@@ -38,7 +38,7 @@ impl Record {
         Record {
             id: 0,
             offset: 0,
-            live_vars: Vec::new(),
+            live_vals: Vec::new(),
             size: 0,
         }
     }
@@ -105,14 +105,14 @@ pub enum Location {
 
 /// A live variable.
 #[derive(Debug)]
-pub struct LiveVar {
+pub struct LiveVal {
     /// The location where this variable is stored (or needs to be written to during
     /// deoptimsation). Typically, this vector only has a single entry, though it is possible for
     /// variables to be stored across multiple locations (e.g. 128bit values).
     locs: Vec<Location>,
 }
 
-impl LiveVar {
+impl LiveVal {
     pub fn len(&self) -> usize {
         self.locs.len()
     }
@@ -247,18 +247,18 @@ impl StackMapParser<'_> {
             v.push(Record {
                 id,
                 offset,
-                live_vars,
+                live_vals: live_vars,
                 size: 0,
             });
         }
         v
     }
 
-    fn read_live_vars(&mut self, num: u16, consts: &[u64]) -> Vec<LiveVar> {
+    fn read_live_vars(&mut self, num: u16, consts: &[u64]) -> Vec<LiveVal> {
         let mut v = Vec::new();
         for _ in 0..num {
             let num_locs = self.read_u8();
-            v.push(LiveVar {
+            v.push(LiveVal {
                 locs: self.read_locations(num_locs, consts),
             });
         }


### PR DESCRIPTION
This PR does two things to yksmp: some tidying up (the first two commits); and some simple optimisations (the second commit).

The optimisations reduce the time to parse yklua's stackmaps from 30ms to 10ms: enough that I can measure a consistent 0.5% improvement to mandelbrot! It's probable that for larger VMs the parsing time will be much larger, so the small extra complexity seems almost certainly worth it.