### PR TITLE
Add yk cleanup in bf tests.

### DIFF
--- a/tests/c/bf.O0.c
+++ b/tests/c/bf.O0.c
@@ -125,7 +125,9 @@ int main(void) {
   }
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
-
+  for (size_t i = 0; i < prog_len; i++) {
+    yk_location_drop(yklocs[i]);
+  }
+  yk_mt_shutdown(mt);
   free(cells);
-  free(yklocs);
 }

--- a/tests/c/bf.O1.c
+++ b/tests/c/bf.O1.c
@@ -126,6 +126,9 @@ int main(void) {
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 
+  for (size_t i = 0; i < prog_len; i++) {
+    yk_location_drop(yklocs[i]);
+  }
+  yk_mt_shutdown(mt);
   free(cells);
-  free(yklocs);
 }

--- a/tests/c/bf.O2.c
+++ b/tests/c/bf.O2.c
@@ -126,6 +126,9 @@ int main(void) {
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 
+  for (size_t i = 0; i < prog_len; i++) {
+    yk_location_drop(yklocs[i]);
+  }
+  yk_mt_shutdown(mt);
   free(cells);
-  free(yklocs);
 }

--- a/tests/c/bf.O3.c
+++ b/tests/c/bf.O3.c
@@ -126,6 +126,9 @@ int main(void) {
 
   interp(INPUT_PROG, &INPUT_PROG[prog_len], cells, cells_end, mt, yklocs);
 
+  for (size_t i = 0; i < prog_len; i++) {
+    yk_location_drop(yklocs[i]);
+  }
+  yk_mt_shutdown(mt);
   free(cells);
-  free(yklocs);
 }


### PR DESCRIPTION
Add `yk_location_drop` and `yk_mt_shutdown` calls at the end of the tests.