### PR TITLE
We no longer need this feature.

### DIFF
--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![cfg_attr(test, feature(test))]
 #![feature(assert_matches)]
-#![feature(int_roundings)]
 #![feature(let_chains)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]


### PR DESCRIPTION
A subset of this feature is stable, and, fortunately, that's the subset we use!