### PR TITLE
Make the AUX buffer bigger.

### DIFF
--- a/hwtracer/src/perf/mod.rs
+++ b/hwtracer/src/perf/mod.rs
@@ -6,10 +6,10 @@ pub(crate) mod collect;
 /// The default perf data buffer size, measured in pages. Must be a power of 2.
 const PERF_DFLT_DATA_BUFSIZE: size_t = 16; // 64KiB (w/4096 byte pages).
 /// The default perf aux buffer size, measured in pages. Must be a power of 2.
-const PERF_DFLT_AUX_BUFSIZE: size_t = 1024; // 4MiB (w/4096 byte pages)
+const PERF_DFLT_AUX_BUFSIZE: size_t = 8192; // 32MiB (w/4096 byte pages)
 /// The size of the final memory returned, measured in bytes. There are no constraints on size or
-/// alignment but it needs to big enough to contain the AUX buffers.
-const TRACE_RESULT_SIZE: size_t = 4 * 1024 * 1024; // 4MiB
+/// alignment.
+const TRACE_RESULT_SIZE: size_t = 32 * 1024 * 1024; // 32MiB
 
 /// Configures the Perf collector.
 ///


### PR DESCRIPTION
Following in-person experimentation yesterday, we decided to try bumping the AUX buffer size from 4MiB to 32MiB to reduce the number of PERF_AUX_FLAG_TRUNCATED samples reported (especially in deltablue and havlak). When such an event happens, it means we couldn't keep up with copying out the PT payload.

Mostly some small speedups and slowdowns that may be within noise, but lulpeg slows down quite a bit (about 14% on b16). Observations from manual inspection of that benchmark:

 - It is indeed slower.

 - We have 4 fewer overflow errors (from 18 to 14)

 - The number of traces we compile is about 60% higher than before (about 1000 before and 1750 after).

 - This benchmark exhibits a lot of "tracing went outside of starting frame", both before and after my change.

From this, I conclude that this change did improve the number of overflows as intended, but this has had knock-on effects that will need further inspection later (yes, we are building more traces now, but are they good ones?).

All benchmarks (3 invocations, 10 iterations):

```
 Benchmark                  Datum1 (ms)  Datum0 (ms)  Ratio  Summary
 Towers/YkLua/600           934          901          0.96   3.61% faster
 Bounce/YkLua/1500          965          943          0.98   2.27% faster
 List/YkLua/1500            803          787          0.98   2.01% faster
 Richards/YkLua/100         4244         4159         0.98   2.00% faster
 fannkuchredux/YkLua/10     1193         1177         0.99   1.33% faster
 Sieve/YkLua/3000           396          391          0.99   1.31% faster
 revcomp/YkLua/default      563          556          0.99   1.24% faster
 binarytrees/YkLua/15       1285         1273         0.99   0.98% faster
 NBody/YkLua/250000         467          462          0.99   0.93% faster
 HashIds/YkLua/6000         1075         1077         1.00   0.13% slower
 BigLoop/YkLua/1000000000   1571         1574         1.00   0.20% slower
 spectralnorm/YkLua/1000    934          937          1.00   0.29% slower
 Mandelbrot/YkLua/500       130          131          1.01   0.78% slower
 Storage/YkLua/1000         3056         3083         1.01   0.87% slower
 DeltaBlue/YkLua/12000      1166         1183         1.01   1.50% slower
 Json/YkLua/100             1475         1499         1.02   1.64% slower
 fasta/YkLua/500000         823          838          1.02   1.74% slower
 Heightmap/YkLua/2000       747          761          1.02   1.88% slower
 Permute/YkLua/1000         794          810          1.02   2.05% slower
 Queens/YkLua/1000          485          497          1.02   2.44% slower
 Havlak/YkLua/1500          8430         8643         1.03   2.52% slower
 knucleotide/YkLua/default  1292         1334         1.03   3.30% slower
 CD/YkLua/250               3997         4168         1.04   4.28% slower
 LuLPeg/YkLua/default       1479         1693         1.14   14.43% slower
 ```