### PR TITLE
Give more information about "overflow events".

### DIFF
--- a/hwtracer/src/errors.rs
+++ b/hwtracer/src/errors.rs
@@ -19,9 +19,8 @@ pub enum HWTracerError {
 pub enum TemporaryErrorKind {
     /// Memory allocation failed.
     CantAllocate,
-    /// The trace buffer has overflowed. Either record a smaller trace or increase the size of the
-    /// trace buffer.
-    TraceBufferOverflow,
+    /// Something buffer-related went wrong during tracing.
+    TraceBufferOverflow(String),
     /// The trace was interrupted.
     TraceInterrupted,
     /// Perf can't set itself up.
@@ -30,9 +29,9 @@ pub enum TemporaryErrorKind {
 
 impl Display for TemporaryErrorKind {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match *self {
+        match self {
             TemporaryErrorKind::CantAllocate => write!(f, "Unable to allocate memory"),
-            TemporaryErrorKind::TraceBufferOverflow => write!(f, "Trace buffer overflow"),
+            TemporaryErrorKind::TraceBufferOverflow(s) => write!(f, "{s}"),
             TemporaryErrorKind::TraceInterrupted => write!(f, "Trace interrupted"),
             TemporaryErrorKind::PerfBusy => write!(f, "Perf busy"),
         }

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -722,7 +722,9 @@ impl YkPTBlockIterator<'_> {
 
             if pkt.kind() == PacketKind::OVF {
                 return Err(IteratorError::HWTracerError(HWTracerError::Temporary(
-                    TemporaryErrorKind::TraceBufferOverflow,
+                    TemporaryErrorKind::TraceBufferOverflow(
+                        "Encountered PT overflow packet".into(),
+                    ),
                 )));
             }
 

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -188,9 +188,9 @@ impl Iterator for HWTTraceIterator {
                     self.upcoming.pop();
                 }
                 Some(Err(BlockIteratorError::HWTracerError(HWTracerError::Temporary(
-                    TemporaryErrorKind::TraceBufferOverflow,
+                    TemporaryErrorKind::TraceBufferOverflow(s),
                 )))) => {
-                    return Some(Err(AOTTraceIteratorError::RecorderOverflow));
+                    return Some(Err(AOTTraceIteratorError::RecorderOverflow(s)));
                 }
                 Some(Err(e)) => return Some(Err(AOTTraceIteratorError::Other(e.to_string()))),
                 None => return Some(Err(AOTTraceIteratorError::PrematureEnd)),
@@ -212,9 +212,9 @@ impl Iterator for HWTTraceIterator {
                     return Some(Err(AOTTraceIteratorError::LongJmpEncountered));
                 }
                 Some(Err(BlockIteratorError::HWTracerError(HWTracerError::Temporary(
-                    TemporaryErrorKind::TraceBufferOverflow,
+                    TemporaryErrorKind::TraceBufferOverflow(s),
                 )))) => {
-                    return Some(Err(AOTTraceIteratorError::RecorderOverflow));
+                    return Some(Err(AOTTraceIteratorError::RecorderOverflow(s)));
                 }
                 Some(Err(e)) => return Some(Err(AOTTraceIteratorError::Other(e.to_string()))),
                 None => {

--- a/ykrt/src/trace/hwt/mod.rs
+++ b/ykrt/src/trace/hwt/mod.rs
@@ -38,8 +38,8 @@ impl TraceRecorder for HWTTraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, TraceRecorderError> {
         match self.thread_tracer.stop_collector() {
             Ok(x) => Ok(Box::new(HWTTraceIterator::new(x)?)),
-            Err(HWTracerError::Temporary(TemporaryErrorKind::TraceBufferOverflow)) => {
-                Err(TraceRecorderError::TraceTooLong)
+            Err(HWTracerError::Temporary(TemporaryErrorKind::TraceBufferOverflow(s))) => {
+                Err(TraceRecorderError::TraceBufferOverflow(s))
             }
             _ => todo!(),
         }

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -62,10 +62,10 @@ pub enum TraceRecorderError {
     #[error("Trace empty")]
     #[allow(dead_code)]
     TraceEmpty,
-    /// The trace being recorded was too long.
-    #[error("Trace overflowed recorder's storage")]
+    /// A trace buffer-related overflow occurred.
+    #[error("{0}")]
     #[allow(dead_code)]
-    TraceTooLong,
+    TraceBufferOverflow(String),
 }
 
 /// An iterator which [TraceRecord]s use to process a trace into [TraceAction]s. The iterator must
@@ -90,10 +90,10 @@ pub(crate) enum AOTTraceIteratorError {
     #[error("Trace ended prematurely")]
     #[allow(dead_code)]
     PrematureEnd,
-    /// The trace being recorded exceeded the tracing recorder's storage.
-    #[error("Trace overflowed recorder's storage")]
+    /// A trace buffer-related overflow occurred.
+    #[error("{0}")]
     #[allow(dead_code)]
-    RecorderOverflow,
+    RecorderOverflow(String),
     /// The trace exceeds yk's limit for IR instructions.
     #[error("Trace would contain too many IR elements")]
     #[allow(dead_code)]


### PR DESCRIPTION
After auditing the system, there are 4 ways we can see something that we broadly classify as an "overflow event" when using our system:

 - The AUX buffer was truncated (we didn't copy out quick enough).
 - There wasn't space in the (fixed-size) "final" trace buffer we copy into.
 - Perf reported a "lost sample".
 - PT gave us a OVF (internal overflow) packet.

Before we just got a generic error message. This change makes the error message specific.

E.g.:
```
Starting havlak benchmark ...
...
yk-warning: stop-tracing-aborted: AUX buffer overflow
```

While here, rename 'TraceTooLong', since that's not an accurate name for the error any more.