### PR TITLE
Skip PAD packets fast.

### DIFF
--- a/hwtracer/src/pt/ykpt/packets.rs
+++ b/hwtracer/src/pt/ykpt/packets.rs
@@ -2,6 +2,11 @@
 
 use deku::prelude::*;
 
+/// A byte representing a PAD packet.
+///
+/// We ignore PAD packets, since they don't carry any useful information.
+pub(super) const PAD_BYTE: u8 = 0;
+
 /// The `IPBytes` field common to all IP packets.
 ///
 /// This tells us what kind of compression was used for a `TargetIP`.
@@ -130,11 +135,6 @@ pub(super) struct CBRPacket {
 #[derive(Debug, DekuRead)]
 #[deku(magic = b"\x02\x23")]
 pub(super) struct PSBENDPacket {}
-
-/// Padding (PAD) packet.
-#[derive(Debug, DekuRead)]
-#[deku(magic = b"\x00")]
-pub(super) struct PADPacket {}
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Bitness {
@@ -371,7 +371,6 @@ pub(super) enum PacketKind {
     PSB,
     CBR,
     PSBEND,
-    PAD,
     MODEExec,
     MODETSX,
     TIPPGE,
@@ -394,7 +393,6 @@ impl PacketKind {
             Self::PSB
             | Self::CBR
             | Self::PSBEND
-            | Self::PAD
             | Self::MODEExec
             | Self::MODETSX
             | Self::ShortTNT
@@ -414,7 +412,6 @@ impl PacketKind {
             | Self::CYC
             | Self::FUP
             | Self::LongTNT
-            | Self::PAD
             | Self::PSB
             | Self::PSBEND
             | Self::ShortTNT
@@ -437,7 +434,6 @@ pub(super) enum Packet {
     PSB(PSBPacket),
     CBR(CBRPacket),
     PSBEND(PSBENDPacket),
-    PAD(PADPacket),
     MODEExec(MODEExecPacket),
     MODETSX(MODETSXPacket),
     TIPPGE(TIPPGEPacket, Option<usize>),
@@ -463,7 +459,6 @@ impl Packet {
             Self::PSB(_)
             | Self::CBR(_)
             | Self::PSBEND(_)
-            | Self::PAD(_)
             | Self::MODEExec(_)
             | Self::MODETSX(_)
             | Self::ShortTNT(_)
@@ -480,7 +475,6 @@ impl Packet {
             Self::PSB(_) => PacketKind::PSB,
             Self::CBR(_) => PacketKind::CBR,
             Self::PSBEND(_) => PacketKind::PSBEND,
-            Self::PAD(_) => PacketKind::PAD,
             Self::MODEExec(_) => PacketKind::MODEExec,
             Self::MODETSX(_) => PacketKind::MODETSX,
             Self::TIPPGE(..) => PacketKind::TIPPGE,
@@ -508,7 +502,6 @@ impl Packet {
             Self::PSB(_)
             | Self::CBR(_)
             | Self::PSBEND(_)
-            | Self::PAD(_)
             | Self::MODEExec(_)
             | Self::MODETSX(_)
             | Self::TIPPGE(_, _)


### PR DESCRIPTION
We know that the most common packet in a PT trace is PAD, and we often decode millions of them. PAD carries no useful information.

This change does two related things:
 - skips over PAD packets fast and early.
 - doesn't bother returning PAD packets the iterator consumer, they will only discard them anyway.

On the "better PT filtering" branch, with a 16MB AUX buffer, running 2 serialised iterations of havlak, this improves mapping performance by about 5%.

(I doubt we will see actual benchmark performance improvements on master, but this can't hurt)