### PR TITLE
Update Rust edition.

### DIFF
--- a/hwtracer/Cargo.toml
+++ b/hwtracer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hwtracer"
 version = "0.1.0"
 authors = ["The Yk Developers"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]

--- a/hwtracer/build.rs
+++ b/hwtracer/build.rs
@@ -36,7 +36,7 @@ mod inner {
         // Generate a `compile_commands.json` database for clangd.
         let ccg = CompletionWrapper::new(ykllvm_bin("clang"), "hwtracer");
         for (k, v) in ccg.build_env() {
-            env::set_var(k, v);
+            unsafe { env::set_var(k, v) };
         }
         c_build.compiler(ccg.wrapper_path());
 

--- a/hwtracer/src/lib.rs
+++ b/hwtracer/src/lib.rs
@@ -143,7 +143,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{trace_closure, work_loop, Tracer, TracerBuilder, TracerKind};
+    use crate::{Tracer, TracerBuilder, TracerKind, trace_closure, work_loop};
     use std::{sync::Arc, thread};
 
     fn all_collectors() -> Vec<Arc<dyn Tracer>> {

--- a/hwtracer/src/llvm_blockmap.rs
+++ b/hwtracer/src/llvm_blockmap.rs
@@ -4,7 +4,7 @@ use byteorder::{NativeEndian, ReadBytesExt};
 use intervaltree::IntervalTree;
 use object::{Object, ObjectSection};
 use std::{
-    io::{prelude::*, Cursor, SeekFrom},
+    io::{Cursor, SeekFrom, prelude::*},
     sync::LazyLock,
 };
 use ykaddr::obj::SELF_BIN_MMAP;

--- a/hwtracer/src/pt/ykpt/mod.rs
+++ b/hwtracer/src/pt/ykpt/mod.rs
@@ -41,10 +41,10 @@ mod packets;
 mod parser;
 
 use crate::{
-    errors::{HWTracerError, TemporaryErrorKind},
-    llvm_blockmap::{BlockMapEntry, SuccessorKind, LLVM_BLOCK_MAP},
-    perf::collect::PerfTraceBuf,
     Block, BlockIteratorError,
+    errors::{HWTracerError, TemporaryErrorKind},
+    llvm_blockmap::{BlockMapEntry, LLVM_BLOCK_MAP, SuccessorKind},
+    perf::collect::PerfTraceBuf,
 };
 use intervaltree::IntervalTree;
 use std::{
@@ -874,7 +874,7 @@ fn is_ret_near(inst: &iced_x86::Instruction) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{perf::PerfCollectorConfig, trace_closure, work_loop, TracerBuilder, TracerKind};
+    use crate::{TracerBuilder, TracerKind, perf::PerfCollectorConfig, trace_closure, work_loop};
 
     // FIXME: This test won't work until we teach rustc to embed bitcode and emit a basic block
     // section etc.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tests"
 version = "0.1.0"
 authors = ["The Yk Developers"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 
 [lib]

--- a/tests/benches/collect_and_decode.rs
+++ b/tests/benches/collect_and_decode.rs
@@ -1,8 +1,8 @@
 //! Critereon benchmarks.
 
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
-    Criterion, SamplingMode,
+    BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main,
+    measurement::Measurement,
 };
 use std::{
     env,

--- a/tests/benches/promote.rs
+++ b/tests/benches/promote.rs
@@ -1,8 +1,8 @@
 //! Critereon benchmarks for measuring the impact of promotion.
 
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
-    Criterion, SamplingMode,
+    BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main,
+    measurement::Measurement,
 };
 use std::{
     env,

--- a/tests/langtest_c.rs
+++ b/tests/langtest_c.rs
@@ -7,7 +7,7 @@ use std::{
     process::Command,
 };
 use tempfile::TempDir;
-use tests::{mk_compiler, EXTRA_LINK};
+use tests::{EXTRA_LINK, mk_compiler};
 use ykbuild::{completion_wrapper::CompletionWrapper, ykllvm_bin};
 
 const COMMENT: &str = "//";
@@ -21,18 +21,28 @@ fn main() {
     // Generate a `compile_commands.json` database for clangd.
     let ccg = CompletionWrapper::new(ykllvm_bin("clang"), "c_tests");
     for (k, v) in ccg.build_env() {
-        env::set_var(k, v);
+        // While this is unsafe, this is only for clangd and doesn't affect the tests.
+        unsafe { env::set_var(k, v) };
     }
     let wrapper_path = ccg.wrapper_path();
 
     // Set variables for tests `ignore-if`s.
+    // These env vars stay the same for the entirety of the `cargo test` run, so we don't need to
+    // worry about this being unsafe.
     #[cfg(cargo_profile = "debug")]
-    env::set_var("YK_CARGO_PROFILE", "debug");
+    unsafe {
+        env::set_var("YK_CARGO_PROFILE", "debug")
+    };
     #[cfg(cargo_profile = "release")]
-    env::set_var("YK_CARGO_PROFILE", "release");
+    unsafe {
+        env::set_var("YK_CARGO_PROFILE", "release")
+    };
 
+    // As with the above, this env var remains the same for the entire `cargo test` run.
     #[cfg(target_arch = "x86_64")]
-    env::set_var("YK_ARCH", "x86_64");
+    unsafe {
+        env::set_var("YK_ARCH", "x86_64")
+    };
     #[cfg(not(target_arch = "x86_64"))]
     panic!("Unknown target_arch");
 

--- a/tests/langtest_lua.rs
+++ b/tests/langtest_lua.rs
@@ -18,9 +18,9 @@ mod inner {
     use regex::Regex;
     use std::{
         env,
-        fs::{canonicalize, create_dir_all, read_to_string, write, File},
+        fs::{File, canonicalize, create_dir_all, read_to_string, write},
         path::Path,
-        process::{exit, Command},
+        process::{Command, exit},
     };
     use ykbuild::{target_dir, ykllvm_bin_dir};
 
@@ -35,8 +35,8 @@ mod inner {
 
         if !Path::new(&format!("{}/Makefile", YKLUA_SUBMODULE_PATH)).is_file() {
             panic!(
-            "yklua submodule not found. To checkout:\n  git submodule update --init --recursive"
-        );
+                "yklua submodule not found. To checkout:\n  git submodule update --init --recursive"
+            );
         }
 
         // Set variables for tests `ignore-if`s.
@@ -156,12 +156,18 @@ mod inner {
 
         // Set variables for tests `ignore-if`s.
         #[cfg(cargo_profile = "debug")]
-        env::set_var("YK_CARGO_PROFILE", "debug");
+        unsafe {
+            env::set_var("YK_CARGO_PROFILE", "debug")
+        };
         #[cfg(cargo_profile = "release")]
-        env::set_var("YK_CARGO_PROFILE", "release");
+        unsafe {
+            env::set_var("YK_CARGO_PROFILE", "release")
+        };
 
         #[cfg(target_arch = "x86_64")]
-        env::set_var("YK_ARCH", "x86_64");
+        unsafe {
+            env::set_var("YK_ARCH", "x86_64")
+        };
         #[cfg(not(target_arch = "x86_64"))]
         panic!("Unknown target_arch");
 

--- a/tests/src/bin/dump_ir.rs
+++ b/tests/src/bin/dump_ir.rs
@@ -2,7 +2,7 @@ use std::{
     env,
     error::Error,
     path::PathBuf,
-    process::{exit, Command},
+    process::{Command, exit},
 };
 use tempfile::TempDir;
 use ykrt::compile::jitc_yk::aot_ir;

--- a/tests/src/bin/gdb_c_test.rs
+++ b/tests/src/bin/gdb_c_test.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 use std::{env, path::PathBuf, process::Command};
 use tempfile::TempDir;
-use tests::{mk_compiler, EXTRA_LINK};
+use tests::{EXTRA_LINK, mk_compiler};
 use ykbuild::ykllvm_bin;
 
 /// Run a C test under gdb.

--- a/tests/src/hwtracer_ykpt.rs
+++ b/tests/src/hwtracer_ykpt.rs
@@ -16,7 +16,7 @@
 use hwtracer::{BlockIteratorError, ThreadTracer, Trace, TracerBuilder};
 use std::ffi::c_void;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// The value returned by this function *must* be passed to [__hwykpt_stop_collector] or memory
 /// will leak.
 pub extern "C" fn __hwykpt_start_collector() -> *mut Box<dyn ThreadTracer> {
@@ -26,7 +26,7 @@ pub extern "C" fn __hwykpt_start_collector() -> *mut Box<dyn ThreadTracer> {
     Box::into_raw(Box::new(tt))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// The value passed to this function *must* have come from [ __hwykpt_start_collector]; doing
 /// otherwise leads to undefined behaviour.
 pub extern "C" fn __hwykpt_stop_collector(tc: *mut Box<dyn ThreadTracer>) -> *mut c_void {
@@ -46,7 +46,7 @@ use hwtracer::errors::HWTracerError;
 /// Panics on fatal errors.
 ///
 /// Used for benchmarks.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __hwykpt_decode_trace(trace: *mut Box<dyn Trace>) -> bool {
     let trace: Box<Box<dyn Trace>> = unsafe { Box::from_raw(trace) };
     for b in trace.iter_blocks() {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::process::{exit, Command};
+use std::process::{Command, exit};
 use walkdir::WalkDir;
 use ykbuild::ykllvm_bin;
 

--- a/ykaddr/Cargo.toml
+++ b/ykaddr/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ykaddr"
 version = "0.1.0"
 authors = ["The Yk Developers"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]

--- a/ykaddr/src/addr.rs
+++ b/ykaddr/src/addr.rs
@@ -2,7 +2,7 @@
 
 use crate::obj::{PHDR_OBJECT_CACHE, SELF_BIN_PATH};
 use cached::proc_macro::cached;
-use libc::{c_void, dlsym, Dl_info, RTLD_DEFAULT};
+use libc::{Dl_info, RTLD_DEFAULT, c_void, dlsym};
 use std::{
     error::Error,
     ffi::{CStr, CString},
@@ -165,9 +165,9 @@ pub fn symbol_to_ptr(name: &str) -> Result<*const (), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{off_to_vaddr, vaddr_to_obj_and_off, vaddr_to_sym_and_obj, MaybeUninit};
+    use super::{MaybeUninit, off_to_vaddr, vaddr_to_obj_and_off, vaddr_to_sym_and_obj};
     use crate::obj::PHDR_MAIN_OBJ;
-    use libc::{dlsym, Dl_info};
+    use libc::{Dl_info, dlsym};
     use std::{ffi::CString, ptr};
 
     #[test]
@@ -194,12 +194,13 @@ mod tests {
         let (obj, off) = vaddr_to_obj_and_off(vaddr as usize).unwrap();
         // because the loader will load the object a +ve offset from the start of the address space.
         assert!(off < u64::try_from(vaddr as usize).unwrap());
-        assert!(obj
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .starts_with("ykaddr-"));
+        assert!(
+            obj.file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("ykaddr-")
+        );
     }
 
     /// Check that converting a virtual address (from a shared object) to a file offset and back to

--- a/ykaddr/src/obj.rs
+++ b/ykaddr/src/obj.rs
@@ -115,7 +115,7 @@ pub static PHDR_OBJECT_CACHE: LazyLock<Vec<Object>> = LazyLock::new(|| {
 #[cfg(target_os = "linux")]
 pub static PHDR_MAIN_OBJ: LazyLock<PathBuf> = LazyLock::new(PathBuf::new);
 
-extern "C" {
+unsafe extern "C" {
     fn find_main() -> *const c_void;
 }
 

--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ykbuild"
 version = "0.1.0"
 authors = ["The Yk Developers"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 # The following makes ykbuild's cargo metadata available to any crate which
 # depends on it, providing depedents with the location of the ykllvm install dir.

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -5,7 +5,7 @@ use rerun_except::rerun_except;
 use std::{
     collections::HashMap,
     env,
-    fs::{canonicalize, create_dir_all, read_to_string, write, File},
+    fs::{File, canonicalize, create_dir_all, read_to_string, write},
     path::Path,
     process::Command,
 };

--- a/ykbuild/src/completion_wrapper.rs
+++ b/ykbuild/src/completion_wrapper.rs
@@ -4,7 +4,7 @@ use crate::target_dir;
 use glob::glob;
 use std::{
     env,
-    fs::{create_dir_all, File},
+    fs::{File, create_dir_all},
     io::{Read, Write},
     path::{Path, PathBuf},
 };

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ykcapi"
 version = "0.1.0"
 authors = ["The Yk Developers"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 
 [lib]

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -17,14 +17,14 @@
 #[cfg(feature = "ykd")]
 use std::ffi::CStr;
 use std::{
-    ffi::{c_char, c_void, CString},
+    ffi::{CString, c_char, c_void},
     mem::forget,
     ptr,
     sync::Arc,
 };
 use ykrt::{HotThreshold, Location, MT};
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *const MT {
     match MT::new() {
         Ok(mt) => Arc::into_raw(mt),
@@ -45,14 +45,14 @@ pub unsafe extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *const MT {
 }
 
 /// Shutdown this MT instance. Will panic if an error is detected when doing so.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn yk_mt_shutdown(mt: *const MT) {
     unsafe { Arc::from_raw(mt) }.shutdown();
 }
 
 // The "dummy control point" that is replaced in an LLVM pass.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn yk_mt_control_point(_mt: *mut MT, _loc: *mut Location) {
     // Intentionally empty.
 }
@@ -60,7 +60,7 @@ pub extern "C" fn yk_mt_control_point(_mt: *mut MT, _loc: *mut Location) {
 // The new control point called after the interpreter has been patched by ykllvm.
 #[cfg(target_arch = "x86_64")]
 #[unsafe(naked)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __ykrt_control_point(
     mt: *const MT,
     loc: *mut Location,
@@ -117,7 +117,7 @@ pub extern "C" fn __ykrt_control_point(
 }
 
 // The actual control point, after we have pushed the callee-saved registers.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn __ykrt_control_point_real(
     mt: *const MT,
@@ -136,27 +136,27 @@ pub extern "C" fn __ykrt_control_point_real(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn yk_mt_hot_threshold_set(mt: *const MT, hot_threshold: HotThreshold) {
     let arc = unsafe { Arc::from_raw(mt) };
     arc.set_hot_threshold(hot_threshold);
     forget(arc);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn yk_mt_sidetrace_threshold_set(mt: *const MT, hot_threshold: HotThreshold) {
     let arc = unsafe { Arc::from_raw(mt) };
     arc.set_sidetrace_threshold(hot_threshold);
     forget(arc);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn yk_location_new() -> Location {
     Location::new()
 }
 
 #[cfg(feature = "ykd")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn yk_location_set_debug_str(loc: *mut Location, s: *const c_char) {
     let s = unsafe { CStr::from_ptr(s) }.to_string_lossy().into_owned();
     let loc = unsafe { &*loc };
@@ -164,12 +164,12 @@ pub unsafe extern "C" fn yk_location_set_debug_str(loc: *mut Location, s: *const
     loc.set_hl_debug_str(s);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn yk_location_null() -> Location {
     Location::null()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn yk_location_drop(loc: Location) {
     drop(loc)
 }

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ykrt"
 version = "0.1.0"
 authors = ["The Yk Developers"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -5,7 +5,7 @@ use which::which;
 use {
     std::env,
     std::io::{self, Write},
-    std::process::{exit, Command},
+    std::process::{Command, exit},
 };
 
 pub fn main() {

--- a/ykrt/src/compile/guard.rs
+++ b/ykrt/src/compile/guard.rs
@@ -5,7 +5,7 @@ use crate::{
     mt::{AtomicTraceCompilationErrorThreshold, HotThreshold, MT},
 };
 use parking_lot::Mutex;
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::Ordering};
 
 /// Responsible for tracking how often a guard in a `CompiledTrace` fails. A hotness counter is
 /// incremented each time the matching guard failure in a `CompiledTrace` is triggered. Also stores

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -1053,11 +1053,7 @@ impl Inst {
                 // The type of the newly-defined local is the return type of the callee.
                 if let Ty::Func(ft) = m.type_(m.func(*callee).tyidx) {
                     let ty = m.type_(ft.ret_ty);
-                    if ty != &Ty::Void {
-                        Some(ty)
-                    } else {
-                        None
-                    }
+                    if ty != &Ty::Void { Some(ty) } else { None }
                 } else {
                     panic!(); // IR malformed.
                 }
@@ -1083,11 +1079,7 @@ impl Inst {
                 // The type of the newly-defined local is the return type of the callee.
                 if let Ty::Func(ft) = m.type_(*ftyidx) {
                     let ty = m.type_(ft.ret_ty);
-                    if ty != &Ty::Void {
-                        Some(ty)
-                    } else {
-                        None
-                    }
+                    if ty != &Ty::Void { Some(ty) } else { None }
                 } else {
                     panic!(); // IR malformed.
                 }
@@ -1098,11 +1090,7 @@ impl Inst {
             Self::LoadArg { arg_idx: _, ty_idx } => Some(m.type_(*ty_idx)),
             Self::Unimplemented { tyidx, .. } => {
                 let ty = m.type_(*tyidx);
-                if ty != &Ty::Void {
-                    Some(ty)
-                } else {
-                    None
-                }
+                if ty != &Ty::Void { Some(ty) } else { None }
             }
             Self::Nop => None,
             Self::FCmp { tyidx, .. } => Some(m.type_(*tyidx)),
@@ -1129,7 +1117,7 @@ impl Inst {
     pub(crate) fn safepoint(&'static self) -> Option<&'static DeoptSafepoint> {
         match self {
             Self::Call { safepoint, .. } => safepoint.as_ref(),
-            Self::CondBr { ref safepoint, .. } => Some(safepoint),
+            Self::CondBr { safepoint, .. } => Some(safepoint),
             _ => None,
         }
     }

--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -5,9 +5,9 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{jitc_yk::jit_ir::Module, CompiledTrace},
-    location::HotLocation,
     MT,
+    compile::{CompiledTrace, jitc_yk::jit_ir::Module},
+    location::HotLocation,
 };
 use parking_lot::Mutex;
 use std::{error::Error, sync::Arc};

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -11,16 +11,16 @@ use page_size;
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
 use std::{
-    alloc::{alloc, realloc, Layout},
+    alloc::{Layout, alloc, realloc},
     ptr,
     sync::{
-        atomic::{AtomicPtr, AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicPtr, AtomicUsize, Ordering},
     },
 };
 use yksmp::Location as SMLocation;
 
-use super::{X64CompiledTrace, RBP_DWARF_NUM, REG64_BYTESIZE};
+use super::{RBP_DWARF_NUM, REG64_BYTESIZE, X64CompiledTrace};
 
 thread_local! {
     // This caches the memory we use to generate the "new stack" that deopt has to create.
@@ -54,7 +54,7 @@ const REGISTER_NUM: usize = RECOVER_REG.len() + 2;
 ///   order as [crate::compile::jitc_yk::codegen::x64::lsregalloc::GP_REGS]
 /// * `fp_regs` - a pointer to the saved values of the 16 floating point registers
 /// * `ctrid` - the ID of the compiled trace that is being deoptimized
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub(crate) extern "C" fn __yk_deopt(
     frameaddr: *mut c_void,
     gidx: u64,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -19,26 +19,26 @@ use crate::compile::jitc_yk::gdb::{self, GdbCtx};
 use crate::{
     aotsmp::AOT_STACKMAPS,
     compile::{
+        CompilationError, CompiledTrace, Guard, GuardIdx,
         jitc_yk::{
+            CodeGen, YkSideTraceInfo,
             aot_ir::{self, DeoptSafepoint},
             arbbitint::ArbBitInt,
             jit_ir::{
                 self, BinOp, Const, FloatTy, GuardInst, IndirectCallIdx, InlinedFrame, Inst,
                 InstIdx, Module, Operand, TraceKind, Ty,
             },
-            CodeGen, YkSideTraceInfo,
         },
-        CompilationError, CompiledTrace, Guard, GuardIdx,
     },
     location::HotLocation,
-    mt::{TraceId, MT},
+    mt::{MT, TraceId},
 };
 use dynasmrt::{
+    AssemblyOffset, DynamicLabel, DynasmApi, DynasmError, DynasmLabelApi, ExecutableBuffer,
+    Register as dynasmrtRegister,
     components::StaticLabel,
     dynasm,
     x64::{Rq, Rx},
-    AssemblyOffset, DynamicLabel, DynasmApi, DynasmError, DynasmLabelApi, ExecutableBuffer,
-    Register as dynasmrtRegister,
 };
 use indexmap::IndexMap;
 use page_size;
@@ -49,7 +49,7 @@ use std::{
     cell::Cell,
     error::Error,
     slice,
-    sync::{atomic::fence, Arc, Weak},
+    sync::{Arc, Weak, atomic::fence},
 };
 use ykaddr::addr::symbol_to_ptr;
 
@@ -165,7 +165,7 @@ fn get_tls_offset(name: &std::ffi::CString) -> i32 {
 /// A function that we can put a debugger breakpoint on.
 /// FIXME: gross hack.
 #[cfg(debug_assertions)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 pub extern "C" fn __yk_break() {}
 
@@ -3915,11 +3915,11 @@ mod tests {
     use super::{Assemble, X64CompiledTrace};
     use crate::{
         compile::{
-            jitc_yk::jit_ir::{self, Inst, Module, ParamIdx, TraceKind},
             CompiledTrace,
+            jitc_yk::jit_ir::{self, Inst, Module, ParamIdx, TraceKind},
         },
         location::{HotLocation, HotLocationKind},
-        mt::{TraceId, MT},
+        mt::{MT, TraceId},
     };
     use fm::{FMBuilder, FMatcher};
     use lazy_static::lazy_static;

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -354,10 +354,12 @@ impl<'a> RevAnalyse<'a> {
     pub(super) fn next_use(&self, cur_iidx: InstIdx, query_iidx: InstIdx) -> Option<InstIdx> {
         // Our algorithm only works if `self.def_use[query_iidx]` is (a) sorted and (b) in reverse
         // order.
-        debug_assert!(self.def_use[usize::from(query_iidx)]
-            .iter()
-            .rev()
-            .is_sorted());
+        debug_assert!(
+            self.def_use[usize::from(query_iidx)]
+                .iter()
+                .rev()
+                .is_sorted()
+        );
         match self.def_use[usize::from(query_iidx)]
             .iter()
             .position(|x| *x <= cur_iidx)
@@ -800,15 +802,21 @@ mod test {
         assert_eq!(rev_an.reg_hints[1][1].0, InstIdx::unchecked_from(3));
         assert_eq!(rev_an.reg_hints[0][0].1, rev_an.reg_hints[1][1].1);
         assert_eq!(rev_an.reg_hints[0][1].1, rev_an.reg_hints[1][0].1);
-        assert!((0..5).all(|i| rev_an
-            .reg_hint(InstIdx::unchecked_from(i), InstIdx::unchecked_from(0))
-            .is_some()));
-        assert!((1..5).all(|i| rev_an
-            .reg_hint(InstIdx::unchecked_from(i), InstIdx::unchecked_from(0))
-            .is_some()));
-        assert!((2..5).all(|i| rev_an
-            .reg_hint(InstIdx::unchecked_from(i), InstIdx::unchecked_from(2))
-            .is_none()));
+        assert!((0..5).all(|i| {
+            rev_an
+                .reg_hint(InstIdx::unchecked_from(i), InstIdx::unchecked_from(0))
+                .is_some()
+        }));
+        assert!((1..5).all(|i| {
+            rev_an
+                .reg_hint(InstIdx::unchecked_from(i), InstIdx::unchecked_from(0))
+                .is_some()
+        }));
+        assert!((2..5).all(|i| {
+            rev_an
+                .reg_hint(InstIdx::unchecked_from(i), InstIdx::unchecked_from(2))
+                .is_none()
+        }));
         assert_eq!(
             (0..5)
                 .map(|i| rev_an

--- a/ykrt/src/compile/jitc_yk/gdb.rs
+++ b/ykrt/src/compile/jitc_yk/gdb.rs
@@ -9,7 +9,7 @@ use crate::mt::TraceId;
 use deku::prelude::*;
 use indexmap::IndexMap;
 use std::{
-    ffi::{c_char, c_int, CString},
+    ffi::{CString, c_char, c_int},
     io::Write,
     ptr,
     sync::Mutex,
@@ -79,7 +79,7 @@ pub struct JitDescriptor {
 ///
 /// Only [JitDescriptorAccessor] should directly access this.
 #[allow(non_upper_case_globals)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub static mut __jit_debug_descriptor: JitDescriptor = JitDescriptor {
     version: 1,
     action_flag: 0,
@@ -118,7 +118,7 @@ static JIT_DESCRIPTOR_ACCESSOR: JitDescriptorAccessor = JitDescriptorAccessor {
 ///
 /// GDB regognises calls to this function to detect when JITted code is being loaded.
 #[inline(never)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __jit_debug_register_code() {}
 
 /// Describes the mapping from a line in the source file to a virtual address.

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -97,14 +97,14 @@ mod parser;
 #[cfg(any(debug_assertions, test))]
 mod well_formed;
 
-use super::{aot_ir, codegen::x64::Register, YkSideTraceInfo};
+use super::{YkSideTraceInfo, aot_ir, codegen::x64::Register};
 use crate::{
-    compile::{jitc_yk::arbbitint::ArbBitInt, CompilationError, CompiledTrace},
+    compile::{CompilationError, CompiledTrace, jitc_yk::arbbitint::ArbBitInt},
     mt::TraceId,
 };
 use indexmap::IndexSet;
 use std::{
-    ffi::{c_void, CString},
+    ffi::{CString, c_void},
     fmt,
     hash::Hash,
     mem,

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -25,8 +25,8 @@ use super::super::{
     },
 };
 use fm::FMBuilder;
-use lrlex::{lrlex_mod, DefaultLexerTypes, LRNonStreamingLexer};
-use lrpar::{lrpar_mod, NonStreamingLexer, Span};
+use lrlex::{DefaultLexerTypes, LRNonStreamingLexer, lrlex_mod};
+use lrpar::{NonStreamingLexer, Span, lrpar_mod};
 use regex::Regex;
 use smallvec::smallvec;
 use std::{collections::HashMap, convert::TryFrom, error::Error, sync::OnceLock};
@@ -271,7 +271,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                         "ICmp instructions must assign to an i1, not '{}'",
                                         x.display(self.m)
                                     ),
-                                ))
+                                ));
                             }
                         }
                         let inst = ICmpInst::new(
@@ -298,7 +298,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                         "FCmp instructions must assign to an i1, not '{}'",
                                         x.display(self.m)
                                     ),
-                                ))
+                                ));
                             }
                         }
                         let inst = FCmpInst::new(

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -120,10 +120,12 @@ impl Module {
                         .enumerate()
                     {
                         if *par_ty != arg_ty {
-                            panic!("Instruction at position {iidx} passing argument {j} of wrong type ({}, but should be {})\n  {}",
+                            panic!(
+                                "Instruction at position {iidx} passing argument {j} of wrong type ({}, but should be {})\n  {}",
                                 self.type_(arg_ty).display(self),
                                 self.type_(*par_ty).display(self),
-                                inst.display(self, iidx));
+                                inst.display(self, iidx)
+                            );
                         }
                     }
                 }
@@ -149,9 +151,9 @@ impl Module {
                         && x.predicate().signed()
                     {
                         panic!(
-                                "Instruction at position {iidx} compares pointers using a signed predicate\n  {}",
-                                self.inst(iidx).display(self, iidx)
-                            );
+                            "Instruction at position {iidx} compares pointers using a signed predicate\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                 }
                 Inst::Select(x) => {
@@ -239,12 +241,16 @@ impl Module {
                 }
                 Inst::Trunc(x) => {
                     let Ty::Integer(val_bitsize) = self.type_(x.val(self).tyidx(self)) else {
-                        panic!("Instruction at position {iidx} trying to convert from a non-integer type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert from a non-integer type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     };
                     let Ty::Integer(dest_bitsize) = self.type_(x.dest_tyidx()) else {
-                        panic!("Instruction at position {iidx} trying to convert to a non-integer type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert to a non-integer type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     };
                     if dest_bitsize >= val_bitsize {
                         panic!(
@@ -258,32 +264,44 @@ impl Module {
                     let to_type = self.type_(x.dest_tyidx());
 
                     if !matches!(from_type, Ty::Integer(_)) {
-                        panic!("Instruction at position {iidx} trying to convert a non-integer type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert a non-integer type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                     if !matches!(to_type, Ty::Float(_)) {
-                        panic!("Instruction at position {iidx} trying to convert to a non-float type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert to a non-float type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                     if to_type.byte_size() < from_type.byte_size() {
-                        panic!("Instruction at position {iidx} trying to convert to a smaller-sized float\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert to a smaller-sized float\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                 }
                 Inst::FPExt(x) => {
                     let from_type = self.type_(x.val(self).tyidx(self));
                     let to_type = self.type_(x.dest_tyidx());
                     if !matches!(from_type, Ty::Float(_)) {
-                        panic!("Instruction at position {iidx} trying to extend from a non-float type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to extend from a non-float type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                     if !matches!(to_type, Ty::Float(_)) {
-                        panic!("Instruction at position {iidx} trying to extend to a non-float type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to extend to a non-float type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                     if to_type.byte_size() <= from_type.byte_size() {
-                        panic!("Instruction at position {iidx} trying to extend to a smaller-sized float\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to extend to a smaller-sized float\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                 }
                 Inst::FPToSI(x) => {
@@ -291,20 +309,26 @@ impl Module {
                     let to_type = self.type_(x.dest_tyidx());
 
                     if !matches!(from_type, Ty::Float(_)) {
-                        panic!("Instruction at position {iidx} trying to convert a non-float type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert a non-float type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                     if !matches!(to_type, Ty::Integer(_)) {
-                        panic!("Instruction at position {iidx} trying to convert to a non-integer type\n  {}",
-                            self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Instruction at position {iidx} trying to convert to a non-integer type\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                 }
                 Inst::Param(_) => {
                     if let Some(i) = last_inst
                         && !matches!(i, Inst::Param(_) | Inst::TraceHeaderEnd(_))
                     {
-                        panic!("Param instruction may only appear at the beginning of a trace or after another Param instruction, or after the trace header jump\n  {}",
-                                self.inst(iidx).display(self, iidx));
+                        panic!(
+                            "Param instruction may only appear at the beginning of a trace or after another Param instruction, or after the trace header jump\n  {}",
+                            self.inst(iidx).display(self, iidx)
+                        );
                     }
                 }
                 _ => (),

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,10 +2,10 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{jitc_yk::codegen::CodeGen, CompiledTrace, Compiler, GuardIdx},
+    compile::{CompiledTrace, Compiler, GuardIdx, jitc_yk::codegen::CodeGen},
     location::HotLocation,
-    log::{log_ir, should_log_ir, IRPhase},
-    mt::{TraceId, MT},
+    log::{IRPhase, log_ir, should_log_ir},
+    mt::{MT, TraceId},
     trace::AOTTraceIterator,
 };
 use parking_lot::Mutex;

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -2,18 +2,18 @@
 //!
 //! This takes in an (AOT IR, execution trace) pair and constructs a JIT IR trace from it.
 
-use super::aot_ir::{self, BBlockId, BinOp, Module};
 use super::YkSideTraceInfo;
+use super::aot_ir::{self, BBlockId, BinOp, Module};
 use super::{
+    AOT_MOD,
     arbbitint::ArbBitInt,
     jit_ir::{self, Const, Operand, PackedOperand, ParamIdx, TraceKind},
-    AOT_MOD,
 };
 use crate::{
     aotsmp::AOT_STACKMAPS,
     compile::{CompilationError, CompiledTrace},
     log::stats::TimingState,
-    mt::{TraceId, MT},
+    mt::{MT, TraceId},
     trace::{AOTTraceIterator, TraceAction},
 };
 use std::{collections::HashMap, ffi::CString, sync::Arc};

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     compile::jitc_yk::aot_ir::DeoptSafepoint,
     location::HotLocation,
-    mt::{TraceId, MT},
+    mt::{MT, TraceId},
     trace::AOTTraceIterator,
 };
 use libc::c_void;

--- a/ykrt/src/job_queue.rs
+++ b/ykrt/src/job_queue.rs
@@ -1,7 +1,7 @@
 //! The job queue. This runs 1 or more worker threads and has them run compilation jobs as
 //! appropriate.
 
-use crate::mt::{TraceId, MT};
+use crate::mt::{MT, TraceId};
 use parking_lot::{Condvar, Mutex, MutexGuard};
 #[cfg(feature = "yk_testing")]
 use std::env;
@@ -9,8 +9,8 @@ use std::{
     cmp,
     collections::VecDeque,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     thread::{self, JoinHandle},
 };

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![cfg_attr(test, feature(test))]
 #![feature(assert_matches)]
-#![feature(let_chains)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::upper_case_acronyms)]
@@ -19,11 +18,11 @@ pub(crate) mod thread_intercept;
 pub mod trace;
 
 pub use self::location::Location;
-pub use self::mt::{HotThreshold, MTThread, MT};
-use std::ffi::{c_char, CStr};
+pub use self::mt::{HotThreshold, MT, MTThread};
+use std::ffi::{CStr, c_char};
 
 #[allow(clippy::missing_safety_doc)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn yk_debug_str(msg: *const c_char) {
     MTThread::with_borrow_mut(|mtt| {
         mtt.insert_debug_str(unsafe { CStr::from_ptr(msg).to_string_lossy().into_owned() });

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -3,14 +3,14 @@
 use std::{
     mem,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
 use crate::{
     compile::CompiledTrace,
-    mt::{HotThreshold, TraceCompilationErrorThreshold, TraceId, MT},
+    mt::{HotThreshold, MT, TraceCompilationErrorThreshold, TraceId},
 };
 use parking_lot::Mutex;
 
@@ -149,9 +149,11 @@ impl Location {
             let old = (x >> STATE_NUM_BITS) as HotThreshold;
             // The particular value of `new` must fit in the bits we have available.
             let new = old + 1;
-            debug_assert!((new as usize)
-                .checked_shl(u32::try_from(STATE_NUM_BITS).unwrap())
-                .is_some());
+            debug_assert!(
+                (new as usize)
+                    .checked_shl(u32::try_from(STATE_NUM_BITS).unwrap())
+                    .is_some()
+            );
 
             self.inner
                 .compare_exchange_weak(

--- a/ykrt/src/log/stats.rs
+++ b/ykrt/src/log/stats.rs
@@ -293,7 +293,7 @@ mod yk_testing {
         trace_executions: u64,
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn __ykstats_wait_until(
         mt: *const MT,
         test: unsafe extern "C" fn(YkCStats) -> bool,

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -9,8 +9,8 @@ use std::{
     ffi::c_void,
     marker::PhantomData,
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering},
     },
 };
 
@@ -20,15 +20,15 @@ use parking_lot::Mutex;
 use parking_lot_core::SpinWait;
 
 use crate::{
-    aotsmp::{load_aot_stackmaps, AOT_STACKMAPS},
-    compile::{default_compiler, CompilationError, CompiledTrace, Compiler, GuardIdx},
+    aotsmp::{AOT_STACKMAPS, load_aot_stackmaps},
+    compile::{CompilationError, CompiledTrace, Compiler, GuardIdx, default_compiler},
     job_queue::{Job, JobQueue},
     location::{HotLocation, HotLocationKind, Location, TraceFailed},
     log::{
-        stats::{Stats, TimingState},
         Log, Verbosity,
+        stats::{Stats, TimingState},
     },
-    trace::{default_tracer, AOTTraceIterator, TraceRecorder, Tracer},
+    trace::{AOTTraceIterator, TraceRecorder, Tracer, default_tracer},
 };
 
 // Emit a log entry with hot location debug information if present and support is compiled in.
@@ -1159,7 +1159,7 @@ impl MT {
 
 #[cfg(target_arch = "x86_64")]
 #[unsafe(naked)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn __yk_exec_trace(
     frameaddr: *const c_void,
     rsp: *const c_void,
@@ -1355,10 +1355,7 @@ impl MTThread {
     /// If the stack is empty. There should always be at least one element on the stack, so a panic
     /// here means that something has gone wrong elsewhere.
     pub(crate) fn promote_i32(&mut self, val: i32) -> bool {
-        if let MTThreadState::Tracing {
-            ref mut promotions, ..
-        } = self.peek_mut_tstate()
-        {
+        if let MTThreadState::Tracing { promotions, .. } = self.peek_mut_tstate() {
             promotions.extend_from_slice(&val.to_ne_bytes());
         }
         true
@@ -1376,10 +1373,7 @@ impl MTThread {
     /// If the stack is empty. There should always be at least one element on the stack, so a panic
     /// here means that something has gone wrong elsewhere.
     pub(crate) fn promote_u32(&mut self, val: u32) -> bool {
-        if let MTThreadState::Tracing {
-            ref mut promotions, ..
-        } = self.peek_mut_tstate()
-        {
+        if let MTThreadState::Tracing { promotions, .. } = self.peek_mut_tstate() {
             promotions.extend_from_slice(&val.to_ne_bytes());
         }
         true
@@ -1397,10 +1391,7 @@ impl MTThread {
     /// If the stack is empty. There should always be at least one element on the stack, so a panic
     /// here means that something has gone wrong elsewhere.
     pub(crate) fn promote_i64(&mut self, val: i64) -> bool {
-        if let MTThreadState::Tracing {
-            ref mut promotions, ..
-        } = self.peek_mut_tstate()
-        {
+        if let MTThreadState::Tracing { promotions, .. } = self.peek_mut_tstate() {
             promotions.extend_from_slice(&val.to_ne_bytes());
         }
         true
@@ -1418,10 +1409,7 @@ impl MTThread {
     /// If the stack is empty. There should always be at least one element on the stack, so a panic
     /// here means that something has gone wrong elsewhere.
     pub(crate) fn promote_usize(&mut self, val: usize) -> bool {
-        if let MTThreadState::Tracing {
-            ref mut promotions, ..
-        } = self.peek_mut_tstate()
-        {
+        if let MTThreadState::Tracing { promotions, .. } = self.peek_mut_tstate() {
             promotions.extend_from_slice(&val.to_ne_bytes());
         }
         true
@@ -1434,10 +1422,7 @@ impl MTThread {
     /// If the stack is empty. There should always be at least one element on the stack, so a panic
     /// here means that something has gone wrong elsewhere.
     pub(crate) fn insert_debug_str(&mut self, msg: String) -> bool {
-        if let MTThreadState::Tracing {
-            ref mut debug_strs, ..
-        } = self.peek_mut_tstate()
-        {
+        if let MTThreadState::Tracing { debug_strs, .. } = self.peek_mut_tstate() {
             debug_strs.push(msg);
         }
         true

--- a/ykrt/src/promote.rs
+++ b/ykrt/src/promote.rs
@@ -7,7 +7,7 @@ use crate::mt::MTThread;
 use std::ffi::{c_int, c_longlong, c_uint, c_void};
 
 /// Promote a `c_int` during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
     if MTThread::is_tracing() {
@@ -20,7 +20,7 @@ pub extern "C" fn __yk_promote_c_int(val: c_int) -> c_int {
 }
 
 /// Promote a `c_uint` during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_unsigned_int(val: c_uint) -> c_uint {
     if MTThread::is_tracing() {
@@ -33,7 +33,7 @@ pub extern "C" fn __yk_promote_c_unsigned_int(val: c_uint) -> c_uint {
 }
 
 /// Promote a `usize` during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub extern "C" fn __yk_promote_c_long_long(val: c_longlong) -> c_longlong {
     if MTThread::is_tracing() {
@@ -46,7 +46,7 @@ pub extern "C" fn __yk_promote_c_long_long(val: c_longlong) -> c_longlong {
 }
 
 /// Promote a `usize` during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __yk_promote_usize(val: usize) -> usize {
     if MTThread::is_tracing() {
         MTThread::with_borrow_mut(|mtt| {
@@ -58,7 +58,7 @@ pub extern "C" fn __yk_promote_usize(val: usize) -> usize {
 }
 
 /// Promote a pointer during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __yk_promote_ptr(val: *const c_void) -> *const c_void {
     if MTThread::is_tracing() {
         MTThread::with_borrow_mut(|mtt| {
@@ -70,7 +70,7 @@ pub extern "C" fn __yk_promote_ptr(val: *const c_void) -> *const c_void {
 }
 
 /// Records a 64-bit return value of an idempotent function during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __yk_idempotent_promote_i64(val: i64) -> i64 {
     if MTThread::is_tracing() {
         MTThread::with_borrow_mut(|mtt| {
@@ -82,7 +82,7 @@ pub extern "C" fn __yk_idempotent_promote_i64(val: i64) -> i64 {
 }
 
 /// Records a 32-bit return value of an idempotent function during trace recording.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __yk_idempotent_promote_i32(val: i32) -> i32 {
     if MTThread::is_tracing() {
         MTThread::with_borrow_mut(|mtt| {

--- a/ykrt/src/thread_intercept.rs
+++ b/ykrt/src/thread_intercept.rs
@@ -33,7 +33,7 @@ extern "C" fn wrap_thread_routine(tgt: *mut c_void) -> *mut c_void {
     ret
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __wrap_pthread_create(
     thread: *mut libc::pthread_t,
     attr: *const libc::pthread_attr_t,
@@ -54,7 +54,7 @@ pub extern "C" fn __wrap_pthread_create(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __wrap_pthread_exit(_retval: *mut c_void) {
     // FIXME: Using `pthread_exit` doesn't return to `wrap_thread_routine` and thus doesn't free
     // the newly created shadowstack.

--- a/ykrt/src/trace/hwt/mapper.rs
+++ b/ykrt/src/trace/hwt/mapper.rs
@@ -2,8 +2,8 @@
 
 use crate::trace::{AOTTraceIterator, AOTTraceIteratorError, TraceAction, TraceRecorderError};
 use hwtracer::{
-    llvm_blockmap::LLVM_BLOCK_MAP, Block, BlockIteratorError, HWTracerError, TemporaryErrorKind,
-    Trace,
+    Block, BlockIteratorError, HWTracerError, TemporaryErrorKind, Trace,
+    llvm_blockmap::LLVM_BLOCK_MAP,
 };
 use ykaddr::{
     addr::{vaddr_to_obj_and_off, vaddr_to_sym_and_obj},

--- a/ykrt/src/trace/hwt/testing.rs
+++ b/ykrt/src/trace/hwt/testing.rs
@@ -3,7 +3,7 @@
 
 use hwtracer::llvm_blockmap::LLVM_BLOCK_MAP;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __yktrace_hwt_mapper_blockmap_len() -> usize {
     LLVM_BLOCK_MAP.len()
 }

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -50,7 +50,7 @@ thread_local! {
 /// * `function_index` - The index of the function to which the basic block belongs.
 /// * `block_index` - The index of the basic block within the function.
 #[cfg(tracer_swt)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __yk_trace_basicblock(function_index: usize, block_index: usize) {
     if MTThread::is_tracing() {
         BASIC_BLOCKS.with(|v| {

--- a/yksmp/Cargo.toml
+++ b/yksmp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yksmp"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["The Yk Developers"]
 license = "Apache-2.0 OR MIT"
 


### PR DESCRIPTION
This updates the rust edition to 2024 so we can continue using let-chains without getting errors. Unfortunately, this brings with it a bunch of other changes:

- Slightly different formatting of imports
- Some other formatting changes
- Change `#[no_mangle]` to `#[unsafe(no_mangle)]`
- Change `extern` to `unsafe extern`
- Changes in the match ergonomics (see https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html)