### PR TITLE
Disable Pavel's SWT module cloning work for now (and update tests).

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -233,6 +233,11 @@ cargo_deny_mdbook_pid=$!
 for tracer in $TRACERS; do
     export YKB_TRACER="${tracer}"
     echo "===> Running ${tracer} tests"
+
+    # The lua test harness isn't clever enough to rebuild yklua when YKB_TRACER
+    # changes, so for now just nuke any existing yklua to force a rebuild.
+    rm -rf target/release/yklua
+
     RUST_TEST_SHUFFLE=1 cargo test --release
 
     if [ "${tracer}" = "hwt" ]; then

--- a/bin/yk-config
+++ b/bin/yk-config
@@ -101,7 +101,10 @@ handle_arg() {
             # Use software-tracer pass
             if [ "${YKB_TRACER}" = "swt" ]; then
                 OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-basicblock-tracer"
-                OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-module-clone"
+                # Experimental module cloning support.
+                if [ "${YKB_SWTMODCLONE}" = "1" ]; then
+                    OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-module-clone"
+                fi
             fi
             # Disable backend optimisations that Yk can't handle by adding the
             # `optnone` attribute onto every function after high-level IR

--- a/tests/c/many_threads_many_locs.c
+++ b/tests/c/many_threads_many_locs.c
@@ -1,5 +1,3 @@
-// ## FIXME: SWT can't handle control points not in main.
-// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/many_threads_one_loc.c
+++ b/tests/c/many_threads_one_loc.c
@@ -1,5 +1,3 @@
-// ## FIXME: SWT can't handle control points not in main.
-// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/c/nested_sidetrace.c
+++ b/tests/c/nested_sidetrace.c
@@ -1,3 +1,5 @@
+// ## SWT miscompiles the trace, giving the wrong output.
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_LOG=4

--- a/tests/c/promote_guard.c
+++ b/tests/c/promote_guard.c
@@ -1,3 +1,5 @@
+// ## SWT miscompiles the trace, giving the wrong output.
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=4

--- a/tests/c/side-trace.c
+++ b/tests/c/side-trace.c
@@ -1,3 +1,5 @@
+// ## SWT miscompiles the trace, giving the wrong output.
+// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_LOG=4

--- a/tests/c/thread_local_in_trace.c
+++ b/tests/c/thread_local_in_trace.c
@@ -1,5 +1,3 @@
-// ## FIXME: SWT can't handle control points not in main.
-// ignore-if: test "$YKB_TRACER" = "swt"
 // Run-time:
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1

--- a/tests/lua/for_loop.lua
+++ b/tests/lua/for_loop.lua
@@ -1,4 +1,3 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YKD_LOG=4
@@ -8,23 +7,23 @@
 --     0
 --     1
 --     2
---     yk-tracing: start-tracing: for_loop.lua:35: GETTABUP
+--     yk-tracing: start-tracing: for_loop.lua:34: GETTABUP
 --     3
---     yk-tracing: stop-tracing: for_loop.lua:35: GETTABUP
---     --- Begin debugstrs: header: for_loop.lua:35: GETTABUP ---
---       for_loop.lua:35: GETTABUP
---       for_loop.lua:35: GETFIELD
---       for_loop.lua:35: SELF
---       for_loop.lua:35: GETTABUP
---       for_loop.lua:35: MOVE
---       for_loop.lua:35: CALL
---       for_loop.lua:35: LOADK
---       for_loop.lua:35: CALL
---       for_loop.lua:36: ADDI
---       for_loop.lua:34: FORLOOP
+--     yk-tracing: stop-tracing: for_loop.lua:34: GETTABUP
+--     --- Begin debugstrs: header: for_loop.lua:34: GETTABUP ---
+--       for_loop.lua:34: GETTABUP
+--       for_loop.lua:34: GETFIELD
+--       for_loop.lua:34: SELF
+--       for_loop.lua:34: GETTABUP
+--       for_loop.lua:34: MOVE
+--       for_loop.lua:34: CALL
+--       for_loop.lua:34: LOADK
+--       for_loop.lua:34: CALL
+--       for_loop.lua:35: ADDI
+--       for_loop.lua:33: FORLOOP
 --     --- End debugstrs ---
 --     4
---     yk-execution: enter-jit-code: for_loop.lua:35: GETTABUP
+--     yk-execution: enter-jit-code: for_loop.lua:34: GETTABUP
 --     5
 --     6
 --     yk-execution: deoptimise ...

--- a/tests/lua/inline_indirect_call.lua
+++ b/tests/lua/inline_indirect_call.lua
@@ -1,4 +1,4 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
+-- ignore-if: false
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YKD_LOG=4

--- a/tests/lua/nested_loops.lua
+++ b/tests/lua/nested_loops.lua
@@ -1,40 +1,39 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YKD_LOG=4
 --   env-var: YKD_LOG_IR=debugstrs
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
---     yk-tracing: start-tracing: nested_loops.lua:45: ADDI
---     yk-tracing: stop-tracing: nested_loops.lua:45: ADDI
---     --- Begin debugstrs: header: nested_loops.lua:45: ADDI ---
---       nested_loops.lua:45: ADDI
---       nested_loops.lua:44: FORLOOP
+--     yk-tracing: start-tracing: nested_loops.lua:44: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:44: ADDI
+--     --- Begin debugstrs: header: nested_loops.lua:44: ADDI ---
+--       nested_loops.lua:44: ADDI
+--       nested_loops.lua:43: FORLOOP
 --     --- End debugstrs ---
---     yk-execution: enter-jit-code: nested_loops.lua:45: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:44: ADDI
 --     yk-execution: deoptimise ...
---     yk-execution: enter-jit-code: nested_loops.lua:45: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:44: ADDI
 --     yk-execution: deoptimise ...
---     yk-execution: enter-jit-code: nested_loops.lua:45: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:44: ADDI
 --     yk-execution: deoptimise ...
---     yk-execution: enter-jit-code: nested_loops.lua:45: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:44: ADDI
 --     yk-execution: deoptimise ...
---     yk-execution: enter-jit-code: nested_loops.lua:45: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:44: ADDI
 --     yk-execution: deoptimise ...
---     yk-tracing: start-side-tracing: nested_loops.lua:45: ADDI
---     yk-tracing: stop-tracing: nested_loops.lua:43: ADDI
---     yk-tracing: start-tracing: nested_loops.lua:43: ADDI
---     yk-tracing: stop-tracing: nested_loops.lua:45: ADDI
---     --- Begin debugstrs: connector: nested_loops.lua:43: ADDI ---
---       nested_loops.lua:43: ADDI
---       nested_loops.lua:44: LOADI
---       nested_loops.lua:44: LOADI
---       nested_loops.lua:44: LOADI
---       nested_loops.lua:44: FORPREP
+--     yk-tracing: start-side-tracing: nested_loops.lua:44: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:42: ADDI
+--     yk-tracing: start-tracing: nested_loops.lua:42: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:44: ADDI
+--     --- Begin debugstrs: connector: nested_loops.lua:42: ADDI ---
+--       nested_loops.lua:42: ADDI
+--       nested_loops.lua:43: LOADI
+--       nested_loops.lua:43: LOADI
+--       nested_loops.lua:43: LOADI
+--       nested_loops.lua:43: FORPREP
 --     --- End debugstrs ---
---     --- Begin debugstrs: side-trace: nested_loops.lua:45: ADDI ---
---       nested_loops.lua:42: FORLOOP
+--     --- Begin debugstrs: side-trace: nested_loops.lua:44: ADDI ---
+--       nested_loops.lua:41: FORLOOP
 --     --- End debugstrs ---
---     yk-execution: enter-jit-code: nested_loops.lua:45: ADDI
+--     yk-execution: enter-jit-code: nested_loops.lua:44: ADDI
 --     yk-execution: deoptimise ...
 --     251502
 

--- a/tests/lua/recursive_function.lua
+++ b/tests/lua/recursive_function.lua
@@ -1,4 +1,3 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=2
 --   env-var: YKD_LOG=4
@@ -8,25 +7,25 @@
 --     6
 --     5
 --     4
---     yk-tracing: start-tracing: recursive_function.lua:36: GETTABUP
+--     yk-tracing: start-tracing: recursive_function.lua:35: GETTABUP
 --     3
---     yk-tracing: stop-tracing: recursive_function.lua:36: GETTABUP
---     --- Begin debugstrs: header: recursive_function.lua:36: GETTABUP ---
---       recursive_function.lua:36: GETTABUP
---       recursive_function.lua:36: GETFIELD
---       recursive_function.lua:36: SELF
---       recursive_function.lua:36: GETTABUP
---       recursive_function.lua:36: MOVE
---       recursive_function.lua:36: CALL
---       recursive_function.lua:36: LOADK
---       recursive_function.lua:36: CALL
---       recursive_function.lua:37: GTI
---       recursive_function.lua:38: GETTABUP
---       recursive_function.lua:38: ADDI
---       recursive_function.lua:38: CALL
+--     yk-tracing: stop-tracing: recursive_function.lua:35: GETTABUP
+--     --- Begin debugstrs: header: recursive_function.lua:35: GETTABUP ---
+--       recursive_function.lua:35: GETTABUP
+--       recursive_function.lua:35: GETFIELD
+--       recursive_function.lua:35: SELF
+--       recursive_function.lua:35: GETTABUP
+--       recursive_function.lua:35: MOVE
+--       recursive_function.lua:35: CALL
+--       recursive_function.lua:35: LOADK
+--       recursive_function.lua:35: CALL
+--       recursive_function.lua:36: GTI
+--       recursive_function.lua:37: GETTABUP
+--       recursive_function.lua:37: ADDI
+--       recursive_function.lua:37: CALL
 --     --- End debugstrs ---
 --     2
---     yk-execution: enter-jit-code: recursive_function.lua:36: GETTABUP
+--     yk-execution: enter-jit-code: recursive_function.lua:35: GETTABUP
 --     1
 --     0
 --     yk-execution: deoptimise ...

--- a/tests/lua/recursive_function_indirect.lua
+++ b/tests/lua/recursive_function_indirect.lua
@@ -1,4 +1,3 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=2
 --   env-var: YKD_LOG=4
@@ -8,36 +7,36 @@
 --     8
 --     7
 --     6
---     yk-tracing: start-tracing: recursive_function_indirect.lua:48: GETTABUP
+--     yk-tracing: start-tracing: recursive_function_indirect.lua:47: GETTABUP
 --     5
---     yk-tracing: stop-tracing: recursive_function_indirect.lua:48: GETTABUP
---     --- Begin debugstrs: header: recursive_function_indirect.lua:48: GETTABUP ---
---       recursive_function_indirect.lua:48: GETTABUP
---       recursive_function_indirect.lua:48: GETFIELD
---       recursive_function_indirect.lua:48: SELF
---       recursive_function_indirect.lua:48: GETTABUP
---       recursive_function_indirect.lua:48: MOVE
---       recursive_function_indirect.lua:48: CALL
---       recursive_function_indirect.lua:48: LOADK
---       recursive_function_indirect.lua:48: CALL
---       recursive_function_indirect.lua:49: GTI
---       recursive_function_indirect.lua:50: GETTABUP
---       recursive_function_indirect.lua:50: ADDI
---       recursive_function_indirect.lua:50: CALL
---       recursive_function_indirect.lua:55: GETTABUP
---       recursive_function_indirect.lua:55: MOVE
---       recursive_function_indirect.lua:55: TAILCALL
+--     yk-tracing: stop-tracing: recursive_function_indirect.lua:47: GETTABUP
+--     --- Begin debugstrs: header: recursive_function_indirect.lua:47: GETTABUP ---
+--       recursive_function_indirect.lua:47: GETTABUP
+--       recursive_function_indirect.lua:47: GETFIELD
+--       recursive_function_indirect.lua:47: SELF
+--       recursive_function_indirect.lua:47: GETTABUP
+--       recursive_function_indirect.lua:47: MOVE
+--       recursive_function_indirect.lua:47: CALL
+--       recursive_function_indirect.lua:47: LOADK
+--       recursive_function_indirect.lua:47: CALL
+--       recursive_function_indirect.lua:48: GTI
+--       recursive_function_indirect.lua:49: GETTABUP
+--       recursive_function_indirect.lua:49: ADDI
+--       recursive_function_indirect.lua:49: CALL
+--       recursive_function_indirect.lua:54: GETTABUP
+--       recursive_function_indirect.lua:54: MOVE
+--       recursive_function_indirect.lua:54: TAILCALL
 --     --- End debugstrs ---
 --     4
---     yk-tracing: start-tracing: recursive_function_indirect.lua:55: GETTABUP
---     yk-tracing: stop-tracing: recursive_function_indirect.lua:48: GETTABUP
---     --- Begin debugstrs: connector: recursive_function_indirect.lua:55: GETTABUP ---
---       recursive_function_indirect.lua:55: GETTABUP
---       recursive_function_indirect.lua:55: MOVE
---       recursive_function_indirect.lua:55: TAILCALL
+--     yk-tracing: start-tracing: recursive_function_indirect.lua:54: GETTABUP
+--     yk-tracing: stop-tracing: recursive_function_indirect.lua:47: GETTABUP
+--     --- Begin debugstrs: connector: recursive_function_indirect.lua:54: GETTABUP ---
+--       recursive_function_indirect.lua:54: GETTABUP
+--       recursive_function_indirect.lua:54: MOVE
+--       recursive_function_indirect.lua:54: TAILCALL
 --     --- End debugstrs ---
 --     3
---     yk-execution: enter-jit-code: recursive_function_indirect.lua:55: GETTABUP
+--     yk-execution: enter-jit-code: recursive_function_indirect.lua:54: GETTABUP
 --     2
 --     1
 --     0

--- a/tests/lua/sidetrace.lua
+++ b/tests/lua/sidetrace.lua
@@ -1,4 +1,3 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YK_SIDETRACE_THRESHOLD=2
@@ -9,46 +8,46 @@
 --     <0
 --     <1
 --     <2
---     yk-tracing: start-tracing: sidetrace.lua:59: LTI
+--     yk-tracing: start-tracing: sidetrace.lua:58: LTI
 --     <3
---     yk-tracing: stop-tracing: sidetrace.lua:59: LTI
---     --- Begin debugstrs: header: sidetrace.lua:59: LTI ---
---       sidetrace.lua:59: LTI
---       sidetrace.lua:60: GETTABUP
---       sidetrace.lua:60: GETFIELD
---       sidetrace.lua:60: SELF
---       sidetrace.lua:60: LOADK
---       sidetrace.lua:60: GETTABUP
---       sidetrace.lua:60: MOVE
---       sidetrace.lua:60: CALL
---       sidetrace.lua:60: LOADK
---       sidetrace.lua:60: CALL
---       sidetrace.lua:60: JMP
---       sidetrace.lua:58: FORLOOP
+--     yk-tracing: stop-tracing: sidetrace.lua:58: LTI
+--     --- Begin debugstrs: header: sidetrace.lua:58: LTI ---
+--       sidetrace.lua:58: LTI
+--       sidetrace.lua:59: GETTABUP
+--       sidetrace.lua:59: GETFIELD
+--       sidetrace.lua:59: SELF
+--       sidetrace.lua:59: LOADK
+--       sidetrace.lua:59: GETTABUP
+--       sidetrace.lua:59: MOVE
+--       sidetrace.lua:59: CALL
+--       sidetrace.lua:59: LOADK
+--       sidetrace.lua:59: CALL
+--       sidetrace.lua:59: JMP
+--       sidetrace.lua:57: FORLOOP
 --     --- End debugstrs ---
 --     <4
---     yk-execution: enter-jit-code: sidetrace.lua:59: LTI
+--     yk-execution: enter-jit-code: sidetrace.lua:58: LTI
 --     yk-execution: deoptimise ...
 --     >=5
---     yk-execution: enter-jit-code: sidetrace.lua:59: LTI
+--     yk-execution: enter-jit-code: sidetrace.lua:58: LTI
 --     yk-execution: deoptimise ...
---     yk-tracing: start-side-tracing: sidetrace.lua:59: LTI
+--     yk-tracing: start-side-tracing: sidetrace.lua:58: LTI
 --     >=6
---     yk-tracing: stop-tracing: sidetrace.lua:59: LTI
---     --- Begin debugstrs: side-trace: sidetrace.lua:59: LTI ---
---       sidetrace.lua:62: GETTABUP
---       sidetrace.lua:62: GETFIELD
---       sidetrace.lua:62: SELF
---       sidetrace.lua:62: LOADK
---       sidetrace.lua:62: GETTABUP
---       sidetrace.lua:62: MOVE
---       sidetrace.lua:62: CALL
---       sidetrace.lua:62: LOADK
---       sidetrace.lua:62: CALL
---       sidetrace.lua:58: FORLOOP
+--     yk-tracing: stop-tracing: sidetrace.lua:58: LTI
+--     --- Begin debugstrs: side-trace: sidetrace.lua:58: LTI ---
+--       sidetrace.lua:61: GETTABUP
+--       sidetrace.lua:61: GETFIELD
+--       sidetrace.lua:61: SELF
+--       sidetrace.lua:61: LOADK
+--       sidetrace.lua:61: GETTABUP
+--       sidetrace.lua:61: MOVE
+--       sidetrace.lua:61: CALL
+--       sidetrace.lua:61: LOADK
+--       sidetrace.lua:61: CALL
+--       sidetrace.lua:57: FORLOOP
 --     --- End debugstrs ---
 --     >=7
---     yk-execution: enter-jit-code: sidetrace.lua:59: LTI
+--     yk-execution: enter-jit-code: sidetrace.lua:58: LTI
 --     >=8
 --     >=9
 --     >=10

--- a/tests/lua/sidetrace_to_loop.lua
+++ b/tests/lua/sidetrace_to_loop.lua
@@ -1,4 +1,3 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=2
 --   env-var: YK_SIDETRACE_THRESHOLD=2
@@ -7,42 +6,42 @@
 --   env-var: YKD_SERIALISE_COMPILATION=1
 --   stderr:
 --     h1
---     yk-tracing: start-tracing: sidetrace_to_loop.lua:49: GTI
---     yk-tracing: stop-tracing: sidetrace_to_loop.lua:49: GTI
---     --- Begin debugstrs: header: sidetrace_to_loop.lua:49: GTI ---
---       sidetrace_to_loop.lua:49: GTI
---       sidetrace_to_loop.lua:50: TEST
---       sidetrace_to_loop.lua:50: JMP
---       sidetrace_to_loop.lua:59: ADDI
---       sidetrace_to_loop.lua:59: JMP
+--     yk-tracing: start-tracing: sidetrace_to_loop.lua:48: GTI
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:48: GTI
+--     --- Begin debugstrs: header: sidetrace_to_loop.lua:48: GTI ---
+--       sidetrace_to_loop.lua:48: GTI
+--       sidetrace_to_loop.lua:49: TEST
+--       sidetrace_to_loop.lua:49: JMP
+--       sidetrace_to_loop.lua:58: ADDI
+--       sidetrace_to_loop.lua:58: JMP
 --     --- End debugstrs ---
 --     h2
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:49: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:48: GTI
 --     yk-execution: deoptimise ...
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:49: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:48: GTI
 --     yk-execution: deoptimise ...
 --     h3
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:49: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:48: GTI
 --     yk-execution: deoptimise ...
---     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:49: GTI
---     yk-tracing: stop-tracing: sidetrace_to_loop.lua:54: FORLOOP
---     yk-tracing: start-tracing: sidetrace_to_loop.lua:54: FORLOOP
---     yk-tracing: stop-tracing: sidetrace_to_loop.lua:54: FORLOOP
---     --- Begin debugstrs: header: sidetrace_to_loop.lua:54: FORLOOP ---
---       sidetrace_to_loop.lua:54: FORLOOP
+--     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:48: GTI
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:53: FORLOOP
+--     yk-tracing: start-tracing: sidetrace_to_loop.lua:53: FORLOOP
+--     yk-tracing: stop-tracing: sidetrace_to_loop.lua:53: FORLOOP
+--     --- Begin debugstrs: header: sidetrace_to_loop.lua:53: FORLOOP ---
+--       sidetrace_to_loop.lua:53: FORLOOP
 --     --- End debugstrs ---
---     --- Begin debugstrs: side-trace: sidetrace_to_loop.lua:49: GTI ---
---       sidetrace_to_loop.lua:53: TEST
---       sidetrace_to_loop.lua:54: LOADI
---       sidetrace_to_loop.lua:54: LOADI
---       sidetrace_to_loop.lua:54: LOADI
---       sidetrace_to_loop.lua:54: FORPREP
+--     --- Begin debugstrs: side-trace: sidetrace_to_loop.lua:48: GTI ---
+--       sidetrace_to_loop.lua:52: TEST
+--       sidetrace_to_loop.lua:53: LOADI
+--       sidetrace_to_loop.lua:53: LOADI
+--       sidetrace_to_loop.lua:53: LOADI
+--       sidetrace_to_loop.lua:53: FORPREP
 --     --- End debugstrs ---
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:54: FORLOOP
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:53: FORLOOP
 --     yk-execution: deoptimise ...
---     yk-execution: enter-jit-code: sidetrace_to_loop.lua:49: GTI
+--     yk-execution: enter-jit-code: sidetrace_to_loop.lua:48: GTI
 --     yk-execution: deoptimise ...
---     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:49: GTI
+--     yk-tracing: start-side-tracing: sidetrace_to_loop.lua:48: GTI
 --     exit
 
 function h(i, b1, b2)

--- a/tests/lua/while_loop.lua
+++ b/tests/lua/while_loop.lua
@@ -1,4 +1,3 @@
--- ignore-if: test "$YKB_TRACER" = "swt"
 -- Run-time:
 --   env-var: YK_HOT_THRESHOLD=3
 --   env-var: YKD_LOG=4
@@ -8,24 +7,24 @@
 --     0
 --     1
 --     2
---     yk-tracing: start-tracing: while_loop.lua:35: LEI
+--     yk-tracing: start-tracing: while_loop.lua:34: LEI
 --     3
 --     yk-tracing: stop-tracing: ...
---     --- Begin debugstrs: header: while_loop.lua:35: LEI ---
---       while_loop.lua:35: LEI
---       while_loop.lua:36: GETTABUP
---       while_loop.lua:36: GETFIELD
---       while_loop.lua:36: SELF
---       while_loop.lua:36: GETTABUP
---       while_loop.lua:36: MOVE
---       while_loop.lua:36: CALL
---       while_loop.lua:36: LOADK
---       while_loop.lua:36: CALL
---       while_loop.lua:37: ADDI
---       while_loop.lua:37: JMP
+--     --- Begin debugstrs: header: while_loop.lua:34: LEI ---
+--       while_loop.lua:34: LEI
+--       while_loop.lua:35: GETTABUP
+--       while_loop.lua:35: GETFIELD
+--       while_loop.lua:35: SELF
+--       while_loop.lua:35: GETTABUP
+--       while_loop.lua:35: MOVE
+--       while_loop.lua:35: CALL
+--       while_loop.lua:35: LOADK
+--       while_loop.lua:35: CALL
+--       while_loop.lua:36: ADDI
+--       while_loop.lua:36: JMP
 --     --- End debugstrs ---
 --     4
---     yk-execution: enter-jit-code: while_loop.lua:35: LEI
+--     yk-execution: enter-jit-code: while_loop.lua:34: LEI
 --     5
 --     6
 --     yk-execution: deoptimise ...


### PR DESCRIPTION
Set YKB_SWTMODCLONE=1 to turn on Pavel's work.

Many tests can be unignored now module cloning is disabled by default. Three tests have new issues, and have to be disabled for now.

(Heads up @Pavel-Durov)