### PR TITLE
Support traces that end in a different frame than they started in.

### DIFF
--- a/tests/c/early_return1.c
+++ b/tests/c/early_return1.c
@@ -6,24 +6,18 @@
 //     yk-tracing: start-tracing
 //     early return
 //     6
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
-//     5
-//     4
-//     yk-tracing: start-tracing
-//     3
 //     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
+//     return...
 //     --- End jit-pre-opt ---
-//     2
-//     yk-execution: enter-jit-code
-//     1
-//     yk-execution: deoptimise ...
+//     ...
 //     return
 //     exit
 
-// Check that early return from a recursive interpreter loop aborts tracing,
-// but doesn't stop a location being retraced.
+// Used to check that early return from a recursive interpreter loop aborts
+// tracing, but doesn't stop a location being retraced. Now, simply checks that
+// we can trace and compile an early return.
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/c/exit_and_reenter_interploop.c
+++ b/tests/c/exit_and_reenter_interploop.c
@@ -8,11 +8,12 @@
 //     exit
 //     enter
 //     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: returned from function that started tracing
-//     ...
+//     1
+//     exit
 
 // Check that returning from the function that started tracing, then
-// re-entering it and stopping tracing, causes the trace to be aborted.
+// re-entering it and stopping tracing, stops the trace before the return and
+// emits a return itself.
 //
 // This is an interesting case because the frame address of the place we start
 // and stop tracing is the same, so mt.rs cannot catch this.

--- a/tests/c/inline_asm.c
+++ b/tests/c/inline_asm.c
@@ -2,10 +2,15 @@
 //   env-var: YKD_LOG_IR=jit-pre-opt
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=3
-//   status: error
+//   stderr:
+//     ...
+//     yk-warning: trace-compilation-aborted: unimplemented: Unimplemented...
+//     ...
+//     yk-warning: trace-compilation-aborted: unimplemented: Unimplemented...
+//     ...
 
-// Check that we can handle inline asm properly (currently expectely fails
-// until we can deal with calls inside inline asm).
+// Check that we can handle inline asm properly (currently expectely aborts the
+// trace until we can deal with calls inside inline asm).
 
 #include <assert.h>
 #include <stdlib.h>

--- a/tests/c/longjmp_within_trace_confines.c
+++ b/tests/c/longjmp_within_trace_confines.c
@@ -11,7 +11,7 @@
 //     after setjmp
 //     after setjmp
 //     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: irregular control flow detected
+//     yk-warning: trace-compilation-aborted: ...
 //     i=1
 //     after setjmp
 //     after setjmp

--- a/tests/c/nested_execution.c
+++ b/tests/c/nested_execution.c
@@ -7,13 +7,19 @@
 //     yk-tracing: start-tracing
 //     6
 //     enter
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
+//     yk-tracing: stop-tracing
+//     --- Begin jit-pre-opt ---
+//     ...
+//     call @f...
+//     deopt...
+//     --- End jit-pre-opt ---
 //     5
 //     yk-tracing: start-tracing
 //     4
 //     yk-tracing: stop-tracing
 //     --- Begin jit-pre-opt ---
 //     ...
+//     header_end...
 //     --- End jit-pre-opt ---
 //     3
 //     yk-execution: enter-jit-code
@@ -21,19 +27,20 @@
 //     1
 //     yk-execution: deoptimise ...
 //     return
-//     yk-tracing: start-tracing
+//     yk-execution: enter-jit-code
 //     5
 //     enter
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
-//     4
 //     yk-execution: enter-jit-code
+//     4
 //     3
 //     2
 //     1
 //     yk-execution: deoptimise ...
 //     yk-tracing: start-side-tracing
 //     return
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
+//     yk-warning: tracing-aborted: tracing continued into a JIT frame
+//     yk-execution: deoptimise ...
+//     yk-execution: enter-jit-code
 //     4
 //     enter
 //     yk-execution: enter-jit-code
@@ -42,24 +49,29 @@
 //     1
 //     yk-execution: deoptimise ...
 //     return
-//     yk-tracing: start-tracing
+//     yk-execution: deoptimise ...
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     ...
 //     c
 //     3
 //     enter
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
+//     yk-execution: enter-jit-code
 //     2
+//     1
+//     yk-execution: deoptimise ...
+//     yk-tracing: start-side-tracing
+//     return
+//     yk-warning: tracing-aborted: tracing went outside of starting frame
+//     b
+//     2
+//     enter
 //     yk-execution: enter-jit-code
 //     1
 //     yk-execution: deoptimise ...
 //     return
-//     yk-tracing: start-tracing
-//     b
-//     2
-//     enter
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
-//     1
-//     return
-//     yk-tracing: start-tracing
+//     yk-execution: enter-jit-code
+//     yk-execution: deoptimise ...
 //     a
 //     1
 //     enter

--- a/tests/c/trace_while_executing2.c
+++ b/tests/c/trace_while_executing2.c
@@ -17,13 +17,17 @@
 //     yk-execution: deoptimise ...
 //     yk-tracing: start-tracing
 //     1: 3
-//     yk-warning: tracing-aborted: tracing went outside of starting frame
+//     yk-tracing: stop-tracing
+//     ...
 //     0: 2
-//     yk-tracing: start-tracing
+//     yk-execution: enter-jit-code
 //     0: 1
+//     yk-execution: deoptimise...
 //     exit
 
-// Test that we don't record a successful trace if we started tracing in an inner control point.
+// Used to test that we don't record a successful trace if we started tracing
+// in an inner control point. Now checks that we do generate a valid trace from
+// the inner control point.
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/c/tracing_recursion3.c
+++ b/tests/c/tracing_recursion3.c
@@ -1,0 +1,63 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   env-var: YKD_LOG=4
+//   stderr:
+//     ...
+//     yk-execution: deoptimise...
+//     ...
+//     yk-execution: enter-jit-code
+//     1
+//     yk-execution: enter-jit-code
+//     1
+//     yk-execution: deoptimise...
+//     return inner
+//     yk-execution: deoptimise...
+//     return outer
+//     exit
+
+// Test traces recursively calling the interpreter loop which in turn
+// executes another trace, effectively leading to nested trace execution.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+void loop(YkMT *, YkLocation *, YkLocation *, int, char *);
+
+__attribute__((yk_outline))
+void loop(YkMT *mt, YkLocation *loc1, YkLocation *loc2, int i, char* inner) {
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, loc2);
+    fprintf(stderr, "%d\n", i);
+    if (strcmp(inner, "outer") == 0) {
+      loop(mt, NULL, loc1, 1, "inner");
+    }
+    i--;
+  }
+  fprintf(stderr, "return %s\n", inner);
+  return;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 1);
+  yk_mt_sidetrace_threshold_set(mt, 3);
+  YkLocation loc1 = yk_location_new();
+  YkLocation loc2 = yk_location_new();
+
+  // Make sure location 1 is compiled first.
+  loop(mt, NULL, &loc1, 3, "inner");
+
+  // Then compile location 2.
+  loop(mt, &loc1, &loc2, 3, "outer");
+  fprintf(stderr, "exit\n");
+  yk_location_drop(loc1);
+  yk_location_drop(loc2);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/deopt.rs
@@ -42,6 +42,20 @@ const RECOVER_REG: [usize; 31] = [
 /// from zero). This is used to allocate arrays whose indices need to be the DWARF register number.
 const REGISTER_NUM: usize = RECOVER_REG.len() + 2;
 
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn __yk_ret_from_trace(ctrid: u64) {
+    let ctr = MTThread::with_borrow(|mtt| mtt.compiled_trace(TraceId::from_u64(ctrid)))
+        .as_any()
+        .downcast::<X64CompiledTrace>()
+        .unwrap();
+    let mt = Arc::clone(&ctr.mt);
+    mt.deopt();
+    mt.stats
+        .timing_state(crate::log::stats::TimingState::OutsideYk);
+    mt.log
+        .log(Verbosity::Execution, &format!("return {:?}", ctr.ctrid()));
+}
+
 /// Deoptimise back to the interpreter. This function is called from a failing guard (see
 /// [super::Assemble::codegen]).
 ///

--- a/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/lsregalloc.rs
@@ -31,7 +31,9 @@ use super::{Register, VarLocation, rev_analyse::RevAnalyse};
 use crate::compile::jitc_yk::{
     aot_ir,
     codegen::abs_stack::AbstractStack,
-    jit_ir::{Const, ConstIdx, FloatTy, GuardInst, Inst, InstIdx, Module, Operand, PtrAddInst, Ty},
+    jit_ir::{
+        Const, ConstIdx, FloatTy, HasGuardInfo, Inst, InstIdx, Module, Operand, PtrAddInst, Ty,
+    },
 };
 use dynasmrt::{
     DynasmApi, Register as dynasmrtRegister, dynasm,
@@ -306,7 +308,7 @@ impl<'a> LSRegAlloc<'a> {
     pub(super) fn get_ready_for_deopt(
         &mut self,
         asm: &mut Assembler,
-        ginst: GuardInst,
+        ginst: HasGuardInfo,
     ) -> (Rq, Vec<(aot_ir::InstId, VarLocation)>) {
         let patch_reg = self.force_tmp_register(asm, RegSet::with_gp_reserved());
 

--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -25,8 +25,8 @@ use crate::{
             aot_ir::{self, DeoptSafepoint},
             arbbitint::ArbBitInt,
             jit_ir::{
-                self, BinOp, Const, FloatTy, GuardInst, IndirectCallIdx, InlinedFrame, Inst,
-                InstIdx, Module, Operand, TraceKind, Ty,
+                self, BinOp, Const, FloatTy, GuardInfoIdx, HasGuardInfo, IndirectCallIdx,
+                InlinedFrame, Inst, InstIdx, Module, Operand, TraceKind, Ty,
             },
         },
     },
@@ -57,7 +57,7 @@ mod deopt;
 pub(super) mod lsregalloc;
 mod rev_analyse;
 
-use deopt::__yk_deopt;
+use deopt::{__yk_deopt, __yk_ret_from_trace};
 use lsregalloc::{GPConstraint, GuardSnapshot, LSRegAlloc, RegConstraint, RegExtension};
 
 /// General purpose argument registers as defined by the x64 SysV ABI.
@@ -358,7 +358,10 @@ impl<'a> Assemble<'a> {
         // Since we are executing the trace in the main interpreter frame we need this to
         // initialise the trace's register allocator in order to access local variables.
         let sp_offset = match m.tracekind() {
-            TraceKind::HeaderOnly | TraceKind::HeaderAndBody | TraceKind::Connector(_) => {
+            TraceKind::HeaderOnly
+            | TraceKind::HeaderAndBody
+            | TraceKind::Connector(_)
+            | TraceKind::DifferentFrames => {
                 // FIXME: For now the control point stackmap id is always 0. Though
                 // we likely want to support multiple control points in the future. We can either pass
                 // the correct stackmap id in via the control point, or compute the stack size
@@ -600,6 +603,8 @@ impl<'a> Assemble<'a> {
                 jit_ir::Inst::TraceBodyStart => self.cg_body_start(),
                 jit_ir::Inst::TraceBodyEnd => self.cg_body_end(iidx),
                 jit_ir::Inst::SidetraceEnd => self.cg_sidetrace_end(iidx),
+                jit_ir::Inst::Deopt(gidx) => self.cg_deopt(iidx, *gidx),
+                jit_ir::Inst::Return(id) => self.cg_return(iidx, *id),
                 jit_ir::Inst::SExt(i) => self.cg_sext(iidx, i),
                 jit_ir::Inst::ZExt(i) => self.cg_zext(iidx, i),
                 jit_ir::Inst::BitCast(i) => self.cg_bitcast(iidx, i),
@@ -2507,7 +2512,7 @@ impl<'a> Assemble<'a> {
         // Codegen guard
         self.ra.expire_regs(g_iidx);
         self.comment_inst(g_iidx, g_inst.into());
-        let fail_label = self.guard_to_deopt(g_inst);
+        let fail_label = self.guard_to_deopt(HasGuardInfo::Guard(g_inst));
 
         if g_inst.expect() {
             match pred {
@@ -2806,6 +2811,7 @@ impl<'a> Assemble<'a> {
                 assert_eq!(sti.sp_offset, self.sp_offset);
                 (sti.entry_vars.clone(), self.m.trace_header_end())
             }
+            TraceKind::DifferentFrames => panic!(),
         };
 
         // First of all we work out what to do with registers.
@@ -3009,6 +3015,7 @@ impl<'a> Assemble<'a> {
                     ; jmp rdi);
             }
             TraceKind::HeaderOnly | TraceKind::HeaderAndBody | TraceKind::Connector(_) => panic!(),
+            TraceKind::DifferentFrames => panic!(),
         }
     }
 
@@ -3036,6 +3043,7 @@ impl<'a> Assemble<'a> {
             }
             TraceKind::Sidetrace(_) => todo!(),
             TraceKind::Connector(_) => (),
+            TraceKind::DifferentFrames => (),
         }
         self.prologue_offset = self.asm.offset();
     }
@@ -3107,6 +3115,7 @@ impl<'a> Assemble<'a> {
                     .as_any()
                     .downcast::<X64CompiledTrace>()
                     .unwrap();
+
                 self.write_jump_vars(iidx);
                 self.ra.align_stack(SYSV_CALL_STACK_ALIGN);
 
@@ -3121,7 +3130,56 @@ impl<'a> Assemble<'a> {
                     ; jmp rdi);
             }
             TraceKind::Sidetrace(_) => panic!(),
+            TraceKind::DifferentFrames => panic!(),
         }
+    }
+
+    fn cg_deopt(&mut self, _iidx: InstIdx, gidx: GuardInfoIdx) {
+        let fail_label = self.guard_to_deopt(HasGuardInfo::Deopt(gidx));
+        // Until this place is patched with a side-trace, we always forcibly deopt at
+        // this point.
+        dynasm!(self.asm ; jmp =>fail_label);
+    }
+
+    fn cg_return(&mut self, _iidx: InstIdx, safepoint: u64) {
+        // Return from the trace naturally back into the interpreter.
+        let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
+        let (_, pinfo) = aot_smaps.get(usize::try_from(safepoint).unwrap());
+        if !pinfo.hasfp {
+            todo!();
+        }
+        let size = i32::try_from(pinfo.csrs.len()).unwrap() * 8;
+        #[allow(clippy::fn_to_numeric_cast)]
+        {
+            dynasm!(self.asm
+                ; mov rdi, QWORD self.m.ctrid().as_u64().cast_signed()
+                ; mov rax, QWORD __yk_ret_from_trace as i64
+                ; call rax
+                ; mov rsp, rbp
+                ; sub rsp, size
+            );
+        }
+        // Restore callee-saved registers.
+        let mut csrs = pinfo.csrs.clone();
+        csrs.sort_by_key(|v| v.1);
+        for (reg, _) in csrs {
+            let rq = match reg {
+                0 => Rq::RAX,
+                15 => Rq::R15,
+                14 => Rq::R14,
+                13 => Rq::R13,
+                12 => Rq::R12,
+                3 => Rq::RBX,
+                _ => panic!("Not a callee-saved register"),
+            };
+            dynasm!(self.asm
+                ; pop Rq(rq.code())
+            );
+        }
+        dynasm!(self.asm
+            ; pop rbp
+            ; ret
+        );
     }
 
     fn cg_body_start(&mut self) {
@@ -3566,11 +3624,11 @@ impl<'a> Assemble<'a> {
         }
     }
 
-    fn guard_to_deopt(&mut self, ginst: jit_ir::GuardInst) -> DynamicLabel {
+    fn guard_to_deopt(&mut self, hgi: HasGuardInfo) -> DynamicLabel {
         let fail_label = self.asm.new_dynamic_label();
-        let ginfo = ginst.guard_info(self.m);
+        let ginfo = hgi.guard_info(self.m);
         let gd = CompilingGuard {
-            ginst,
+            ginst: hgi,
             guard_snapshot: self.ra.guard_snapshot(),
             bid: ginfo.bid().clone(),
             fail_label,
@@ -3620,7 +3678,7 @@ impl<'a> Assemble<'a> {
     fn cg_guard(&mut self, iidx: jit_ir::InstIdx, inst: &jit_ir::GuardInst) {
         let cond = inst.cond(self.m);
         let reg = self.ra.tmp_register_for_guard(&mut self.asm, iidx, cond);
-        let fail_label = self.guard_to_deopt(*inst);
+        let fail_label = self.guard_to_deopt(HasGuardInfo::Guard(*inst));
         dynasm!(self.asm ; bt Rd(reg.code()), 0);
         if inst.expect() {
             dynasm!(self.asm ; jnb =>fail_label);
@@ -3633,7 +3691,7 @@ impl<'a> Assemble<'a> {
 /// Information required by guards while we're compiling them.
 #[derive(Debug)]
 struct CompilingGuard {
-    ginst: GuardInst,
+    ginst: HasGuardInfo,
     guard_snapshot: GuardSnapshot,
     /// The AOT block that the failing guard originated from.
     bid: aot_ir::BBlockId,

--- a/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/rev_analyse.rs
@@ -137,12 +137,19 @@ impl<'a> RevAnalyse<'a> {
                     }
                 }
             }
+            TraceKind::DifferentFrames => {
+                // We don't care where the register allocator ends since we will always either
+                // deopt or jump into a side-trace at the end of the trace.
+            }
         }
 
         // ...and then we perform the rest of the reverse analysis.
         let mut iter = self.m.iter_skipping_insts().rev();
         match self.m.tracekind() {
-            TraceKind::HeaderOnly | TraceKind::Sidetrace(_) | TraceKind::Connector(_) => {
+            TraceKind::HeaderOnly
+            | TraceKind::Sidetrace(_)
+            | TraceKind::Connector(_)
+            | TraceKind::DifferentFrames => {
                 for (iidx, inst) in self.m.iter_skipping_insts().rev() {
                     self.analyse(iidx, inst);
                 }

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -117,6 +117,17 @@ use ykaddr::addr::symbol_to_ptr;
 // This is simple and can be shared across both IRs.
 pub(crate) use super::aot_ir::{BinOp, FloatPredicate, FloatTy, Predicate};
 
+/// Did this trace end in a different frame than it started in?
+#[derive(Debug)]
+pub(crate) enum TraceEndFrame {
+    /// The trace stopped in the same frame that it started in.
+    Same,
+    /// The trace stopped after entering a new frame.
+    Entered,
+    /// The trace stopped after leaving the starting frame.
+    Left,
+}
+
 /// What kind of trace does this module represent?
 #[derive(Clone)]
 pub(crate) enum TraceKind {
@@ -129,6 +140,8 @@ pub(crate) enum TraceKind {
     /// A sidetrace: this will start at the point of a guard and will jump to
     /// [SideTraceInfo::target_ctr].
     Sidetrace(Arc<YkSideTraceInfo<Register>>),
+    /// A trace where we stopped tracing in a different frame than we started in.
+    DifferentFrames,
 }
 
 impl std::fmt::Debug for TraceKind {
@@ -138,6 +151,7 @@ impl std::fmt::Debug for TraceKind {
             TraceKind::HeaderAndBody => write!(f, "HeaderAndBody"),
             TraceKind::Connector(_) => write!(f, "Connector"),
             TraceKind::Sidetrace(_) => write!(f, "Sidetrace"),
+            TraceKind::DifferentFrames => write!(f, "DifferentFrames"),
         }
     }
 }
@@ -244,6 +258,7 @@ impl Module {
     pub(crate) fn set_tracekind(&mut self, tracekind: TraceKind) {
         match (&self.tracekind, &tracekind) {
             (&TraceKind::HeaderOnly, &TraceKind::HeaderAndBody) => (),
+            (&TraceKind::HeaderOnly, &TraceKind::DifferentFrames) => (),
             (from, to) => panic!("Can't transition from a {from:?} trace to a {to:?} trace"),
         }
         self.tracekind = tracekind;
@@ -643,6 +658,10 @@ impl Module {
         info: GuardInfo,
     ) -> Result<GuardInfoIdx, CompilationError> {
         GuardInfoIdx::try_from(self.guard_info.len()).inspect(|_| self.guard_info.push(info))
+    }
+
+    pub(crate) fn guard_info(&self, gidx: GuardInfoIdx) -> &GuardInfo {
+        &self.guard_info[usize::from(gidx)]
     }
 
     pub(crate) fn trace_header_start(&self) -> &[PackedOperand] {
@@ -1555,6 +1574,8 @@ pub(crate) enum Inst {
     TraceBodyStart,
     TraceBodyEnd,
     SidetraceEnd,
+    Deopt(GuardInfoIdx),
+    Return(u64),
 
     SExt(SExtInst),
     ZExt(ZExtInst),
@@ -1621,6 +1642,8 @@ impl Inst {
             Self::TraceBodyStart => m.void_tyidx(),
             Self::TraceBodyEnd => m.void_tyidx(),
             Self::SidetraceEnd => m.void_tyidx(),
+            Self::Deopt(_) => m.void_tyidx(),
+            Self::Return(_) => m.void_tyidx(),
             Self::SExt(si) => si.dest_tyidx(),
             Self::ZExt(si) => si.dest_tyidx(),
             Self::BitCast(i) => i.dest_tyidx(),
@@ -1671,6 +1694,8 @@ impl Inst {
                 | Inst::TraceBodyStart
                 | Inst::TraceBodyEnd
                 | Inst::SidetraceEnd
+                | Inst::Deopt(_)
+                | Inst::Return(_)
                 | Inst::Param(_)
                 | Inst::DebugStr(..)
         )
@@ -1767,6 +1792,12 @@ impl Inst {
                     x.unpack(m).map_iidx(f);
                 }
             }
+            Inst::Deopt(gidx) => {
+                for (_, pop) in m.guard_info[usize::from(*gidx)].live_vars() {
+                    pop.unpack(m).map_iidx(f);
+                }
+            }
+            Inst::Return(_) => (),
             Inst::SExt(SExtInst { val, .. }) => val.unpack(m).map_iidx(f),
             Inst::ZExt(ZExtInst { val, .. }) => val.unpack(m).map_iidx(f),
             Inst::BitCast(BitCastInst { val, .. }) => val.unpack(m).map_iidx(f),
@@ -1972,6 +2003,38 @@ impl Inst {
                 m.trace_header_end = m.trace_header_end.iter().map(|op| mapper(m, op)).collect();
                 Inst::SidetraceEnd
             }
+            Inst::Deopt(gidx) => {
+                let ginfo = &m.guard_info[usize::from(*gidx)];
+                let newlives = ginfo
+                    .live_vars()
+                    .iter()
+                    .map(|(aot, jit)| (aot.clone(), mapper(m, jit)))
+                    .collect();
+                let inlined_frames = ginfo
+                    .inlined_frames()
+                    .iter()
+                    .map(|x| {
+                        InlinedFrame::new(
+                            x.callinst.clone(),
+                            x.funcidx,
+                            x.safepoint,
+                            x.args
+                                .iter()
+                                .map(|x| op_mapper(m, &x.unpack(m)))
+                                .collect::<Vec<_>>(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let newginfo = GuardInfo::new(
+                    ginfo.bid().clone(),
+                    newlives,
+                    inlined_frames,
+                    ginfo.safepoint_id,
+                );
+                let newgidx = m.push_guardinfo(newginfo).unwrap();
+                Inst::Deopt(newgidx)
+            }
+            Inst::Return(id) => Inst::Return(*id),
             Inst::Trunc(TruncInst { val, dest_tyidx }) => Inst::Trunc(TruncInst {
                 val: mapper(m, val),
                 dest_tyidx: *dest_tyidx,
@@ -2274,6 +2337,27 @@ impl fmt::Display for DisplayableInst<'_> {
                     }
                 }
                 write!(f, "]")
+            }
+            Inst::Deopt(gidx) => {
+                let gi = &self.m.guard_info[usize::from(*gidx)];
+                let live_vars = gi
+                    .live_vars()
+                    .iter()
+                    .map(|(x, y)| {
+                        format!(
+                            "{}:%{}_{}: {}",
+                            usize::from(x.funcidx()),
+                            usize::from(x.bbidx()),
+                            usize::from(x.iidx()),
+                            y.unpack(self.m).display(self.m),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "deopt [{live_vars}]")
+            }
+            Inst::Return(id) => {
+                write!(f, "return [safepoint: {id}]")
             }
             Inst::SExt(i) => {
                 write!(f, "sext {}", i.val(self.m).display(self.m),)
@@ -3184,6 +3268,21 @@ impl GuardInst {
 
     pub(crate) fn guard_info<'a>(&self, m: &'a Module) -> &'a GuardInfo {
         &m.guard_info[usize::from(self.gidx)]
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum HasGuardInfo {
+    Guard(GuardInst),
+    Deopt(GuardInfoIdx),
+}
+
+impl HasGuardInfo {
+    pub(crate) fn guard_info<'a>(&self, m: &'a Module) -> &'a GuardInfo {
+        match self {
+            Self::Guard(inst) => inst.guard_info(m),
+            Self::Deopt(gidx) => m.guard_info(*gidx),
+        }
     }
 }
 

--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -41,6 +41,7 @@ impl Module {
                 }
             }
             super::TraceKind::Sidetrace(_) | super::TraceKind::Connector(_) => (),
+            super::TraceKind::DifferentFrames => (),
         }
 
         let mut last_inst = None;

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -61,6 +61,7 @@ impl Opt {
             // peeling.
             TraceKind::Sidetrace(_) => false,
             TraceKind::Connector(_) => false,
+            TraceKind::DifferentFrames => false,
         };
 
         // Step 1: optimise the module as-is.

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -4,11 +4,13 @@
 
 use super::YkSideTraceInfo;
 use super::aot_ir::{self, BBlockId, BinOp, Module};
+use super::jit_ir::TraceEndFrame;
 use super::{
     AOT_MOD,
     arbbitint::ArbBitInt,
     jit_ir::{self, Const, Operand, PackedOperand, ParamIdx, TraceKind},
 };
+use crate::compile::jitc_yk::aot_ir::DeoptSafepoint;
 use crate::{
     aotsmp::AOT_STACKMAPS,
     compile::{CompilationError, CompiledTrace},
@@ -18,6 +20,14 @@ use crate::{
 };
 use std::{collections::HashMap, ffi::CString, sync::Arc};
 use ykaddr::addr::symbol_to_ptr;
+
+/// The mode for processing blocks.
+enum ProcessMode {
+    /// Process blocks normally.
+    Normal,
+    /// Don't process any remaining blocks (except in order to count promotions/debugstrs etc).
+    Skip,
+}
 
 /// Given an execution trace and AOT IR, creates a JIT IR trace.
 pub(crate) struct TraceBuilder {
@@ -53,6 +63,12 @@ pub(crate) struct TraceBuilder {
     debug_str_idx: usize,
     /// Local variables that we have inferred to be constant.
     inferred_consts: HashMap<jit_ir::InstIdx, jit_ir::ConstIdx>,
+    /// Did this trace end in another frame?
+    endframe: TraceEndFrame,
+    /// Current mode for processing blocks.
+    process_mode: ProcessMode,
+    /// Info regarding the most recently seen recursive call to the interpreter.
+    last_interp_call: Option<(BBlockId, &'static DeoptSafepoint)>,
 }
 
 impl TraceBuilder {
@@ -70,6 +86,7 @@ impl TraceBuilder {
         ctrid: TraceId,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
+        endframe: TraceEndFrame,
     ) -> Result<Self, CompilationError> {
         Ok(Self {
             aot_mod,
@@ -91,6 +108,9 @@ impl TraceBuilder {
             debug_strs,
             debug_str_idx: 0,
             inferred_consts: HashMap::new(),
+            endframe,
+            process_mode: ProcessMode::Normal,
+            last_interp_call: None,
         })
     }
 
@@ -119,7 +139,7 @@ impl TraceBuilder {
     ) -> Result<(), CompilationError> {
         // Find the control point call to retrieve the live variables from its safepoint.
         let safepoint = match self.jit_mod.tracekind() {
-            TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
+            TraceKind::HeaderOnly | TraceKind::HeaderAndBody | TraceKind::DifferentFrames => {
                 let mut inst_iter = blk.insts.iter().enumerate().rev();
                 let mut safepoint = None;
                 for (_, inst) in inst_iter.by_ref() {
@@ -340,7 +360,9 @@ impl TraceBuilder {
                     let nextinst = blk.insts.last().unwrap();
                     self.handle_idempotent_promote(bid, iidx, val, nextinst)
                 }
-                _ => todo!("{:?}", inst),
+                _ => Err(CompilationError::General(format!(
+                    "unimplemented: {inst:?}"
+                ))),
             }?;
         }
         Ok(())
@@ -545,10 +567,10 @@ impl TraceBuilder {
     fn create_guard(
         &mut self,
         bid: &aot_ir::BBlockId,
-        cond: &jit_ir::Operand,
+        cond: Option<&jit_ir::Operand>,
         expect: bool,
         safepoint: &'static aot_ir::DeoptSafepoint,
-    ) -> Result<jit_ir::GuardInst, CompilationError> {
+    ) -> Result<jit_ir::Inst, CompilationError> {
         // Assign this branch's stackmap to the current frame.
         self.frames.last_mut().unwrap().safepoint = Some(safepoint);
 
@@ -597,7 +619,7 @@ impl TraceBuilder {
                                 // simpler, because it means it doesn't have to be clever when
                                 // analysing a guard's live variables.
                                 match cond {
-                                    Operand::Var(cond_idx) if *cond_idx == liidx => {
+                                    Some(Operand::Var(cond_idx)) if *cond_idx == liidx => {
                                         let cidx = if expect {
                                             self.jit_mod.false_constidx()
                                         } else {
@@ -632,12 +654,17 @@ impl TraceBuilder {
         let gi = jit_ir::GuardInfo::new(bid.clone(), live_vars, callframes, safepoint.id);
         let gi_idx = self.jit_mod.push_guardinfo(gi)?;
 
+        if cond.is_none() {
+            // This is a deopt instruction which always fails and thus doesn't have a condition.
+            return Ok(jit_ir::Inst::Deopt(gi_idx));
+        }
+
         // Can we infer a constant from this?
         //
         // If this is a `guard true` and the condition is a `eq` with a constant, then we have
         // inferred a constant *after* the guard.
         if expect {
-            match cond {
+            match cond.unwrap() {
                 jit_ir::Operand::Var(iidx) => {
                     // Using `inst_nocopy()` here because `Inst::Const` can arise.
                     if let jit_ir::Inst::ICmp(icmp) = self.jit_mod.inst_nocopy(*iidx).unwrap()
@@ -650,11 +677,11 @@ impl TraceBuilder {
                         self.inferred_consts.insert(var_lhs, const_rhs);
                     }
                 }
-                jit_ir::Operand::Const(_) => todo!(),
+                jit_ir::Operand::Const(_) => (),
             };
         }
 
-        Ok(jit_ir::GuardInst::new(cond.clone(), expect, gi_idx))
+        Ok(jit_ir::GuardInst::new(cond.unwrap().clone(), expect, gi_idx).into())
     }
 
     /// Translate a conditional `Br` instruction.
@@ -667,8 +694,9 @@ impl TraceBuilder {
         true_bb: &aot_ir::BBlockIdx,
     ) -> Result<(), CompilationError> {
         let jit_cond = self.handle_operand(cond)?;
-        let guard = self.create_guard(bid, &jit_cond, *true_bb == next_bb.bbidx(), safepoint)?;
-        self.jit_mod.push(guard.into())?;
+        let guard =
+            self.create_guard(bid, Some(&jit_cond), *true_bb == next_bb.bbidx(), safepoint)?;
+        self.jit_mod.push(guard)?;
         Ok(())
     }
 
@@ -688,10 +716,25 @@ impl TraceBuilder {
             }
             Ok(())
         } else {
-            // We've returned out of the function that started tracing, which isn't allowed.
-            Err(CompilationError::General(
-                "returned from function that started tracing".into(),
-            ))
+            if let TraceKind::Sidetrace(_) = self.jit_mod.tracekind() {
+                // Even though we currently catch side-traces that leave the main interpreter loop
+                // in `mt.rs`, it can happen that a trace re-enters the main interpreter loop after
+                // leaving it briefly without encountering a non-null location. As we only check
+                // the frame addresses at non-null locations, this special case slips through and
+                // we have to handle it here.
+                // FIXME: Abort side-traces the same way we do normal traces by emitting a return
+                // instruction.
+                return Err(CompilationError::General(
+                    "Returning out of sidetrace currently unsupported.".into(),
+                ));
+            }
+            // We've returned out of the function that started tracing. Stop processing any
+            // remaining blocks and emit a return instruction that naturally returns from a
+            // compiled trace into the interpreter.
+            let safepoint = frame.safepoint.unwrap();
+            self.jit_mod.push(jit_ir::Inst::Return(safepoint.id))?;
+            self.process_mode = ProcessMode::Skip;
+            Ok(())
         }
     }
 
@@ -860,7 +903,6 @@ impl TraceBuilder {
 
         // Check if this is a recursive call by scanning the call stack for the callee.
         let is_recursive = self.frames.iter().any(|f| f.funcidx == Some(*callee));
-
         let func = self.aot_mod.func(*callee);
         if !func.is_declaration()
             && !func.is_outline()
@@ -898,6 +940,11 @@ impl TraceBuilder {
                 None, // Note: the `idem_const` field may be populated later.
             )?
             .into();
+            if self.frames.first().unwrap().funcidx == Some(*callee) {
+                // Store the block id and safepoint for the most recently seen recursive
+                // interpreter call.
+                self.last_interp_call = Some((bid.clone(), safepoint.unwrap()));
+            }
             self.copy_inst(inst, bid, aot_inst_idx)
         }
     }
@@ -1068,7 +1115,7 @@ impl TraceBuilder {
                 let jit_cond = self.jit_mod.push_and_make_operand(cmp_inst.into())?;
 
                 // Guard the result of the comparison.
-                self.create_guard(bid, &jit_cond, bb == next_bb.bbidx(), safepoint)?
+                self.create_guard(bid, Some(&jit_cond), bb == next_bb.bbidx(), safepoint)?
             }
             None => {
                 // If this assertion fails then the basic block that was executed next wasn't an
@@ -1123,10 +1170,10 @@ impl TraceBuilder {
                 // Guard the result of ORing all the comparisons together.
                 // unwrap can't fail: we already disregarded degenerate switches with no
                 // non-default cases.
-                self.create_guard(bid, &jit_cond.unwrap(), false, safepoint)?
+                self.create_guard(bid, Some(&jit_cond.unwrap()), false, safepoint)?
             }
         };
-        self.copy_inst(guard.into(), bid, aot_inst_idx)
+        self.copy_inst(guard, bid, aot_inst_idx)
     }
 
     fn handle_phi(
@@ -1272,8 +1319,8 @@ impl TraceBuilder {
                     jit_ir::Operand::Const(cidx),
                 );
                 let jit_cond = self.jit_mod.push_and_make_operand(cmp_instr.into())?;
-                let guard = self.create_guard(bid, &jit_cond, true, safepoint)?;
-                self.copy_inst(guard.into(), bid, aot_inst_idx)
+                let guard = self.create_guard(bid, Some(&jit_cond), true, safepoint)?;
+                self.copy_inst(guard, bid, aot_inst_idx)
             }
             jit_ir::Operand::Const(_cidx) => todo!(),
         }
@@ -1377,6 +1424,7 @@ impl TraceBuilder {
             Some(b) => self.lookup_aot_block(b),
             _ => todo!(),
         };
+
         let mut trace_iter = tas.into_iter().peekable();
 
         mt.stats.timing_state(TimingState::Compiling);
@@ -1476,7 +1524,10 @@ impl TraceBuilder {
         }
 
         match self.jit_mod.tracekind() {
-            TraceKind::HeaderOnly | TraceKind::HeaderAndBody | TraceKind::Connector(_) => {
+            TraceKind::HeaderOnly
+            | TraceKind::HeaderAndBody
+            | TraceKind::Connector(_)
+            | TraceKind::DifferentFrames => {
                 // Find the block containing the control point call. This is the (sole) predecessor of the
                 // first (guaranteed mappable) block in the trace. Note that empty traces are handled in
                 // the tracing phase so the `unwrap` is safe.
@@ -1553,6 +1604,9 @@ impl TraceBuilder {
                             // started outlining. We are done and can continue processing
                             // blocks normally.
                             self.outline_target_blk = None;
+                            // We've returned from the recursive interpreter call so this info is
+                            // no longer needed.
+                            self.last_interp_call = None;
                         } else {
                             // We are outlining so just skip this block. However, we still need to
                             // process promoted values to make sure we've processed all promotion
@@ -1585,7 +1639,11 @@ impl TraceBuilder {
                     // In order to emit guards for conditional branches we need to peek at the next
                     // block.
                     let nextbb = trace_iter.peek().and_then(|x| self.lookup_aot_block(x));
-                    self.process_block(&bid, &prev_bid, nextbb)?;
+                    if let ProcessMode::Skip = self.process_mode {
+                        self.process_promotions_and_debug_strs_only(&bid)?;
+                    } else {
+                        self.process_block(&bid, &prev_bid, nextbb)?;
+                    }
                     if self.cp_block.as_ref() == Some(&bid) {
                         // When using the hardware tracer we will see two control point
                         // blocks here. We must only process one of them. The simplest way
@@ -1616,7 +1674,8 @@ impl TraceBuilder {
 
         assert_eq!(self.promote_idx, self.promotions.len());
         assert_eq!(self.debug_str_idx, self.debug_strs.len());
-        let blk = self.aot_mod.bblock(self.cp_block.as_ref().unwrap());
+        let bid = self.cp_block.as_ref().unwrap();
+        let blk = self.aot_mod.bblock(bid);
         let cpcall = blk.insts.iter().rev().nth(1).unwrap();
         debug_assert!(cpcall.is_control_point(self.aot_mod));
         let safepoint = cpcall.safepoint().unwrap();
@@ -1625,17 +1684,38 @@ impl TraceBuilder {
             let jit_op = &self.local_map[&aot_op.to_inst_id()];
             self.jit_mod.push_header_end_var(jit_op.clone());
         }
-        match self.jit_mod.tracekind() {
+
+        let tracekind = self.jit_mod.tracekind();
+        match tracekind {
             TraceKind::HeaderOnly | TraceKind::HeaderAndBody => {
+                assert!(matches!(self.endframe, TraceEndFrame::Same));
                 self.jit_mod.push(jit_ir::Inst::TraceHeaderEnd(false))?;
             }
             TraceKind::Connector(_) => {
+                assert!(matches!(self.endframe, TraceEndFrame::Same));
                 self.jit_mod.push(jit_ir::Inst::TraceHeaderEnd(true))?;
             }
             TraceKind::Sidetrace(_) => {
+                assert!(matches!(self.endframe, TraceEndFrame::Same));
                 self.jit_mod.push(jit_ir::Inst::SidetraceEnd)?;
             }
-        }
+            TraceKind::DifferentFrames => {
+                if let TraceEndFrame::Entered = self.endframe {
+                    if let Some((bid, safepoint)) = &self.last_interp_call.take() {
+                        let deopt = self.create_guard(bid, None, false, safepoint)?;
+                        self.jit_mod.push(deopt)?;
+                    } else {
+                        // We traced a recursive call to the interpreter inside of another
+                        // outlined/unmappable function. Since these functions don't have
+                        // safepoints attached to them we currently can't emit the deopt. Thus, at
+                        // least for the time being, abort the trace.
+                        return Err(CompilationError::General(
+                            "Recursive interpreter call inside outlined function.".to_string(),
+                        ));
+                    }
+                }
+            }
+        };
 
         Ok(self.jit_mod)
     }
@@ -1661,13 +1741,22 @@ pub(super) fn build(
     promotions: Box<[u8]>,
     debug_strs: Vec<String>,
     connector_tid: Option<Arc<dyn CompiledTrace>>,
+    endframe: TraceEndFrame,
 ) -> Result<jit_ir::Module, CompilationError> {
-    let tracekind = if let Some(x) = sti {
-        TraceKind::Sidetrace(x)
-    } else if let Some(connector_tid) = connector_tid {
-        TraceKind::Connector(connector_tid)
-    } else {
-        TraceKind::HeaderOnly
+    let tracekind = match endframe {
+        TraceEndFrame::Same => {
+            if let Some(x) = sti {
+                TraceKind::Sidetrace(x)
+            } else if let Some(connector_tid) = connector_tid {
+                TraceKind::Connector(connector_tid)
+            } else {
+                TraceKind::HeaderOnly
+            }
+        }
+        TraceEndFrame::Entered | TraceEndFrame::Left => TraceKind::DifferentFrames,
     };
-    TraceBuilder::new(mt, tracekind, aot_mod, ctrid, promotions, debug_strs)?.build(mt, ta_iter)
+    TraceBuilder::new(
+        mt, tracekind, aot_mod, ctrid, promotions, debug_strs, endframe,
+    )?
+    .build(mt, ta_iter)
 }

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     mt::{MT, TraceId},
     trace::AOTTraceIterator,
 };
+use jitc_yk::jit_ir::TraceEndFrame;
 use libc::c_void;
 use parking_lot::Mutex;
 use std::{
@@ -51,6 +52,7 @@ pub(crate) trait Compiler: Send + Sync {
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
         connector_ctr: Option<Arc<dyn CompiledTrace>>,
+        endframe: TraceEndFrame,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 
     /// Compile a guard trace into machine code.
@@ -65,6 +67,7 @@ pub(crate) trait Compiler: Send + Sync {
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
         debug_strs: Vec<String>,
+        endframe: TraceEndFrame,
     ) -> Result<Arc<dyn CompiledTrace>, CompilationError>;
 }
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -21,7 +21,10 @@ use parking_lot_core::SpinWait;
 
 use crate::{
     aotsmp::{AOT_STACKMAPS, load_aot_stackmaps},
-    compile::{CompilationError, CompiledTrace, Compiler, GuardIdx, default_compiler},
+    compile::{
+        CompilationError, CompiledTrace, Compiler, GuardIdx, default_compiler,
+        jitc_yk::jit_ir::TraceEndFrame,
+    },
     job_queue::{Job, JobQueue},
     location::{HotLocation, HotLocationKind, Location, TraceFailed},
     log::{
@@ -231,6 +234,7 @@ impl MT {
         hl_arc: Arc<Mutex<HotLocation>>,
         trid: TraceId,
         connector_tid: Option<TraceId>,
+        endframe: TraceEndFrame,
     ) {
         self.stats.trace_recorded_ok();
 
@@ -251,6 +255,7 @@ impl MT {
                 trace_iter.1,
                 trace_iter.2,
                 connector_ctr,
+                endframe,
             ) {
                 Ok(ctr) => {
                     assert_eq!(ctr.ctrid(), trid);
@@ -337,6 +342,7 @@ impl MT {
         parent_ctr: Arc<dyn CompiledTrace>,
         gidx: GuardIdx,
         connector_tid: TraceId,
+        endframe: TraceEndFrame,
     ) {
         self.stats.trace_recorded_ok();
         let mt = Arc::clone(self);
@@ -361,6 +367,7 @@ impl MT {
                 Arc::clone(&hl_arc),
                 trace_iter.1,
                 trace_iter.2,
+                endframe,
             ) {
                 Ok(ctr) => {
                     assert_eq!(ctr.ctrid(), trid);
@@ -513,6 +520,7 @@ impl MT {
                             parent_ctr,
                             gidx,
                             connector_tid,
+                            TraceEndFrame::Same,
                         );
                         if start {
                             self.start_tracing(
@@ -622,7 +630,7 @@ impl MT {
     ) {
         // Assuming no bugs elsewhere, the `unwrap`s cannot fail, because `StartTracing`
         // will have put a `Some` in the `Rc`.
-        let (hl, thread_tracer, promotions, debug_strs) =
+        let (hl, thread_tracer, promotions, debug_strs, endframe) =
             MTThread::with_borrow_mut(|mtt| match mtt.pop_tstate() {
                 MTThreadState::Tracing {
                     trid: _,
@@ -636,8 +644,14 @@ impl MT {
                 } => {
                     // If this assert fails then the code in `transition_control_point`,
                     // which rejects traces that end in another frame, didn't work.
-                    assert_eq!(frameaddr, tracing_frameaddr);
-                    (hl, thread_tracer, promotions, debug_strs)
+                    let endframe = if frameaddr < tracing_frameaddr {
+                        TraceEndFrame::Entered
+                    } else if frameaddr > tracing_frameaddr {
+                        TraceEndFrame::Left
+                    } else {
+                        TraceEndFrame::Same
+                    };
+                    (hl, thread_tracer, promotions, debug_strs, endframe)
                 }
                 _ => unreachable!(),
             });
@@ -656,6 +670,7 @@ impl MT {
                     hl,
                     trid,
                     connector_tid,
+                    endframe,
                 );
             }
             Err(e) => {
@@ -817,20 +832,30 @@ impl MT {
         else {
             panic!()
         };
+        if frameaddr != *tracing_frameaddr {
+            // We traced into or out of a recursive interpreter call.
+            let mut lk = tracing_hl.lock();
+            match lk.kind {
+                HotLocationKind::Compiled(_)
+                | HotLocationKind::Compiling(_)
+                | HotLocationKind::Counting(_)
+                | HotLocationKind::DontTrace => (),
+                HotLocationKind::Tracing(trid) => {
+                    lk.kind = HotLocationKind::Compiling(trid);
+                    return TransitionControlPoint::StopTracing(trid, None);
+                }
+            }
+        }
 
         match loc.hot_location() {
             Some(hl) => {
                 let mut akind = None;
-                if !std::ptr::eq(frameaddr, *tracing_frameaddr) {
-                    // We're tracing but no longer in the frame we started in, so we
-                    // need to stop tracing and report the original [HotLocation] as
-                    // having failed to trace properly.
-                    akind = Some(AbortKind::OutOfFrame);
-                }
+                assert!(std::ptr::eq(frameaddr, *tracing_frameaddr));
 
                 if let Some(x) = loc.hot_location().map(|x| x as *const Mutex<HotLocation>)
                     && !seen_hls.insert(x)
                 {
+                    // We have traced this location more than once.
                     akind = Some(AbortKind::Unrolled);
                 }
 
@@ -870,7 +895,6 @@ impl MT {
                         };
                         drop(lk);
                         let mut lk = tracing_hl.lock();
-                        // let trid = self.next_trace_id();
                         lk.kind = HotLocationKind::Compiling(*tracing_trid);
                         TransitionControlPoint::StopTracing(*tracing_trid, Some(compiled_trid))
                     }
@@ -903,12 +927,7 @@ impl MT {
                     None => loc.hot_location().map(|x| x as *const Mutex<HotLocation>),
                 };
                 if let Some(hl_ptr) = hl_ptr {
-                    if !std::ptr::eq(frameaddr, *tracing_frameaddr) {
-                        // We're tracing but no longer in the frame we started in, so we
-                        // need to stop tracing and report the original [HotLocation] as
-                        // having failed to trace properly.
-                        return TransitionControlPoint::AbortTracing(AbortKind::OutOfFrame);
-                    }
+                    assert!(std::ptr::eq(frameaddr, *tracing_frameaddr));
                     if !seen_hls.insert(hl_ptr) {
                         return TransitionControlPoint::AbortTracing(AbortKind::Unrolled);
                     }
@@ -1070,14 +1089,33 @@ impl MT {
             match st {
                 MTThreadState::Interpreting => todo!(),
                 MTThreadState::Tracing {
-                    hl, thread_tracer, ..
+                    trid,
+                    hl,
+                    thread_tracer,
+                    gtrace,
+                    ..
                 } => {
                     let mut lk = hl.lock();
                     match &lk.kind {
-                        HotLocationKind::Compiled(_) => todo!(),
-                        HotLocationKind::Compiling(_) => todo!(),
-                        HotLocationKind::Counting(_) => todo!(),
-                        HotLocationKind::DontTrace => todo!(),
+                        HotLocationKind::Compiled(_) => {
+                            if let Some((parent_ctr, gidx)) = gtrace {
+                                // An inner trace has started side-tracing, then returned to the
+                                // outer trace, which deopts.
+                                let mt = Arc::clone(self);
+                                parent_ctr.guard(gidx).trace_or_compile_failed(&mt);
+                                mt.stats.trace_recorded_err();
+                                self.job_queue.notify_failure(self, trid);
+                            } else {
+                                todo!();
+                            }
+                        }
+                        HotLocationKind::Compiling(_) => {
+                            todo!();
+                        }
+                        HotLocationKind::Counting(_) => {
+                            todo!();
+                        }
+                        HotLocationKind::DontTrace => {}
                         HotLocationKind::Tracing(trid) => {
                             let trid = *trid;
                             match lk.tracecompilation_error(self) {


### PR DESCRIPTION
We currently quite often abort traces where the trace stopped tracing in a different frame than it started in. This happens when the interpreter calls itself recursively.

There's two cases for this:

1) Stop tracing after entering a recursive interpreter call. To compile
   such traces we outline anything following the recursive call, emit a
   call instruction, and deopt immediately upon returning from that
   call.

2) Stop tracing after returning from a recursive interpreter call. To
   compile these traces, we ignore any blocks following the return and
   emit a return instruction at the end of the trace. After restoring
   callee-saved registers and informing the meta-tracer that we exited
   the compiled trace, this naturally returns back into the interpeter.

There's some more things we could have done here, but there appear to be many corner cases and trying to implement these quickly exceeded the scope of this change:

1) By default recursive interpreter calls are outlined. In some traces
   we can get multiple recursive interpreter calls, which happens when
   the trace doesn't hit a non-null location within the recursion.
   Since, by definition, this means this call doesn't contain loops and
   is likely fairly small, it could be beneficial to inline these calls.

2) In order to detect a recursive interpreter call in trace-builder we
   need to be able to see the actual call in the IR. It can happen,
   however, that the call is hidden within an unmappable or outlined
   block. Not only does this make them difficult to detect, it also
   means these calls have no safepoints/stackmaps attached to them,
   which are required to emit the deopt at the end of the trace.

In terms of performance I couldn't measure any significant improvements or degradations and we still abort many traces. Hopefully, once we solve some of the other aborted traces, we will get some return of investment on this.