### PR TITLE
Rename `GuardIdx` to `GuardId`.

### DIFF
--- a/ykrt/src/compile/guard.rs
+++ b/ykrt/src/compile/guard.rs
@@ -75,12 +75,12 @@ impl Guard {
     /// directly into the parent trace.
     /// * `ctr`: The compiled side-trace.
     /// * `parent`: The immediate parent of the side-trace.
-    /// * `gidx`: The guard id of the side-trace.
+    /// * `gid`: The guard id of the side-trace.
     pub fn set_ctr(
         &self,
         ctr: Arc<dyn CompiledTrace>,
         parent: &Arc<dyn CompiledTrace>,
-        gidx: GuardIdx,
+        gid: GuardId,
     ) {
         let mut lk = self.kind.lock();
         let addr = ctr.entry();
@@ -92,24 +92,26 @@ impl Guard {
         // race condition. If we were to patch the parent trace first, there is a small window
         // where another thread takes the patched jump and deopts before we had a chance to call
         // `set_ctr` which sets information required by deopt.
-        parent.patch_guard(gidx, addr);
+        parent.patch_guard(gid, addr);
     }
 }
 
-/// Identify a [Guard] within a trace.
+/// Uniquely identify a [Guard] within a trace.
 ///
-/// This is guaranteed to be an index into an array that is freely convertible to/from [usize].
+/// The value contained in this ID has no specific semantics to the front-end: it is a token that
+/// compilers can interpret however they want provided they maintain the basic guarantee "this
+/// token uniquely identifies a guard within a given trace".
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct GuardIdx(usize);
+pub(crate) struct GuardId(usize);
 
-impl From<usize> for GuardIdx {
+impl From<usize> for GuardId {
     fn from(v: usize) -> Self {
         Self(v)
     }
 }
 
-impl From<GuardIdx> for usize {
-    fn from(v: GuardIdx) -> Self {
+impl From<GuardId> for usize {
+    fn from(v: GuardId) -> Self {
         v.0
     }
 }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -777,7 +777,7 @@ impl fmt::Display for DisplayableOperand<'_> {
             Operand::Local(iid) => {
                 write!(f, "%{}_{}", usize::from(iid.bbidx), usize::from(iid.iidx))
             }
-            Operand::Global(gidx) => write!(f, "@{}", self.m.global_decls[*gidx].name()),
+            Operand::Global(gid) => write!(f, "@{}", self.m.global_decls[*gid].name()),
             Operand::Func(fidx) => write!(f, "{}", self.m.funcs[*fidx].name()),
         }
     }

--- a/ykrt/src/compile/jitc_yk/codegen/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/mod.rs
@@ -30,7 +30,7 @@ pub(crate) trait CodeGen: Send + Sync {
     ///   defined in [super::YkSideTraceInfo::sp_offset].
     /// * `root_offset` - Stack pointer offset of the root trace as defined in
     ///   [super::YkSideTraceInfo::sp_offset].
-    /// * `prevguards` - List of [GuardIdx]'s of previous guards failures leading up to this trace.
+    /// * `prevguards` - List of [GuardId]'s of previous guards failures leading up to this trace.
     fn codegen(
         &self,
         m: Module,

--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -2208,7 +2208,7 @@ impl fmt::Display for DisplayableInst<'_> {
                     .join(", ");
                 write!(
                     f,
-                    "guard {}, {}, [{live_vars}] ; trace_gidx {gidx} safepoint_id {}",
+                    "guard {}, {}, [{live_vars}] ; trace_gid {gidx} safepoint_id {}",
                     if *expect { "true" } else { "false" },
                     cond.unpack(self.m).display(self.m),
                     gi.safepoint_id

--- a/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/parser.rs
@@ -213,7 +213,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                             ));
                             inst_off += 1;
                         }
-                        let gidx = self
+                        let gid = self
                             .m
                             .push_guardinfo(GuardInfo::new(
                                 aot_ir::BBlockId::new(0.into(), 0.into()),
@@ -222,7 +222,7 @@ impl<'lexer, 'input: 'lexer> JITIRParser<'lexer, 'input, '_> {
                                 0,
                             ))
                             .unwrap();
-                        let inst = GuardInst::new(self.process_operand(cond)?, is_true, gidx);
+                        let inst = GuardInst::new(self.process_operand(cond)?, is_true, gid);
                         self.m.push(inst.into()).unwrap();
                     }
                     ASTInst::ICall {

--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -2,7 +2,7 @@
 
 use super::CompilationError;
 use crate::{
-    compile::{CompiledTrace, Compiler, GuardIdx, jitc_yk::codegen::CodeGen},
+    compile::{CompiledTrace, Compiler, GuardId, jitc_yk::codegen::CodeGen},
     location::HotLocation,
     log::{IRPhase, log_ir, should_log_ir},
     mt::{MT, TraceId},
@@ -218,7 +218,7 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
         aottrace_iter: Box<dyn AOTTraceIterator>,
         ctrid: TraceId,
         parent_ctr: Arc<dyn CompiledTrace>,
-        gidx: GuardIdx,
+        gid: GuardId,
         target_ctr: Arc<dyn CompiledTrace>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
@@ -228,7 +228,7 @@ impl<Register: Send + Sync + 'static> Compiler for JITCYk<Register> {
             .as_any()
             .downcast::<codegen::x64::X64CompiledTrace>()
             .unwrap();
-        let sti = parent_ctr.sidetraceinfo(gidx, Arc::clone(&target_ctr));
+        let sti = parent_ctr.sidetraceinfo(gid, Arc::clone(&target_ctr));
         self.compile(
             mt,
             aottrace_iter,

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -14,7 +14,7 @@ use std::{
 use thiserror::Error;
 
 pub(crate) mod guard;
-pub(crate) use guard::{Guard, GuardIdx};
+pub(crate) use guard::{Guard, GuardId};
 #[cfg(jitc_yk)]
 pub mod jitc_yk;
 
@@ -60,7 +60,7 @@ pub(crate) trait Compiler: Send + Sync {
         aottrace_iter: Box<dyn AOTTraceIterator>,
         ctrid: TraceId,
         parent_ctr: Arc<dyn CompiledTrace>,
-        gidx: GuardIdx,
+        gid: GuardId,
         target_ctr: Arc<dyn CompiledTrace>,
         hl: Arc<Mutex<HotLocation>>,
         promotions: Box<[u8]>,
@@ -89,9 +89,9 @@ pub(crate) trait CompiledTrace: fmt::Debug + Send + Sync {
     fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static>;
 
     /// Return a reference to the guard `id`.
-    fn guard(&self, gidx: GuardIdx) -> &Guard;
+    fn guard(&self, gid: GuardId) -> &Guard;
 
-    fn patch_guard(&self, gidx: GuardIdx, target: *const std::ffi::c_void);
+    fn patch_guard(&self, gid: GuardId, target: *const std::ffi::c_void);
 
     /// The pointer to this trace's executable code.
     fn entry(&self) -> *const c_void;
@@ -139,11 +139,11 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn guard(&self, _gidx: GuardIdx) -> &Guard {
+        fn guard(&self, _gid: GuardId) -> &Guard {
             panic!();
         }
 
-        fn patch_guard(&self, _gidx: GuardIdx, _target: *const std::ffi::c_void) {
+        fn patch_guard(&self, _gid: GuardId, _target: *const std::ffi::c_void) {
             panic!();
         }
 
@@ -194,12 +194,12 @@ mod compiled_trace_testing {
             panic!();
         }
 
-        fn guard(&self, gidx: GuardIdx) -> &Guard {
-            assert_eq!(usize::from(gidx), 0);
+        fn guard(&self, gid: GuardId) -> &Guard {
+            assert_eq!(usize::from(gid), 0);
             &self.guard
         }
 
-        fn patch_guard(&self, _gidx: GuardIdx, _target: *const std::ffi::c_void) {
+        fn patch_guard(&self, _gid: GuardId, _target: *const std::ffi::c_void) {
             panic!();
         }
 


### PR DESCRIPTION
This struct sits outside a specific compiler, and there's no reason that we need to force it to be an index.

I did toy with making this a `trait`. That would allow each compiler to hide its preferred notion of "guard ID" more completely but (a) we'd then have to `Box` guard IDs which, though infrequent, still feels a bit wasteful (b) each compiler would have to `downcast` the result, which always feels a bit icky.

In that sense, "guard ID as `usize`" is a pragmatic compromise. It's efficient and flexible (a compiler could stuff a pointer in it!), even if it doesn't quite integrate with the type checker in a way that I might ideally like.