### PR TITLE
Remove field that's always empty.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/mod.rs
@@ -1493,8 +1493,6 @@ pub(crate) struct InlinedFrame {
     pub(crate) funcidx: aot_ir::FuncIdx,
     /// The deopt safepoint for [callinst].
     pub(crate) safepoint: &'static aot_ir::DeoptSafepoint,
-    /// The [Operand]s passed to [funcidx].
-    pub(crate) args: Vec<PackedOperand>,
 }
 
 impl InlinedFrame {
@@ -1502,13 +1500,11 @@ impl InlinedFrame {
         callinst: Option<aot_ir::InstId>,
         funcidx: aot_ir::FuncIdx,
         safepoint: &'static aot_ir::DeoptSafepoint,
-        args: Vec<Operand>,
     ) -> InlinedFrame {
         InlinedFrame {
             callinst,
             funcidx,
             safepoint,
-            args: args.iter().map(PackedOperand::new).collect::<Vec<_>>(),
         }
     }
 }
@@ -1883,17 +1879,7 @@ impl Inst {
                 let inlined_frames = ginfo
                     .inlined_frames()
                     .iter()
-                    .map(|x| {
-                        InlinedFrame::new(
-                            x.callinst.clone(),
-                            x.funcidx,
-                            x.safepoint,
-                            x.args
-                                .iter()
-                                .map(|x| op_mapper(m, &x.unpack(m)))
-                                .collect::<Vec<_>>(),
-                        )
-                    })
+                    .map(|x| InlinedFrame::new(x.callinst.clone(), x.funcidx, x.safepoint))
                     .collect::<Vec<_>>();
                 let newginfo = GuardInfo::new(
                     ginfo.bid().clone(),

--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -565,9 +565,6 @@ impl TraceBuilder {
                 frame.callinst.clone(),
                 frame.funcidx.unwrap(),
                 frame.safepoint.unwrap(),
-                // We don't need to copy the arguments since they are only required for LoadArg
-                // instructions which we won't see at the beginning of a sidetrace.
-                Vec::new(),
             ));
 
             // Collect live variables.
@@ -1419,7 +1416,9 @@ impl TraceBuilder {
                     funcidx: Some(x.funcidx),
                     callinst: x.callinst.clone(),
                     safepoint: Some(x.safepoint),
-                    args: x.args.clone(),
+                    // We don't need to copy the arguments since they are only required for LoadArg
+                    // instructions which we won't see at the beginning of a sidetrace.
+                    args: vec![],
                 })
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
`jit_ir/mod.rs` and `trace_builder.rs` both have similar (but different!) structs called `InlinedFrame`. The former is used to transmit data between the compilation of different traces, but -- as a comment below shows -- side-traces can never use the `args` of a frame inlined before the start of the side trace.

This commit removes the `args` field from `jir_ir::InlinedFrame`, and explicitly comments -- in the right place I believe! -- that when we copy such frames over to `trace_builder` that `args` can safely be set to the empty list.