### PR TITLE
Reduce the control point's overhead.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -458,9 +458,6 @@ impl MT {
                     });
                 });
                 self.stats.timing_state(TimingState::JitExecuting);
-
-                // FIXME: Calling this function overwrites the current (Rust) function frame,
-                // rather than unwinding it. https://github.com/ykjit/yk/issues/778.
                 unsafe { __yk_exec_trace(frameaddr, rsp, trace_addr) };
             }
             TransitionControlPoint::StartTracing(hl, trid) => {
@@ -1164,32 +1161,10 @@ unsafe extern "C" fn __yk_exec_trace(
     frameaddr: *const c_void,
     rsp: *const c_void,
     trace: *const c_void,
-) -> ! {
+) {
     std::arch::naked_asm!(
-        // Reset RBP
-        "mov rbp, rdi",
-        // Reset RSP to the end of the control point frame (this includes the registers we pushed
-        // just before the control point)
-        "mov rsp, rsi",
-        "sub rsp, 8",   // Return address of control point call
-        "sub rsp, 104", // Registers pushed in naked cp call (includes alignment)
-        // Restore registers which were pushed to the stack in [ykcapi::__ykrt_control_point].
-        "pop r15",
-        "pop r14",
-        "pop r13",
-        "pop r12",
-        "pop r11",
-        "pop r10",
-        "pop r9",
-        "pop r8",
-        "pop rsi",
-        "pop rdi",
-        "pop rbx",
-        "pop rcx",
-        "pop rax",
-        "add rsp, 8", // Remove return pointer
-        // Call the trace function.
-        "jmp rdx",
+        // Write trace address over the return address of the control point call.
+        "mov [rsi-8], rdx",
         "ret",
     )
 }


### PR DESCRIPTION
Every time we call the control point (which is on each interpreter loop iteration) we currently need to push and pop a lot of registers. This is quite expensive, especially when the location is null and we return from the control point call immediately.

The reason we do this because we execute compiled traces in the interpreter frame and the compiled trace expects live values to live in certain registers as specified by the stackmap accompanying the control point. This makes it necessary to reset the interpreter (i.e. live values in registers) to the state just before the control point was called.

To avoid having to do these pushes and pops, we need to work around two register types:

1) Callee-saved registers. Currently, when executing a trace we jump
   into the trace from within the control point, immediately after
   hard-resetting the stack. This means callee-saved registers are not
   restored by the control points epilogue. We can fix this, but
   overwriting the control points return address with the address of the
   trace we want to execute. As a bonus this solves long-standing worry
   we had about not properly returning from Rust functions which may
   have repercussions due to drop methods not being executed.

2) Caller-saved registers. Even though we are now returning normally from the control
   point, this does not help for caller-saved registers which are
   restored upon returning to the interpreter. This does not happen when
   we instead jump to a trace. However, we know that any live value that
   is stored in a caller-saved register needs to have been spilled. We
   can use this to replace all caller-saved registers in the trace's
   input params with their spill location, thus no longer depending on
   these registers having the correct value.

Performance-wise this gives us a juice 7% on Richards, Bounce, and LuLPeg, and 5% on Queens. There's some 4% improvements but they may or may not be noise.

On the other end we get a 5% slowdown on Bigloop. I could not find a satisfying explanation for this. We seem to be spending an extra 0.5s running traces (7.7s vs 8.2s), though apart from an extra `nop` in the loop body I can't see a good reason for the slowdown (maybe alignment?). There's also some extra moves and `nop`s in the header and deopt routines, but those shouldn't have an observable effect as they are only executed once.