### PR TITLE
Prevent infinite stall in `wait_until`.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -169,6 +169,13 @@ impl MT {
         }
     }
 
+    /// Check the integrity of the job queue: if any job queue thread has panicked, this function
+    /// will itself panic. This should only be used for testing purposes.
+    #[cfg(feature = "yk_testing")]
+    pub(crate) fn check_job_queue_integrity(&self) {
+        self.job_queue.check_integrity();
+    }
+
     /// Return this `MT` instance's current hot threshold. Notice that this value can be changed by
     /// other threads and is thus potentially stale as soon as it is read.
     pub fn hot_threshold(self: &Arc<Self>) -> HotThreshold {


### PR DESCRIPTION
`wait_until` allows us to write tests that wait until some property has been achieved (e.g. "wait until two traces have been compiled"). However, if a worker (e.g. compiler) thread dies, the property will never be met, and `wait_until` stalls indefinitely.

I've long since found this stalling frustrating, but it happened just infrequently enough that I didn't track down the cause. With j2, in its embryonic status, "worker thread dies and stalls `wait_until`" is (and will be for some time) rather common.

This commit addresses this by having `wait_until` occasionally poll the job queue: if a thread has finished and `join` fails, it means that thread has died unexpectedly. That causes `wait_until` itself to panic. If multiple threads are `wait_until`ing this should naturally percolate to all of them (we have no such test yet, so this is a theory rather than a guarantee!).