### PR TITLE
Optimise lookup_aot_block().

### DIFF
--- a/ykrt/src/compile/jitc_yk/trace_builder.rs
+++ b/ykrt/src/compile/jitc_yk/trace_builder.rs
@@ -116,7 +116,6 @@ impl TraceBuilder {
     fn lookup_aot_block(&self, tb: &TraceAction) -> Option<aot_ir::BBlockId> {
         match tb {
             TraceAction::MappedAOTBBlock { func_name, bb } => {
-                let func_name = func_name.to_str().unwrap(); // safe: func names are valid UTF-8.
                 let func = self.aot_mod.funcidx(func_name);
                 if !self.aot_mod.func(func).is_declaration() {
                     Some(aot_ir::BBlockId::new(func, aot_ir::BBlockIdx::new(*bb)))
@@ -830,9 +829,7 @@ impl TraceBuilder {
                 // Find the function the constant pointer is referring to.
                 let dli = ykaddr::addr::dladdr(*vaddr).unwrap();
                 assert_eq!(dli.dli_saddr(), *vaddr);
-                let callee = self
-                    .aot_mod
-                    .funcidx(dli.dli_sname().unwrap().to_str().unwrap());
+                let callee = self.aot_mod.funcidx(dli.dli_sname().unwrap());
                 return self.direct_call_impl(
                     bid,
                     aot_inst_idx,


### PR DESCRIPTION
perf identifies lookup_aot_block() as one of the main costs of the tracebuilder when running the CD benchmark.

This function is very hot (called once per block in the collected trace). In turn we call Module::funcidx() whose job it is to find a named function's index. It does this by looping over the functions of the module doing string comparisons.

This change adds a function index cache to avoid the looping and string comparisons. While we are here, we can avoid some related string conversions too.

Performance change summary (for the CD benchmark):
 - Same number of traces compiled.
 - Half the compilation time.

Typical stats change:
```
-Total Runtime: 76711711us
+Total Runtime: 76719054us
 {
-    "duration_compiling": 34.721,
-    "duration_deopting": 0.408,
-    "duration_jit_executing": 69.668,
-    "duration_outside_yk": 5.612,
-    "duration_trace_mapping": 5.427,
-    "duration_tracing": 1.014,
-    "trace_executions": 290238,
+    "duration_compiling": 15.444,
+    "duration_deopting": 0.411,
+    "duration_jit_executing": 69.906,
+    "duration_outside_yk": 5.473,
+    "duration_trace_mapping": 5.424,
+    "duration_tracing": 0.917,
+    "trace_executions": 293291,
     "traces_compiled_err": 0,
     "traces_compiled_ok": 975,
     "traces_recorded_err": 6,
     "traces_recorded_ok": 981
 }
 ```