### PR TITLE
Fix tests for non-standard cargo profiles.

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -16,9 +16,7 @@ pub fn main() {
     // Expose the cargo profile to run.rs so that it can set the right link flags.
     let profile = env::var("PROFILE").unwrap();
     println!("cargo::rustc-cfg=cargo_profile=\"{profile}\"");
-    println!(
-        r#"cargo::rustc-check-cfg=cfg(cargo_profile, values("debug", "release", "release-with-debug"))"#
-    );
+    println!(r#"cargo::rustc-check-cfg=cfg(cargo_profile, values("debug", "release"))"#);
 
     println!("cargo::rerun-if-env-changed=YKB_TRACER");
     println!("cargo::rustc-check-cfg=cfg(tracer_hwt)");

--- a/tests/langtest_ir_lowering.rs
+++ b/tests/langtest_ir_lowering.rs
@@ -4,6 +4,7 @@ use lang_tester::LangTester;
 use regex::Regex;
 use std::{env, fs::read_to_string, path::PathBuf, process::Command};
 use tempfile::TempDir;
+use tests::full_cargo_profile;
 use ykbuild::ykllvm_bin;
 
 const COMMENT: &str = ";";
@@ -44,11 +45,8 @@ fn main() {
             ]);
 
             let md = env::var("CARGO_MANIFEST_DIR").unwrap();
-            #[cfg(cargo_profile = "debug")]
-            let build_kind = "debug";
-            #[cfg(cargo_profile = "release")]
-            let build_kind = "release";
-            let dumper_path = [&md, "..", "target", build_kind, "dump_ir"]
+            let profile = full_cargo_profile();
+            let dumper_path = [&md, "..", "target", &profile, "dump_ir"]
                 .iter()
                 .collect::<PathBuf>();
             let mut dumper = Command::new(dumper_path);

--- a/tests/langtest_lua.rs
+++ b/tests/langtest_lua.rs
@@ -22,6 +22,7 @@ mod inner {
         path::Path,
         process::{Command, exit},
     };
+    use tests::full_cargo_profile;
     use ykbuild::{target_dir, ykllvm_bin_dir};
 
     const YKLUA_SUBMODULE_PATH: &str = "yklua";
@@ -39,11 +40,6 @@ mod inner {
             );
         }
 
-        // Set variables for tests `ignore-if`s.
-        #[cfg(cargo_profile = "debug")]
-        let profile = "debug";
-        #[cfg(cargo_profile = "release")]
-        let profile = "release";
         let mut yklua_tgt_dir = target_dir();
         yklua_tgt_dir.push("yklua");
         create_dir_all(&yklua_tgt_dir).unwrap();
@@ -103,6 +99,7 @@ mod inner {
         // Because `make` is so quick, we can afford to run it every time this file is run -- if
         // there's nothing to do, it'll finish quicker than we can notice!
         let mut make_cmd = Command::new("make");
+        let profile = full_cargo_profile();
         make_cmd
             .args([
                 "-j".into(),


### PR DESCRIPTION
I wanted to see if running the test suite with `--profile release-with-asserts` would shake out any "easy to fix" unsoundness, but currently running tests with a non "debug" or "release" cargo profile will lead to linker errors like:

```
ld.lld: error: unable to find library -lykcapi
```

This is because we compute the linker path from cargo's `PROFILE` environment, which can only contain "release" or "debug", but when you build with a non-standard profile, the linker path is neither of those.

From the Cargo docs:

> PROFILE -- "release" for release builds, "debug" for other builds.

https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

(Confusingly, if you build with `--profile release-with-debug`, then `PROFILE` will be "release")

This change fixes running the tests with non-standard cargo profiles by computing the linker path from the target sub-directory.