### PR TITLE
Convert a todo! to a FIXME in the trace optimiser.

### DIFF
--- a/ykrt/src/compile/jitc_yk/opt/analyse.rs
+++ b/ykrt/src/compile/jitc_yk/opt/analyse.rs
@@ -69,8 +69,7 @@ impl Analyse {
                         if let (&Operand::Const(_lhs_cidx), &Operand::Const(_rhs_cidx)) =
                             (&lhs, &rhs)
                         {
-                            // Can we still hit this case?
-                            todo!();
+                            // FIXME: implement the optimisation.
                         }
                     }
                     op


### PR DESCRIPTION
This scenario can indeed happen. I've just seen it with the Lua tests with the "really long trace" fix that's pending to merge.

Required for https://github.com/ykjit/yklua/pull/129