### PR TITLE
Fix optimisation of xor on identical operands.

### DIFF
--- a/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
+++ b/ykrt/src/compile/jitc_yk/jit_ir/well_formed.rs
@@ -729,6 +729,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Binop result type incorrect for one or more operands")]
+    fn binop_wrong_result_type() {
+        Module::from_str(
+            "
+              entry:
+                %0: i32 = param reg
+                %1: i1 = xor %0, %0
+            ",
+        );
+    }
+
+    #[test]
     #[should_panic(
         expected = "Param instruction may only appear at the beginning of a trace or after another Param instruction"
     )]

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -612,8 +612,15 @@ impl Opt {
                     }
                 }
                 (Operand::Var(lhs_iidx), Operand::Var(rhs_iidx)) => {
+                    // If the operands are the same, then the result is always a zero.
                     if lhs_iidx == rhs_iidx {
-                        self.m.replace(iidx, Inst::Const(self.m.false_constidx()));
+                        let tyidx = inst.tyidx(&self.m);
+                        let cst = Const::Int(
+                            tyidx,
+                            ArbBitInt::from_u64(self.m.type_(tyidx).bitw().unwrap(), 0),
+                        );
+                        let cidx = self.m.insert_const(cst)?;
+                        self.m.replace(iidx, Inst::Const(cidx));
                     }
                 }
             },
@@ -1808,7 +1815,7 @@ mod test {
           ...
           entry:
             %0: i8 = param ...
-            black_box 0i1
+            black_box 0i8
         ",
         );
     }


### PR DESCRIPTION
Currently:

```
%0: i8 = ...
%1: i8 = xor %0, %0
```

is optimised to:

```
%1: i1 = 0i1
```

i.e. the type is always i1, which isn't right.

(this fixes one problem with https://github.com/ykjit/yklua/pull/129, but looks like there may be one more)