### PR TITLE
Better error messages and non-fatal gdb errors.

### DIFF
--- a/ykrt/src/compile/jitc_yk/gdb.rs
+++ b/ykrt/src/compile/jitc_yk/gdb.rs
@@ -183,7 +183,7 @@ pub(crate) fn register_jitted_code(
     // Write the comment lines out to a "source code file" that we want gdb to show lines from. As
     // we do this, we also build a mapping from virtual addresses to line numbers.
     let mut src_file = NamedTempFile::new()
-        .map_err(|_| CompilationError::InternalError("failed to create gdb src_file".into()))?;
+        .map_err(|e| CompilationError::General(format!("failed to create gdb src_file: {e}")))?;
     let mut lineinfos = Vec::new();
     let mut line_num = 1;
     let code_vaddr = jitted_code as usize;
@@ -193,8 +193,8 @@ pub(crate) fn register_jitted_code(
             vaddr: code_vaddr + off,
         });
         for line in lines {
-            writeln!(src_file, "{line}").map_err(|_| {
-                CompilationError::InternalError("failed to write into gdb src_file".into())
+            writeln!(src_file, "{line}").map_err(|e| {
+                CompilationError::General(format!("failed to write into gdb src_file: {e}"))
             })?;
             line_num += 1;
         }
@@ -202,7 +202,7 @@ pub(crate) fn register_jitted_code(
     // Ensure the source file is fully-written before gdb can read it.
     src_file
         .flush()
-        .map_err(|_| CompilationError::InternalError("failed to flush gdb src_file".into()))?;
+        .map_err(|e| CompilationError::General(format!("failed to flush gdb src_file: {e}")))?;
 
     // Build the symbol file we are going to give to gdb.
     //


### PR DESCRIPTION
I've noticed that if you run some larger Lua programs under yklua with debug assertions enabled, the gdb support code can crash due to maxing out the file descriptor ulimit.

The reason for this is that, in debug mode, each trace writes textual IR into a temp file so that gdb can show it in the source view. This makes debugging JITted code a bit easier.

By default, Linux allows any given process to have 1024 fds, so it's not too hard to max it out with gdb temp files.

This change:

 - Gives more specific error messages, so that you can see the underlying reason for the crash, and in the event of "too many open files" consider upping your `ulimit -n`.

 - Makes failure to write a gdb source file non-fatal. i.e. trace compilation is aborted, instead of the entire program crashing. An interested user can use YKD_LOG=3 to see why the trace was aborted.

Note that this is only ever an issue for debug builds of yk. gdb support isn't built-in to release builds.