### PR TITLE
Reliably detecting longjmp (again).

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -108,6 +108,8 @@ handle_arg() {
             else
                 # SWT-specific flags.
                 OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-basicblock-tracer"
+                # Wrap longjmp so we can detect it.
+                OUTPUT="${OUTPUT} -Wl,--wrap=longjmp"
                 # Experimental module cloning support.
                 if [ "${YKB_SWTMODCLONE}" = "1" ]; then
                     OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-module-clone"

--- a/tests/c/longjmp_from_foreign_into_trace1.c
+++ b/tests/c/longjmp_from_foreign_into_trace1.c
@@ -5,8 +5,7 @@
 //   stderr:
 //     yk-tracing: start-tracing
 //     we jumped
-//     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: irregular control flow detected
+//     yk-warning: stop-tracing-aborted: traced longjmp
 //     ...
 
 // Tests that we can deal with setjmp/longjmp when we jump from foreign code

--- a/tests/c/longjmp_from_foreign_into_trace2.c
+++ b/tests/c/longjmp_from_foreign_into_trace2.c
@@ -5,8 +5,7 @@
 //   stderr:
 //     yk-tracing: start-tracing
 //     we jumped
-//     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: irregular control flow detected
+//     yk-warning: stop-tracing-aborted: traced longjmp
 //     we jumped
 //     exit
 //     ...

--- a/tests/c/longjmp_problem.c
+++ b/tests/c/longjmp_problem.c
@@ -1,0 +1,107 @@
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG_IR=jit-pre-opt
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define ITERS 5
+
+#define G_LONGJMP     1
+#define G_CALL_DEEPER 2
+
+jmp_buf buf;
+
+void g(int x) {
+  if (x == G_LONGJMP) {
+    fprintf(stderr, "I'm in g via a longjump\n");
+  } else {
+    fprintf(stderr, "I'm in g via calling deeper\n");
+  }
+}
+
+// This function is opaque to the JIT.
+__attribute__((noinline, yk_outline))
+void maybe_hidden_longjump(int x) {
+  fprintf(stderr, "%s: x=%d\n", __func__, x);
+  if (x == 4) {
+    // Jumps to main(), unwinding the interpreter loop, but leaving the JIT
+    // state intact (i.e. still tracing).
+    longjmp(buf, G_LONGJMP);
+  } else {
+    g(G_CALL_DEEPER);
+  }
+}
+
+void loop(YkMT *mt, YkLocation *loc, int i) {
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    fprintf(stderr, "in interp loop: i=%d\n", i);
+    yk_mt_control_point(mt, loc);
+    // We are about to call to an opaque (to the JIT) function.
+    //
+    // Generally speaking, one of three things can happen. Either:
+    //
+    //  1. the opaque callee returns normally, without calling back to any
+    //  non-opaque code,  and without any longjmp, thus the next block SWT
+    //  sees is the one after the call. In this case, we'd see the `i--`
+    //  block next.
+    //
+    //  2. the opaque callee at some point calls a non-opaque function, in which
+    //    case the next block SWT sees is the entry block to that function.
+    //
+    //  3. the opaque callee calls longjmp at some point, in which case we
+    //  **might** be able to detect it: if the next block SWT sees is neither
+    //  the `i--` block, nor an function entry block.
+    //
+    // But for this test, we have a scenario where the callee longjumps to
+    // another opaque function further up the stack which then calls the
+    // non-opaque function g(), so the next block SWT sees is the entry block
+    // to g().
+    //
+    // The problem is that there is now ambiguity for cases 2 and 3 above.
+    // The next block SWT will see is the entry block to g(), but there are two
+    // ways to reach that successor: via calling deeper to g(), or via a
+    // longjmp to g() (via main()).
+    //
+    // As it stands, the JIT assumes that the entry block to g() is a deeper
+    // call to g(). It doesn't realise that a longjmp can happen and this
+    // manifests as miscompilation. If you disable the JIT (by setting a high
+    // hot threshold) this is a terminating test, but with the JIT enabled we
+    // compile an infinite loop.
+    //
+    // Maybe we can fix this by checking the stack depth when encounter the
+    // entry point to a function?
+    maybe_hidden_longjump(i);
+    i--;
+  }
+
+}
+
+// This function is also opaque to the JIT.
+__attribute__((noinline, yk_outline))
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int r = setjmp(buf);
+  if (r == 0) {
+    loop(mt, &loc, 4);
+  } else {
+    fprintf(stderr, "longjumped %d!\n", r);
+    g(r);
+    loop(mt, &loc, 3);
+  }
+
+  fprintf(stderr, "exit");
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/longjmp_within_trace_confines.c
+++ b/tests/c/longjmp_within_trace_confines.c
@@ -10,8 +10,7 @@
 //     i=2
 //     after setjmp
 //     after setjmp
-//     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: ...
+//     yk-warning: stop-tracing-aborted: traced longjmp
 //     i=1
 //     after setjmp
 //     after setjmp

--- a/tests/c/shadow_longjmp.c
+++ b/tests/c/shadow_longjmp.c
@@ -1,5 +1,5 @@
 // Run-time:
-//   env-var: YKD_LOG_IR=aot,jit-pre-opt
+//   env-var: YKD_LOG_IR=aot
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=3
 //   stderr:

--- a/tests/c/unmapped_setjmp.c
+++ b/tests/c/unmapped_setjmp.c
@@ -1,7 +1,6 @@
 // ## FIXME: PT IP filtering means we can't reliably detect longjmp() in
 // ##        external code.
-// ## FIXME: Implement setjmp/longjmp detection for swt.
-// ignore-if: true || test "$YKB_TRACER" = "swt"
+// ignore-if: test "$YKB_TRACER" != "swt"
 // Run-time:
 //   env-var: YKD_SERIALISE_COMPILATION=1
 //   env-var: YKD_LOG=3
@@ -9,8 +8,7 @@
 //     yk-tracing: start-tracing
 //     set jump point
 //     jumped!
-//     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: longjmp encountered
+//     yk-warning: stop-tracing-aborted: traced longjmp
 //     ...
 
 // Check that we bork on a call to setjmp in unmapped code.

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -66,6 +66,9 @@ pub enum TraceRecorderError {
     #[error("{0}")]
     #[allow(dead_code)]
     TraceBufferOverflow(String),
+    /// We can't use this trace.
+    #[error("{0}")]
+    TraceInvalid(String),
 }
 
 /// An iterator which [TraceRecord]s use to process a trace into [TraceAction]s. The iterator must

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -4,6 +4,7 @@ use super::{
     AOTTraceIterator, AOTTraceIteratorError, TraceAction, TraceRecorder, TraceRecorderError, Tracer,
 };
 use crate::mt::MTThread;
+use libc;
 use std::{cell::RefCell, error::Error, sync::Arc};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -12,9 +13,61 @@ struct TracingBBlock {
     block_index: usize,
 }
 
+enum SWTBuf {
+    Blocks(Vec<TracingBBlock>),
+    Invalid(String),
+}
+
+impl SWTBuf {
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Blocks(bs) if bs.is_empty())
+    }
+}
+
 thread_local! {
     // Collection of traced basic blocks.
-    static BASIC_BLOCKS: RefCell<Vec<TracingBBlock>> = const { RefCell::new(vec![]) };
+    static BASIC_BLOCKS: RefCell<SWTBuf> = const { RefCell::new(SWTBuf::Blocks(Vec::new())) };
+}
+
+/// Rust's `libc` crate does not expose any of the longjmp-related bits, so we have to define it
+/// ourselves. The exact implementation is very platform specific.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+type JmpBuf = [u64; 8];
+
+unsafe extern "C" {
+    fn longjmp(env: *mut JmpBuf, val: libc::c_int) -> !;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __wrap_longjmp(env: *mut JmpBuf, val: libc::c_int) -> ! {
+    {
+        if MTThread::is_tracing() {
+            BASIC_BLOCKS.with(|v| {
+                let mut v = v.borrow_mut();
+                match &mut *v {
+                    vv @ SWTBuf::Blocks(_) => {
+                        // Invalidate the SWT buffer.
+                        *vv = SWTBuf::Invalid("traced longjmp".into());
+                    }
+                    SWTBuf::Invalid(_) => (), // Buffer already invalid.
+                }
+                drop(v);
+            })
+        }
+    } // Extra scope to be really sure that everything inside is dropped.
+
+    // In general you have to be careful when using setjmp/longjmp from Rust:
+    // https://github.com/rust-lang/rfcs/issues/2625
+    //
+    // We don't call setjmp from Rust, so those concerns can be shelved.
+    //
+    // What remains is that, we have to ensure that as a result of longjmp, no Rust drop methods
+    // could be skipped, and no borrow checking rules could be violated.
+    //
+    // Since this is the only Rust frame between now and the C code we will jump to, we only have
+    // to reason about this wrapper function. Above I've explicitely dropped anything that needs
+    // it, and ensured that no borrows are outstanding at the time of the longjmp.
+    unsafe { longjmp(env, val) }
 }
 
 /// Inserts LLVM IR basicblock metadata into a thread-local BASIC_BLOCKS vector.
@@ -26,11 +79,12 @@ thread_local! {
 #[unsafe(no_mangle)]
 pub extern "C" fn __yk_trace_basicblock(function_index: usize, block_index: usize) {
     if MTThread::is_tracing() {
-        BASIC_BLOCKS.with(|v| {
-            v.borrow_mut().push(TracingBBlock {
+        BASIC_BLOCKS.with(|v| match &mut *v.borrow_mut() {
+            SWTBuf::Blocks(bs) => bs.push(TracingBBlock {
                 function_index,
                 block_index,
-            });
+            }),
+            SWTBuf::Invalid(_) => (),
         })
     }
 }
@@ -55,12 +109,17 @@ struct SWTTraceRecorder {}
 
 impl TraceRecorder for SWTTraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, TraceRecorderError> {
-        let bbs = BASIC_BLOCKS.with(|tb| tb.replace(Vec::new()));
-        if bbs.is_empty() {
-            // FIXME: who should handle an empty trace?
-            panic!();
-        } else {
-            Ok(Box::new(SWTraceIterator::new(bbs)))
+        let bbs = BASIC_BLOCKS.with(|tb| tb.replace(SWTBuf::Blocks(Vec::new())));
+        match bbs {
+            SWTBuf::Blocks(bs) => {
+                if bs.is_empty() {
+                    // FIXME: who should handle an empty trace?
+                    panic!();
+                } else {
+                    Ok(Box::new(SWTraceIterator::new(bs)))
+                }
+            }
+            SWTBuf::Invalid(m) => Err(TraceRecorderError::TraceInvalid(m)),
         }
     }
 }


### PR DESCRIPTION
This is a draft PR that requires discussion. The code is not yet polished.

The other day I devised a [test](ef2ec80813a894591dc892965faad78a833cc872) where it's difficult to say whether a longjmp occurred or not using the information currently available to the system. The test also demonstrates that miscompilation currently occurs because the trace builder fails to recognise the longjmp.

I've been racking my brain trying to find a way to solve this and I've convinced myself that it can't be done using only the information currently available to the JIT (i.e. control-flow-integrity and frame depths).

This PR shows the only other way I can think of detecting longjmp reliably: using `ld --wrap` (similarly to how we do for `pthread_create`) to wrap `longjmp`. In our wrapper, if the system is tracing, we invalidate the trace (and stop pushing into the trace vector). When we stop tracing, we then discard invalid traces.

This catches not only the problematic case that I devised, but also all other cases already tested (as can be seen by the change of error message in those tests).

Pros:
 - We can catch all longjumps in traces in one place via the same method.
 - We can catch them sooner: at stop_tracing time, rather than in the trace compiler.

Cons:
 - Calling longjmp with Rust frames on the stack is a [grey area](https://github.com/rust-lang/rfcs/issues/2625). Then again, if we are careful, I think we might be able to do this safely. See the comment in the code for my attempt at a justification of safety.  It appears to be working in practice.

Preliminary measurements:
```
Datum0: before-longjmp-detect
Datum1: after-longjmp-detect

 Benchmark                  Datum0 (ms)  Datum1 (ms)  Ratio  Summary
 Permute/YkLua/1000         815          778          0.95   4.52% faster
 revcomp/YkLua/default      1838         1758         0.96   4.36% faster
 DeltaBlue/YkLua/12000      2002         1917         0.96   4.27% faster
 Towers/YkLua/600           925          890          0.96   3.84% faster
 LuLPeg/YkLua/default       3244         3122         0.96   3.77% faster
 Storage/YkLua/1000         9816         9477         0.97   3.45% faster
 HashIds/YkLua/6000         2842         2747         0.97   3.32% faster
 binarytrees/YkLua/15       3977         3861         0.97   2.92% faster
 Heightmap/YkLua/2000       774          753          0.97   2.72% faster
 CD/YkLua/250               9004         8822         0.98   2.02% faster
 fasta/YkLua/500000         841          825          0.98   1.91% faster
 Json/YkLua/100             2469         2435         0.99   1.38% faster
 Sieve/YkLua/3000           471          466          0.99   1.07% faster
 knucleotide/YkLua/default  1615         1604         0.99   0.71% faster
 NBody/YkLua/250000         511          508          0.99   0.63% faster
 Richards/YkLua/100         4075         4069         1.00   0.15% faster
 spectralnorm/YkLua/1000    902          901          1.00   0.12% faster
 Mandelbrot/YkLua/500       129          129          1.00   0.08% slower
 Bounce/YkLua/1500          1138         1140         1.00   0.23% slower
 BigLoop/YkLua/1000000000   1614         1625         1.01   0.66% slower
 Havlak/YkLua/1500          19408        19591        1.01   0.94% slower
 Queens/YkLua/1000          492          498          1.01   1.38% slower
 fannkuchredux/YkLua/10     1219         1238         1.02   1.57% slower
 List/YkLua/1500            840          888          1.06   5.75% slower
```

I manually checked the benchmarks with the biggest apparent slowdown (List) and biggest apparent speedup (permute) using multitime. I can't say I see an "obviously significant performance difference". There's some variation at the process execution level and sometimes different traces are collected, but it looks like nothing more than non-determinism. Neither of those benchmarks report longjmps before or after this change.

I'm curious to see what others think.

TODO:
 - detect siglongjmp by the same method.
 - tidy up.