### PR TITLE
Fix missing return value tracking for inlined functions.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -516,10 +516,12 @@ impl<'a> Assemble<'a> {
             match &inst {
                 #[cfg(test)]
                 jit_ir::Inst::BlackBox(_) => (),
-                jit_ir::Inst::Const(_) | jit_ir::Inst::Copy(_) | jit_ir::Inst::Tombstone => {
+                jit_ir::Inst::Const(_)
+                | jit_ir::Inst::Copy(_)
+                | jit_ir::Inst::Tombstone
+                | jit_ir::Inst::Placeholder(_) => {
                     unreachable!();
                 }
-
                 jit_ir::Inst::BinOp(i) => self.cg_binop(iidx, i),
                 jit_ir::Inst::Param(i) => {
                     // Right now, `Param`s in the body contain dummy values, and shouldn't be

--- a/ykrt/src/compile/jitc_yk/opt/mod.rs
+++ b/ykrt/src/compile/jitc_yk/opt/mod.rs
@@ -214,7 +214,11 @@ impl Opt {
         match self.m.inst(iidx) {
             #[cfg(test)]
             Inst::BlackBox(_) => (),
-            Inst::Const(_) | Inst::Copy(_) | Inst::Tombstone | Inst::TraceHeaderStart => {
+            Inst::Const(_)
+            | Inst::Copy(_)
+            | Inst::Tombstone
+            | Inst::TraceHeaderStart
+            | Inst::Placeholder(_) => {
                 unreachable!()
             }
             Inst::BinOp(x) => self.opt_binop(iidx, x)?,


### PR DESCRIPTION
# Changes

Track inlined function return values.

Currently we don't track return values of inlined functions, which results in an error if these values are referenced later on.

**Example:**

```
bb13:
    %13_1: i32 = call f(...)
bb14:
    %14_1: i1 = eq %13_1, 0i32
```

When function `f` is inlined, we need to add the return value to the `local_map` so that later instructions that reference `%13_1` (like the `eq` instruction) can be executed properly.


## The Placeholder Solution:

The placeholder mechanism solves this by creating a two-stage process:

1. Placeholder Creation (when encountering the inlined call):
    1. Create a placeholder instruction that represents the future return value.
    1. Add this placeholder to the local_map with the expected instruction ID.
1. Placeholder Resolution (when the inlined function returns):
    1. Replace the placeholder with the actual value in handle_ret().    

# Benchmarks

`datum 5` - function-inlining-placeholders
`datum 6`- master

| Benchmark             | Datum 5 (ms) | Datum 6 (ms) | Ratio | Summary        |
|-----------------------|--------------|--------------|-------|----------------|
| Havlak/YkLua/1500     | 18771        | 17243        | 0.92  | 8.14% faster   |
| Json/YkLua/100        | 2459         | 2276         | 0.93  | 7.45% faster   |
| CD/YkLua/250          | 8572         | 7996         | 0.93  | 6.72% faster   |
| Storage/YkLua/1000    | 8514         | 7950         | 0.93  | 6.62% faster   |
| DeltaBlue/YkLua/12000 | 1912         | 1809         | 0.95  | 5.40% faster   |
| Richards/YkLua/100    | 4087         | 3984         | 0.97  | 2.52% faster   |
| Sieve/YkLua/3000      | 461          | 451          | 0.98  | 2.27% faster   |
| List/YkLua/1500       | 841          | 831          | 0.99  | 1.22% faster   |
| NBody/YkLua/250000    | 466          | 461          | 0.99  | 1.13% faster   |
| Towers/YkLua/600      | 893          | 885          | 0.99  | 0.93% faster   |
| Bounce/YkLua/1500     | 1119         | 1115         | 1.00  | 0.41% faster   |
| Mandelbrot/YkLua/500  | 130          | 129          | 1.00  | 0.16% faster   |
| Queens/YkLua/1000     | 492          | 495          | 1.01  | 0.79% slower   |
| Permute/YkLua/1000    | 798          | 816          | 1.02  | 2.20% slower   |
