### PR TITLE
Use yk-outline-untraceable.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -61,7 +61,7 @@ export RUSTUP_HOME
 export RUSTUP_INIT_SKIP_PATH_CHECK="yes"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
 sh rustup.sh --default-host x86_64-unknown-linux-gnu \
-    --default-toolchain nightly \
+    --default-toolchain nightly-2025-08-17 \
     --no-modify-path \
     --profile default \
     -y

--- a/bin/yk-config
+++ b/bin/yk-config
@@ -119,6 +119,11 @@ handle_arg() {
             # optimisations have finished.
             OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-optnone-after-ir-passes"
 
+            # Apply `yk_outline` to functions that can never be traced so that
+            # we don't pay the cost for unnecessary instrumentation (e.g.
+            # stackmaps, swt recording, ...).
+            OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-outline-untraceable"
+
             # Ensure all symbols are exported so that the JIT can use them.
             # FIXME: https://github.com/ykjit/yk/issues/381
             # Find a better way of handling unexported globals inside a trace.

--- a/tests/c/idempotent_outline.c
+++ b/tests/c/idempotent_outline.c
@@ -69,6 +69,9 @@ int main(int argc, char **argv) {
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
+  // Prevent the OutlineUntraceable pass from marking g() yk_outline.
+  g(0, 0);
+
   size_t i = 4;
   NOOPT_VAL(loc);
   NOOPT_VAL(i);

--- a/tests/c/idempotent_outline_simple.c
+++ b/tests/c/idempotent_outline_simple.c
@@ -60,6 +60,9 @@ int main(int argc, char **argv) {
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
+  // Prevent the OutlineUntraceable pass from marking g() yk_outline.
+  g(0);
+
   size_t i = 4;
   NOOPT_VAL(loc);
   NOOPT_VAL(i);

--- a/tests/c/outline_promoted_ptr.c
+++ b/tests/c/outline_promoted_ptr.c
@@ -36,6 +36,9 @@ int main(int argc, char **argv) {
   yk_mt_hot_threshold_set(mt, 0);
   YkLocation loc = yk_location_new();
 
+  // Prevent the OutlineUntraceable pass from marking g() yk_outline.
+  g(NULL);
+
   int i = 4;
   NOOPT_VAL(loc);
   NOOPT_VAL(i);

--- a/tests/c/yk_debug_str_outline.c
+++ b/tests/c/yk_debug_str_outline.c
@@ -62,6 +62,9 @@ int main(int argc, char **argv) {
   YkLocation loc = yk_location_new();
   char msg[MAX_MSG];
 
+  // Prevent the OutlineUntraceable pass from marking g() yk_outline.
+  g();
+
   int i = 4;
   NOOPT_VAL(loc);
   NOOPT_VAL(i);


### PR DESCRIPTION
Requires https://github.com/ykjit/ykllvm/pull/270

This flag marks functions which could never be traced with `yk_outline`. This causes instrumentation passes that insert (e.g.) stackmaps and swt recording, to ignore these functiions. In turn this means we don't pay the performance penalty of tracing, for things that could never be traced anyway.

Leads to good speedups for benchmarks:

```
 Benchmark                  Datum0 (ms)  Datum1 (ms)  Ratio  Summary
 revcomp/YkLua/default      1772         479          0.27   72.96% faster
 fasta/YkLua/500000         799          369          0.46   53.80% faster
 LuLPeg/YkLua/default       3105         1481         0.48   52.31% faster
 HashIds/YkLua/6000         2724         1490         0.55   45.29% faster
 Storage/YkLua/1000         9523         6598         0.69   30.72% faster
 binarytrees/YkLua/15       3896         2699         0.69   30.71% faster
 CD/YkLua/250               8791         6342         0.72   27.86% faster
 Havlak/YkLua/1500          18459        13493        0.73   26.90% faster
 DeltaBlue/YkLua/12000      1926         1535         0.80   20.28% faster
 Json/YkLua/100             2336         1921         0.82   17.75% faster
 Sieve/YkLua/3000           487          447          0.92   8.28% faster
 Bounce/YkLua/1500          1121         1032         0.92   7.96% faster
 List/YkLua/1500            857          818          0.96   4.50% faster
 knucleotide/YkLua/default  1555         1510         0.97   2.91% faster
 Permute/YkLua/1000         821          806          0.98   1.92% faster
 Heightmap/YkLua/2000       746          734          0.98   1.71% faster
 Queens/YkLua/1000          480          475          0.99   1.18% faster
 Mandelbrot/YkLua/500       128          127          0.99   0.90% faster
 BigLoop/YkLua/1000000000   2362         2358         1.00   0.16% faster
 spectralnorm/YkLua/1000    897          896          1.00   0.11% faster
 fannkuchredux/YkLua/10     1208         1222         1.01   1.15% slower
 Richards/YkLua/100         4021         4114         1.02   2.32% slower
 Towers/YkLua/600           870          895          1.03   2.96% slower
 NBody/YkLua/250000         458          478          1.04   4.42% slower
```