### PR TITLE
Determine the trace optimisation level in MT.

### DIFF
--- a/ykrt/src/compile/jitc_yk/mod.rs
+++ b/ykrt/src/compile/jitc_yk/mod.rs
@@ -11,7 +11,6 @@ use crate::{
 use jit_ir::TraceEndFrame;
 use parking_lot::Mutex;
 use std::{
-    env,
     error::Error,
     fmt,
     marker::PhantomData,
@@ -30,15 +29,6 @@ mod int_signs;
 pub mod jit_ir;
 mod opt;
 mod trace_builder;
-
-/// Should we turn trace optimisations on or off? Defaults to "on".
-static YKD_OPT: LazyLock<bool> = LazyLock::new(|| {
-    let x = env::var("YKD_OPT");
-    match x.as_ref().map(|x| x.as_str()) {
-        Ok("0") => false,
-        Ok(_) | Err(_) => true,
-    }
-});
 
 pub(crate) static AOT_MOD: LazyLock<aot_ir::Module> = LazyLock::new(|| {
     let ir_slice = yk_ir_section().unwrap();
@@ -163,7 +153,7 @@ impl<Register: Send + Sync + 'static> JITCYk<Register> {
             ));
         }
 
-        if *YKD_OPT {
+        if mt.opt_level() > 0 {
             jit_mod = opt::opt(jit_mod)?;
             if should_log_ir(IRPhase::PostOpt) {
                 jit_mod.dead_code_elimination();


### PR DESCRIPTION
Rather than having each JIT backend interpret `YKD_OPT` (which, perhaps, should be `YK_OPT` but that's a decision for another day), record it at the `MT` level. We could be very clever with what the levels mean (should they be an `Option`? an `enum`? or ...?), but ultimately each backend optimiser can interpret them differently: really only "0" and "not 0" make sense at a global level. Hence defaulting to "1" is probably good enough for now and quite a way into the future.