### PR TITLE
Add YK_JITC=none to disable the JIT.

### DIFF
--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -1,5 +1,11 @@
 # Debugging
 
+## Disabling the JIT
+
+Sometimes it is useful to completely disable the JIT to verify that a problem is
+JIT-related. You can do this with the `YK_JITC` environment variable (see
+[run-time configuration](runtime_config.md) for details).
+
 ## Trace optimisation
 
 Trace optimisation can make it difficult to understand why a yk interpreter has

--- a/docs/src/dev/runtime_config.md
+++ b/docs/src/dev/runtime_config.md
@@ -13,6 +13,10 @@ The following environment variables are available:
 * `YK_HOT_THRESHOLD`: an integer from 0..4294967295 (both inclusive) that
   determines how many executions of a hot loop are needed before it is traced.
   Defaults to 131.
+* `YK_JITC`: selects the JIT compiler to use. Set to "none" to disable JIT
+  compilation entirely. When disabled, the hot location counter will not
+  increment, preventing any tracing or compilation from occurring. When not set,
+  defaults to JIT compilation enabled.
 * `YK_SIDETRACE_THRESHOLD`: an integer from 0..4294967295 (both inclusive) that
   determines how many times a guard needs to fail before a sidetrace is created.
   Defaults to 5.

--- a/tests/c/jit_disabled.c
+++ b/tests/c/jit_disabled.c
@@ -1,0 +1,42 @@
+// Run-time:
+//   env-var: YK_JITC=none
+//   env-var: YKD_LOG=4
+//   stderr:
+//     4
+//     3
+//     2
+//     1
+//     exit
+
+// Check that YK_JITC=none disables JIT compilation.
+// The program should run without any tracing or JIT execution events.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "%d\n", i);
+    i--;
+  }
+  fprintf(stderr, "exit\n");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}
+


### PR DESCRIPTION
Add `YK_JITC=none` option to control whether JIT is enabled or not. Mainly useful for testing and running benchmarks.
Example:
```
$ YK_JITC=none YKD_LOG=4  lua loop.lua
Sum:	500000500000

$ YKD_LOG=4  lua loop.lua
yk-tracing: start-tracing
yk-tracing: stop-tracing
yk-execution: enter-jit-code
yk-execution: deoptimise TraceId(0) GuardId(8)
Sum:	500000500000
```
