### PR TITLE
Allow multiple `VLoc`s in textual input HIR

### DIFF
--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -2618,10 +2618,10 @@ mod test {
     fn arg_cannot_appear_after_entry() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i8 = 1
           %2: i16 = sext %0
-          %3: i8 = arg reg
+          %3: i8 = arg [reg]
         ",
         );
     }
@@ -2631,10 +2631,10 @@ mod test {
     fn entry_instructions_are_arg_const() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i8 = 1
           %2: i16 = sext %0
-          %3: i8 = arg reg
+          %3: i8 = arg [reg]
         ",
         );
     }
@@ -2644,7 +2644,7 @@ mod test {
     fn exit_must_come_last() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           exit [%0]
           %2: i8 = add %0, %0
         ",
@@ -2656,7 +2656,7 @@ mod test {
     fn exit_vars_must_match_exit_vlocs() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           exit []
         ",
         );
@@ -2675,7 +2675,7 @@ mod test {
     fn abs_type_consistency() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i16 = abs %0
         ",
         );
@@ -2686,8 +2686,8 @@ mod test {
     fn add_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = add %0, %1
         ",
         );
@@ -2698,8 +2698,8 @@ mod test {
     fn add_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = add %0, %1
         ",
         );
@@ -2710,8 +2710,8 @@ mod test {
     fn and_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = and %0, %1
         ",
         );
@@ -2722,8 +2722,8 @@ mod test {
     fn and_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = and %0, %1
         ",
         );
@@ -2734,8 +2734,8 @@ mod test {
     fn ashr_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = ashr %0, %1
         ",
         );
@@ -2746,8 +2746,8 @@ mod test {
     fn ashr_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = ashr %0, %1
         ",
         );
@@ -2759,7 +2759,7 @@ mod test {
         str_to_mod::<DummyReg>(
             "
           extern f();
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i16 = call f %0()
         ",
         );
@@ -2771,7 +2771,7 @@ mod test {
         str_to_mod::<DummyReg>(
             "
           extern f(i32);
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i16 = call f %0()
         ",
         );
@@ -2783,7 +2783,7 @@ mod test {
         str_to_mod::<DummyReg>(
             "
           extern f();
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i16 = call f %0(%0)
         ",
         );
@@ -2795,7 +2795,7 @@ mod test {
         str_to_mod::<DummyReg>(
             "
           extern f(i32);
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i8 = 0
           call f %0(%1)
         ",
@@ -2807,7 +2807,7 @@ mod test {
     fn dynptradd_not_ptr() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i8 = 0
           %2: ptr = dynptradd %0, %1, 1
         ",
@@ -2819,7 +2819,7 @@ mod test {
     fn dynptradd_not_int() {
         str_to_mod::<DummyReg>(
             "
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: ptr = dynptradd %0, %0, 1
         ",
         );
@@ -2830,8 +2830,8 @@ mod test {
     fn fadd_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: double = arg reg
+          %0: float = arg [reg]
+          %1: double = arg [reg]
           %2: float = fadd %0, %1
         ",
         );
@@ -2842,8 +2842,8 @@ mod test {
     fn fadd_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: float = arg reg
+          %0: float = arg [reg]
+          %1: float = arg [reg]
           %2: double = fadd %0, %1
         ",
         );
@@ -2854,8 +2854,8 @@ mod test {
     fn fdiv_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: double = arg reg
+          %0: float = arg [reg]
+          %1: double = arg [reg]
           %2: float = fdiv %0, %1
         ",
         );
@@ -2866,8 +2866,8 @@ mod test {
     fn fdiv_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: float = arg reg
+          %0: float = arg [reg]
+          %1: float = arg [reg]
           %2: double = fdiv %0, %1
         ",
         );
@@ -2878,8 +2878,8 @@ mod test {
     fn fmul_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: double = arg reg
+          %0: float = arg [reg]
+          %1: double = arg [reg]
           %2: float = fmul %0, %1
         ",
         );
@@ -2890,8 +2890,8 @@ mod test {
     fn fmul_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: float = arg reg
+          %0: float = arg [reg]
+          %1: float = arg [reg]
           %2: double = fmul %0, %1
         ",
         );
@@ -2902,8 +2902,8 @@ mod test {
     fn fsub_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: double = arg reg
+          %0: float = arg [reg]
+          %1: double = arg [reg]
           %2: float = fsub %0, %1
         ",
         );
@@ -2914,8 +2914,8 @@ mod test {
     fn fsub_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: float = arg reg
-          %1: float = arg reg
+          %0: float = arg [reg]
+          %1: float = arg [reg]
           %2: double = fsub %0, %1
         ",
         );
@@ -2926,7 +2926,7 @@ mod test {
     fn guard_cond_must_be_i1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           guard true, %0, []
         ",
         );
@@ -2937,8 +2937,8 @@ mod test {
     fn icmp_inconsistent_types() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i1 = eq %0, %1
         ",
         );
@@ -2949,7 +2949,7 @@ mod test {
     fn inttoptr_must_take_int() {
         str_to_mod::<DummyReg>(
             "
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: ptr = inttoptr %0
         ",
         );
@@ -2960,7 +2960,7 @@ mod test {
     fn inttoptr_must_return_pointer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i64 = arg reg
+          %0: i64 = arg [reg]
           %1: i64 = inttoptr %0
         ",
         );
@@ -2971,7 +2971,7 @@ mod test {
     fn load_must_take_pointer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i64 = arg reg
+          %0: i64 = arg [reg]
           %1: i8 = load %0
         ",
         );
@@ -2982,8 +2982,8 @@ mod test {
     fn lshr_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = lshr %0, %1
         ",
         );
@@ -2994,8 +2994,8 @@ mod test {
     fn lshr_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = lshr %0, %1
         ",
         );
@@ -3006,8 +3006,8 @@ mod test {
     fn mul_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = mul %0, %1
         ",
         );
@@ -3018,8 +3018,8 @@ mod test {
     fn mul_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = mul %0, %1
         ",
         );
@@ -3030,8 +3030,8 @@ mod test {
     fn or_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = or %0, %1
         ",
         );
@@ -3042,8 +3042,8 @@ mod test {
     fn or_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = or %0, %1
         ",
         );
@@ -3054,7 +3054,7 @@ mod test {
     fn ptradd_not_ptr() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: ptr = ptradd %0, 1
         ",
         );
@@ -3065,7 +3065,7 @@ mod test {
     fn ptrtoint_must_take_pointer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i64 = arg reg
+          %0: i64 = arg [reg]
           %1: i64 = ptrtoint %0
         ",
         );
@@ -3076,7 +3076,7 @@ mod test {
     fn ptrtoint_must_return_pointer() {
         str_to_mod::<DummyReg>(
             "
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: ptr = ptrtoint %0
         ",
         );
@@ -3087,8 +3087,8 @@ mod test {
     fn select_cond_must_be_i1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i32 = arg reg
+          %0: i8 = arg [reg]
+          %1: i32 = arg [reg]
           %2: i32 = select %0, %1, %1
         ",
         );
@@ -3099,8 +3099,8 @@ mod test {
     fn select_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i1 = arg reg
-          %1: i32 = arg reg
+          %0: i1 = arg [reg]
+          %1: i32 = arg [reg]
           %2: i32 = select %0, %0, %1
         ",
         );
@@ -3111,7 +3111,7 @@ mod test {
     fn sext_must_take_integer() {
         str_to_mod::<DummyReg>(
             "
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i64 = sext %0
         ",
         );
@@ -3122,7 +3122,7 @@ mod test {
     fn sext_must_return_integer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i1 = arg reg
+          %0: i1 = arg [reg]
           %1: ptr = sext %0
         ",
         );
@@ -3133,7 +3133,7 @@ mod test {
     fn sext_must_extend() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i8 = sext %0
         ",
         );
@@ -3144,8 +3144,8 @@ mod test {
     fn shl_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = shl %0, %1
         ",
         );
@@ -3156,8 +3156,8 @@ mod test {
     fn shl_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = shl %0, %1
         ",
         );
@@ -3168,7 +3168,7 @@ mod test {
     fn store_must_take_pointer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i64 = arg reg
+          %0: i64 = arg [reg]
           store %0, %0
         ",
         );
@@ -3179,8 +3179,8 @@ mod test {
     fn sub_type_consistency1() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i16 = arg reg
+          %0: i8 = arg [reg]
+          %1: i16 = arg [reg]
           %2: i16 = sub %0, %1
         ",
         );
@@ -3191,8 +3191,8 @@ mod test {
     fn sub_type_consistency2() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
-          %1: i8 = arg reg
+          %0: i8 = arg [reg]
+          %1: i8 = arg [reg]
           %2: i16 = sub %0, %1
         ",
         );
@@ -3203,7 +3203,7 @@ mod test {
     fn trunc_must_take_integer() {
         str_to_mod::<DummyReg>(
             "
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i64 = trunc %0
         ",
         );
@@ -3214,7 +3214,7 @@ mod test {
     fn trunc_must_return_integer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i1 = arg reg
+          %0: i1 = arg [reg]
           %1: ptr = trunc %0
         ",
         );
@@ -3225,7 +3225,7 @@ mod test {
     fn trunc_must_truncate() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i8 = trunc %0
         ",
         );
@@ -3236,7 +3236,7 @@ mod test {
     fn zext_must_take_integer() {
         str_to_mod::<DummyReg>(
             "
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i64 = zext %0
         ",
         );
@@ -3247,7 +3247,7 @@ mod test {
     fn zext_must_return_integer() {
         str_to_mod::<DummyReg>(
             "
-          %0: i1 = arg reg
+          %0: i1 = arg [reg]
           %1: ptr = zext %0
         ",
         );
@@ -3258,7 +3258,7 @@ mod test {
     fn zext_must_extend() {
         str_to_mod::<DummyReg>(
             "
-          %0: i8 = arg reg
+          %0: i8 = arg [reg]
           %1: i8 = zext %0
         ",
         );

--- a/ykrt/src/compile/j2/hir.y
+++ b/ykrt/src/compile/j2/hir.y
@@ -74,8 +74,8 @@ Inst -> Result<AstInst, Box<dyn Error>>:
   | "LOCAL" ":" Ty "=" "ASHR" "LOCAL" "," "LOCAL" {
       Ok(AstInst::AShr { local: $1?.span(), ty: $3?, lhs: $6?.span(), rhs: $8?.span() })
     }
-  | "LOCAL" ":" Ty "=" "ARG" VLoc {
-      Ok(AstInst::Arg { local: $1?.span(), ty: $3?, vloc: $6? })
+  | "LOCAL" ":" Ty "=" "ARG" "[" ArgList "]" {
+      Ok(AstInst::Arg { local: $1?.span(), ty: $3?, vlocs: $7? })
     }
   | "LOCAL" ":" Ty "=" Const {
        Ok(AstInst::Const { local: $1?.span(), ty: $3?, kind: $5? })
@@ -149,6 +149,11 @@ Inst -> Result<AstInst, Box<dyn Error>>:
   | "LOCAL" ":" Ty "=" "ZEXT" "LOCAL" {
       Ok(AstInst::ZExt { local: $1?.span(), ty: $3?, val: $6?.span() })
     }
+  ;
+
+ArgList -> Result<Vec<AstVLoc>, Box<dyn Error>>:
+    ArgList "," VLoc { flattenr($1, $3) }
+  | VLoc { Ok(vec![$1?]) }
   ;
 
 Const -> Result<AstConst, Box<dyn Error>>:

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -2502,8 +2502,8 @@ mod test {
     fn simple() {
         build_and_test(
             r#"
-          %0: i8 = arg reg "GPR0"
-          %1: i8 = arg reg "GPR1"
+          %0: i8 = arg [reg "GPR0"]
+          %1: i8 = arg [reg "GPR1"]
           %2: i8 = add %0, %1
           blackbox %2
         "#,
@@ -2520,8 +2520,8 @@ mod test {
     fn cycles() {
         build_and_test(
             r#"
-          %0: i8 = arg reg "GPR1"
-          %1: i8 = arg reg "GPR0"
+          %0: i8 = arg [reg "GPR1"]
+          %1: i8 = arg [reg "GPR0"]
           %2: i8 = add %0, %1
           blackbox %2
         "#,
@@ -2544,9 +2544,9 @@ mod test {
 
         build_and_test(
             r#"
-          %0: i8 = arg reg "GPR0"
-          %1: i8 = arg reg "GPR1"
-          %2: i8 = arg reg "GPR2"
+          %0: i8 = arg [reg "GPR0"]
+          %1: i8 = arg [reg "GPR1"]
+          %2: i8 = arg [reg "GPR2"]
           %3: i8 = add %0, %1
           %4: i8 = add %2, %3
           blackbox %4
@@ -2574,10 +2574,10 @@ mod test {
 
         build_and_test(
             r#"
-          %0: i8 = arg reg "GPR3"
-          %1: i8 = arg reg "GPR2"
-          %2: i8 = arg reg "GPR1"
-          %3: i8 = arg reg "GPR0"
+          %0: i8 = arg [reg "GPR3"]
+          %1: i8 = arg [reg "GPR2"]
+          %2: i8 = arg [reg "GPR1"]
+          %3: i8 = arg [reg "GPR0"]
           %4: i8 = add %0, %1
           %5: i8 = add %4, %2
           %6: i8 = add %5, %3
@@ -2625,8 +2625,8 @@ mod test {
         // not used in the trace: that's the guard optimism being undone.
         build_and_test(
             r#"
-          %0: i8 = arg reg "GPR0"
-          %1: i8 = arg reg "GPR1"
+          %0: i8 = arg [reg "GPR0"]
+          %1: i8 = arg [reg "GPR1"]
           %2: i8 = add %0, %1
           %3: i8 = add %2, %2
           %4: i8 = add %3, %3
@@ -2654,7 +2654,7 @@ mod test {
     fn arrange_fills_once() {
         build_and_test(
             r#"
-          %0: i8 = arg reg "GPR0"
+          %0: i8 = arg [reg "GPR0"]
           %1: i8 = add %0, %0
           blackbox %1
           exit [%0]

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -3162,7 +3162,7 @@ mod test {
             "
           extern abort()
 
-          %0: ptr = arg reg
+          %0: ptr = arg [reg]
           %1: i8 = load %0
           %2: i8 = 10
           %3: i8 = add %1, %2
@@ -3228,7 +3228,7 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = abs %0
               exit [%1]
             ",
@@ -3248,8 +3248,8 @@ mod test {
         // i8
         codegen_and_test(
             "
-              %0: i8 = arg reg
-              %1: i8 = arg reg
+              %0: i8 = arg [reg]
+              %1: i8 = arg [reg]
               %2: i8 = add %0, %1
               exit [%0, %2]
             ",
@@ -3263,7 +3263,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i8 = arg reg
+              %0: i8 = arg [reg]
               %1: i8 = 32
               %2: i8 = add %0, %1
               exit [%2]
@@ -3279,8 +3279,8 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: i32 = arg reg
-              %1: i32 = arg reg
+              %0: i32 = arg [reg]
+              %1: i32 = arg [reg]
               %2: i32 = add %0, %1
               exit [%0, %2]
             ",
@@ -3294,7 +3294,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: i32 = 32
               %2: i32 = add %0, %1
               exit [%2]
@@ -3309,7 +3309,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: i32 = 0xFFFFFFFF
               %2: i32 = add %0, %1
               exit [%2]
@@ -3325,8 +3325,8 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: i64 = arg reg
-              %1: i64 = arg reg
+              %0: i64 = arg [reg]
+              %1: i64 = arg [reg]
               %2: i64 = add %0, %1
               exit [%0, %2]
             ",
@@ -3340,7 +3340,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 32
               %2: i64 = add %0, %1
               exit [%2]
@@ -3355,7 +3355,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0xFFFFFFFF
               %2: i64 = add %0, %1
               exit [%2]
@@ -3371,7 +3371,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0xFFFFFFFFAB
               %2: i64 = add %0, %1
               exit [%2]
@@ -3387,7 +3387,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0xFFFFFFFFFFFFFFFF
               %2: i64 = add %0, %1
               exit [%2]
@@ -3406,7 +3406,7 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: i32 = 0xFFFFFFFF
               %2: i32 = and %0, %1
               exit [%2]
@@ -3422,7 +3422,7 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0x0FFFFFFF
               %2: i64 = and %0, %1
               exit [%2]
@@ -3469,7 +3469,7 @@ mod test {
             "
               extern abort()
 
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               call abort %0()
               exit [%0]
             ",
@@ -3486,7 +3486,7 @@ mod test {
             "
               extern puts(ptr) -> i32
 
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: ptr = @puts
               %2: i32 = call puts %1(%0)
               %3: i32 = 1
@@ -3526,8 +3526,8 @@ mod test {
             "
               extern puts(ptr) -> i32
 
-              %0: ptr = arg reg
-              %1: ptr = arg reg
+              %0: ptr = arg [reg]
+              %1: ptr = arg [reg]
               %2: i32 = call puts %1(%0)
               %3: i32 = 1
               %4: i32 = add %2, %3
@@ -3549,7 +3549,7 @@ mod test {
             "
               extern printf(ptr, ...) -> i32
 
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: ptr = @printf
               %2: i64 = 2
               %3: i32 = call printf %1(%0, %2)
@@ -3573,8 +3573,8 @@ mod test {
             "
               extern printf(ptr, ...) -> i32
 
-              %0: ptr = arg reg
-              %1: ptr = arg reg
+              %0: ptr = arg [reg]
+              %1: ptr = arg [reg]
               %2: i64 = 2
               %3: i32 = call printf %1(%0, %2)
               %4: i32 = 1
@@ -3597,9 +3597,9 @@ mod test {
             r#"
               extern f(float, double)
 
-              %0: ptr = arg reg "rax"
-              %1: float = arg reg "xmm15"
-              %2: double = arg reg "xmm14"
+              %0: ptr = arg [reg "rax"]
+              %1: float = arg [reg "xmm15"]
+              %2: double = arg [reg "xmm14"]
               call f %0(%1, %2)
               exit [%0, %1, %2]
             "#,
@@ -3621,8 +3621,8 @@ mod test {
             r#"
               extern f() -> double
 
-              %0: double = arg reg "xmm15"
-              %1: ptr = arg reg "r15"
+              %0: double = arg [reg "xmm15"]
+              %1: ptr = arg [reg "r15"]
               %2: double = call f %1()
               %3: double = fadd %0, %2
               exit [%3, %1]
@@ -3643,8 +3643,8 @@ mod test {
             r#"
               extern f(double) -> double
 
-              %0: double = arg reg "xmm15"
-              %1: ptr = arg reg "r15"
+              %0: double = arg [reg "xmm15"]
+              %1: ptr = arg [reg "r15"]
               %2: double = call f %1(%0)
               %3: double = fadd %0, %2
               exit [%3, %1]
@@ -3666,9 +3666,9 @@ mod test {
             r#"
               extern f(float, double, ...)
 
-              %0: ptr = arg reg "rax"
-              %1: float = arg reg "xmm15"
-              %2: double = arg reg "xmm14"
+              %0: ptr = arg [reg "rax"]
+              %1: float = arg [reg "xmm15"]
+              %2: double = arg [reg "xmm14"]
               call f %0(%1, %2)
               exit [%0, %1, %2]
             "#,
@@ -3692,8 +3692,8 @@ mod test {
             r#"
               extern f(...) -> double
 
-              %0: double = arg reg "xmm15"
-              %1: ptr = arg reg "r15"
+              %0: double = arg [reg "xmm15"]
+              %1: ptr = arg [reg "r15"]
               %2: double = call f %1()
               %3: double = fadd %0, %2
               exit [%3, %1]
@@ -3714,8 +3714,8 @@ mod test {
             r#"
               extern f(double, ...) -> double
 
-              %0: double = arg reg "xmm15"
-              %1: ptr = arg reg "r15"
+              %0: double = arg [reg "xmm15"]
+              %1: ptr = arg [reg "r15"]
               %2: double = call f %1(%0)
               %3: double = fadd %0, %2
               exit [%3, %1]
@@ -3852,8 +3852,8 @@ mod test {
     fn cg_dynptradd() {
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i64 = arg reg
+              %0: ptr = arg [reg]
+              %1: i64 = arg [reg]
               %2: ptr = dynptradd %0, %1, 1
               %3: ptr = dynptradd %0, %1, 2
               %4: ptr = dynptradd %0, %1, 4
@@ -3888,8 +3888,8 @@ mod test {
     fn cg_fadd() {
         codegen_and_test(
             "
-              %0: float = arg reg
-              %1: float = arg reg
+              %0: float = arg [reg]
+              %1: float = arg [reg]
               %2: float = fadd %0, %1
               exit [%0, %2]
             ",
@@ -3903,8 +3903,8 @@ mod test {
 
         codegen_and_test(
             "
-              %0: double = arg reg
-              %1: double = arg reg
+              %0: double = arg [reg]
+              %1: double = arg [reg]
               %2: double = fadd %0, %1
               exit [%0, %2]
             ",
@@ -3921,8 +3921,8 @@ mod test {
     fn cg_fdiv() {
         codegen_and_test(
             "
-              %0: float = arg reg
-              %1: float = arg reg
+              %0: float = arg [reg]
+              %1: float = arg [reg]
               %2: float = fdiv %0, %1
               exit [%0, %2]
             ",
@@ -3936,8 +3936,8 @@ mod test {
 
         codegen_and_test(
             "
-              %0: double = arg reg
-              %1: double = arg reg
+              %0: double = arg [reg]
+              %1: double = arg [reg]
               %2: double = fdiv %0, %1
               exit [%0, %2]
             ",
@@ -3954,8 +3954,8 @@ mod test {
     fn cg_fmul() {
         codegen_and_test(
             "
-              %0: float = arg reg
-              %1: float = arg reg
+              %0: float = arg [reg]
+              %1: float = arg [reg]
               %2: float = fmul %0, %1
               exit [%0, %2]
             ",
@@ -3969,8 +3969,8 @@ mod test {
 
         codegen_and_test(
             "
-              %0: double = arg reg
-              %1: double = arg reg
+              %0: double = arg [reg]
+              %1: double = arg [reg]
               %2: double = fmul %0, %1
               exit [%0, %2]
             ",
@@ -3987,8 +3987,8 @@ mod test {
     fn cg_fsub() {
         codegen_and_test(
             "
-              %0: float = arg reg
-              %1: float = arg reg
+              %0: float = arg [reg]
+              %1: float = arg [reg]
               %2: float = fsub %0, %1
               exit [%0, %2]
             ",
@@ -4002,8 +4002,8 @@ mod test {
 
         codegen_and_test(
             "
-              %0: double = arg reg
-              %1: double = arg reg
+              %0: double = arg [reg]
+              %1: double = arg [reg]
               %2: double = fsub %0, %1
               exit [%0, %2]
             ",
@@ -4020,7 +4020,7 @@ mod test {
     fn cg_fpext() {
         codegen_and_test(
             "
-              %0: float = arg reg
+              %0: float = arg [reg]
               %1: double = fpext %0
               blackbox %1
               exit [%0]
@@ -4040,7 +4040,7 @@ mod test {
         // The standard cases
         codegen_and_test(
             "
-              %0: i1 = arg reg
+              %0: i1 = arg [reg]
               guard true, %0, []
               exit [%0]
             ",
@@ -4065,7 +4065,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i1 = arg reg
+              %0: i1 = arg [reg]
               guard false, %0, []
               exit [%0]
             ",
@@ -4091,8 +4091,8 @@ mod test {
         // ICmp optimisation
         codegen_and_test(
             "
-              %0: i32 = arg reg
-              %1: i32 = arg reg
+              %0: i32 = arg [reg]
+              %1: i32 = arg [reg]
               %2: i1 = eq %0, %1
               guard true, %2, []
               exit [%0, %1]
@@ -4111,7 +4111,7 @@ mod test {
         // Icmp-const optimisation
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: i32 = 0x14
               %2: i1 = eq %0, %1
               guard true, %2, []
@@ -4131,8 +4131,8 @@ mod test {
         // ICmp optimisation and zero/sign fill
         codegen_and_test(
             "
-              %0: i8 = arg reg
-              %1: i8 = arg reg
+              %0: i8 = arg [reg]
+              %1: i8 = arg [reg]
               %2: i1 = eq %0, %1
               guard true, %2, []
               exit [%0, %1]
@@ -4154,8 +4154,8 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i8 = arg reg
-              %1: i8 = arg reg
+              %0: i8 = arg [reg]
+              %1: i8 = arg [reg]
               %2: i1 = sgt %0, %1
               guard true, %2, []
               exit [%0, %1]
@@ -4177,8 +4177,8 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i8 = arg reg
-              %1: i8 = arg reg
+              %0: i8 = arg [reg]
+              %1: i8 = arg [reg]
               %2: i1 = ugt %0, %1
               guard true, %2, []
               exit [%0, %1]
@@ -4203,8 +4203,8 @@ mod test {
     fn cg_icmp() {
         codegen_and_test(
             "
-              %0: i32 = arg reg
-              %1: i32 = arg reg
+              %0: i32 = arg [reg]
+              %1: i32 = arg [reg]
               %2: i1 = eq %0, %1
               exit [%0, %2]
             ",
@@ -4223,7 +4223,7 @@ mod test {
         // double
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: double = load %0
               blackbox %1
               exit [%0]
@@ -4239,7 +4239,7 @@ mod test {
         // float
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: float = load %0
               blackbox %1
               exit [%0]
@@ -4258,7 +4258,7 @@ mod test {
         // i8
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i8 = load %0
               exit [%1]
             ",
@@ -4273,7 +4273,7 @@ mod test {
         // i16
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i16 = load %0
               exit [%1]
             ",
@@ -4288,7 +4288,7 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i32 = load %0
               exit [%1]
             ",
@@ -4303,7 +4303,7 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i64 = load %0
               exit [%1]
             ",
@@ -4318,7 +4318,7 @@ mod test {
         // ptradd optimisation
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: ptr = ptradd %0, 8
               %2: i8 = load %1
               exit [%2]
@@ -4336,7 +4336,7 @@ mod test {
         // i8
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i8 = load %0
               %2: i64 = sext %1
               exit [%2]
@@ -4353,7 +4353,7 @@ mod test {
         // i16
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i16 = load %0
               %2: i64 = sext %1
               exit [%2]
@@ -4370,7 +4370,7 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i32 = load %0
               %2: i64 = sext %1
               exit [%2]
@@ -4391,7 +4391,7 @@ mod test {
         // i8
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i8 = load %0
               %2: i64 = zext %1
               exit [%2]
@@ -4408,7 +4408,7 @@ mod test {
         // i16
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i16 = load %0
               %2: i64 = zext %1
               exit [%2]
@@ -4425,7 +4425,7 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i32 = load %0
               %2: i64 = zext %1
               exit [%2]
@@ -4447,8 +4447,8 @@ mod test {
         // i8
         codegen_and_test(
             r#"
-              %0: i8 = arg reg "R8"
-              %1: i8 = arg reg "R9"
+              %0: i8 = arg [reg "R8"]
+              %1: i8 = arg [reg "R9"]
               %2: i8 = mul %0, %1
               exit [%0, %2]
             "#,
@@ -4465,8 +4465,8 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: i32 = arg reg
-              %1: i32 = arg reg
+              %0: i32 = arg [reg]
+              %1: i32 = arg [reg]
               %2: i32 = mul %0, %1
               exit [%0, %2]
             ",
@@ -4481,8 +4481,8 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: i64 = arg reg
-              %1: i64 = arg reg
+              %0: i64 = arg [reg]
+              %1: i64 = arg [reg]
               %2: i64 = mul %0, %1
               exit [%0, %2]
             ",
@@ -4500,8 +4500,8 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: i32 = arg reg
-              %1: i32 = arg reg
+              %0: i32 = arg [reg]
+              %1: i32 = arg [reg]
               %2: i32 = or %0, %1
               exit [%0, %2]
             ",
@@ -4518,8 +4518,8 @@ mod test {
     fn cg_ptradd() {
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i64 = arg reg
+              %0: ptr = arg [reg]
+              %1: i64 = arg [reg]
               %2: ptr = ptradd %0, 1
               exit [%0, %2]
             ",
@@ -4536,9 +4536,9 @@ mod test {
     fn cg_select() {
         codegen_and_test(
             "
-              %0: i1 = arg reg
-              %1: ptr = arg reg
-              %2: ptr = arg reg
+              %0: i1 = arg [reg]
+              %1: ptr = arg [reg]
+              %2: ptr = arg [reg]
               %3: ptr = select %0, %1, %2
               exit [%0, %3, %2]
             ",
@@ -4556,7 +4556,7 @@ mod test {
     fn cg_sext() {
         codegen_and_test(
             "
-              %0: i1 = arg reg
+              %0: i1 = arg [reg]
               %1: i64 = sext %0
               exit [%1]
             ",
@@ -4576,7 +4576,7 @@ mod test {
         // float
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: float = sitofp %0
               blackbox %1
               exit [%0]
@@ -4595,7 +4595,7 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: double = sitofp %0
               blackbox %1
               exit [%0]
@@ -4612,7 +4612,7 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: double = sitofp %0
               blackbox %1
               exit [%0]
@@ -4632,8 +4632,8 @@ mod test {
         // double
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: double = arg reg
+              %0: ptr = arg [reg]
+              %1: double = arg [reg]
               store %1, %0
               exit [%0, %1]
             ",
@@ -4648,8 +4648,8 @@ mod test {
         // float
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: float = arg reg
+              %0: ptr = arg [reg]
+              %1: float = arg [reg]
               store %1, %0
               exit [%0, %1]
             ",
@@ -4667,8 +4667,8 @@ mod test {
         // i8
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i8 = arg reg
+              %0: ptr = arg [reg]
+              %1: i8 = arg [reg]
               store %1, %0
               exit [%0, %1]
             ",
@@ -4682,7 +4682,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i8 = 2
               store %1, %0
               exit [%0]
@@ -4698,8 +4698,8 @@ mod test {
         // i16
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i16 = arg reg
+              %0: ptr = arg [reg]
+              %1: i16 = arg [reg]
               store %1, %0
               exit [%0, %1]
             ",
@@ -4713,7 +4713,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i16 = 0x200
               store %1, %0
               exit [%0]
@@ -4729,8 +4729,8 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i32 = arg reg
+              %0: ptr = arg [reg]
+              %1: i32 = arg [reg]
               store %1, %0
               exit [%0, %1]
             ",
@@ -4744,7 +4744,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i32 = 0x2000
               store %1, %0
               exit [%0]
@@ -4760,8 +4760,8 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i64 = arg reg
+              %0: ptr = arg [reg]
+              %1: i64 = arg [reg]
               store %1, %0
               exit [%0, %1]
             ",
@@ -4775,7 +4775,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: ptr = arg reg
+              %0: ptr = arg [reg]
               %1: i64 = 0x20000
               store %1, %0
               exit [%0]
@@ -4791,8 +4791,8 @@ mod test {
         // ptradd optimisation
         codegen_and_test(
             "
-              %0: ptr = arg reg
-              %1: i8 = arg reg
+              %0: ptr = arg [reg]
+              %1: i8 = arg [reg]
               %2: ptr = ptradd %0, 8
               store %1, %2
               exit [%0, %1]
@@ -4811,8 +4811,8 @@ mod test {
         // i32
         codegen_and_test(
             "
-              %0: i32 = arg reg
-              %1: i32 = arg reg
+              %0: i32 = arg [reg]
+              %1: i32 = arg [reg]
               %2: i32 = sub %0, %1
               exit [%0, %2]
             ",
@@ -4826,7 +4826,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: i32 = 32
               %2: i32 = sub %0, %1
               exit [%2]
@@ -4841,7 +4841,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i32 = arg reg
+              %0: i32 = arg [reg]
               %1: i32 = 0xFFFFFFFF
               %2: i32 = sub %0, %1
               exit [%2]
@@ -4857,8 +4857,8 @@ mod test {
         // i64
         codegen_and_test(
             "
-              %0: i64 = arg reg
-              %1: i64 = arg reg
+              %0: i64 = arg [reg]
+              %1: i64 = arg [reg]
               %2: i64 = sub %0, %1
               exit [%0, %2]
             ",
@@ -4872,7 +4872,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0
               %2: i64 = sub %1, %0
               exit [%2]
@@ -4887,7 +4887,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 32
               %2: i64 = sub %0, %1
               exit [%2]
@@ -4902,7 +4902,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0xFFFFFFFF
               %2: i64 = sub %0, %1
               exit [%2]
@@ -4918,7 +4918,7 @@ mod test {
 
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i64 = 0xFFFFFFFFFFFFFFFF
               %2: i64 = sub %1, %0
               exit [%2]
@@ -4937,7 +4937,7 @@ mod test {
     fn cg_trunc() {
         codegen_and_test(
             "
-              %0: i64 = arg reg
+              %0: i64 = arg [reg]
               %1: i1 = trunc %0
               exit [%1]
             ",
@@ -4954,7 +4954,7 @@ mod test {
     fn cg_zext() {
         codegen_and_test(
             "
-              %0: i1 = arg reg
+              %0: i1 = arg [reg]
               %1: i64 = zext %0
               exit [%1]
             ",


### PR DESCRIPTION
The main commit here is https://github.com/ykjit/yk/commit/bdda6eee2e596bf58fe993c514f32737fcb3bae8. There is a lot of churn in text input, but better to bite the bullet now than later!