### PR TITLE
Only optimise `eq`.

### DIFF
--- a/ykrt/src/compile/j2/opt/opt.rs
+++ b/ykrt/src/compile/j2/opt/opt.rs
@@ -120,7 +120,12 @@ impl OptT for Opt {
                     return Ok(*cond);
                 }
                 if *expect
-                    && let Inst::ICmp(ICmp { lhs, rhs, .. }) = &self.insts[*cond]
+                    && let Inst::ICmp(ICmp {
+                        lhs,
+                        rhs,
+                        pred: IPred::Eq,
+                        ..
+                    }) = &self.insts[*cond]
                     && let Inst::Const(_) = &self.insts[*rhs]
                 {
                     match &self.ranges[*lhs] {
@@ -130,7 +135,7 @@ impl OptT for Opt {
                 }
             }
             Inst::ICmp(ICmp {
-                pred: _,
+                pred: IPred::Eq,
                 lhs,
                 rhs,
                 samesign: _,


### PR DESCRIPTION
This is what happens when I quickly hack an optimiser: I make silly mistakes! Still, these are easily fixed. In essence, we can only learn that x==y if there really is an `==` (and not, say, `!=`).

A proper, tested, optimiser is on my todo list, but there are higher priority items right now, so this quick fix will have to do.