### PR TITLE
Use the `gridx` passed to the function.

### DIFF
--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -2124,6 +2124,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
             expect,
             cond,
             entry_vars,
+            gridx,
             ..
         }: &Guard,
     ) -> Result<Self::Label, CompilationError> {
@@ -2142,9 +2143,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
                     clobber: false,
                 },
                 RegCnstr::KeepAlive {
-                    gridx: GuardRestoreIdx::from(
-                        self.m.guard_restores().len() - self.guards.len() - 1,
-                    ),
+                    gridx: *gridx,
                     iidxs: entry_vars,
                 },
             ],


### PR DESCRIPTION
`self.m.guard_restores().len()` is always 0 when the function below is called: this leads to a situation where guard optimisation is given the wrong `gridx` and hilarity ensues. This is doubly unfortunate because the function is quite literally passed the correct `gridx` and doesn't have to try to calculate itself!

Unfortunately, this turns out to be _very_ difficult to test, because the resulting error causes a problem in the register allocator, with a (delayed) second order effect on guard bodies. On one massive trace of 3000+ instructions, this problem crops up once. Needless to say, I don't think that would be a very maintainable test, and I haven't succeeded in meaningfully chopping it down. I need to think if there's a more reasonable way to test this, but for now a fix is better than nothing.