### PR TITLE
Make registering a new shadow stack thread-safe.

### DIFF
--- a/tests/c/many_threads_many_locs.c
+++ b/tests/c/many_threads_many_locs.c
@@ -1,5 +1,3 @@
-// ## segs with: tcache_thread_shutdown(): unaligned tcache chunk detected
-// ignore-if: true
 // Run-time:
 //   env-var: YKD_LOG=4
 //   env-var: YKD_SERIALISE_COMPILATION=1


### PR DESCRIPTION
By eyeballing core dumps I was able to see that the many_threads_many_locs test crashes non-deterministically when two threads happen to be inside `ShadowStacks::register_current_thread()` at the same time (there were actually several failure modes, but this is the one that pinpointed the issue for me).

When we spin up a new interpreter thread, we create a shadow stack for the thread and then record the base of the shadow stack in a global variable `SHADOW_STACKS`.

The problem is that `SHADOW_STACKS` can be mutated by multiple threads, but there's nothing to guard against concurrent accesses (the global variable is `static mut` and accessed by `unsafe` code!). This meant that two threads could be manipulating a Rust vector at the same time, thus causing occasional crashes.

This change fixes the crashes by wrapping `SHADOW_STACKS` in a Mutex.

(It appears that someone knew this might be a problem, as there was FIXME comment saying this should have a mutex)

After the fix, I've run the flaky test 2000 times with no crash. Before I could usually get a crash after 20 or so runs.