### PR TITLE
Remove compile-time guards.

### DIFF
--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -10,11 +10,6 @@ use {
 
 pub fn main() {
     println!("cargo::rerun-if-env-changed=YKB_TRACER");
-    // Always compile in yk's default JIT compiler.
-    println!("cargo::rustc-cfg=jitc_yk");
-    println!("cargo::rustc-check-cfg=cfg(jitc_yk)");
-    println!("cargo::rustc-cfg=jitc_j2");
-    println!("cargo::rustc-check-cfg=cfg(jitc_j2)");
 
     println!("cargo::rustc-check-cfg=cfg(tracer_hwt)");
     println!("cargo::rustc-check-cfg=cfg(tracer_swt)");

--- a/ykrt/src/compile/mod.rs
+++ b/ykrt/src/compile/mod.rs
@@ -16,9 +16,7 @@ use thiserror::Error;
 
 pub(crate) mod guard;
 pub(crate) use guard::{Guard, GuardId};
-#[cfg(jitc_j2)]
 pub mod j2;
-#[cfg(jitc_yk)]
 pub mod jitc_yk;
 
 /// A failure to compile a trace.
@@ -74,12 +72,10 @@ pub(crate) trait Compiler: Send + Sync {
 }
 
 pub(crate) fn default_compiler() -> Result<Arc<dyn Compiler>, Box<dyn Error>> {
-    #[cfg(jitc_j2)]
     if std::env::var("YK_JITC").is_ok_and(|x| x == "j2") {
         return Ok(j2::J2::new()?);
     }
 
-    #[cfg(jitc_yk)]
     return Ok(jitc_yk::JITCYk::new()?);
 
     #[allow(unreachable_code)]


### PR DESCRIPTION
These are always, and will almost certainly always be, on -- until we remove a backend at which point we'll remove all the relevant code.

At the moment their only practical effect is to confuse rust-analyzer (causing it to sometimes stop completing things in one other subsystem), which isn't a price that seems worth paying.