### PR TITLE
Reorder and rename `arrange_fill`s `bitw` -> `dst_bitw`.

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -658,7 +658,10 @@ pub(super) trait HirToAsmBackend {
     /// Move the [super::regalloc::VarLoc::StackOff] address `stack_off` into `reg`.
     fn move_stackoff(&mut self, reg: Self::Reg, stack_off: u32) -> Result<(), CompilationError>;
 
-    fn arrange_fill(&mut self, reg: Self::Reg, bitw: u32, src_fill: RegFill, dst_fill: RegFill);
+    /// Adjust `dst_bitw` bits of `reg` from `src_fill` to `dst_fill`.
+    fn arrange_fill(&mut self, reg: Self::Reg, src_fill: RegFill, dst_bitw: u32, dst_fill: RegFill);
+
+    /// Copy `from_reg` to `to_reg`.
     fn copy_reg(&mut self, from_reg: Self::Reg, to_reg: Self::Reg) -> Result<(), CompilationError>;
 
     /// If the stack is currently at offset `stack_off`, return an aligned offset suitable for a

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -1066,15 +1066,15 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         Ok(())
     }
 
-    fn arrange_fill(&mut self, reg: Reg, bitw: u32, src_fill: RegFill, dst_fill: RegFill) {
+    fn arrange_fill(&mut self, reg: Reg, src_fill: RegFill, dst_bitw: u32, dst_fill: RegFill) {
         match (src_fill, dst_fill) {
             (RegFill::Undefined, RegFill::Undefined) => (),
-            (RegFill::Undefined | RegFill::Signed, RegFill::Zeroed) => match bitw {
+            (RegFill::Undefined | RegFill::Signed, RegFill::Zeroed) => match dst_bitw {
                 1..=31 => {
                     self.asm.push_inst(IcedInst::with2(
                         Code::And_rm32_imm32,
                         reg.to_reg32(),
-                        ((1u64 << bitw) - 1) as i32,
+                        ((1u64 << dst_bitw) - 1) as i32,
                     ));
                 }
                 32 => {
@@ -1089,7 +1089,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
             },
             (RegFill::Zeroed, RegFill::Undefined) => (),
             (RegFill::Zeroed, RegFill::Zeroed) => (),
-            (RegFill::Undefined | RegFill::Zeroed, RegFill::Signed) => match bitw {
+            (RegFill::Undefined | RegFill::Zeroed, RegFill::Signed) => match dst_bitw {
                 1 => {
                     self.asm
                         .push_inst(IcedInst::with1(Code::Neg_rm64, reg.to_reg64()));


### PR DESCRIPTION
Neither name is quite perfect, but this gets across the intended semantics somewhat better: we don't actually know how big the source value is in some sense; we care only about the fills of `dst_bitw` bits.