### PR TITLE
Implement various 64 bit cases we see in yklua tests

### DIFF
--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -3554,6 +3554,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         )?;
         self.asm.push_inst(match bitw {
             1..=32 => IcedInst::with2(Code::Xor_rm32_r32, lhsr.to_reg32(), rhsr.to_reg32()),
+            64 => IcedInst::with2(Code::Xor_rm64_r64, lhsr.to_reg64(), rhsr.to_reg64()),
             x => todo!("{x}"),
         });
 
@@ -7236,6 +7237,22 @@ mod test {
               ...
               ; %2: i32 = xor %0, %1
               xor r.32._, r.32._
+              ...
+            "],
+        );
+
+        // i64
+        codegen_and_test(
+            "
+              %0: i64 = arg [reg]
+              %1: i64 = arg [reg]
+              %2: i64 = xor %0, %1
+              exit [%0, %2]
+            ",
+            &["
+              ...
+              ; %2: i64 = xor %0, %1
+              xor r.64._, r.64._
               ...
             "],
         );


### PR DESCRIPTION
These are mostly fairly mechanical, though I've made one "mild optimisation" since I noticed it in this process (https://github.com/ykjit/yk/commit/51e89e8f09e475799edc3fb042ac2ead44a3a48c).