### PR TITLE
New versions of mdbook complain about the `multilingual` flag.

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["The Software Development Team"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Yk"


### PR DESCRIPTION
With luck, once this has merged, https://github.com/ykjit/yk/pull/1940 can be tried again.