### PR TITLE
Introduce code buffer structs

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -31,6 +31,7 @@ use crate::{
     compile::{
         CompilationError, CompiledTrace,
         j2::{
+            codebuf::ExeCodeBuf,
             compiled_trace::{DeoptFrame, J2CompiledGuard, J2CompiledTrace, J2CompiledTraceKind},
             hir::*,
             regalloc::{RegAlloc, RegFill, RegT, SnapshotIdx, VarLocs},
@@ -664,7 +665,7 @@ pub(super) trait HirToAsmBackend {
         labels: &[Self::Label],
     ) -> Result<
         (
-            *mut c_void,
+            ExeCodeBuf,
             IndexVec<GuardRestoreIdx, J2CompiledGuard<Self::Reg>>,
             Option<String>,
             Vec<usize>,

--- a/ykrt/src/compile/j2/mod.rs
+++ b/ykrt/src/compile/j2/mod.rs
@@ -24,8 +24,8 @@ mod x64;
 
 use crate::{
     compile::{
-        CompilationError, CompiledTrace, Compiler, GuardId, TraceEndFrame, j2::codebuf::CodeBuf,
-        jitc_yk::AOT_MOD,
+        CompilationError, CompiledTrace, Compiler, GuardId, TraceEndFrame,
+        j2::codebuf::CodeBufInProgress, jitc_yk::AOT_MOD,
     },
     location::HotLocation,
     mt::{MT, TraceId},
@@ -135,7 +135,7 @@ impl Compiler for J2 {
 
         #[cfg(target_arch = "x86_64")]
         let minlen = x64::x64hir_to_asm::X64HirToAsm::codebuf_minlen(&hm);
-        let buf = CodeBuf::new(minlen);
+        let buf = CodeBufInProgress::new(minlen);
         #[cfg(target_arch = "x86_64")]
         let be = x64::x64hir_to_asm::X64HirToAsm::new(&hm, buf);
 
@@ -177,7 +177,7 @@ impl Compiler for J2 {
 
         #[cfg(target_arch = "x86_64")]
         let minlen = x64::x64hir_to_asm::X64HirToAsm::codebuf_minlen(&hm);
-        let buf = CodeBuf::new(minlen);
+        let buf = CodeBufInProgress::new(minlen);
         #[cfg(target_arch = "x86_64")]
         let be = x64::x64hir_to_asm::X64HirToAsm::new(&hm, buf);
 

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -1892,7 +1892,7 @@ mod test {
     use super::*;
     use crate::{
         compile::{
-            j2::{hir::Mod, hir::*, hir_parser::str_to_mod, hir_to_asm::*},
+            j2::{codebuf::ExeCodeBuf, hir::Mod, hir::*, hir_parser::str_to_mod, hir_to_asm::*},
             jitc_yk::aot_ir,
         },
         location::{HotLocation, HotLocationKind},
@@ -2093,7 +2093,7 @@ mod test {
             _labels: &[Self::Label],
         ) -> Result<
             (
-                *mut std::ffi::c_void,
+                ExeCodeBuf,
                 IndexVec<
                     GuardRestoreIdx,
                     crate::compile::j2::compiled_trace::J2CompiledGuard<Self::Reg>,


### PR DESCRIPTION
This PR moves j2's code storage from `*mut u8` (and a `usize`) to two structs that hide away some of the functionality we don't want to always expose. Right now, this is of some benefit, but I expect to build further upon this soon. For example, it will make it easier to (finally!) not leave `PROT_WRITE` on at all points.