### PR TITLE
Try to `mmap` memory near the interpreter and existing traces.

### DIFF
--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -4034,7 +4034,7 @@ mod test {
             #[cfg(feature = "ykd")]
             debug_str: None,
         }));
-        let be = X64HirToAsm::new(&m, CodeBufInProgress::new(4096));
+        let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing());
         let log = HirToAsm::new(&m, hl, be).build_test().unwrap();
 
         let mut failures = Vec::new();
@@ -4067,7 +4067,7 @@ mod test {
         else {
             panic!()
         };
-        let be = X64HirToAsm::new(&m, CodeBufInProgress::new(4096));
+        let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing());
 
         assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(0)), Some(0));
         assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(1)), Some(0xFF));
@@ -4104,7 +4104,7 @@ mod test {
         else {
             panic!()
         };
-        let be = X64HirToAsm::new(&m, CodeBufInProgress::new(4096));
+        let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing());
 
         assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(6)), Some(0));
         assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(7)), Some(-1));
@@ -4164,7 +4164,7 @@ mod test {
         else {
             panic!()
         };
-        let be = X64HirToAsm::new(&m, CodeBufInProgress::new(4096));
+        let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing());
 
         assert_eq!(
             be.try_load_to_mem_op(b, InstIdx::from(3), InstIdx::from(1)),


### PR DESCRIPTION
If we leave `mmap` to its own devices, it will often (but, at least on Linux, not always!) put traces very
far in virtual memory from the interpreter. That means we end up having to do inefficient far calls from traces back to the interpreter.

This commit takes inspiration from LuaJIT: we try to force `mmap` to allocate traces near to the interpreter. We use `mmap`'s "hint" feature: if you give it an address, it will "try" to allocate memory nearby in virtual memory. However, if nothing nearby is available, it will give up, and allocate somewhere completely different. What we do is to look at the address we've got back and see if, on our current platform, the address is nearby; if not, we `munmap` the memory, and try a different hint address.

This works quite well for yklua. My guess is that for interpreters with a much greater quantity of code (e.g. CPython / CRuby), we might have to fiddle with the "try another hint address" heuristic, but that's a bridge we can cross when we get to it.