### PR TITLE
Fix incorrect extension in jitc_yk cg_udiv.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1390,7 +1390,7 @@ impl<'a> Assemble<'a> {
                         },
                         GPConstraint::Input {
                             op: rhs,
-                            in_ext: RegExtension::SignExtended,
+                            in_ext: RegExtension::ZeroExtended,
                             force_reg: None,
                             clobber_reg: false,
                         },
@@ -5403,7 +5403,7 @@ mod tests {
                 ; %4: i16 = udiv %0, %1
                 mov r.64.a, r.64._
                 and eax, 0xffff
-                movsx r.64.b, r.16.b
+                and r.32.b, 0xffff
                 xor rdx, rdx
                 div r.64.b
                 ; %5: i32 = udiv %2, %3


### PR DESCRIPTION
This has been bugging me for a while.

I'm pretty sure the input operands for a udiv should be zero extended, yet the right hand side is sign-extended.

Looking to j2 for a second opinion, we have:
```
        let [_lhsr, rhsr, _] = ra.alloc(
            self,
            iidx,
            [
                RegCnstr::InputOutput {
                    in_iidx: *lhs,
                    in_fill: RegCnstrFill::Zeroed,
                    out_fill: RegCnstrFill::Zeroed,
                    regs: &[Reg::RAX],
                },
                RegCnstr::Input {
                    in_iidx: *rhs,
                    in_fill: RegCnstrFill::Zeroed,
                    regs: &NORMAL_GP_REGS,
                    clobber: false,
                },
                RegCnstr::Clobber { reg: Reg::RDX },
            ],
        )?;
```

i.e. inputs are zero extended there too.

Should be zero extended, right?