### PR TITLE
Make the `mmap` hint address including the length requested.

### DIFF
--- a/ykrt/src/compile/j2/mod.rs
+++ b/ykrt/src/compile/j2/mod.rs
@@ -113,7 +113,7 @@ impl J2 {
             };
 
             if is_near {
-                *lk = SyncSafePtr(buf);
+                *lk = SyncSafePtr(unsafe { buf.byte_add(len) });
                 return CodeBufInProgress::new(buf as *mut u8, len);
             }
 


### PR DESCRIPTION
When we compile long traces, this makes it significantly more likely that `mmap` succeeds in giving us a "nearby" address on its first try. On some benchmarks, this can stop us from having to do many retries to doing none (after the very first call to this function when we're hunting for a free page near `main`).

This helps us in two ways: first, all compilation threads currently block on `mmap_hint`, so the less time we spend with that lock held, the better. Second `mmap` itself is rather expensive, so the fewer times we do that, the better!