### PR TITLE
Fix j2 w.r.t. the recent block-splitting change.

### DIFF
--- a/ykrt/src/compile/j2/compiled_trace.rs
+++ b/ykrt/src/compile/j2/compiled_trace.rs
@@ -271,12 +271,8 @@ impl<Reg: RegT> J2CompiledGuard<Reg> {
 /// The information about a frame necessary for deopt and side-tracing.
 #[derive(Debug)]
 pub(super) struct DeoptFrame<Reg: RegT> {
-    pub safepoint: &'static DeoptSafepoint,
-    /// If this is an inlined frame (i.e. for all but the bottom frame), this is the [InstId] of
-    /// the call instruction. This is used to link the return value when the inlined frame is
-    /// popped.
-    pub call_iid: Option<aot_ir::InstId>,
-    pub func: aot_ir::FuncIdx,
+    pub pc: InstId,
+    pub pc_safepoint: &'static DeoptSafepoint,
     /// The information necessary for deopt and side-tracing: in a sense we precalculate this from
     /// `self.vars` to (a) avoid us having to carry around a [hir::Module] (b) optimise how much we
     /// need to read/write. It's currently unclear whether doing this is a good trade

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -3478,12 +3478,10 @@ impl InstT for ZExt {
 /// Information about a guard necessary for deopt and side-tracing.
 #[derive(Clone, Debug)]
 pub(super) struct Frame {
-    pub safepoint: &'static aot_ir::DeoptSafepoint,
-    /// If this is an inlined frame (i.e. for all but the bottom frame), this is the [InstId] of
-    /// the call instruction. This is used to link the return value when the inlined frame is
-    /// popped.
-    pub call_iid: Option<aot_ir::InstId>,
-    pub func: aot_ir::FuncIdx,
+    pub pc: aot_ir::InstId,
+    /// The current safepoint for this frame. This has no initial value at frame entry, and is
+    /// updated at every call site.
+    pub pc_safepoint: &'static DeoptSafepoint,
     /// One [InstIdx] for each live variable in `safepoint.lives`, stored in order relative to
     /// `safepoint.lives`.
     pub exit_vars: Vec<InstIdx>,

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -330,21 +330,19 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 .iter()
                 .map(
                     |Frame {
-                         safepoint,
-                         call_iid,
-                         func,
+                         pc,
+                         pc_safepoint,
                          exit_vars,
                      }| {
-                        let smap = aot_smaps.get(usize::try_from(safepoint.id).unwrap()).0;
-                        assert_eq!(exit_vars.len(), safepoint.lives.len());
+                        let smap = aot_smaps.get(usize::try_from(pc_safepoint.id).unwrap()).0;
+                        assert_eq!(exit_vars.len(), pc_safepoint.lives.len());
                         assert_eq!(exit_vars.len(), smap.live_vals.len());
                         DeoptFrame {
-                            safepoint,
-                            call_iid: call_iid.to_owned(),
-                            func: *func,
+                            pc: pc.clone(),
+                            pc_safepoint,
                             vars: exit_vars
                                 .iter()
-                                .zip(safepoint.lives.iter().zip(smap.live_vals.iter()))
+                                .zip(pc_safepoint.lives.iter().zip(smap.live_vals.iter()))
                                 .map(|(iidx, (aot_op, smap_loc))| {
                                     let fromvlocs = ra.varlocs_for_deopt(*iidx);
                                     let mut tovlocs = AB::smp_to_vloc(smap_loc);

--- a/ykrt/src/compile/j2/opt/opt.rs
+++ b/ykrt/src/compile/j2/opt/opt.rs
@@ -130,7 +130,11 @@ impl OptT for Opt {
                 {
                     match &self.ranges[*lhs] {
                         Range::Unknown => self.ranges[*lhs] = Range::Equivalent(*rhs),
-                        Range::Equivalent(_) => todo!(),
+                        Range::Equivalent(x) => {
+                            if x != rhs {
+                                todo!("{x:?} {rhs:?}");
+                            }
+                        }
                     }
                 }
             }

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -466,7 +466,6 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                         .unwrap()
                         .0,
                 );
-                println!("{break_reg:?} {:?}", ractions.distinct_copies);
 
                 ractions.spills.push(RegSpill {
                     iidxs: self.rstates.iidxs(break_reg).clone(),

--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -193,7 +193,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
     // already exists, rather than creating one from scratch.
     {
         let frame = &deopt_frames[0];
-        let (smap, prologue) = aot_smaps.get(usize::try_from(frame.safepoint.id).unwrap());
+        let (smap, prologue) = aot_smaps.get(usize::try_from(frame.pc_safepoint.id).unwrap());
         if prologue.hasfp {
             // Update RBP to represent this frame's address.
             gp_regs[DeoptGpReg::RBP.idx()] = prev_faddr as u64;
@@ -207,7 +207,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
 
     // Deal with all the remaining frames: we create each of these from scratch.
     for frame in deopt_frames.iter().skip(1) {
-        let (smap, prologue) = aot_smaps.get(usize::try_from(frame.safepoint.id).unwrap());
+        let (smap, prologue) = aot_smaps.get(usize::try_from(frame.pc_safepoint.id).unwrap());
 
         // How much room does this frame need?
         let flen = 8 + usize::try_from(smap.size).unwrap();
@@ -289,7 +289,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
 
     let fdst = {
         let (smap, prologue) =
-            aot_smaps.get(usize::try_from(deopt_frames[0].safepoint.id).unwrap());
+            aot_smaps.get(usize::try_from(deopt_frames[0].pc_safepoint.id).unwrap());
         if prologue.hasfp {
             unsafe { faddr.byte_sub(usize::try_from(smap.size - 8).unwrap()) }
         } else {


### PR DESCRIPTION
j2 is slightly behind the times and couldn't deal properly with the changes resulting from block splitting in
c0e34fb5ecb922c18ae523a40b76979cc9f54be2.

I'm not entirely happy with this commit: it's a little messy. However, when I tried doing a "better" fix, I ran into a number of rough edges. On balance, this fix is worth getting in, I can then try and smooth off the rough edges, and then have another go at aot_to_hir.