### PR TITLE
Split the optimiser into parts that are plausibly maintainable.

### DIFF
--- a/ykrt/src/compile/j2/opt/mod.rs
+++ b/ykrt/src/compile/j2/opt/mod.rs
@@ -6,6 +6,7 @@ use index_vec::IndexVec;
 pub(super) mod noopt;
 #[allow(clippy::module_inception)]
 pub(super) mod opt;
+mod strength_fold;
 
 /// An optimiser. By definition this operates on one [Block] at a time, so it is both [ModLikeT]
 /// and [BlockLikeT].
@@ -42,10 +43,10 @@ pub(super) trait OptT: ModLikeT + BlockLikeT {
     /// If `iidx` is greater than the number of instructions the optimiser currently holds.
     fn map_iidx(&self, iidx: InstIdx) -> InstIdx;
 
-    /// Push an instruction and return an [InstIdx]. The returned [InstIdx] may refer to a
-    /// previously inserted instruction, as an optimiser might prove that `inst` is unneeded.
-    /// That previously inserted instruction may not even be of the same kind as `inst`!
-    fn push_inst(&mut self, inst: Inst) -> Result<InstIdx, CompilationError>;
+    /// Feed an instruction into the optimiser and return an [InstIdx]. The returned [InstIdx] may
+    /// refer to a previously inserted instruction, as an optimiser might prove that `inst` is
+    /// unneeded. That previously inserted instruction may not even be of the same kind as `inst`!
+    fn feed(&mut self, inst: Inst) -> Result<InstIdx, CompilationError>;
 
     /// Push a type [ty]. This type may be cached, and thus the [TyIdx] returned may not
     /// monotonically increase.

--- a/ykrt/src/compile/j2/opt/noopt.rs
+++ b/ykrt/src/compile/j2/opt/noopt.rs
@@ -51,7 +51,7 @@ impl OptT for NoOpt {
         iidx
     }
 
-    fn push_inst(&mut self, inst: Inst) -> Result<InstIdx, CompilationError> {
+    fn feed(&mut self, inst: Inst) -> Result<InstIdx, CompilationError> {
         Ok(self.insts.push(inst))
     }
 

--- a/ykrt/src/compile/j2/opt/strength_fold.rs
+++ b/ykrt/src/compile/j2/opt/strength_fold.rs
@@ -1,0 +1,142 @@
+//! Strength reduction and constant folding
+
+use crate::compile::{
+    j2::{
+        hir::*,
+        opt::opt::{Opt, OptOutcome},
+    },
+    jitc_yk::arbbitint::ArbBitInt,
+};
+
+pub(super) fn strength_fold(opt: &mut Opt, inst: Inst) -> OptOutcome {
+    match inst {
+        Inst::And(x) => opt_and(opt, x),
+        _ => OptOutcome::Unchanged(inst),
+    }
+}
+
+fn opt_and(opt: &mut Opt, inst @ And { tyidx, lhs, rhs }: And) -> OptOutcome {
+    if lhs == rhs {
+        // Reduce x & x with x.
+        return OptOutcome::ReducedTo(lhs);
+    } else if let (
+        Inst::Const(Const {
+            kind: ConstKind::Int(lhs_c),
+            ..
+        }),
+        Inst::Const(Const {
+            kind: ConstKind::Int(rhs_c),
+            ..
+        }),
+    ) = (opt.inst(lhs), &opt.inst(rhs))
+    {
+        // Constant fold `c1 & c2`.
+        return OptOutcome::Rewritten(Inst::Const(Const {
+            tyidx,
+            kind: ConstKind::Int(lhs_c.bitand(rhs_c)),
+        }));
+    } else if let Inst::Const(Const {
+        kind: ConstKind::Int(rhs_c),
+        ..
+    }) = opt.inst(rhs)
+    {
+        if rhs_c.to_zero_ext_u8() == Some(0) {
+            // Reduce `x & 0` to `0`.
+            return OptOutcome::ReducedTo(rhs);
+        }
+        if rhs_c == &ArbBitInt::all_bits_set(rhs_c.bitw()) {
+            // Reduce `x & y` to `x` if `y` is a constant that has all
+            // the necessary bits set for this integer type. For an i1, for
+            // example, `x & 1` can be replaced with `x`.
+            return OptOutcome::ReducedTo(lhs);
+        }
+    }
+
+    OptOutcome::Unchanged(inst.into())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::compile::j2::opt::opt::test::opt_and_test;
+
+    fn test_sf(mod_s: &str, ptn: &str) {
+        opt_and_test(mod_s, strength_fold, ptn);
+    }
+
+    #[test]
+    fn opt_and() {
+        // x & x == x
+        test_sf(
+            "
+          %0: i8 = arg [reg]
+          %1: i8 = and %0, %0
+          exit [%1]
+        ",
+            "
+          ...
+          %0: i8 = arg
+          exit [%0]
+        ",
+        );
+
+        // Simple constant folding e.g `1 & 2`.
+        test_sf(
+            "
+          %0: i8 = 2
+          %1: i8 = 3
+          %2: i8 = and %0, %1
+          blackbox %2
+        ",
+            "
+          ...
+          %2: i8 = 2
+          blackbox %2
+        ",
+        );
+
+        test_sf(
+            "
+          %0: i8 = 0
+          %1: i8 = 255
+          %2: i8 = and %0, %1
+          blackbox %2
+        ",
+            "
+          ...
+          %2: i8 = 0
+          blackbox %2
+        ",
+        );
+
+        // Strength reduction of `y & 0`.
+        test_sf(
+            "
+          %0: i8 = arg [ reg ]
+          %1: i8 = 0
+          %2: i8 = and %0, %1
+          exit [%2]
+        ",
+            "
+          ...
+          %1: i8 = 0
+          exit [%1]
+        ",
+        );
+
+        // Strength reduction of `y & 0b1111111` (i.e. all bits set in the appropriate type).
+        test_sf(
+            "
+          %0: i8 = arg [ reg ]
+          %1: i8 = 255
+          %2: i8 = and %0, %1
+          exit [%1]
+        ",
+            "
+          ...
+          %1: i8 = 255
+          exit [%1]
+        ",
+        );
+    }
+}

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -1887,7 +1887,7 @@ impl Iterator for MaxBitIter {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
     use crate::{
         compile::{
@@ -1965,7 +1965,7 @@ mod test {
 
     #[derive(Copy, Clone, Debug, Display, EnumCount, FromRepr, PartialEq)]
     #[repr(u8)]
-    enum TestReg {
+    pub(crate) enum TestReg {
         GPR0,
         GPR1,
         GPR2,
@@ -2016,7 +2016,7 @@ mod test {
     }
 
     index_vec::define_index_type! {
-        pub(super) struct TestRegIdx = u8;
+        pub(crate) struct TestRegIdx = u8;
     }
 
     struct TestRegTestIter<Reg> {

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -4067,7 +4067,7 @@ mod test {
         for ptn in ptns {
             match fmatcher(ptn).matches(&log) {
                 Ok(()) => return,
-                Err(e) => failures.push(format!("{e:?}\n\n{log}\n\n{ptn}")),
+                Err(e) => failures.push(e.to_string()),
             }
         }
         panic!("{}", failures.join("\n\n"));

--- a/ykrt/src/compile/jitc_yk/arbbitint.rs
+++ b/ykrt/src/compile/jitc_yk/arbbitint.rs
@@ -136,6 +136,7 @@ impl ArbBitInt {
     }
 
     /// Sign extend the underlying value and, if it is representable as an `isize`, return it.
+    #[allow(dead_code)]
     pub(crate) fn to_sign_ext_isize(&self) -> Option<isize> {
         assert_eq!(
             usize::try_from(isize::BITS).unwrap(),


### PR DESCRIPTION
Before this commit, j2's current optimiser was a minimal test that something like this would work: it was comically incomplete, untested, and internally unstructured.

This commit starts to get j2's optimiser into some sort of shape. It breaks strength reduction and constant folding into its own module, and makes it testable. I've tried to avoid one of jitc_yk's notable overheads by removing the concept of "decopy_eq" (we could sometimes spend 40% of compilation time in such functions!) by using `map_iidxs` and a new `OptOutcome` enum. I haven't fully convinced myself that this will handle everything we need in the future, but until I've got further into this, it's hard to know for sure --- and it is simple!

So as not to overload this commit, this can currently only optimise `and`: we can add further optimisations in subsequent commits.