### PR TITLE
Fix the topological sort nodes / edges.

### DIFF
--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -4752,8 +4752,8 @@ mod test {
               ; %1: float = arg [Reg("xmm15")]
               ; %2: double = arg [Reg("xmm14")]
               ...
-              movsd xmm0, xmm15
               movsd xmm1, xmm14
+              movsd xmm0, xmm15
               ; call %0(%1, %2)
               call rax
               ...
@@ -4822,8 +4822,8 @@ mod test {
               ; %2: double = arg [Reg("xmm14")]
               ...
               mov r.64.x, rax
-              movsd xmm0, xmm15
               movsd xmm1, xmm14
+              movsd xmm0, xmm15
               ; call %0(%1, %2)
               mov eax, 2
               call r.64.x
@@ -6940,8 +6940,8 @@ mod test {
               movsxd r.64.y, r.32._
               ...
               ; %2: i32 = smax %0, %1
-              cmp r.64.x, r.64.y
-              cmovl r.64.x, r.64.y
+              cmp r.64.y, r.64.x
+              cmovl r.64.y, r.64.x
               ...
             "],
         );
@@ -6981,8 +6981,8 @@ mod test {
               movsxd r.64.y, r.32._
               ...
               ; %2: i32 = smin %0, %1
-              cmp r.64.x, r.64.y
-              cmovg r.64.x, r.64.y
+              cmp r.64.y, r.64.x
+              cmovg r.64.y, r.64.x
               ...
             "],
         );


### PR DESCRIPTION
Long story short: I got what should be nodes and edges in the topological sort the wrong way around and this commit fixes them, and adds a test that identified the mistake.

Slightly expanding: registers are now nodes and `RegCopy`s define edges. The core topological sort algorithm was correct before, but now it's operating on the right things! There is one additional subtlety: we want the register _copies_ to be in order, not the _registers themselves. When the topological sort succeeds, it produces sorted nodes, which we can then use to sort the edges.

Note: because there are often multiple valid topological sort, this can lead to the order that registers are copied in changing (and you can see that in a couple of tests below).