### PR TITLE
Remove guard optimism.

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -531,7 +531,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     assert!(cnd_idx <= grestores.len());
                     if cnd_idx == grestores.len() {
                         let label = self.be.i_guard(&mut ra, b, iidx, x)?;
-                        let sidx = ra.snapshot(iidx, *gridx);
+                        let sidx = ra.snapshot(iidx);
                         grestores.push(AsmGuardRestore {
                             gridx: *gridx,
                             label,

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -268,7 +268,6 @@ impl<'a> X64HirToAsm<'a> {
         iidx: InstIdx,
         Guard {
             expect,
-            gridx,
             cond,
             entry_vars,
             ..
@@ -336,10 +335,7 @@ impl<'a> X64HirToAsm<'a> {
                             regs: &NORMAL_GP_REGS,
                             clobber: false,
                         },
-                        RegCnstr::KeepAlive {
-                            gridx: *gridx,
-                            iidxs: entry_vars,
-                        },
+                        RegCnstr::KeepAlive { iidxs: entry_vars },
                     ],
                 )?;
                 RegOrMemOp::MemOp(lhsr, off)
@@ -354,10 +350,7 @@ impl<'a> X64HirToAsm<'a> {
                             regs: &NORMAL_GP_REGS,
                             clobber: false,
                         },
-                        RegCnstr::KeepAlive {
-                            gridx: *gridx,
-                            iidxs: entry_vars,
-                        },
+                        RegCnstr::KeepAlive { iidxs: entry_vars },
                     ],
                 )?;
                 RegOrMemOp::Reg(lhsr)
@@ -389,10 +382,7 @@ impl<'a> X64HirToAsm<'a> {
                                 regs: &NORMAL_GP_REGS,
                                 clobber: false,
                             },
-                            RegCnstr::KeepAlive {
-                                gridx: *gridx,
-                                iidxs: entry_vars,
-                            },
+                            RegCnstr::KeepAlive { iidxs: entry_vars },
                         ],
                     )?;
                     (RegOrMemOp::MemOp(lhsr, off), rhsr)
@@ -413,10 +403,7 @@ impl<'a> X64HirToAsm<'a> {
                                 regs: &NORMAL_GP_REGS,
                                 clobber: false,
                             },
-                            RegCnstr::KeepAlive {
-                                gridx: *gridx,
-                                iidxs: entry_vars,
-                            },
+                            RegCnstr::KeepAlive { iidxs: entry_vars },
                         ],
                     )?;
                     (RegOrMemOp::Reg(lhsr), rhsr)
@@ -2512,7 +2499,6 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
             expect,
             cond,
             entry_vars,
-            gridx,
             ..
         }: &Guard,
     ) -> Result<Self::Label, CompilationError> {
@@ -2530,10 +2516,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
                     regs: &NORMAL_GP_REGS,
                     clobber: false,
                 },
-                RegCnstr::KeepAlive {
-                    gridx: *gridx,
-                    iidxs: entry_vars,
-                },
+                RegCnstr::KeepAlive { iidxs: entry_vars },
             ],
         )?;
 


### PR DESCRIPTION
There is a subtle bug in the way this is currently implemented and fixing it would be a pain. As I intend a more generic optimisation which will subsume this, it doesn't seem worth carrying around all this code (even if it's fixed). This does slow down a small number of benchmarks by 2-6%, so it has an impact, but small.