### PR TITLE
Rework the internal optimiser API.

### DIFF
--- a/ykrt/src/compile/j2/opt/noopt.rs
+++ b/ykrt/src/compile/j2/opt/noopt.rs
@@ -4,7 +4,10 @@
 
 use crate::compile::{
     CompilationError,
-    j2::{hir::*, opt::OptT},
+    j2::{
+        hir::*,
+        opt::{EquivIIdxT, OptT},
+    },
 };
 use index_vec::*;
 use std::collections::HashMap;
@@ -51,10 +54,6 @@ impl OptT for NoOpt {
         todo!()
     }
 
-    fn equiv_iidx(&self, iidx: InstIdx) -> InstIdx {
-        iidx
-    }
-
     fn feed(&mut self, inst: Inst) -> Result<InstIdx, CompilationError> {
         assert_ne!(*inst.ty(self), Ty::Void);
         Ok(self.insts.push(inst))
@@ -72,5 +71,11 @@ impl OptT for NoOpt {
         let tyidx = self.tys.push(ty.clone());
         self.ty_map.insert(ty, tyidx);
         Ok(tyidx)
+    }
+}
+
+impl EquivIIdxT for NoOpt {
+    fn equiv_iidx(&self, iidx: InstIdx) -> InstIdx {
+        iidx
     }
 }

--- a/ykrt/src/compile/j2/opt/strength_fold.rs
+++ b/ykrt/src/compile/j2/opt/strength_fold.rs
@@ -4,47 +4,59 @@ use crate::compile::{
     j2::{
         hir::*,
         opt::{
-            OptT,
-            fullopt::{FullOpt, OptOutcome},
+            EquivIIdxT,
+            fullopt::{OptOutcome, PassOpt, PassT},
         },
     },
     jitc_yk::arbbitint::ArbBitInt,
 };
 
-pub(super) fn strength_fold(opt: &mut FullOpt, inst: Inst) -> OptOutcome {
-    match inst {
-        Inst::Abs(x) => opt_abs(opt, x),
-        Inst::AShr(x) => opt_ashr(opt, x),
-        Inst::Add(x) => opt_add(opt, x),
-        Inst::And(x) => opt_and(opt, x),
-        Inst::CtPop(x) => opt_ctpop(opt, x),
-        Inst::DynPtrAdd(x) => opt_dynptradd(opt, x),
-        Inst::FAdd(x) => opt_fadd(opt, x),
-        Inst::FDiv(x) => opt_fdiv(opt, x),
-        Inst::FMul(x) => opt_fmul(opt, x),
-        Inst::FSub(x) => opt_fsub(opt, x),
-        Inst::Guard(x) => opt_guard(opt, x),
-        Inst::ICmp(x) => opt_icmp(opt, x),
-        Inst::IntToPtr(x) => opt_inttoptr(opt, x),
-        Inst::LShr(x) => opt_lshr(opt, x),
-        Inst::MemCpy(x) => opt_memcpy(opt, x),
-        Inst::Mul(x) => opt_mul(opt, x),
-        Inst::Or(x) => opt_or(opt, x),
-        Inst::PtrAdd(x) => opt_ptradd(opt, x),
-        Inst::PtrToInt(x) => opt_ptrtoint(opt, x),
-        Inst::Select(x) => opt_select(opt, x),
-        Inst::SExt(x) => opt_sext(opt, x),
-        Inst::Shl(x) => opt_shl(opt, x),
-        Inst::Sub(x) => opt_sub(opt, x),
-        Inst::Trunc(x) => opt_trunc(opt, x),
-        Inst::UDiv(x) => opt_udiv(opt, x),
-        Inst::Xor(x) => opt_xor(opt, x),
-        Inst::ZExt(x) => opt_zext(opt, x),
-        _ => OptOutcome::Rewritten(inst),
+pub(super) struct StrengthFold;
+
+impl StrengthFold {
+    pub(super) fn new() -> Self {
+        Self
     }
 }
 
-fn opt_abs(opt: &mut FullOpt, mut inst: Abs) -> OptOutcome {
+impl PassT for StrengthFold {
+    fn feed(&mut self, opt: &mut PassOpt, inst: Inst) -> OptOutcome {
+        match inst {
+            Inst::Abs(x) => opt_abs(opt, x),
+            Inst::AShr(x) => opt_ashr(opt, x),
+            Inst::Add(x) => opt_add(opt, x),
+            Inst::And(x) => opt_and(opt, x),
+            Inst::CtPop(x) => opt_ctpop(opt, x),
+            Inst::DynPtrAdd(x) => opt_dynptradd(opt, x),
+            Inst::FAdd(x) => opt_fadd(opt, x),
+            Inst::FDiv(x) => opt_fdiv(opt, x),
+            Inst::FMul(x) => opt_fmul(opt, x),
+            Inst::FSub(x) => opt_fsub(opt, x),
+            Inst::Guard(x) => opt_guard(opt, x),
+            Inst::ICmp(x) => opt_icmp(opt, x),
+            Inst::IntToPtr(x) => opt_inttoptr(opt, x),
+            Inst::LShr(x) => opt_lshr(opt, x),
+            Inst::MemCpy(x) => opt_memcpy(opt, x),
+            Inst::Mul(x) => opt_mul(opt, x),
+            Inst::Or(x) => opt_or(opt, x),
+            Inst::PtrAdd(x) => opt_ptradd(opt, x),
+            Inst::PtrToInt(x) => opt_ptrtoint(opt, x),
+            Inst::Select(x) => opt_select(opt, x),
+            Inst::SExt(x) => opt_sext(opt, x),
+            Inst::Shl(x) => opt_shl(opt, x),
+            Inst::Sub(x) => opt_sub(opt, x),
+            Inst::Trunc(x) => opt_trunc(opt, x),
+            Inst::UDiv(x) => opt_udiv(opt, x),
+            Inst::Xor(x) => opt_xor(opt, x),
+            Inst::ZExt(x) => opt_zext(opt, x),
+            _ => OptOutcome::Rewritten(inst),
+        }
+    }
+
+    fn inst_committed(&mut self, _inst: &Inst) {}
+}
+
+fn opt_abs(opt: &mut PassOpt, mut inst: Abs) -> OptOutcome {
     inst.canonicalise(opt);
     let Abs {
         tyidx,
@@ -61,7 +73,7 @@ fn opt_abs(opt: &mut FullOpt, mut inst: Abs) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_add(opt: &mut FullOpt, mut inst: Add) -> OptOutcome {
+fn opt_add(opt: &mut PassOpt, mut inst: Add) -> OptOutcome {
     inst.canonicalise(opt);
     let Add {
         tyidx,
@@ -92,7 +104,7 @@ fn opt_add(opt: &mut FullOpt, mut inst: Add) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_and(opt: &mut FullOpt, mut inst: And) -> OptOutcome {
+fn opt_and(opt: &mut PassOpt, mut inst: And) -> OptOutcome {
     inst.canonicalise(opt);
     let And { tyidx, lhs, rhs } = inst;
     if lhs == rhs {
@@ -126,7 +138,7 @@ fn opt_and(opt: &mut FullOpt, mut inst: And) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_ashr(opt: &mut FullOpt, mut inst: AShr) -> OptOutcome {
+fn opt_ashr(opt: &mut PassOpt, mut inst: AShr) -> OptOutcome {
     inst.canonicalise(opt);
     let AShr {
         tyidx,
@@ -142,7 +154,7 @@ fn opt_ashr(opt: &mut FullOpt, mut inst: AShr) -> OptOutcome {
 /// Optimise the common parts of `ashr` and `lshr`, outsourcing the difference between the two to
 /// `f`.
 fn opt_ashr_lshr<F>(
-    opt: &mut FullOpt,
+    opt: &mut PassOpt,
     inst: Inst,
     tyidx: TyIdx,
     lhs: InstIdx,
@@ -182,7 +194,7 @@ where
     OptOutcome::Rewritten(inst)
 }
 
-fn opt_ctpop(opt: &mut FullOpt, mut inst: CtPop) -> OptOutcome {
+fn opt_ctpop(opt: &mut PassOpt, mut inst: CtPop) -> OptOutcome {
     inst.canonicalise(opt);
     let CtPop { tyidx, val } = inst;
     if let Some(ConstKind::Int(c)) = opt.as_constkind(val) {
@@ -198,7 +210,7 @@ fn opt_ctpop(opt: &mut FullOpt, mut inst: CtPop) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_dynptradd(opt: &mut FullOpt, mut inst: DynPtrAdd) -> OptOutcome {
+fn opt_dynptradd(opt: &mut PassOpt, mut inst: DynPtrAdd) -> OptOutcome {
     inst.canonicalise(opt);
     let DynPtrAdd {
         ptr,
@@ -236,7 +248,7 @@ fn opt_dynptradd(opt: &mut FullOpt, mut inst: DynPtrAdd) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_fadd(opt: &mut FullOpt, mut inst: FAdd) -> OptOutcome {
+fn opt_fadd(opt: &mut PassOpt, mut inst: FAdd) -> OptOutcome {
     inst.canonicalise(opt);
     let FAdd { tyidx, lhs, rhs } = inst;
 
@@ -262,7 +274,7 @@ fn opt_fadd(opt: &mut FullOpt, mut inst: FAdd) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_fdiv(opt: &mut FullOpt, mut inst: FDiv) -> OptOutcome {
+fn opt_fdiv(opt: &mut PassOpt, mut inst: FDiv) -> OptOutcome {
     inst.canonicalise(opt);
     let FDiv { tyidx, lhs, rhs } = inst;
 
@@ -287,7 +299,7 @@ fn opt_fdiv(opt: &mut FullOpt, mut inst: FDiv) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_fmul(opt: &mut FullOpt, mut inst: FMul) -> OptOutcome {
+fn opt_fmul(opt: &mut PassOpt, mut inst: FMul) -> OptOutcome {
     inst.canonicalise(opt);
     let FMul { tyidx, lhs, rhs } = inst;
 
@@ -313,7 +325,7 @@ fn opt_fmul(opt: &mut FullOpt, mut inst: FMul) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_fsub(opt: &mut FullOpt, mut inst: FSub) -> OptOutcome {
+fn opt_fsub(opt: &mut PassOpt, mut inst: FSub) -> OptOutcome {
     inst.canonicalise(opt);
     let FSub { tyidx, lhs, rhs } = inst;
 
@@ -339,7 +351,7 @@ fn opt_fsub(opt: &mut FullOpt, mut inst: FSub) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_guard(opt: &mut FullOpt, mut inst @ Guard { expect, cond, .. }: Guard) -> OptOutcome {
+fn opt_guard(opt: &mut PassOpt, mut inst @ Guard { expect, cond, .. }: Guard) -> OptOutcome {
     // Since guards tend to have lots of operands, we avoid `canonicalising` unless we really need
     // to. This needs to be done carefully, because after we've called `set_equiv` below,
     // recanonicalising the guard would change the `entry_vars` in a semantically incorrect way.
@@ -380,7 +392,7 @@ fn opt_guard(opt: &mut FullOpt, mut inst @ Guard { expect, cond, .. }: Guard) ->
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_icmp(opt: &mut FullOpt, mut inst: ICmp) -> OptOutcome {
+fn opt_icmp(opt: &mut PassOpt, mut inst: ICmp) -> OptOutcome {
     inst.canonicalise(opt);
     let ICmp {
         pred,
@@ -443,7 +455,7 @@ fn opt_icmp(opt: &mut FullOpt, mut inst: ICmp) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_inttoptr(opt: &mut FullOpt, mut inst: IntToPtr) -> OptOutcome {
+fn opt_inttoptr(opt: &mut PassOpt, mut inst: IntToPtr) -> OptOutcome {
     inst.canonicalise(opt);
     let IntToPtr { val, .. } = inst;
     if let Some(ConstKind::Int(c)) = opt.as_constkind(val) {
@@ -461,7 +473,7 @@ fn opt_inttoptr(opt: &mut FullOpt, mut inst: IntToPtr) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_lshr(opt: &mut FullOpt, mut inst: LShr) -> OptOutcome {
+fn opt_lshr(opt: &mut PassOpt, mut inst: LShr) -> OptOutcome {
     inst.canonicalise(opt);
     let LShr {
         tyidx,
@@ -474,7 +486,7 @@ fn opt_lshr(opt: &mut FullOpt, mut inst: LShr) -> OptOutcome {
     })
 }
 
-fn opt_memcpy(opt: &mut FullOpt, mut inst: MemCpy) -> OptOutcome {
+fn opt_memcpy(opt: &mut PassOpt, mut inst: MemCpy) -> OptOutcome {
     inst.canonicalise(opt);
     let MemCpy {
         dst,
@@ -504,7 +516,7 @@ fn opt_memcpy(opt: &mut FullOpt, mut inst: MemCpy) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_mul(opt: &mut FullOpt, mut inst: Mul) -> OptOutcome {
+fn opt_mul(opt: &mut PassOpt, mut inst: Mul) -> OptOutcome {
     inst.canonicalise(opt);
     let Mul {
         tyidx,
@@ -534,15 +546,13 @@ fn opt_mul(opt: &mut FullOpt, mut inst: Mul) -> OptOutcome {
                 }
                 Some(x) if x.is_power_of_two() => {
                     // Replace `x * y` with `x << ...`.
-                    let c_iidx = opt
-                        .feed(Inst::Const(Const {
-                            tyidx,
-                            kind: ConstKind::Int(ArbBitInt::from_u64(
-                                rhs_c.bitw(),
-                                u64::from(x.ilog2()),
-                            )),
-                        }))
-                        .unwrap();
+                    let c_iidx = opt.push_pre_inst(Inst::Const(Const {
+                        tyidx,
+                        kind: ConstKind::Int(ArbBitInt::from_u64(
+                            rhs_c.bitw(),
+                            u64::from(x.ilog2()),
+                        )),
+                    }));
                     return OptOutcome::Rewritten(
                         Shl {
                             tyidx,
@@ -563,7 +573,7 @@ fn opt_mul(opt: &mut FullOpt, mut inst: Mul) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_ptradd(opt: &mut FullOpt, mut inst: PtrAdd) -> OptOutcome {
+fn opt_ptradd(opt: &mut PassOpt, mut inst: PtrAdd) -> OptOutcome {
     // LLVM semantics require pointer arithmetic to wrap as though they were "pointer index typed"
     // (a pointer-sized integer, for addrspace 0, the only address space we support right now).
     let mut off: isize = 0;
@@ -604,7 +614,7 @@ fn opt_ptradd(opt: &mut FullOpt, mut inst: PtrAdd) -> OptOutcome {
     }
 }
 
-fn opt_or(opt: &mut FullOpt, mut inst: Or) -> OptOutcome {
+fn opt_or(opt: &mut PassOpt, mut inst: Or) -> OptOutcome {
     inst.canonicalise(opt);
     let Or {
         tyidx,
@@ -642,7 +652,7 @@ fn opt_or(opt: &mut FullOpt, mut inst: Or) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_ptrtoint(opt: &mut FullOpt, mut inst: PtrToInt) -> OptOutcome {
+fn opt_ptrtoint(opt: &mut PassOpt, mut inst: PtrToInt) -> OptOutcome {
     inst.canonicalise(opt);
     let PtrToInt { tyidx, val } = inst;
     if let Some(ConstKind::Ptr(addr)) = opt.as_constkind(val) {
@@ -661,7 +671,7 @@ fn opt_ptrtoint(opt: &mut FullOpt, mut inst: PtrToInt) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_select(opt: &mut FullOpt, mut inst: Select) -> OptOutcome {
+fn opt_select(opt: &mut PassOpt, mut inst: Select) -> OptOutcome {
     inst.canonicalise(opt);
     let Select {
         cond,
@@ -685,7 +695,7 @@ fn opt_select(opt: &mut FullOpt, mut inst: Select) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_sext(opt: &mut FullOpt, mut inst: SExt) -> OptOutcome {
+fn opt_sext(opt: &mut PassOpt, mut inst: SExt) -> OptOutcome {
     inst.canonicalise(opt);
     let SExt { tyidx, val } = inst;
     match opt.as_constkind(val) {
@@ -703,7 +713,7 @@ fn opt_sext(opt: &mut FullOpt, mut inst: SExt) -> OptOutcome {
     }
 }
 
-fn opt_shl(opt: &mut FullOpt, mut inst: Shl) -> OptOutcome {
+fn opt_shl(opt: &mut PassOpt, mut inst: Shl) -> OptOutcome {
     inst.canonicalise(opt);
     let Shl {
         tyidx,
@@ -742,7 +752,7 @@ fn opt_shl(opt: &mut FullOpt, mut inst: Shl) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_sub(opt: &mut FullOpt, mut inst: Sub) -> OptOutcome {
+fn opt_sub(opt: &mut PassOpt, mut inst: Sub) -> OptOutcome {
     inst.canonicalise(opt);
     let Sub {
         tyidx,
@@ -772,7 +782,7 @@ fn opt_sub(opt: &mut FullOpt, mut inst: Sub) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_trunc(opt: &mut FullOpt, mut inst: Trunc) -> OptOutcome {
+fn opt_trunc(opt: &mut PassOpt, mut inst: Trunc) -> OptOutcome {
     inst.canonicalise(opt);
     let Trunc {
         tyidx,
@@ -793,7 +803,7 @@ fn opt_trunc(opt: &mut FullOpt, mut inst: Trunc) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_udiv(opt: &mut FullOpt, mut inst: UDiv) -> OptOutcome {
+fn opt_udiv(opt: &mut PassOpt, mut inst: UDiv) -> OptOutcome {
     inst.canonicalise(opt);
     let UDiv {
         tyidx,
@@ -822,15 +832,13 @@ fn opt_udiv(opt: &mut FullOpt, mut inst: UDiv) -> OptOutcome {
                 }
                 Some(x) if x.is_power_of_two() => {
                     // Replace `x * y` with `x >> ...`.
-                    let c_iidx = opt
-                        .feed(Inst::Const(Const {
-                            tyidx,
-                            kind: ConstKind::Int(ArbBitInt::from_u64(
-                                rhs_c.bitw(),
-                                u64::from(x.ilog2()),
-                            )),
-                        }))
-                        .unwrap();
+                    let c_iidx = opt.push_pre_inst(Inst::Const(Const {
+                        tyidx,
+                        kind: ConstKind::Int(ArbBitInt::from_u64(
+                            rhs_c.bitw(),
+                            u64::from(x.ilog2()),
+                        )),
+                    }));
                     return OptOutcome::Rewritten(
                         LShr {
                             tyidx,
@@ -849,7 +857,7 @@ fn opt_udiv(opt: &mut FullOpt, mut inst: UDiv) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_xor(opt: &mut FullOpt, mut inst: Xor) -> OptOutcome {
+fn opt_xor(opt: &mut PassOpt, mut inst: Xor) -> OptOutcome {
     inst.canonicalise(opt);
     let Xor { tyidx, lhs, rhs } = inst;
     let bitw = opt.ty(tyidx).bitw();
@@ -880,7 +888,7 @@ fn opt_xor(opt: &mut FullOpt, mut inst: Xor) -> OptOutcome {
     OptOutcome::Rewritten(inst.into())
 }
 
-fn opt_zext(opt: &mut FullOpt, mut inst: ZExt) -> OptOutcome {
+fn opt_zext(opt: &mut PassOpt, mut inst: ZExt) -> OptOutcome {
     inst.canonicalise(opt);
     let ZExt { tyidx, val } = inst;
     match opt.as_constkind(val) {
@@ -908,7 +916,7 @@ mod test {
             mod_s,
             |opt, mut inst| {
                 inst.canonicalise(opt);
-                strength_fold(opt, inst)
+                StrengthFold::new().feed(opt, inst)
             },
             ptn,
         );


### PR DESCRIPTION
The previous API was a rush job, and not a good one at that: it had no explicit notions of "passes", and had to treat `cse` differently than `strength_fold`; and it presented the same API to `aot_to_hir` as to "passes".

The main thing this commit does is to split the optimiser such that it has two different APIs: an outward-facing API for `aot_to_hir` and an internal-facing API (`PassOpt`) for optimisation passes. Both `strength_fold` and `cse` are now "proper" passes (implementing a trait `PassT`) on an equal footing.

The way this is achieved is by having the outward and internal facing objects share a `OptInternal` struct. The main advantage of this is that it allows us to assuage the borrow-checker. However, it also indirectly means that we can expose different functionality in the outward and inward-facing APIs. That does mean some changes in `hir`, in particular the introduction of a new trait `EquivIIdxT`, which allows us to pass much "smaller" objects around (i.e. not full optimisers!).

That allows this commit to deal with one of the true horrors of the previous situation: `strength_fold` could insert instructions into the trace. These are now "preinstructions" and the API makes it much harder for them to be used incorrectly (as well as documenting why/where one should think carefully about them).

Overall I think this commit shoves us a long way in the right direction. There is still work to do though -- notably `OptOutcome` as it currently stands doesn't allow a pass to hand-over knowledge it has about an instruction. However, this commit is big enough as-is, and I haven't yet fully worked out what the next step would be. So it feels better to consider this now, rather than wait ever longer for perfection.