### PR TITLE
Rethink trace kinds.

### DIFF
--- a/ykrt/src/compile/j2/hir_parser.rs
+++ b/ykrt/src/compile/j2/hir_parser.rs
@@ -870,7 +870,8 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
         let block = Block { insts: self.insts };
         let m = Mod {
             trid: TraceId::testing(),
-            kind: ModKind::Test { entry_vlocs, block },
+            trace_start: TraceStart::Test,
+            trace_end: TraceEnd::Test { entry_vlocs, block },
             tys: self.tys,
             guard_restores,
             addr_name_map: None,

--- a/ykrt/src/compile/j2/opt/fullopt.rs
+++ b/ykrt/src/compile/j2/opt/fullopt.rs
@@ -489,10 +489,10 @@ pub(in crate::compile::j2::opt) mod test {
         let m = str_to_mod::<TestReg>(mod_s);
         let mut fopt = Box::new(FullOpt::new());
         fopt.inner.tys = m.tys;
-        let ModKind::Test {
+        let TraceEnd::Test {
             entry_vlocs,
             block: Block { insts },
-        } = m.kind
+        } = m.trace_end
         else {
             panic!()
         };
@@ -553,7 +553,8 @@ pub(in crate::compile::j2::opt) mod test {
         let (block, tys) = fopt.build();
         let m = Mod {
             trid: m.trid,
-            kind: ModKind::Test { entry_vlocs, block },
+            trace_start: TraceStart::Test,
+            trace_end: TraceEnd::Test { entry_vlocs, block },
             tys,
             guard_restores: IndexVec::new(),
             addr_name_map: None,


### PR DESCRIPTION
Previously we represented the various kinds of traces with an enum (well, more than one, but we can ignore that) which was essentially:

```rust
enum TraceKind { Coupler, Loop, Side, Return }
```

The obvious problem with this is that it causes us to duplicate quite a lot of code because Coupler, Loop, and Return traces are rather similar. Worse, it meant that I didn't spot that "return" traces come in two variants: those that start from control points and those that that start from guards.

This commit completely rethinks how we represents trace kinds. They are now a pair `TraceStart, TraceEnd` where these are two enums:

```rust
enum TraceStart { ControlPoint, Guard }
enum TraceEnd { Coupler, Loop, Return }
```

Perhaps the most surprising thing about this design is that it makes sense for `Block`s to live in `TraceEnd`s rather than `TraceStart`s.

The mapping from old to new names is:

* "Coupler trace" -> (ControlPoint, Coupler)
* "Loop trace" -> (ControlPoint, Loop)
* "Return trace" -> (ControlPoint, Return)
* "Side trace" -> (Guard, Coupler)

The pairwise options are all valid except (ControlPoint, Loop) which can be represented as (ControlPoint, Coupler).

As this might then suggest, we currently don't implement (Guard, Return): we did before 2d399e4a, accidentally, but that commit wiped out such traces and I didn't even notice. This commit does not reintroduce them, but it should make it much easier to do so in the near future.

As the diff shows, this commit allows us to simplify a lot of things: we have less code duplication, and a more explicit delineation of what's what. There are more parts that could stand being adjusted (e.g. `BuildKind`), but this commit is already complex enough, and does enough useful things that I think it's worth considering it now, and iterating it further in-tree.