### PR TITLE
Check abs for ArbBitInt

### DIFF
--- a/ykrt/src/compile/j2/opt/strength_fold.rs
+++ b/ykrt/src/compile/j2/opt/strength_fold.rs
@@ -64,10 +64,12 @@ fn opt_abs(opt: &mut PassOpt, mut inst: Abs) -> OptOutcome {
         int_min_poison,
     } = inst;
     assert!(int_min_poison);
-    if let Some(ConstKind::Int(val_c)) = opt.as_constkind(val) {
+    if let Some(ConstKind::Int(val_c)) = opt.as_constkind(val)
+        && let Some(c) = val_c.checked_abs()
+    {
         return OptOutcome::Rewritten(Inst::Const(Const {
             tyidx,
-            kind: ConstKind::Int(val_c.bitabs()),
+            kind: ConstKind::Int(c),
         }));
     }
     OptOutcome::Rewritten(inst.into())


### PR DESCRIPTION
So this was trickier than I expected.

I've verified the regression test added fails on current unmodified main. There are two problems: 
1. `abs` is dependent on bitwidth in Rust. So we cannot sign extend to i64 then call abs on it. Instead, we have to sign extend to the correct bitwidth and then `checked_abs` on it.
2. We cannot call abs on `INT_MIN`, as that will overflow. So we need to use `checked_abs` instead of `abs`.