### PR TITLE
Find symbol names for promoted constants.

### DIFF
--- a/tests/c/promoted_const_names.j2.c
+++ b/tests/c/promoted_const_names.j2.c
@@ -1,0 +1,67 @@
+// ignore-if: test "$YK_JITC" != "j2"
+// Run-time:
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   stderr:
+//     hello 0 4
+//     ...
+//     --- Begin jit-pre-opt ---
+//     ...
+//     %{{16}}: ptr = 0x{{_}} ; @my_print0
+//     ...
+//     call %{{16}}(%{{_}}) ; @my_print0
+//     ...
+//     --- End jit-pre-opt ---
+//     hello 0 3
+//     hello 0 2
+//     hello 0 1
+//     exit
+
+// Check that constant promoted values have their symbols attached.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+static void my_print0(int x) {
+    fprintf(stderr, "hello 0 %d\n", x);
+}
+
+static void my_print1(int x) {
+    fprintf(stderr, "hello 1 %d\n", x);
+}
+
+typedef void (*func_ty)(int);
+
+void *funcptr_table[2] = {
+    (void *)my_print0,
+    (void *)my_print1,
+};
+
+static void call(int x, int id) {
+    func_ty callable = (func_ty)yk_promote(funcptr_table[id]);
+    callable(x);
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int i = 4;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    call(i, 0);
+    i--;
+  }
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  fprintf(stderr, "exit\n");
+
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -246,7 +246,7 @@ pub(super) struct Mod<Reg: RegT> {
     /// Extra information that is too big to fit in a [Guard] instruction.
     pub guard_extras: IndexVec<GuardExtraIdx, GuardExtra>,
     /// A map of names to pointers. Will be `None` if logging was disabled.
-    pub addr_name_map: Option<HashMap<usize, String>>,
+    pub addr_name_map: Option<HashMap<usize, Option<String>>>,
 }
 
 impl<Reg: RegT> Mod<Reg> {
@@ -294,7 +294,8 @@ impl<Reg: RegT> ModLikeT for Mod<Reg> {
     fn addr_to_name(&self, addr: usize) -> Option<&str> {
         self.addr_name_map
             .as_ref()
-            .and_then(|x| x.get(&addr).map(|y| y.as_str()))
+            .and_then(|x| x.get(&addr))
+            .and_then(|x| x.as_ref().map(|y| y.as_str()))
     }
 
     fn gextra(&self, geidx: GuardExtraIdx) -> &GuardExtra {


### PR DESCRIPTION
j2 prints symbol names for pointers when logged, basing them on the cached result of `dlsym` calls. However, this doesn't work for pointers that come out "thin air" (e.g. via promotion): there isn't a `dlsym` for them!

This commit tries to catch some of these cases, and call `dladdr` for them. Since `dladdr` might not find a symbol name, we need to cache `Option<String>` for these. Since it was easy to do, I have mirrored the `dksym` approach of caching these results per-cache and only, if necessary, looking them up in the global j2 instance (which requires a mutex lock).

Note: this commit doesn't catch every possible place a pointer might appear out of thin air. Should we find further cases which aren't caught, we might need to do a more thorough change to `aot_to_hit`, but this will probably do well enough for now.

Note: this is inspired by https://github.com/ykjit/yk/pull/2027/, but is somewhat different in detailed method. In particular, it is often available to deal in `&str`s, only occasionally falling back on `String`s. 