### PR TITLE
Ensure that guards are only fed in via `feed_guard`.

### DIFF
--- a/ykrt/src/compile/j2/opt/fullopt.rs
+++ b/ykrt/src/compile/j2/opt/fullopt.rs
@@ -139,10 +139,7 @@ impl FullOpt {
     }
 
     #[cfg(test)]
-    pub(in crate::compile::j2) fn new_testing(
-        guard_extras: IndexVec<GuardExtraIdx, GuardExtra>,
-        tys: IndexVec<TyIdx, Ty>,
-    ) -> Self {
+    pub(in crate::compile::j2) fn new_testing(tys: IndexVec<TyIdx, Ty>) -> Self {
         let ty_map = HashMap::from_iter(
             tys.iter()
                 .enumerate()
@@ -158,7 +155,7 @@ impl FullOpt {
             inner: OptInternal {
                 insts: IndexVec::new(),
                 consts_map: HashMap::new(),
-                guard_extras,
+                guard_extras: IndexVec::new(),
                 tys,
                 ty_map,
             },
@@ -188,9 +185,8 @@ impl FullOpt {
             }
         }
 
-        if let Inst::Guard(Guard { ref mut geidx, .. }) = inst
-            && *geidx == GuardExtraIdx::MAX
-        {
+        if let Inst::Guard(Guard { ref mut geidx, .. }) = inst {
+            assert_eq!(*geidx, GuardExtraIdx::MAX);
             *geidx = self.inner.guard_extras.push(popt_inner.gextra.unwrap());
         } else {
             assert!(popt_inner.gextra.is_none());
@@ -288,6 +284,7 @@ impl OptT for FullOpt {
 
     fn feed_void(&mut self, inst: Inst) -> Result<Option<InstIdx>, CompilationError> {
         assert_eq!(*inst.ty(self), Ty::Void);
+        assert!(!matches!(inst, Inst::Guard(_)));
         self.feed_internal(PassOptInner::new(), inst)
     }
 

--- a/ykrt/src/compile/j2/opt/mod.rs
+++ b/ykrt/src/compile/j2/opt/mod.rs
@@ -31,16 +31,19 @@ pub(super) trait OptT: EquivIIdxT + ModLikeT + BlockLikeT {
     #[allow(dead_code)]
     fn peel(self) -> (Block, Block);
 
-    /// Feed a non-void instruction into the optimiser and return an [InstIdx]. The returned
+    /// Feed a non-[Ty::Void] instruction into the optimiser and return an [InstIdx]. The returned
     /// [InstIdx] may refer to a previously inserted instruction, as an optimiser might prove that
     /// `inst` is unneeded. That previously inserted instruction may not even be of the same kind
     /// as `inst`!
     fn feed(&mut self, inst: Inst) -> Result<InstIdx, CompilationError>;
 
-    /// Feed a possibly removable instruction into the optimiser, returning `Some([InstIdx])` if it
-    /// was not removed. If `Some` is returned, the [InstIdx] may refer to a previously inserted
-    /// instruction, as an optimiser might prove that `inst` is unneeded. That previously inserted
-    /// instruction may not even be of the same kind as `inst`!
+    /// Feed a [Ty::Void], but not a [Guard], instruction into the optimiser, returning
+    /// `Some([InstIdx])` if it was not removed. If `Some` is returned, the [InstIdx] may refer to
+    /// a previously inserted instruction, as an optimiser might prove that `inst` is unneeded.
+    /// That previously inserted instruction may not even be of the same kind as `inst`!
+    ///
+    /// Note: it is undefined behaviour to pass a [Guard] instruction to `feed_void`.
+    /// [Self::feed_guard] must be used instead.
     fn feed_void(&mut self, inst: Inst) -> Result<Option<InstIdx>, CompilationError>;
 
     // Feed an argument into the trace. Arguments are either [Arg] or [Inst] instructions, and are
@@ -50,6 +53,9 @@ pub(super) trait OptT: EquivIIdxT + ModLikeT + BlockLikeT {
 
     /// Feed a [Guard], and its associated [GuardExtra] into the optimiser. The [Guard] must have
     /// its `geidx` value set to `GuardExtraIdx::MAX` or the optimiser will panic.
+    ///
+    /// Guards, by definition, are never returned as equivalent to a previous guard. If `Some` is
+    /// returned, then a new guard has definitely been inserted into the instruction sequence.
     fn feed_guard(
         &mut self,
         inst: Guard,

--- a/ykrt/src/compile/j2/opt/noopt.rs
+++ b/ykrt/src/compile/j2/opt/noopt.rs
@@ -77,6 +77,7 @@ impl OptT for NoOpt {
 
     fn feed_void(&mut self, inst: Inst) -> Result<Option<InstIdx>, CompilationError> {
         assert_eq!(*inst.ty(self), Ty::Void);
+        assert!(!matches!(inst, Inst::Guard(_)));
         Ok(Some(self.insts.push(inst)))
     }
 


### PR DESCRIPTION
`feed_void` is for "normal" but `Ty::Void` instructions. `feed_guard` is for guards. Guards are also `Ty::Void`, but that's a sort-of fiction: they're not really the same as, say, a `Store`.

I should have enforced this before, but I didn't think about it explicitly. Fortunately I only broke the implicit contract in one test, so fixing this is quite easy.

The optimiser API is now starting to look a bit fiddly. I suspect there's a nicer API lurking out there somewhere, but I don't quite know what it is, and I can probably get away with what we have for now.