### PR TITLE
Inform passes of a committed equivalence.

### DIFF
--- a/ykrt/src/compile/j2/opt/cse.rs
+++ b/ykrt/src/compile/j2/opt/cse.rs
@@ -97,6 +97,8 @@ impl PassT for CSE {
         self.predecessors.push(prev);
         self.heads[dim_off] = InstIdx::from_usize(self.predecessors.len() - 1);
     }
+
+    fn equiv_committed(&mut self, _equiv1: InstIdx, _equiv2: InstIdx) {}
 }
 
 #[cfg(test)]
@@ -119,6 +121,7 @@ mod test {
                 }
             },
             |opt, iidx, inst| cse.borrow_mut().inst_committed(opt, iidx, inst),
+            |_, _| (),
             ptn,
         );
     }

--- a/ykrt/src/compile/j2/opt/known_bits.rs
+++ b/ykrt/src/compile/j2/opt/known_bits.rs
@@ -47,6 +47,8 @@ impl PassT for KnownBits {
         assert_eq!(iidx.index(), self.known_bits.len());
         self.known_bits.push(self.pending_commit.clone());
     }
+
+    fn equiv_committed(&mut self, _equiv1: InstIdx, _equiv2: InstIdx) {}
 }
 
 impl KnownBits {
@@ -442,6 +444,7 @@ mod test {
                 }
             },
             |opt, iidx, inst| known_bits.borrow_mut().inst_committed(opt, iidx, inst),
+            |equiv1, equiv2| known_bits.borrow_mut().equiv_committed(equiv1, equiv2),
             ptn,
         );
     }

--- a/ykrt/src/compile/j2/opt/load_store.rs
+++ b/ykrt/src/compile/j2/opt/load_store.rs
@@ -141,6 +141,8 @@ impl PassT for LoadStore {
             _ => (),
         }
     }
+
+    fn equiv_committed(&mut self, _equiv1: InstIdx, _equiv2: InstIdx) {}
 }
 
 /// An abstract "address" representing a location in RAM.
@@ -216,6 +218,7 @@ mod test {
                 }
             },
             |opt, iidx, inst| ls.borrow_mut().inst_committed(opt, iidx, inst),
+            |_, _| (),
             ptn,
         );
     }

--- a/ykrt/src/compile/j2/opt/strength_fold.rs
+++ b/ykrt/src/compile/j2/opt/strength_fold.rs
@@ -54,6 +54,8 @@ impl PassT for StrengthFold {
     }
 
     fn inst_committed(&mut self, _opt: &CommitInstOpt, _iidx: InstIdx, _inst: &Inst) {}
+
+    fn equiv_committed(&mut self, _equiv1: InstIdx, _equiv2: InstIdx) {}
 }
 
 fn opt_abs(opt: &mut PassOpt, mut inst: Abs) -> OptOutcome {
@@ -925,6 +927,7 @@ mod test {
                 StrengthFold::new().feed(opt, inst)
             },
             |_, _, _| (),
+            |_, _| (),
             ptn,
         );
     }


### PR DESCRIPTION
Currently this is a no-op, but this is likely to be necessary for the known_bits pass (and, almost certainly, others) to work as expected.