### PR TITLE
Make known bits analysis the last pass

### DIFF
--- a/ykrt/src/compile/j2/opt/fullopt.rs
+++ b/ykrt/src/compile/j2/opt/fullopt.rs
@@ -160,10 +160,10 @@ impl FullOpt {
         ty_map.insert(Ty::Int(1), tyidx_int1);
         Self {
             passes: [
-                Box::new(KnownBits::new()),
                 Box::new(StrengthFold::new()),
                 Box::new(LoadStore::new()),
                 Box::new(CSE::new()),
+                Box::new(KnownBits::new()),
             ],
             inner: OptInternal {
                 insts: IndexVec::new(),


### PR DESCRIPTION
We've come to realise known bits benefits more from equivalences + canonicalisation of previous passes, such as in strength fold and CSE.

This PR just moves the known bits pass to the last one.