### PR TITLE
Add Location null check at control point.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -71,6 +71,14 @@ pub extern "C" fn __ykrt_control_point(
     // FIXME: We could get rid of this entire function if we pass the frame's base pointer into the
     // control point from the interpreter.
     std::arch::naked_asm!(
+        // Fast-path check: Is location null?
+        "mov rax, [rsi]", // location is passed in rsi
+        "test rax, rax",  // Check if null
+        "jnz .slow_path", // If NOT null, jump to slow path
+        // Fast-path return (null location)
+        "ret",
+        // Slow path: proceed with full control point logic
+        ".slow_path:",
         "sub rsp, 8", // Alignment
         // Push the callee-save registers to the stack. This is required so that traces can read
         // live variables from them.


### PR DESCRIPTION
Add a fast-path check in the control point assembly code to skip expensive register save/restore operations when a null location is passed.

This change speeds up 3 benchmarks by **5–9%** when running with the interpreter only (JIT disabled):

| Benchmark | Baseline (ms) | This Change (ms) | Speedup |
|-----------|---------------|------------------|---------|
| Richards  | 1,460         | 1,385            | **5.2%** |
| Havlak    | 97,069        | 91,672           | **5.6%** |
| LuLPeg    | 62,344        | 56,885           | **8.8%** |

Key reductions:
- `Location::is_null` overhead: **1.4% → 0.1%**
- `__ykrt_control_point_real` overhead: **7–9% → 0.3%**


## Perf stats

Note: perf data collected with `YKD_JITC=none`

### LuLPeg

| Function                    | Baseline % | Baseline Samples | This Change % | This Change Samples |
|-----------------------------|------------|------------------|---------------|---------------------|
| `Location::is_null`         | 1.41%      | 3,524            | 0.10%         | 222                 |
| `__ykrt_control_point_real` | 8.75%      | 21,824           | 0.32%         | 734                 |

*Baseline total: 249K samples, This Change total: 227K samples*

### Richards

| Function                    | Baseline % | Baseline Samples | This Change % | This Change Samples |
|-----------------------------|------------|------------------|---------------|---------------------|
| `Location::is_null`         | 1.38%      | 81               | 0.07%         | 4                   |
| `__ykrt_control_point_real` | 7.25%      | 425              | 0.34%         | 19                  |

*Baseline total: 5K samples, This Change total: 5K samples*

### Havlak

| Function                    | Baseline % | Baseline Samples | This Change % | This Change Samples |
|-----------------------------|------------|------------------|---------------|---------------------|
| `Location::is_null`         | 0.87%      | 3,392            | 0.06%         | 208                 |
| `__ykrt_control_point_real` | 5.42%      | 21,029           | 0.33%         | 1,210               |