### PR TITLE
Deduplicate guard exit vars

### DIFF
--- a/tests/c/guard_blocks2.j2.c
+++ b/tests/c/guard_blocks2.j2.c
@@ -1,0 +1,81 @@
+// ignore-if: test "$YK_JITC" != "j2"
+// Run-time:
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG_IR=jit-pre-opt
+//   stderr:
+//     yk-tracing: start-tracing
+//     y=100
+//     yk-tracing: stop-tracing
+//     --- Begin jit-pre-opt ---
+//     ...
+//     ; guard 0
+//     %0: ptr = arg
+//     %1: ptr = arg
+//     %2: ptr = arg
+//     %3: ptr = arg
+//     %4: ptr = arg
+//     %5: i64 = arg
+//     %6: i64 = arg
+//     %7: ptr = arg
+//     %8: ptr = arg
+//     %9: i64 = arg
+//     term [%0, %1, %2, %3, %4, %5, %6, %7, %7, %8, %9, %9]
+//     ...
+//     --- End jit-pre-opt ---
+//     y=200
+//     yk-execution: enter-jit-code
+//     y=300
+//     y=400
+//     y=500
+//     yk-execution: deoptimise ...
+//     y=700
+//     yk-execution: enter-jit-code
+//     y=800
+//     y=900
+//     y=1000
+//     yk-execution: deoptimise ...
+//     y=1999
+
+// Check that repeated instruction indexes in guards work correctly: note the
+// repeated `%7`s and `%9`s in the `term` instruction above.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define ELEMS 10
+
+size_t inner(size_t x, size_t y) {
+  yk_promote(x);
+  y += x;
+  return y;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  // We will trace 100 baked into the trace, and every iteration where there's
+  // a 200 we should guard fail.
+  size_t xs[ELEMS] = {100, 100, 100, 100, 100, 200, 100, 100, 100, 999};
+  size_t y = 0;
+  NOOPT_VAL(xs);
+
+  // On the third iteration, a guard must fail to stop us blindly adding 100
+  // instead of 200.
+  for (int i = 0; i < ELEMS; i++) {
+    yk_mt_control_point(mt, &loc);
+    y = inner(xs[i], y);
+    fprintf(stderr, "y=%" PRIu64 "\n", y);
+  }
+
+  NOOPT_VAL(y);
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -360,15 +360,48 @@ impl<Reg: RegT + 'static> AotToHir<Reg> {
         switch: Option<hir::Switch>,
     ) -> Result<(), CompilationError> {
         self.frames.last_mut().unwrap().pc_safepoint = Some(guard_safepoint);
-        let mut deopt_frames = SmallVec::with_capacity(self.frames.len());
+
+        // If the condition variable is referenced in the guard's exit vars, we'll change it to
+        // reference a const -- but we construct this as-needed.
+        let mut cond_inverse_iidx = None;
+
         // The list of variables tends to be long enough that we'll get more than one resizing, so
         // the precalculation is worth it.
-        let mut exit_vars = Vec::with_capacity(
-            self.frames
-                .iter()
-                .map(|x| x.pc_safepoint.unwrap().lives.len())
-                .sum(),
-        );
+        let deopt_vars_len = self
+            .frames
+            .iter()
+            .map(|x| x.pc_safepoint.unwrap().lives.len())
+            .sum();
+
+        let mut guard_exit_vars = Vec::with_capacity(deopt_vars_len);
+        for i in 0..self.frames.len() {
+            let pc_safepoint = self.frames[i].pc_safepoint.unwrap();
+            for j in 0..pc_safepoint.lives.len() {
+                let mut iidx =
+                    self.frames[i].get_local(&*self.opt, &pc_safepoint.lives[j].to_inst_id());
+                if iidx == cond_iidx {
+                    if cond_inverse_iidx.is_none() {
+                        let tyidx = self.opt.push_ty(hir::Ty::Int(1))?;
+                        cond_inverse_iidx = Some(self.const_to_iidx(
+                            tyidx,
+                            hir::ConstKind::Int(ArbBitInt::from_u64(
+                                1,
+                                !u64::from(expect_true) & 0b1,
+                            )),
+                        )?);
+                    }
+                    iidx = cond_inverse_iidx.unwrap();
+                }
+                guard_exit_vars.push(iidx);
+            }
+        }
+        // The good news is that `guard_exit_vars` will tend to be mostly sorted, so this rarely
+        // has to do much work.
+        guard_exit_vars.sort();
+        guard_exit_vars.dedup();
+
+        let mut deopt_frames = SmallVec::with_capacity(self.frames.len());
+        let mut deopt_vars = Vec::with_capacity(deopt_vars_len);
         for (
             i,
             frame @ Frame {
@@ -382,27 +415,18 @@ impl<Reg: RegT + 'static> AotToHir<Reg> {
             } else {
                 iid.clone()
             };
-            exit_vars.extend(
-                pc_safepoint
-                    .lives
-                    .iter()
-                    .map(|x| frame.get_local(&*self.opt, &x.to_inst_id())),
-            );
+            for mut iidx in pc_safepoint
+                .lives
+                .iter()
+                .map(|x| frame.get_local(&*self.opt, &x.to_inst_id()))
+            {
+                if iidx == cond_iidx {
+                    iidx = cond_inverse_iidx.unwrap();
+                }
+                let i = guard_exit_vars.binary_search(&iidx).unwrap();
+                deopt_vars.push(hir::InstIdx::from(i));
+            }
             deopt_frames.push(hir::Frame { pc, pc_safepoint });
-        }
-
-        // In many cases, the last variable in a guards' list of variables is the condition
-        // variable: by definition, we know that if the guard is taken the value will be
-        // `!expect_true`. We could leave this for the optimiser, but it's cheaper to do it here.
-        if let Operand::Local(last_iid) = guard_safepoint.lives.last().unwrap()
-            && cond_iidx == self.frames.last().unwrap().get_local(&*self.opt, last_iid)
-        {
-            let tyidx = self.opt.push_ty(hir::Ty::Int(1))?;
-            let ciidx = self.const_to_iidx(
-                tyidx,
-                hir::ConstKind::Int(ArbBitInt::from_u64(1, !u64::from(expect_true) & 0b1)),
-            )?;
-            *exit_vars.last_mut().unwrap() = ciidx;
         }
 
         let hinst = hir::Guard {
@@ -413,7 +437,8 @@ impl<Reg: RegT + 'static> AotToHir<Reg> {
         let gextra = hir::GuardExtra {
             bid,
             switch,
-            exit_vars,
+            guard_exit_vars,
+            deopt_vars,
             deopt_frames,
             gbidx: None,
         };

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -2052,11 +2052,11 @@ impl InstT for Guard {
         self.cond = opt.equiv_iidx(self.cond);
         // To avoid allocating, we swap in an empty vec, mutate what we've taken out, and put it
         // back in just below.
-        let mut exit_vars = std::mem::take(&mut opt.gextra_mut(self.geidx).exit_vars);
-        for x in exit_vars.iter_mut() {
+        let mut guard_exit_vars = std::mem::take(&mut opt.gextra_mut(self.geidx).guard_exit_vars);
+        for x in guard_exit_vars.iter_mut() {
             *x = opt.equiv_iidx(*x);
         }
-        opt.gextra_mut(self.geidx).exit_vars = exit_vars;
+        opt.gextra_mut(self.geidx).guard_exit_vars = guard_exit_vars;
     }
 
     fn cse_eq(&self, _opt: &dyn EquivIIdxT, _other: &Inst) -> bool {
@@ -2073,7 +2073,7 @@ impl InstT for Guard {
         F: FnMut(InstIdx) -> InstIdx,
     {
         self.cond = iidx_map(self.cond);
-        for x in m.gextra_mut(self.geidx).exit_vars.iter_mut() {
+        for x in m.gextra_mut(self.geidx).guard_exit_vars.iter_mut() {
             *x = iidx_map(*x);
         }
     }
@@ -2084,7 +2084,7 @@ impl InstT for Guard {
             if self.expect { "true" } else { "false" },
             usize::from(self.cond),
             m.gextra(self.geidx)
-                .exit_vars
+                .guard_exit_vars
                 .iter()
                 .map(|iidx| format!("%{}", usize::from(*iidx)))
                 .collect::<Vec<_>>()
@@ -2109,10 +2109,13 @@ pub(super) struct GuardExtra {
     /// then this records the information necessary for subsequent sidetraces to deal with the
     /// switch properly.
     pub switch: Option<Switch>,
-    /// The variables used if the guard fails and exits to a side-trcae. These are stored as an
-    /// ordered, flat, sequence, corresponding to the sequence of `exit_frames`. For example, if
-    /// `exit_frames` has 2 frames, the first of which needs 3 variables and the second 1 variable
-    /// `exit_vars` would look as follows:
+    /// The variables that will be passed from the main trace [Block] to a guard [Block]. These
+    /// are unordered, but must not contain duplicates.
+    pub guard_exit_vars: Vec<InstIdx>,
+    /// The variables used for deopt and side-tracing. These are stored as an ordered, flat,
+    /// sequence, corresponding to the sequence of `deopt_frames`. For example, if `deopt_frames`
+    /// has 2 frames, the first of which needs 3 variables and the second 1 variable `deopt_vars`
+    /// would look as follows:
     /// ```text
     /// [a, b, c, d]
     ///  ^^^^^^^
@@ -2121,7 +2124,7 @@ pub(super) struct GuardExtra {
     ///     |
     ///  deopt_frames[0] variables
     /// ```
-    pub exit_vars: Vec<InstIdx>,
+    pub deopt_vars: Vec<InstIdx>,
     /// The frames needed for deopt and side-tracing with the most recent frame at the tail-end of
     /// this list. This is a 1:1 mapping with the call frames at the point of the respective guard
     /// *except* that the most recent call frame is replaced with the deopt information for the
@@ -3987,12 +3990,13 @@ impl<'a> Iterator for IterIidxsIterator<'a> {
                     let GuardExtra {
                         bid: _,
                         switch: _,
-                        exit_vars,
+                        guard_exit_vars,
+                        deopt_vars: _,
                         deopt_frames: _,
                         gbidx: _,
                     } = self.m.gextra(*geidx);
-                    if self.i - 1 <= exit_vars.len() {
-                        return Some(exit_vars[self.i - 2]);
+                    if self.i - 1 <= guard_exit_vars.len() {
+                        return Some(guard_exit_vars[self.i - 2]);
                     }
                 }
             }

--- a/ykrt/src/compile/j2/hir_parser.rs
+++ b/ykrt/src/compile/j2/hir_parser.rs
@@ -11,6 +11,8 @@
 //! 3. Integers are either (possibly negative) decimal numbers or (always positive) hex numbers.
 //!    i.e. `-15` is allowed, but `-0xF` is not. Where sign extension is relevant, use decimal
 //!    numbers if you want sign extension, and hex numbers if you do not want sign extension.
+//! 4. Guard exit vars are considered as _both_ [GuardExtra::guard_exit_vars] and
+//!    [GuardExtra::deopt_vars]. The former are reordered and deduplicated as appropriate.
 
 use crate::{
     compile::{
@@ -475,18 +477,26 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
                         .map(|x| self.p_local(x))
                         .collect::<Vec<_>>();
                     let mut ginsts = IndexVec::with_capacity(exit_vars.len());
+                    let mut guard_exit_vars = Vec::new();
+                    let mut deopt_vars = Vec::new();
                     for iidx in &exit_vars {
-                        match &self.insts[*iidx] {
-                            Inst::Const(x) => {
-                                ginsts.push(x.clone().into());
+                        if let Err(x) = guard_exit_vars.binary_search(iidx) {
+                            match &self.insts[*iidx] {
+                                Inst::Const(x) => {
+                                    ginsts.push(x.clone().into());
+                                }
+                                Inst::Guard(_) => panic!(),
+                                Inst::Term(_) => panic!(),
+                                x => {
+                                    ginsts.push(Inst::Arg(Arg {
+                                        tyidx: x.tyidx(&self),
+                                    }));
+                                }
                             }
-                            Inst::Guard(_) => panic!(),
-                            Inst::Term(_) => panic!(),
-                            x => {
-                                ginsts.push(Inst::Arg(Arg {
-                                    tyidx: x.tyidx(&self),
-                                }));
-                            }
+                            deopt_vars.push(InstIdx::from(guard_exit_vars.len()));
+                            guard_exit_vars.insert(x, *iidx);
+                        } else {
+                            deopt_vars.push(InstIdx::from(guard_exit_vars.len() - 1));
                         }
                     }
                     ginsts.push(Inst::Term(Term(
@@ -497,7 +507,8 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
                     let geidx = guards.push(GuardExtra {
                         bid,
                         switch: None,
-                        exit_vars,
+                        guard_exit_vars,
+                        deopt_vars,
                         deopt_frames: SmallVec::new(),
                         gbidx,
                     });

--- a/ykrt/src/compile/j2/opt/noopt.rs
+++ b/ykrt/src/compile/j2/opt/noopt.rs
@@ -101,8 +101,8 @@ impl OptT for NoOpt {
         // won't let us iterate over the `guard_extras` directly _and_ call `self.inst`, so we have
         // to iterate over the indices.
         for i in 0..self.guard_extras.len() {
-            let mut ginsts = IndexVec::with_capacity(self.guard_extras[i].exit_vars.len());
-            for iidx in &self.guard_extras[i].exit_vars {
+            let mut ginsts = IndexVec::with_capacity(self.guard_extras[i].guard_exit_vars.len());
+            for iidx in &self.guard_extras[i].guard_exit_vars {
                 match self.inst(*iidx) {
                     Inst::Const(x) => {
                         ginsts.push(x.clone().into());
@@ -116,11 +116,9 @@ impl OptT for NoOpt {
                     }
                 }
             }
-            ginsts.push(Inst::Term(Term(
-                (0..self.guard_extras[i].exit_vars.len())
-                    .map(InstIdx::from)
-                    .collect::<Vec<_>>(),
-            )));
+            ginsts.push(Inst::Term(Term(std::mem::take(
+                &mut self.guard_extras[i].deopt_vars,
+            ))));
             self.guard_extras[i].gbidx = Some(guards.push(Block { insts: ginsts }));
         }
         Ok((

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -2384,7 +2384,7 @@ pub(crate) mod test {
             }: &Guard,
         ) -> Result<Self::Label, CompilationError> {
             let GuardExtra {
-                exit_vars: entry_vars,
+                guard_exit_vars: exit_vars,
                 ..
             } = self.m.gextra(*geidx);
             let [cndr, _] = ra.alloc(
@@ -2397,7 +2397,7 @@ pub(crate) mod test {
                         regs: &GP_REGS,
                         clobber: false,
                     },
-                    RegCnstr::KeepAlive { iidxs: entry_vars },
+                    RegCnstr::KeepAlive { iidxs: exit_vars },
                 ],
             )?;
 

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -277,7 +277,10 @@ impl<'a> X64HirToAsm<'a> {
         else {
             panic!()
         };
-        let GuardExtra { exit_vars, .. } = self.m.gextra(*geidx);
+        let GuardExtra {
+            guard_exit_vars: exit_vars,
+            ..
+        } = self.m.gextra(*geidx);
 
         let bitw = b.inst_bitw(self.m, *lhs);
         let (imm, mut in_fill) = if pred.is_signed() {
@@ -2544,7 +2547,10 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
             return self.i_icmp_guard(ra, b, iidx, ginst);
         }
 
-        let GuardExtra { exit_vars, .. } = self.m.gextra(*geidx);
+        let GuardExtra {
+            guard_exit_vars: exit_vars,
+            ..
+        } = self.m.gextra(*geidx);
         let [cndr, _] = ra.alloc(
             self,
             iidx,


### PR DESCRIPTION
The main part of this PR is https://github.com/ykjit/yk/commit/d35b38564ac37c2286b4d585df15e10b8446dbd3: as such it isn't a huge change, but it is the next step on the way towards guard bodies we can actually stuff "real" instructions into.