### PR TITLE
Add conditional promote calls optimisation

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -108,6 +108,8 @@ handle_arg() {
             else
                 # SWT-specific flags.
                 OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-basicblock-tracer"
+                # Wrap promote calls with TLS check to skip when not tracing.
+                OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-conditional-promote-calls"
                 # Make optimised clones of functions.
                 OUTPUT="${OUTPUT} -Wl,--mllvm=--yk-module-clone"
             fi

--- a/tests/langtest_ir_lowering.rs
+++ b/tests/langtest_ir_lowering.rs
@@ -49,6 +49,8 @@ fn main() {
                 "-Wl,-mllvm=--yk-embed-ir",
                 // The serialiser now assumes that we are doing software tracing.
                 "-Wl,--mllvm=--yk-basicblock-tracer",
+                // Enable conditional promote calls.
+                "-Wl,--mllvm=--yk-conditional-promote-calls",
                 // Use direct calls (bypassing PLT) for yk patchpoint functions.
                 "-Wl,--mllvm=--yk-patchpoint-direct-functions-call",
                 // Link libykcapi so that the tests inherit the necessary software tracing symbols.


### PR DESCRIPTION
This optimisation reduces the number of promote calls - `__yk_promote_*` and `__yk_idempotent_promote_*` executed when JIT is not tracing by checking thread-local tracing state first.

## Profiling Results


### Richards (5,423 total samples)

| Function                          | Samples (Before) | Samples (After) |
|-----------------------------------|------------------|-----------------|
| `__yk_promote_ptr`                | 193              | 0               |
| `__yk_promote_ptr@plt`            | 67               | 0               |
| `__yk_idempotent_promote_i32`     | 187              | 0               |
| `__yk_idempotent_promote_i32@plt` | 62               | 0               |
| `__yk_promote_usize`              | 177              | 0               |
| `__yk_promote_usize@plt`          | 51               | 0               |
| `__yk_promote_c_int`              | 3                | 0               |
| `__yk_promote_c_int@plt`          | 1                | 0               |
| **Total**                         | **741 (13.67%)** | **0 (0%)**      |

### Havlak (366,012 total samples)

| Function                          | Samples (Before) | Samples (After) |
|-----------------------------------|------------------|-----------------|
| `__yk_promote_ptr`                | 9,050            | 0               |
| `__yk_promote_ptr@plt`            | 2,983            | 0               |
| `__yk_idempotent_promote_i32`     | 8,927            | 0               |
| `__yk_idempotent_promote_i32@plt` | 3,111            | 0               |
| `__yk_promote_usize`              | 8,925            | 0               |
| `__yk_promote_usize@plt`          | 2,956            | 0               |
| `__yk_promote_c_int`              | 327              | 0               |
| `__yk_promote_c_int@plt`          | 104              | 0               |
| **Total**                         | **36,383 (9.95%)** | **0 (0%)**    |

### LuLPeg (225,869 total samples)

| Function                          | Samples (Before) | Samples (After) |
|-----------------------------------|------------------|-----------------|
| `__yk_promote_ptr`                | 9,970            | 0               |
| `__yk_promote_ptr@plt`            | 3,319            | 0               |
| `__yk_idempotent_promote_i32`     | 9,598            | 0               |
| `__yk_idempotent_promote_i32@plt` | 3,443            | 0               |
| `__yk_promote_usize`              | 9,987            | 0               |
| `__yk_promote_usize@plt`          | 3,301            | 0               |
| `__yk_promote_c_int`              | 341              | 0               |
| `__yk_promote_c_int@plt`          | 120              | 0               |
| **Total**                         | **40,079 (17.75%)** | **0 (0%)**   |

**Result**: This optimisation eliminates 10–18% of profiled CPU overhead from promote function calls when not tracing.

### Runtime Benchmarks

#### Summary
With JIT enabled - No measurable difference (all benchmarks indistinguishable), this is expected — when JIT is active, we spend significant time in tracing and executing traces, not only in the interpreter execution.

With JIT disabled - 5.6–17.2% faster across all benchmarks. The optimisation eliminates promote call overhead entirely since tracing never occurs.

## AWFY Benchmarks with jit enabled

```
Datum10: yklua (main)
Datum11: yklua (this change)

confidence level: 99%

 Benchmark              Datum10 (ms)  Datum11 (ms)  Ratio  Summary           
 permute/yklua/1000      10101 ± 831    9591 ± 439   0.95  indistinguishable 
 queens/yklua/1000        6451 ± 233    6315 ± 296   0.98  indistinguishable 
 towers/yklua/600        11009 ±  74   10798 ± 194   0.98  indistinguishable 
 sieve/yklua/3000         4771 ±  96    4691 ±  33   0.98  indistinguishable 
 storage/yklua/1000      28183 ± 186   27782 ± 261   0.99  indistinguishable 
 deltablue/yklua/12000   10385 ±  51   10323 ±  36   0.99  indistinguishable 
 cd/yklua/250            36375 ± 306   36179 ± 488   0.99  indistinguishable 
 richards/yklua/100      47931 ± 637   47705 ±1805   1.00  indistinguishable 
 json/yklua/100          13659 ±  35   13666 ±  72   1.00  indistinguishable 
 mandelbrot/yklua/500     1169 ±   1    1171 ±  12   1.00  indistinguishable 
 havlak/yklua/1500       65878 ±5289   66003 ±3894   1.00  indistinguishable 
 bounce/yklua/1500       10182 ± 689   10448 ± 779   1.03  indistinguishable 
 nbody/yklua/250000       5706 ± 451    5858 ± 666   1.03  indistinguishable 
 list/yklua/1500          8950 ± 665    9364 ± 892   1.05  indistinguishable 
```
## AWFY Benchmarks with jit disabled  (YK_JITC = none)
```
Datum9: yklua (main)
Datum8: yklua (this change)

confidence level: 99%

 Benchmark               Datum9 (ms)   Datum8 (ms)  Ratio  Summary       
 list/yklua/1500         77086 ±1406   63795 ± 131   0.83  17.24% faster 
 towers/yklua/600        89875 ±1481   77696 ±1615   0.86  13.55% faster 
 bounce/yklua/1500       89617 ± 415   77703 ± 483   0.87  13.30% faster 
 queens/yklua/1000       64137 ±1158   55945 ± 739   0.87  12.77% faster 
 sieve/yklua/3000       101787 ±4236   90078 ±2137   0.88  11.50% faster 
 mandelbrot/yklua/500    41589 ±1604   36991 ± 147   0.89  11.06% faster 
 nbody/yklua/250000      72752 ± 523   64808 ± 724   0.89  10.92% faster 
 json/yklua/100          57825 ± 376   51698 ± 276   0.89  10.60% faster 
 richards/yklua/100     279444 ±1417  252180 ±2626   0.90  9.76% faster  
 cd/yklua/250           141318 ± 424  127964 ± 779   0.91  9.45% faster  
 permute/yklua/1000      91889 ±2431   83227 ± 588   0.91  9.43% faster  
 deltablue/yklua/12000   34029 ±  43   31425 ± 262   0.92  7.65% faster  
 storage/yklua/1000      82357 ± 722   77188 ± 272   0.94  6.28% faster  
 havlak/yklua/1500      197292 ±1638  186203 ± 893   0.94  5.62% faster  
```
Related ykllvm PR https://github.com/ykjit/ykllvm/pull/301