### PR TITLE
Move and rename `AsmGuardIdx` to `CompiledTraceIdx`.

### DIFF
--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -20,9 +20,10 @@ use crate::{
         CompilationError, CompiledTrace, GuardId,
         j2::{
             J2,
-            compiled_trace::{DeoptFrame, DeoptVar, J2CompiledTrace, J2TraceStart},
+            compiled_trace::{
+                CompiledGuardIdx, DeoptFrame, DeoptVar, J2CompiledTrace, J2TraceStart,
+            },
             hir,
-            hir_to_asm::AsmGuardIdx,
             opt::{OptT, fullopt::FullOpt, noopt::NoOpt},
             regalloc::{RegT, VarLoc, VarLocs},
         },
@@ -179,7 +180,7 @@ impl<Reg: RegT + 'static> AotToHir<Reg> {
                     .as_any()
                     .downcast::<J2CompiledTrace<Reg>>()
                     .unwrap();
-                let src_gidx = AsmGuardIdx::from(usize::from(*src_gid));
+                let src_gidx = CompiledGuardIdx::from(usize::from(*src_gid));
                 let prev_bid = src_ctr.bid(src_gidx);
                 self.prev_bid = Some(prev_bid);
                 let tgt_ctr = Arc::clone(tgt_ctr)
@@ -648,7 +649,7 @@ impl<Reg: RegT + 'static> AotToHir<Reg> {
     fn p_start_side(
         &mut self,
         src_ctr: &Arc<J2CompiledTrace<Reg>>,
-        src_gidx: AsmGuardIdx,
+        src_gidx: CompiledGuardIdx,
         _tgt_ctr: &Arc<J2CompiledTrace<Reg>>,
     ) -> Result<Vec<VarLocs<Reg>>, CompilationError> {
         assert!(self.frames.is_empty());
@@ -1945,7 +1946,7 @@ enum BuildModKind<Reg: RegT> {
         prev_bid: BBlockId,
         entry_vlocs: Vec<VarLocs<Reg>>,
         src_ctr: Arc<J2CompiledTrace<Reg>>,
-        src_gidx: AsmGuardIdx,
+        src_gidx: CompiledGuardIdx,
         tgt_ctr: Arc<J2CompiledTrace<Reg>>,
     },
 }

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -155,8 +155,7 @@
 use crate::{
     compile::{
         j2::{
-            compiled_trace::J2CompiledTrace,
-            hir_to_asm::AsmGuardIdx,
+            compiled_trace::{CompiledGuardIdx, J2CompiledTrace},
             opt::EquivIIdxT,
             regalloc::{RegT, VarLocs},
         },
@@ -370,7 +369,7 @@ pub(super) enum TraceStart<Reg: RegT> {
     /// This trace started from a guard failing.
     Guard {
         src_ctr: Arc<J2CompiledTrace<Reg>>,
-        src_gidx: AsmGuardIdx,
+        src_gidx: CompiledGuardIdx,
         entry_vlocs: Vec<VarLocs<Reg>>,
     },
     /// This is a trace intended for unit testing.

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -95,7 +95,8 @@ use crate::{
         j2::{
             codebuf::ExeCodeBuf,
             compiled_trace::{
-                DeoptFrame, DeoptVar, J2CompiledGuard, J2CompiledTrace, J2TraceStart,
+                CompiledGuardIdx, DeoptFrame, DeoptVar, J2CompiledGuard, J2CompiledTrace,
+                J2TraceStart,
             },
             hir::*,
             regalloc::{RegAlloc, RegFill, RegT, VarLoc, VarLocs},
@@ -337,7 +338,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
         {
             let patch_label = self
                 .be
-                .guard_end(self.m.trid, AsmGuardIdx::from(usize::from(gbidx)))?;
+                .guard_end(self.m.trid, CompiledGuardIdx::from(usize::from(gbidx)))?;
             let gextra = self.m.guard_extra(aguard.geidx);
             self.be.guard_completed(
                 aguard.label.clone(),
@@ -365,7 +366,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             let gblock = &self.m.gblocks[gbidx];
             let patch_label = self
                 .be
-                .guard_end(self.m.trid, AsmGuardIdx::from(usize::from(gbidx)))?;
+                .guard_end(self.m.trid, CompiledGuardIdx::from(usize::from(gbidx)))?;
             let gextra = self.m.guard_extra(aguard.geidx);
 
             let mut stack_off = aguard.stack_off;
@@ -762,7 +763,7 @@ pub(super) trait HirToAsmBackend {
     ) -> Result<
         (
             ExeCodeBuf,
-            IndexVec<AsmGuardIdx, J2CompiledGuard<Self::Reg>>,
+            IndexVec<CompiledGuardIdx, J2CompiledGuard<Self::Reg>>,
             Option<String>,
             Vec<usize>,
         ),
@@ -894,7 +895,7 @@ pub(super) trait HirToAsmBackend {
     fn guard_end(
         &mut self,
         trid: TraceId,
-        gidx: AsmGuardIdx,
+        gidx: CompiledGuardIdx,
     ) -> Result<Self::Label, CompilationError>;
 
     /// The current guard has been completed:
@@ -1266,10 +1267,6 @@ pub(super) trait HirToAsmBackend {
 
 index_vec::define_index_type! {
     pub(super) struct FrameIdx = u16;
-}
-
-index_vec::define_index_type! {
-    pub(super) struct AsmGuardIdx = u16;
 }
 
 #[derive(Debug)]

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -1787,7 +1787,7 @@ pub(crate) mod test {
             DeoptSafepoint,
             j2::{
                 codebuf::ExeCodeBuf,
-                compiled_trace::{DeoptFrame, DeoptVar, J2CompiledTrace},
+                compiled_trace::{CompiledGuardIdx, DeoptFrame, DeoptVar, J2CompiledTrace},
                 hir::Mod,
                 hir::*,
                 hir_parser::str_to_mod,
@@ -1998,7 +1998,7 @@ pub(crate) mod test {
             (
                 ExeCodeBuf,
                 IndexVec<
-                    AsmGuardIdx,
+                    CompiledGuardIdx,
                     crate::compile::j2::compiled_trace::J2CompiledGuard<Self::Reg>,
                 >,
                 Option<String>,
@@ -2152,7 +2152,7 @@ pub(crate) mod test {
         fn guard_end(
             &mut self,
             _trid: crate::mt::TraceId,
-            _gridx: AsmGuardIdx,
+            _gridx: CompiledGuardIdx,
         ) -> Result<Self::Label, CompilationError> {
             Ok(TestLabelIdx::new(0))
         }

--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -5,9 +5,8 @@ use crate::{
     compile::{
         CompiledTrace, GuardId,
         j2::{
-            compiled_trace::{DeoptVar, J2CompiledTrace},
+            compiled_trace::{CompiledGuardIdx, DeoptVar, J2CompiledTrace},
             hir::ConstKind,
-            hir_to_asm::AsmGuardIdx,
             regalloc::{RegFill, VarLoc},
             x64::x64regalloc::Reg,
         },
@@ -141,7 +140,7 @@ thread_local! {
 #[unsafe(no_mangle)]
 pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> ! {
     let gid = GuardId::from(usize::try_from(gid).unwrap());
-    let gidx = AsmGuardIdx::from(usize::from(gid));
+    let gidx = CompiledGuardIdx::from(usize::from(gid));
     let ctr = MTThread::with_borrow(|mtt| mtt.compiled_trace(TraceId::from_u64(trid)))
         .as_any()
         .downcast::<J2CompiledTrace<Reg>>()

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -39,10 +39,11 @@ use crate::{
         j2::{
             codebuf::{CodeBufInProgress, ExeCodeBuf},
             compiled_trace::{
-                DeoptFrame, DeoptVar, J2CompiledGuard, J2CompiledTrace, J2TraceStart,
+                CompiledGuardIdx, DeoptFrame, DeoptVar, J2CompiledGuard, J2CompiledTrace,
+                J2TraceStart,
             },
             hir::*,
-            hir_to_asm::{AsmGuardIdx, HirToAsmBackend},
+            hir_to_asm::HirToAsmBackend,
             regalloc::{AnyOfFill, RegAlloc, RegCnstr, RegCnstrFill, RegFill, VarLoc, VarLocs},
             x64::{
                 asm::{Asm, BLOCK_ALIGNMENT, LabelIdx, RelocKind},
@@ -67,7 +68,7 @@ pub(in crate::compile::j2) struct X64HirToAsm<'a> {
     /// The data section: we map any given (align, byte sequence) pair to [LabelIdx]s, which will
     /// eventually be output as their own pseudo-block.
     data_sec: HashMap<Vec<u8>, (u32, LabelIdx)>,
-    guards: IndexVec<AsmGuardIdx, IntermediateGuard>,
+    guards: IndexVec<CompiledGuardIdx, IntermediateGuard>,
 }
 
 impl<'a> X64HirToAsm<'a> {
@@ -855,7 +856,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
     ) -> Result<
         (
             ExeCodeBuf,
-            IndexVec<AsmGuardIdx, J2CompiledGuard<Reg>>,
+            IndexVec<CompiledGuardIdx, J2CompiledGuard<Reg>>,
             Option<String>,
             Vec<usize>,
         ),
@@ -1385,7 +1386,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
     fn guard_end(
         &mut self,
         trid: TraceId,
-        gidx: AsmGuardIdx,
+        gidx: CompiledGuardIdx,
     ) -> Result<LabelIdx, CompilationError> {
         self.asm
             .push_inst(IcedInst::with1(Code::Call_rm64, IcedReg::RAX));


### PR DESCRIPTION
The original name, and its definition point, is confusing (and has confused me multiple times): it refers both to intermediate guard indexes and, more importantly, fully compiled guard indexes that later traces rely on. This is a relic of previous development that I should have addressed some time ago.

This commit, in essence, moves the index type from `hir_to_asm.rs` to `compiled_trace.rs` and renames it. If, later, we need intermediate index types, we can then create them without having this construct confusing us by its location and name.