### PR TITLE
Fix miscompliation of dyn_ptr_add when using negative indices.

### DIFF
--- a/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
+++ b/ykrt/src/compile/jitc_yk/codegen/x64/mod.rs
@@ -1631,7 +1631,7 @@ impl<'a> Assemble<'a> {
                     [
                         GPConstraint::Input {
                             op: inst.num_elems(self.m),
-                            in_ext: RegExtension::ZeroExtended,
+                            in_ext: RegExtension::SignExtended,
                             force_reg: None,
                             clobber_reg: false,
                         },
@@ -1672,7 +1672,7 @@ impl<'a> Assemble<'a> {
                     [
                         GPConstraint::InputOutput {
                             op: inst.num_elems(self.m),
-                            in_ext: RegExtension::ZeroExtended,
+                            in_ext: RegExtension::SignExtended,
                             out_ext: RegExtension::ZeroExtended,
                             force_reg: None,
                         },
@@ -4654,7 +4654,7 @@ mod tests {
             "
                 ...
                 ; %2: ptr = dyn_ptr_add %0, %1, 1
-                mov r.32.x, r.32.x
+                movsxd r.64.x, r.32.x
                 lea r.64._, [r.64._+r.64.x*1]
                 ",
             false,
@@ -4671,7 +4671,7 @@ mod tests {
             "
                 ...
                 ; %2: ptr = dyn_ptr_add %0, %1, 2
-                mov r.32.x, r.32.x
+                movsxd r.64.x, r.32.x
                 lea r.64._, [r.64._+r.64.x*2]
                 ",
             false,
@@ -4688,7 +4688,7 @@ mod tests {
             "
                 ...
                 ; %2: ptr = dyn_ptr_add %0, %1, 4
-                mov r.32.x, r.32.x
+                movsxd r.64.x, r.32.x
                 lea r.64._, [r.64._+r.64.x*4]
                 ...
                 ",
@@ -4706,7 +4706,7 @@ mod tests {
             "
                 ...
                 ; %2: ptr = dyn_ptr_add %0, %1, 5
-                mov r.32.x, r.32.x
+                movsxd r.64.x, r.32.x
                 imul r.64.x, r.64.x, 0x05
                 add r.64.x, r.64._
                 ",
@@ -4724,7 +4724,7 @@ mod tests {
             "
                 ...
                 ; %2: ptr = dyn_ptr_add %0, %1, 16
-                mov r.32.x, r.32.x
+                movsxd r.64.x, r.32.x
                 shl r.64.x, 0x04
                 add r.64.x, r.64._
                 ...
@@ -4743,7 +4743,7 @@ mod tests {
             "
                 ...
                 ; %2: ptr = dyn_ptr_add %0, %1, 77
-                mov r.32.x, r.32.x
+                movsxd r.64.x, r.32.x
                 imul r.64.x, r.64.x, 0x4d
                 add r.64.x, r.64._
                 ",


### PR DESCRIPTION
Our `dyn_ptr_add` instructions are born out of tracing code from an LLVM getelementptr where an index is dynamic.

Whilst explaining the semantics of getelementptr, the LLVM docs say:

> The indices are first converted to offsets in the pointer’s index
> type. If the currently indexed type is a struct type, the struct
> offset corresponding to the index is sign-extended or truncated to
> the pointer index type. Otherwise, the index itself is sign-extended
> or truncated, and then multiplied by the type allocation size
> (that is, the size rounded up to the ABI alignment) of the currently
> indexed type.

In other words, for correctness, the indices, if smaller than a pointer, must be sign-extended up to pointer size.

We can prove this with the following LLVM IR function, which accepts a `char *` and accesses the `%1`th element, and %1 may be negative.

```
declare i32 @putchar(i32);

define void @f(ptr %0, i32 %1) {
  %4 = getelementptr i32, ptr %0, i32 %1
  %5 = load i32, ptr %4
  %7 = call i32 @putchar(i32 %5)
  ret void
}
```

Compiled with -O3 on x86_64 gives:

```
0000000000000000 <f>:
   0:   48 63 c6                movsxd rax,esi
   3:   8b 3c 87                mov    edi,DWORD PTR [rdi+rax*4]
   6:   e9 00 00 00 00          jmp    b <f+0xb>
```

Here `movsxd` is doing the sign extension before the address is computed and loaded (here it can do the computation and load in one `mov` using SIB).

In our IR, an equivalent operation is an instruction like:
```
%4: ptr = dyn_ptr_add %0, %1, 4
```

Which, before this change codegenned to (e.g.):
```
mov eax, esi
lea rax, [r11+rax*4]
```

But the `mov` is a zero extend, not a sign extend, which can give incorrect semantics if the index is negative.

Instead of a `mov` we want a `movsxd`. This is just a matter of adjusting the register allocator constraints.

Although I saw this in the wild with yklua, I was unable to make a small C test where IR is generated that passes an non-pointer-sized index to a getelementptr: clang seems to explicitely emit a (redundant) sext instruction prior to the getelementptr. Unit tests will have to do.