### PR TITLE
Implement a simple "trace too long" heuristic.

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -414,6 +414,7 @@ impl MT {
                     _ => unreachable!(),
                 });
                 thread_tracer.stop().ok();
+                self.stats.trace_recorded_err();
                 MTThread::set_tracing(IsTracing::None);
                 yklog!(
                     self.log,
@@ -480,6 +481,7 @@ impl MT {
                     }
                 });
                 let _ = thread_tracer.stop();
+                self.stats.trace_recorded_err();
                 self.start_tracing(
                     frameaddr,
                     loc,

--- a/ykrt/src/trace/mod.rs
+++ b/ykrt/src/trace/mod.rs
@@ -60,6 +60,10 @@ pub enum TraceRecorderError {
     #[error("{0}")]
     #[allow(dead_code)]
     TraceBufferOverflow(String),
+    /// A trace buffer-related overflow occurred.
+    #[error("Trace too long")]
+    #[allow(dead_code)]
+    TraceTooLong,
 }
 
 /// An iterator which [TraceRecord]s use to process a trace into [TraceAction]s. The iterator must

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -6,6 +6,9 @@ use super::{
 use crate::mt::MTThread;
 use std::{cell::RefCell, error::Error, sync::Arc};
 
+/// Traces with more than this many items will be turned into [TraceRecorderError::TraceTooLong].
+static TRACE_TOO_LONG: usize = 15000;
+
 #[derive(Debug, Eq, PartialEq, Clone)]
 struct TracingBBlock {
     function_index: u16,
@@ -62,7 +65,11 @@ impl TraceRecorder for SWTTraceRecorder {
             // FIXME: who should handle an empty trace?
             panic!();
         } else {
-            Ok(Box::new(SWTraceIterator::new(bbs)))
+            if bbs.len() > TRACE_TOO_LONG {
+                Err(TraceRecorderError::TraceTooLong)
+            } else {
+                Ok(Box::new(SWTraceIterator::new(bbs)))
+            }
         }
     }
 }


### PR DESCRIPTION
I've chosen this to be quite a high (i.e. conservative) value to start off: we want to stop ludicrously long traces that end up exceeding an `i16` but, right now, we have a pretty poor idea of what "too long" really should be.