### PR TITLE
Fix panic in p_block when all control-point live values are globals

### DIFF
--- a/tests/c/guard_body_no_args.c
+++ b/tests/c/guard_body_no_args.c
@@ -1,0 +1,57 @@
+// Run-time:
+//   env-var: YKD_LOG=4
+//   env-var: YKD_LOG_IR=aot,hir
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   stderr:
+//     yk-tracing: start-tracing
+//     ...
+//     yk-tracing: stop-tracing
+//     ...
+//     call llvm.experimental.patchpoint.void(0i64, 13i32, __ykrt_control_point, 3i32, %7_0, @location, 0i64) [safepoint: 0i64, ()]
+//     ...
+//     --- Begin hir ---
+//     ; {
+//     ...
+//     ; }
+//     %0: ptr = 0x{{_}} ; @global_var
+//     %1: {{_}} = load %0
+//     ...
+//     %0: ptr = 0x{{_}} ; @global_var
+//     %1: {{_}} = load %0
+//     ...
+//     --- End hir ---
+//     ...
+//     yk-execution: enter-jit-code
+//     ...
+
+// Testing that when all interpreter state is in globals the JIT produces
+// a trace block with no Arg instructions.
+//
+// The AOT patchpoint passes `@location` and `@global_var` as global address
+// constants (not live locals). The empty safepoint `()` confirms this: live
+// locals would appear there if interpreter state were in local variables.
+
+
+
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+YkMT *g_mt = NULL;
+YkLocation location;
+long global_var = 0;
+
+int main(void) {
+  g_mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(g_mt, 0);
+  yk_mt_sidetrace_threshold_set(g_mt, 4);
+  location = yk_location_new();
+
+  for (; global_var < 20; global_var++) {
+    yk_mt_control_point(g_mt, &location);
+  }
+
+  yk_location_drop(location);
+  yk_mt_shutdown(g_mt);
+  return EXIT_SUCCESS;
+}

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -860,11 +860,9 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 break;
             }
             let Some((iidx, hinst)) = insts_iter.next() else {
-                // By definition there must be no `Arg` instructions in this trace, which is only
-                // plausible in testing mode.
-                #[cfg(not(test))]
-                panic!();
-                #[cfg(test)]
+                // No Arg instructions: Can happen when all live values at this control point are globals.
+                // Their addresses are baked into the IR, so nothing needs to be passed in
+                // via registers or stack at trace entry.
                 break;
             };
             match hinst {


### PR DESCRIPTION
This is something came up while ykifying the yksompp interpreter - there are a lot of static and global varibles.

When all live values at a control point are globals, their addresses are baked into the IR and nothing needs passing via registers or stack. This produces a trace block with no Arg instructions, which previously caused an unconditional panic in p_block.

This fix make yksompp ~20% faster on `AWFY List 150 4`.