### PR TITLE
Pop a tstate when a trace `ret`s.

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -1376,7 +1376,8 @@ pub(super) trait HirToAsmBackend {
 
     /// Produce code for the end of a (*, Return) trace. The safepoint of the `return` is
     /// `exit_safepoint`. If a value should be returned to the caller, the relevant [InstIdx] is
-    /// passed in `ret_val`.
+    /// passed in `ret_val`. This function _must_ ensure that [MTThread::trace_returned] is
+    /// called as part of the generated code.
     fn star_return_end(
         &mut self,
         ra: &mut RegAlloc<Self>,

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -34,6 +34,7 @@
 #[cfg(not(test))]
 use crate::aotsmp::AOT_STACKMAPS;
 use crate::{
+    MTThread,
     compile::{
         CompilationError, DeoptSafepoint,
         j2::{
@@ -1512,7 +1513,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
             IcedReg::RBP,
         ));
 
-        if let Some(ret_val) = ret_val {
+        let callr = if let Some(ret_val) = ret_val {
             match b.inst_ty(self.m, ret_val) {
                 Ty::Double => todo!(),
                 Ty::Float => todo!(),
@@ -1520,20 +1521,42 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
                 Ty::Int(_) | Ty::Ptr(_) => {
                     let bitw = b.inst_bitw(self.m, ret_val);
                     assert!(bitw <= 64);
-                    let [_] = ra.alloc(
+                    let [callr, _] = ra.alloc(
                         self,
                         iidx,
-                        [RegCnstr::Input {
-                            in_iidx: ret_val,
-                            in_fill: RegCnstrFill::Zeroed,
-                            regs: &[Reg::RAX],
-                            clobber: false,
-                        }],
+                        [
+                            RegCnstr::Temp {
+                                regs: &NORMAL_GP_REGS,
+                            },
+                            RegCnstr::Input {
+                                in_iidx: ret_val,
+                                in_fill: RegCnstrFill::Zeroed,
+                                regs: &[Reg::RAX],
+                                clobber: false,
+                            },
+                        ],
                     )?;
+                    callr
                 }
                 Ty::Void => unreachable!(),
             }
-        }
+        } else {
+            ra.alloc(
+                self,
+                iidx,
+                [RegCnstr::Temp {
+                    regs: &NORMAL_GP_REGS,
+                }],
+            )?[0]
+        };
+        self.asm
+            .push_inst(IcedInst::with1(Code::Call_rm64, callr.to_reg64()));
+        self.asm.push_inst(IcedInst::with2(
+            Code::Mov_r64_imm64,
+            callr.to_reg64(),
+            // This cast is fine on x64, and this module will only be compiled on that platform.
+            MTThread::trace_returned as *const () as i64,
+        ));
 
         Ok(())
     }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -1317,6 +1317,15 @@ impl MTThread {
         THREAD_MTTHREAD.with_borrow_mut(|mtt| f(mtt))
     }
 
+    #[unsafe(no_mangle)]
+    pub(crate) fn trace_returned() {
+        THREAD_MTTHREAD.with_borrow_mut(|mtt| {
+            let MTThreadState::Executing { .. } = mtt.pop_tstate() else {
+                panic!()
+            };
+        });
+    }
+
     /// Return a reference to the [CompiledTrace] with ID `ctrid`.
     ///
     /// # Panics


### PR DESCRIPTION
`tstate`s track the state of execution: if we're interpreting, executing etc. We maintain a stack, which, it turns out, we (I!) didn't maintain properly: if a trace ended in `ret`, we didn't pop the associated `Executing` state.