### PR TITLE
Fix icmp_guard.

### DIFF
--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -567,7 +567,7 @@ impl<'a> X64HirToAsm<'a> {
             RegOrMemOp::MemOp(lhsr, disp) => match bitw {
                 32 => IcedInst::with2(
                     Code::Cmp_rm32_r32,
-                    MemoryOperand::with_base_displ(lhsr.to_reg32(), disp),
+                    MemoryOperand::with_base_displ(lhsr.to_reg64(), disp),
                     rhsr.to_reg32(),
                 ),
                 64 => IcedInst::with2(
@@ -6686,7 +6686,7 @@ mod test {
               ; %2: i32 = load %0
               ; %3: i1 = icmp ugt %2, %1
               ; guard true, %3, []
-              cmp [r.32.x], r.32.y
+              cmp [r.64.x], r.32.y
               jbe l{{1}}
               ; term [%0, %1]
             "#],


### PR DESCRIPTION
This is a silly typo: we incorrect used a 32-bit register as the base, rather than a 64-bit register. We sometimes got away with this in the past when the address in a register happened to be 32 bits.