### PR TITLE
Use an easier-to-understand API for comparing frame pointers.

### DIFF
--- a/ykrt/src/frame.rs
+++ b/ykrt/src/frame.rs
@@ -1,13 +1,27 @@
 use std::ffi::c_void;
 
-/// Return `true` if the frame at address `cnd_callee` is definitely a callee of `cnd_caller`.
+/// What is the relationship between `frame1` and `frame2`?
+///
+/// This assumes that you are passing in a stable address per frame (e.g. a frame pointer such as
+/// `rbp` on x64). If you pass two addresses that are e.g. for two variables in the same frame, or
+/// from frames in different threads, etc, bad things will happen.
 #[cfg(target_arch = "x86_64")]
-pub(crate) fn is_callee_frame(cnd_caller: *const c_void, cnd_callee: *const c_void) -> bool {
-    cnd_callee > cnd_caller
+pub(crate) fn frame_relationship(
+    frame1: *const c_void,
+    frame2: *const c_void,
+) -> FrameRelationship {
+    if frame1.addr() > frame2.addr() {
+        FrameRelationship::Frame1IsCallerOfFrame2
+    } else if frame2.addr() > frame1.addr() {
+        FrameRelationship::Frame2IsCallerOfFrame1
+    } else {
+        FrameRelationship::SameFrame
+    }
 }
 
-/// Return `true` if the frame at address `cnd_caller` is definitely a caller of `cnd_callee`.
-#[cfg(target_arch = "x86_64")]
-pub(crate) fn is_caller_frame(cnd_caller: *const c_void, cnd_callee: *const c_void) -> bool {
-    cnd_callee < cnd_caller
+#[derive(PartialEq)]
+pub(crate) enum FrameRelationship {
+    Frame1IsCallerOfFrame2,
+    Frame2IsCallerOfFrame1,
+    SameFrame,
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -24,7 +24,7 @@ use crate::{
         CompilationError, CompiledTrace, Compiler, GuardId, Trace, TraceEnd, TraceStart,
         default_compiler,
     },
-    frame::{is_callee_frame, is_caller_frame},
+    frame::{FrameRelationship, frame_relationship},
     job_queue::{Job, JobQueue},
     location::{HotLocation, HotLocationKind, Location, SeenHotLocations, TraceFailed},
     log::{
@@ -824,7 +824,9 @@ impl MT {
         else {
             panic!()
         };
-        if is_caller_frame(frameaddr, *tracing_frameaddr) {
+        if frame_relationship(frameaddr, *tracing_frameaddr)
+            == FrameRelationship::Frame1IsCallerOfFrame2
+        {
             // We traced out of the frame we started tracing in. This is not necessarily a
             // correctness issue, but for now such traces will always become (*, Return) traces, so
             // there's no point tracing further.
@@ -838,8 +840,9 @@ impl MT {
                 let mut lk = hl.lock();
                 if seen_hls.push_and_check_any_loop_closed(Arc::clone(&hl)) {
                     // We have traced this location more than once...
-                    //
-                    if is_callee_frame(frameaddr, *tracing_frameaddr) {
+                    if frame_relationship(frameaddr, *tracing_frameaddr)
+                        == FrameRelationship::Frame2IsCallerOfFrame1
+                    {
                         lk.kind = match lk.tracecompilation_error(self) {
                             TraceFailed::KeepTrying => HotLocationKind::Counting(0),
                             TraceFailed::DontTrace => HotLocationKind::DontTrace,
@@ -874,7 +877,9 @@ impl MT {
                         };
                         drop(lk);
                         let mut lk = tracing_hl.lock();
-                        if is_callee_frame(frameaddr, *tracing_frameaddr) {
+                        if frame_relationship(frameaddr, *tracing_frameaddr)
+                            == FrameRelationship::Frame2IsCallerOfFrame1
+                        {
                             lk.kind = match lk.tracecompilation_error(self) {
                                 TraceFailed::KeepTrying => HotLocationKind::Counting(0),
                                 TraceFailed::DontTrace => HotLocationKind::DontTrace,
@@ -934,7 +939,12 @@ impl MT {
             panic!()
         };
 
-        if is_caller_frame(frameaddr, *tracing_frameaddr) {
+        if frame_relationship(frameaddr, *tracing_frameaddr)
+            == FrameRelationship::Frame1IsCallerOfFrame2
+        {
+            // We traced out of the frame we started tracing in. This is not necessarily a
+            // correctness issue, but for now such traces will always become (*, Return) traces, so
+            // there's no point tracing further.
             let Some((parent_ctr, gid)) = gtrace else {
                 panic!()
             };
@@ -966,7 +976,9 @@ impl MT {
                         let Some((parent_ctr, gid)) = gtrace else {
                             panic!()
                         };
-                        if is_callee_frame(frameaddr, *tracing_frameaddr) {
+                        if frame_relationship(frameaddr, *tracing_frameaddr)
+                            == FrameRelationship::Frame2IsCallerOfFrame1
+                        {
                             parent_ctr.guard(*gid).trace_or_compile_failed(self);
                             TransitionControlPoint::AbortTracing
                         } else {
@@ -989,7 +1001,9 @@ impl MT {
                             panic!()
                         };
                         let gid = *gid;
-                        if is_callee_frame(frameaddr, *tracing_frameaddr) {
+                        if frame_relationship(frameaddr, *tracing_frameaddr)
+                            == FrameRelationship::Frame2IsCallerOfFrame1
+                        {
                             parent_ctr.guard(gid).trace_or_compile_failed(self);
                             TransitionControlPoint::AbortTracing
                         } else {
@@ -1020,7 +1034,9 @@ impl MT {
                         };
                         let gid = *gid;
                         let parent_ctr = Arc::clone(parent_ctr);
-                        if is_callee_frame(frameaddr, *tracing_frameaddr) {
+                        if frame_relationship(frameaddr, *tracing_frameaddr)
+                            == FrameRelationship::Frame2IsCallerOfFrame1
+                        {
                             parent_ctr.guard(gid).trace_or_compile_failed(self);
                             return TransitionControlPoint::AbortTracing;
                         } else {


### PR DESCRIPTION
I have endlessly confused myself with the old API, which is almost impossible to use without looking very carefully at the function definitions. Off with its head.