### PR TITLE
yk_longjmp

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,8 +3,8 @@ confidence-threshold = 1.0
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
+    "ISC",
     "MIT",
-    "MPL-2.0",
     "Unicode-3.0"
 ]
 

--- a/tests/c/yk_longjmp.c
+++ b/tests/c/yk_longjmp.c
@@ -1,0 +1,46 @@
+// Run-time:
+//   env-var: YKD_LOG_IR=hir
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=3
+//   stderr:
+//     i=3
+//     yk-tracing: start-tracing
+//     i=2
+//     yk-warning: tracing-aborted: longjmp encountered
+//     i=1
+//     exit
+
+// Check that something sensible happens when there's a longjmp within the
+// confines of the trace.
+
+#include <assert.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 1);
+  YkLocation loc = yk_location_new();
+  jmp_buf buf;
+
+  int i = 3;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(i);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    fprintf(stderr, "i=%d\n", i);
+
+    int r = setjmp(buf);
+    if (r == 0) {
+      yk_longjmp(buf, 1);
+    }
+    i--;
+  }
+  fprintf(stderr, "exit");
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  return (EXIT_SUCCESS);
+}

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 libc = "0.2.148"
+setjmp = "0.1.4"
 ykrt = { path = "../ykrt" }
 
 [build-dependencies]

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -14,10 +14,11 @@
 
 #![allow(clippy::missing_safety_doc)]
 
+use setjmp::{jmp_buf, longjmp};
 #[cfg(feature = "ykd")]
 use std::ffi::CStr;
 use std::{
-    ffi::{CString, c_char},
+    ffi::{CString, c_char, c_int},
     mem::forget,
     os::raw::c_void,
     ptr,
@@ -169,6 +170,13 @@ pub extern "C" fn yk_location_null() -> Location {
 #[unsafe(no_mangle)]
 pub extern "C" fn yk_location_drop(loc: Location) {
     drop(loc)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn yk_longjmp(env: *mut jmp_buf, val: c_int) {
+    unsafe {
+        longjmp(env, val);
+    }
 }
 
 /// Call a function for each shadow stack.

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -173,7 +173,10 @@ pub extern "C" fn yk_location_drop(loc: Location) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn yk_longjmp(env: *mut jmp_buf, val: c_int) {
+pub unsafe extern "C" fn yk_longjmp(env: *mut jmp_buf, val: c_int) {
+    if MTThread::is_tracing() {
+        MTThread::longjmp_encountered();
+    }
     unsafe {
         longjmp(env, val);
     }

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -1,6 +1,7 @@
 #ifndef YK_H
 #define YK_H
 
+#include <setjmp.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -121,6 +122,11 @@ int yk_pthread_create(
     void *(*start_routine)(void *),
     void *restrict arg
 );
+
+/// Interpreters must call this instead of `longjmp` to ensure that yk can,
+/// when tracing, deal properly with the effects of `longjmp`.
+__attribute__((noreturn))
+void yk_longjmp(jmp_buf env, int val);
 
 void yk_foreach_shadowstack(void (*closure)(void* shadow_start, void* shadow_end));
 

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -505,6 +505,7 @@ impl MT {
                 let (thread_tracer, promotions, debug_strs) =
                     MTThread::with_borrow_mut(|mtt| match mtt.pop_tstate() {
                         MTThreadState::Tracing {
+                            mt: _,
                             trid: _,
                             hl,
                             thread_tracer,
@@ -595,6 +596,7 @@ impl MT {
             match Arc::clone(&tracer).start_recorder() {
                 Ok(tt) => {
                     mtt.push_tstate(MTThreadState::Tracing {
+                        mt: Arc::clone(self),
                         hl: Arc::clone(&hl),
                         trid,
                         thread_tracer: tt,
@@ -628,6 +630,7 @@ impl MT {
         let (hl, thread_tracer, promotions, debug_strs) =
             MTThread::with_borrow_mut(|mtt| match mtt.pop_tstate() {
                 MTThreadState::Tracing {
+                    mt: _,
                     trid: _,
                     hl,
                     thread_tracer,
@@ -1122,6 +1125,32 @@ impl MT {
         }
     }
 
+    /// Deal with `longjmp` while tracing. Note: the caller _must_ have checked that the current
+    /// thread is tracing before calling this function.
+    fn longjmp_encountered(self: &Arc<Self>) {
+        let MTThreadState::Tracing {
+            thread_tracer, hl, ..
+        } = MTThread::with_borrow_mut(|mtt| mtt.pop_tstate())
+        else {
+            panic!()
+        };
+        thread_tracer.stop().ok();
+        let mut lk = hl.lock();
+        lk.kind = match lk.tracecompilation_error(self) {
+            TraceFailed::KeepTrying => HotLocationKind::Counting(0),
+            TraceFailed::DontTrace => HotLocationKind::DontTrace,
+        };
+        drop(lk);
+        MTThread::set_tracing(IsTracing::None);
+        yklog!(
+            self.log,
+            Verbosity::Warning,
+            &format!("tracing-aborted: {}", AbortKind::LongJmpEncountered),
+            Some(&*hl)
+        );
+        self.stats.trace_recorded_err();
+    }
+
     /// Inform this meta-tracer that guard `gid` has failed.
     ///
     // FIXME: Don't side trace the last guard of a side-trace as this guard always fails.
@@ -1154,6 +1183,7 @@ impl MT {
                 MTThread::set_tracing(IsTracing::Guard);
                 MTThread::with_borrow_mut(|mtt| match Arc::clone(&tracer).start_recorder() {
                     Ok(tt) => mtt.push_tstate(MTThreadState::Tracing {
+                        mt: Arc::clone(self),
                         trid,
                         hl: Arc::clone(&hl),
                         thread_tracer: tt,
@@ -1196,6 +1226,7 @@ enum MTThreadState {
     Interpreting,
     /// This thread is recording a trace.
     Tracing {
+        mt: Arc<MT>,
         /// The ID of this trace (and which will be -- if everything is successful! -- the ID of
         /// the subsequent [CompiledTrace]).
         trid: TraceId,
@@ -1290,6 +1321,18 @@ impl MTThread {
             TRACING_THREAD_COUNT.fetch_add(1, Ordering::Relaxed);
         } else if was_tracing && !now_tracing {
             TRACING_THREAD_COUNT.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// This function must only be called by ykcapi.
+    #[doc(hidden)]
+    pub fn longjmp_encountered() {
+        let mt = THREAD_MTTHREAD.with_borrow_mut(|mtt| match mtt.peek_mut_tstate() {
+            MTThreadState::Tracing { mt, .. } => Some(Arc::clone(mt)),
+            _ => None,
+        });
+        if let Some(mt) = mt {
+            mt.longjmp_encountered();
         }
     }
 
@@ -1547,12 +1590,14 @@ enum TransitionControlPoint {
 enum AbortKind {
     /// While tracing we fell back from an interpreter to a JIT frame.
     BackIntoExecution,
+    LongJmpEncountered,
 }
 
 impl std::fmt::Display for AbortKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             AbortKind::BackIntoExecution => write!(f, "tracing continued into a JIT frame"),
+            AbortKind::LongJmpEncountered => write!(f, "longjmp encountered"),
         }
     }
 }
@@ -1641,6 +1686,7 @@ mod tests {
         MTThread::set_tracing(IsTracing::Loop);
         MTThread::with_borrow_mut(|mtt| {
             mtt.push_tstate(MTThreadState::Tracing {
+                mt: Arc::clone(mt),
                 trid,
                 hl: Arc::clone(&hl),
                 thread_tracer: Box::new(DummyTraceRecorder),
@@ -1674,6 +1720,7 @@ mod tests {
         MTThread::set_tracing(IsTracing::Guard);
         MTThread::with_borrow_mut(|mtt| {
             mtt.push_tstate(MTThreadState::Tracing {
+                mt: Arc::clone(mt),
                 trid,
                 hl: Arc::clone(&hl),
                 thread_tracer: Box::new(DummyTraceRecorder),
@@ -1803,6 +1850,7 @@ mod tests {
                     MTThread::set_tracing(IsTracing::Loop);
                     MTThread::with_borrow_mut(|mtt| {
                         mtt.push_tstate(MTThreadState::Tracing {
+                            mt: Arc::clone(&mt),
                             trid,
                             hl: Arc::clone(&hl),
                             thread_tracer: Box::new(DummyTraceRecorder),
@@ -2042,6 +2090,7 @@ mod tests {
                             MTThread::set_tracing(IsTracing::Loop);
                             MTThread::with_borrow_mut(|mtt| {
                                 mtt.push_tstate(MTThreadState::Tracing {
+                                    mt: Arc::clone(&mt),
                                     trid,
                                     hl: Arc::clone(&hl),
                                     thread_tracer: Box::new(DummyTraceRecorder),


### PR DESCRIPTION
This PR addresses a deep soundness issue that has always been present in yklua: `longjmp` during tracing is, in the general case, unsound.

Here's a minimal test case for yklua:

```lua
function b()
	while 0 do
		a()
	end
end
pcall(b)
for a = 0, 0 do
end
```

This causes a (spurious) error in yk's optimiser: it's not its fault because it's received a broken trace! `pcall` can -- and in this example does! -- call `longjmp`, leading to a broken trace that `outline_until` can't detect. I think we can do something somewhat sophisticated in many cases as an optimisation but, for now, I just want a way for interpreters to be sound!

Thus PR adds a function `yk_longjmp` which interpreter authors should call instead of normal `longjmp`. It both calls `longjmp` but also allows yk to do whatever it needs to in order to make tracing (etc) sound. Right now that means that it aborts tracing (if tracing is occurring). This fixes yklua (but I'll have to make a separate PR to update yklua in this repo) by aborting traces if `pcall` calls `longjmp`.