### PR TITLE
Introduce an explicit `StackMapIdx`.

### DIFF
--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
     ptr,
     sync::Arc,
 };
-use ykrt::{HotThreshold, Location, MT, MTThread};
+use ykrt::{HotThreshold, Location, MT, MTThread, StackMapIdx};
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn yk_mt_new(err_msg: *mut *const c_char) -> *const MT {
@@ -67,7 +67,7 @@ pub extern "C" fn __ykrt_control_point(
     mt: *const MT,
     loc: *mut Location,
     // Stackmap id for the control point.
-    smid: u64,
+    smapidx: StackMapIdx,
 ) {
     // FIXME: We could get rid of this entire function if we pass the frame's base pointer into the
     // control point from the interpreter.
@@ -114,7 +114,7 @@ pub extern "C" fn __ykrt_control_point_real(
     mt: *const MT,
     loc: *mut Location,
     // Stackmap id for the control point.
-    smid: u64,
+    smapidx: StackMapIdx,
     // Frame address of caller.
     frameaddr: *mut c_void,
 ) {
@@ -122,7 +122,7 @@ pub extern "C" fn __ykrt_control_point_real(
     let loc = unsafe { &*loc };
     if !loc.is_null() {
         let arc = unsafe { Arc::from_raw(mt) };
-        arc.control_point(loc, frameaddr, smid);
+        arc.control_point(loc, frameaddr, smapidx);
         forget(arc);
     }
 }

--- a/ykrt/src/aotsmp.rs
+++ b/ykrt/src/aotsmp.rs
@@ -1,3 +1,4 @@
+use index_vec::{IndexVec, define_index_type};
 use object::{Object, ObjectSection};
 use std::sync::LazyLock;
 #[cfg(not(test))]
@@ -5,18 +6,24 @@ use std::thread;
 use ykaddr::obj::SELF_BIN_MMAP;
 use yksmp::{PrologueInfo, Record, StackMapParser};
 
+define_index_type! {
+    /// The index of a given stackmap in a module's [Record]s.
+    pub struct StackMapIdx = usize;
+    DISPLAY_FORMAT = "{}";
+}
+
 /// Parsed stackmap information of the AOT module.
 pub(crate) struct AOTStackmapInfo {
     /// Prologue information for each function.
     pinfos: Vec<PrologueInfo>,
     /// All stackmap records of the module, and the index of the prologue info relevant for each
     /// record.
-    records: Vec<(Record, usize)>,
+    records: IndexVec<StackMapIdx, (Record, usize)>,
 }
 
 impl AOTStackmapInfo {
-    pub(crate) fn get(&self, stackmapid: usize) -> (&Record, &PrologueInfo) {
-        let (rec, pid) = &self.records[stackmapid];
+    pub(crate) fn get(&self, smapidx: StackMapIdx) -> (&Record, &PrologueInfo) {
+        let (rec, pid) = &self.records[smapidx];
         let pinfo = &self.pinfos[*pid];
         (rec, pinfo)
     }
@@ -38,7 +45,10 @@ pub(crate) static AOT_STACKMAPS: LazyLock<Result<AOTStackmapInfo, String>> = Laz
         // Parse the stackmap.
         let data = sec.data().map_err(|e| errstr(&e.to_string()))?;
         let (pinfos, records) = StackMapParser::parse(data);
-        Ok(AOTStackmapInfo { pinfos, records })
+        Ok(AOTStackmapInfo {
+            pinfos,
+            records: IndexVec::from_vec(records),
+        })
     }
 
     load_stackmaps()

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -15,6 +15,8 @@
 //! pushed instruction might be proven to be equivalent to a previous instruction; guards might be
 //! optimised away entirely; and so on.
 
+#[cfg(test)]
+use crate::aotsmp::StackMapIdx;
 use crate::{
     compile::{
         CompilationError, CompiledTrace, GuardId,
@@ -469,7 +471,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 pc,
                 pc_statepoint,
                 #[cfg(test)]
-                smapidx: hir::StackMapIdx::new(0),
+                smapidx: StackMapIdx::new(0),
             });
         }
 

--- a/ykrt/src/compile/j2/compiled_trace.rs
+++ b/ykrt/src/compile/j2/compiled_trace.rs
@@ -328,11 +328,15 @@ index_vec::define_index_type! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compile::j2::{
-        hir::{Block, TraceEnd},
-        x64::Reg,
+    use crate::{
+        aotsmp::StackMapIdx,
+        compile::j2::{
+            hir::{Block, TraceEnd},
+            x64::Reg,
+        },
     };
     use index_vec::IndexVec;
+    use std::sync::LazyLock;
 
     fn empty_block() -> Block {
         Block {
@@ -342,10 +346,10 @@ mod tests {
     }
 
     // Dummy DeoptStatepoint for testing
-    static TEST_DEOPT_STATEPOINT: Statepoint = Statepoint {
-        id: 0,
+    static TEST_DEOPT_STATEPOINT: LazyLock<Statepoint> = LazyLock::new(|| Statepoint {
+        smapidx: StackMapIdx::new(0),
         lives: Vec::new(),
-    };
+    });
 
     #[test]
     fn test_get_trace_name_control_loop() {

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -162,6 +162,8 @@
 //! generate code for that instruction! For example, [PtrAdd] instructions are often inlined into
 //! other instructions.
 
+#[cfg(test)]
+use crate::aotsmp::StackMapIdx;
 use crate::{
     compile::{
         j2::{
@@ -4905,11 +4907,6 @@ impl PartialEq for Frame {
             && std::ptr::eq(self.pc_statepoint, other.pc_statepoint)
             && self.smapidx == other.smapidx
     }
-}
-
-#[cfg(test)]
-index_vec::define_index_type! {
-    pub(crate) struct StackMapIdx = usize;
 }
 
 #[cfg(test)]

--- a/ykrt/src/compile/j2/hir_parser.rs
+++ b/ykrt/src/compile/j2/hir_parser.rs
@@ -22,6 +22,7 @@
 #[cfg(test)]
 use crate::compile::jitc_yk::aot_ir::{BBlockInstIdx, InstId};
 use crate::{
+    aotsmp::StackMapIdx,
     compile::{
         j2::{
             hir::*,
@@ -38,7 +39,7 @@ use index_vec::IndexVec;
 use lrlex::{DefaultLexerTypes, LRNonStreamingLexer, lrlex_mod};
 use lrpar::{NonStreamingLexer, Span, lrpar_mod};
 use smallvec::SmallVec;
-use std::{collections::HashMap, ffi::CString, marker::PhantomData};
+use std::{collections::HashMap, ffi::CString, marker::PhantomData, sync::LazyLock};
 
 lrlex_mod!("compile/j2/hir.l");
 lrpar_mod!("compile/j2/hir.y");
@@ -47,10 +48,10 @@ type StorageT = u16;
 /// In unit test mode, there are are no [DeoptStatepoint]s, since we're running as a normal Rust
 /// binary, not a ykllvm compiled C program. If we want to use a [DeoptStatepoint] in tests, we
 /// have to create a dummy.
-static TEST_DEOPT_STATEPOINT: Statepoint = Statepoint {
-    id: 0,
+static TEST_DEOPT_STATEPOINT: LazyLock<Statepoint> = LazyLock::new(|| Statepoint {
+    smapidx: StackMapIdx::from(0),
     lives: Vec::new(),
-};
+});
 
 struct HirParser<'lexer, 'input: 'lexer, Reg: RegT> {
     lexer: &'lexer LRNonStreamingLexer<'lexer, 'input, DefaultLexerTypes<StorageT>>,

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -90,6 +90,7 @@
 
 use crate::{
     aotsmp::AOT_STACKMAPS,
+    aotsmp::StackMapIdx,
     compile::{
         CompilationError, CompiledTrace, Statepoint,
         j2::{
@@ -148,7 +149,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
                 // FIXME: Relying on stackmap 0 being the control point is a horrible hack.
                 let base_stack_off = u32::try_from({
-                    let (smap, prologue) = aot_smaps.get(0);
+                    let (smap, prologue) = aot_smaps.get(StackMapIdx::from(0));
                     if prologue.hasfp {
                         // FIXME: This needs porting! https://github.com/ykjit/yk/issues/1936
                         #[cfg(not(target_arch = "x86_64"))]
@@ -162,7 +163,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 })
                 .unwrap();
 
-                let (rec, _) = aot_smaps.get(usize::try_from(entry_statepoint.id).unwrap());
+                let (rec, _) = aot_smaps.get(entry_statepoint.smapidx);
                 let mut args_vlocs = rec
                     .live_vals
                     .iter()
@@ -639,7 +640,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             for frame in gextra.deopt_frames.iter() {
                 #[cfg(not(test))]
                 let smap_lives_iter = aot_smaps
-                    .get(usize::try_from(frame.pc_statepoint.id).unwrap())
+                    .get(frame.pc_statepoint.smapidx)
                     .0
                     .live_vals
                     .iter();

--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -192,7 +192,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
     // already exists, rather than creating one from scratch.
     {
         let frame = &guard.deopt_frames[0];
-        let (smap, prologue) = aot_smaps.get(usize::try_from(frame.pc_statepoint.id).unwrap());
+        let (smap, prologue) = aot_smaps.get(frame.pc_statepoint.smapidx);
         if prologue.hasfp {
             // Update RBP to represent this frame's address.
             gp_regs[DeoptGpReg::RBP.idx()] = prev_faddr as u64;
@@ -215,7 +215,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
 
     // Deal with all the remaining frames: we create each of these from scratch.
     for frame in guard.deopt_frames.iter().skip(1) {
-        let (smap, prologue) = aot_smaps.get(usize::try_from(frame.pc_statepoint.id).unwrap());
+        let (smap, prologue) = aot_smaps.get(frame.pc_statepoint.smapidx);
 
         // How much room does this frame need?
         let flen = 8 + usize::try_from(smap.size).unwrap();
@@ -303,8 +303,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
     }
 
     let fdst = {
-        let (smap, prologue) =
-            aot_smaps.get(usize::try_from(guard.deopt_frames[0].pc_statepoint.id).unwrap());
+        let (smap, prologue) = aot_smaps.get(guard.deopt_frames[0].pc_statepoint.smapidx);
         if prologue.hasfp {
             unsafe { faddr.byte_sub(usize::try_from(smap.size - 8).unwrap()) }
         } else {

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -1483,13 +1483,13 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         #[cfg(not(test))]
         let csrs = {
             let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
-            let (_, prologue) = aot_smaps.get(usize::try_from(exit_statepoint.id).unwrap());
+            let (_, prologue) = aot_smaps.get(exit_statepoint.smapidx);
             &prologue.csrs
         };
 
         #[cfg(test)]
         let csrs = {
-            assert_eq!(exit_statepoint.id, 0);
+            assert_eq!(exit_statepoint.smapidx, 0);
             [(3, -6), (12, -5), (13, -4), (14, -3), (15, -2)]
         };
 

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -27,6 +27,7 @@
 //! textual JIT IR. See the docstring for the [super::jit_ir] module.
 #![allow(dead_code)]
 
+use crate::aotsmp::StackMapIdx;
 use byteorder::{NativeEndian, ReadBytesExt};
 use deku::prelude::*;
 use std::{
@@ -396,6 +397,16 @@ index!(PathIdx);
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ArgIdx(usize);
 index!(ArgIdx);
+
+/// Helper function for deku `map` attribute. It is necessary to write all the types out in full to
+/// avoid type inference errors, so it's easier to have a single helper function rather than inline
+/// this into each `map` attribute.
+fn map_to_stackmapidx(v: u64) -> Result<StackMapIdx, DekuError> {
+    match usize::try_from(v).map(StackMapIdx::try_from) {
+        Ok(Ok(x)) => Ok(x),
+        _ => Err(DekuError::Parse(Cow::Borrowed("Couldn't map StackMapIdx"))),
+    }
+}
 
 /// Helper function for deku `map` attribute. It is necessary to write all the types out in full to
 /// avoid type inference errors, so it's easier to have a single helper function rather than inline
@@ -831,7 +842,8 @@ impl fmt::Display for DisplayableOperand<'_> {
 #[deku_derive(DekuRead)]
 #[derive(Clone, Debug)]
 pub(crate) struct Statepoint {
-    pub(crate) id: u64,
+    #[deku(map = "map_to_stackmapidx")]
+    pub(crate) smapidx: StackMapIdx,
     #[deku(temp)]
     num_lives: u32,
     #[deku(count = "num_lives")]
@@ -861,7 +873,11 @@ impl fmt::Display for DisplayableStatepoint<'_> {
             .map(|a| a.display(self.m).to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "[statepoint: {}i64, ({})]", self.statepoint.id, lives_s)
+        write!(
+            f,
+            "[statepoint: {}i64, ({})]",
+            self.statepoint.smapidx, lives_s
+        )
     }
 }
 

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -26,6 +26,7 @@ pub use thread_intercept::{yk_foreach_shadowstack, yk_thread_shadowstack_bounds}
 
 pub use self::location::Location;
 pub use self::mt::{HotThreshold, MT, MTThread};
+pub use aotsmp::StackMapIdx;
 use std::ffi::{CStr, c_char};
 
 #[allow(clippy::missing_safety_doc)]

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 use parking_lot_core::SpinWait;
 
 use crate::{
-    aotsmp::{AOT_STACKMAPS, load_aot_stackmaps},
+    aotsmp::{AOT_STACKMAPS, StackMapIdx, load_aot_stackmaps},
     compile::{
         CompilationError, CompiledTrace, Compiler, GuardId, Trace, TraceEnd, TraceStart,
         default_compiler,
@@ -407,7 +407,12 @@ impl MT {
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn control_point(self: &Arc<Self>, loc: &Location, frameaddr: *mut c_void, smid: u64) {
+    pub fn control_point(
+        self: &Arc<Self>,
+        loc: &Location,
+        frameaddr: *mut c_void,
+        smapidx: StackMapIdx,
+    ) {
         match self.transition_control_point(loc, frameaddr) {
             TransitionControlPoint::NoAction => (),
             TransitionControlPoint::AbortTracing => {
@@ -438,10 +443,7 @@ impl MT {
                 self.stats.trace_executed();
 
                 // Compute the rsp of the control_point frame.
-                let (rec, pinfo) = AOT_STACKMAPS
-                    .as_ref()
-                    .unwrap()
-                    .get(usize::try_from(smid).unwrap());
+                let (rec, pinfo) = AOT_STACKMAPS.as_ref().unwrap().get(smapidx);
                 let mut rsp = unsafe { frameaddr.byte_sub(usize::try_from(rec.size).unwrap()) };
                 if pinfo.hasfp {
                     rsp = unsafe { rsp.byte_add(REG64_SIZE) };


### PR DESCRIPTION
Previously we mostly called this `id` and it had a type of either `usize` or `u64`, obscuring whether we were referring to the same thing or not.