### PR TITLE
Show `gidx`s in assembled code.

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -775,6 +775,9 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     switch: gextra.switch.clone(),
                 });
             }
+            if self.log {
+                self.be.log(format!("gidx {gidx:?}"));
+            }
 
             // Make sure we reuse the `ginsts` and `gterms` allocations.
             ginsts = std::mem::take(&mut gblock.insts);
@@ -2427,6 +2430,7 @@ mod test {
           guard_completed:
             fromvlocs=[Stack(8)]
             tovlocs=[Reg(R0, Undefined)]
+          ; gidx 0
         "#],
         );
 
@@ -2460,6 +2464,7 @@ mod test {
             tovlocs=[Reg(R0, Undefined)]
             fromvlocs=[Stack(16)]
             tovlocs=[Reg(R1, Undefined)]
+          ; gidx 0
         "#],
         );
 
@@ -2494,6 +2499,7 @@ mod test {
           guard_completed:
             fromvlocs=[Stack(8)]
             tovlocs=[Reg(R0, Undefined)]
+          ; gidx 0
         "#],
         );
 
@@ -2625,6 +2631,7 @@ mod test {
           guard_completed:
             fromvlocs=[Stack(8)]
             tovlocs=[Stack(24)]
+          ; gidx 0
         "#],
         );
     }
@@ -2685,6 +2692,7 @@ mod test {
           guard_completed:
             fromvlocs=[Stack(8)]
             tovlocs=[Reg(R2, Undefined)]
+          ; gidx 0
         "#],
         );
     }

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -6533,6 +6533,7 @@ mod test {
               term [%0]
             ",
             &["
+              ; gidx 0
               ; l{{1}}
               sub rsp, 0x80
               ; term []
@@ -6561,6 +6562,7 @@ mod test {
               term [%0]
             ",
             &["
+              ; gidx 0
               ; l{{1}}
               sub rsp, 0x80
               ; term []


### PR DESCRIPTION
This is something of a mess, at least in the sense that it doesn't fully match user expectations: `gidx`s are only confirmed at assembly time when we have considered a guard for merging. Thus even though we would like to know the `gidx` at HIR-time, that does not match the `gidx`s we see at run-time. Still, even this simple change is better than nothing, in terms of understanding what's going on.