### PR TITLE
Pass a closure to logging.

### DIFF
--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -150,14 +150,14 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
     mt.stats
         .timing_state(crate::log::stats::TimingState::Deopting);
 
-    mt.log.log(
-        Verbosity::Execution,
-        &format!(
+    mt.log.log(Verbosity::Execution, |log| {
+        write!(
+            log,
             "deoptimise {{\"trid\": \"{:?}\", \"gidx\": \"{}\"}}",
             ctr.ctrid().as_u64(),
             usize::from(gidx)
-        ),
-    );
+        )
+    });
 
     mt.deopt();
 

--- a/ykrt/src/log/mod.rs
+++ b/ykrt/src/log/mod.rs
@@ -5,7 +5,7 @@
 
 #[cfg(feature = "ykd")]
 use parking_lot::Mutex;
-use std::{env, error::Error, fs::File, io::Write, path::PathBuf};
+use std::{env, error::Error, fmt, fs::File, io::Write, path::PathBuf};
 use strum::{EnumCount, FromRepr};
 
 #[cfg(feature = "ykd")]
@@ -74,14 +74,17 @@ impl Log {
     }
 
     #[cfg(feature = "ykd")]
-    pub(crate) fn log_with_hl_debug(&self, level: Verbosity, msg: &str, hl: &Mutex<HotLocation>) {
-        // If the hot location has a debug string, append it to the log message.
-        let msg = if let Some(dstr) = hl.lock().debug_str.as_ref() {
-            &format!("{msg}: {dstr}")
-        } else {
-            msg
-        };
-        self.log(level, msg);
+    pub(crate) fn log_with_hl_debug<F>(&self, level: Verbosity, msg: F, hl: &Mutex<HotLocation>)
+    where
+        F: FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+    {
+        self.log(level, |log| {
+            msg(log)?;
+            if let Some(dstr) = hl.lock().debug_str.as_ref() {
+                write!(log, ": {dstr}")?;
+            }
+            Ok(())
+        });
     }
 
     /// Log `msg` with the [Verbosity] level `verbosity`.
@@ -89,7 +92,10 @@ impl Log {
     /// # Panics
     ///
     /// If `level == Verbosity::None`.
-    pub(crate) fn log(&self, level: Verbosity, msg: &str) {
+    pub(crate) fn log<F>(&self, level: Verbosity, msg: F)
+    where
+        F: FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+    {
         if level <= self.level {
             let prefix = match level {
                 Verbosity::Disabled => panic!(),
@@ -98,9 +104,13 @@ impl Log {
                 Verbosity::Tracing => "yk-tracing",
                 Verbosity::Execution => "yk-execution",
             };
+            let mut buf = String::new();
+            if msg(&mut buf).is_err() {
+                return;
+            }
             match &self.path {
                 Some(p) => {
-                    let s = format!("{prefix}: {msg}\n");
+                    let s = format!("{prefix}: {buf}\n");
                     File::options()
                         .append(true)
                         .open(p)
@@ -108,7 +118,7 @@ impl Log {
                         .ok();
                 }
                 None => {
-                    eprintln!("{prefix}: {msg}");
+                    eprintln!("{prefix}: {buf}");
                 }
             }
         }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -360,25 +360,24 @@ impl MT {
                     mt.stats.trace_compiled_err();
                     match e {
                         CompilationError::General(e) | CompilationError::LimitExceeded(e) => {
-                            mt.log.log(
-                                Verbosity::Warning,
-                                &format!("trace-compilation-aborted: {e}"),
-                            );
+                            mt.log.log(Verbosity::Warning, |log| {
+                                write!(log, "trace-compilation-aborted: {e}")
+                            });
                         }
                         CompilationError::InternalError(e) => {
                             #[cfg(feature = "ykd")]
                             panic!("{e}");
                             #[cfg(not(feature = "ykd"))]
                             {
-                                mt.log.log(
-                                    Verbosity::Error,
-                                    &format!("trace-compilation-aborted: {e}"),
-                                );
+                                mt.log.log(Verbosity::Error, |log| {
+                                    write!(log, "trace-compilation-aborted: {e}")
+                                });
                             }
                         }
                         CompilationError::ResourceExhausted(e) => {
-                            mt.log
-                                .log(Verbosity::Error, &format!("trace-compilation-aborted: {e}"));
+                            mt.log.log(Verbosity::Error, |log| {
+                                write!(log, "trace-compilation-aborted: {e}")
+                            });
                         }
                     }
                     match trace_start {
@@ -428,7 +427,7 @@ impl MT {
                 yklog!(
                     self.log,
                     Verbosity::Warning,
-                    "abort-tracing",
+                    |log| write!(log, "abort-tracing"),
                     loc.hot_location()
                 );
                 self.stats.trace_recorded_err();
@@ -437,7 +436,11 @@ impl MT {
                 yklog!(
                     self.log,
                     Verbosity::Execution,
-                    &format!("enter-jit-code {{\"trid\": \"{}\"}}", ctr.ctrid().as_u64()),
+                    |log| write!(
+                        log,
+                        "enter-jit-code {{\"trid\": \"{}\"}}",
+                        ctr.ctrid().as_u64()
+                    ),
                     loc.hot_location()
                 );
                 self.stats.trace_executed();
@@ -477,7 +480,7 @@ impl MT {
                 yklog!(
                     self.log,
                     Verbosity::Warning,
-                    "tracing-aborted: unrolled inner loop",
+                    |log| write!(log, "tracing-aborted: unrolled inner loop"),
                     loc.hot_location()
                 );
                 let thread_tracer = MTThread::with_borrow_mut(|mtt| {
@@ -530,7 +533,7 @@ impl MT {
                         yklog!(
                             self.log,
                             Verbosity::Tracing,
-                            "stop-tracing",
+                            |log| write!(log, "stop-tracing"),
                             loc.hot_location()
                         );
                         let trace_end = match coupler_tid {
@@ -562,7 +565,7 @@ impl MT {
                         yklog!(
                             self.log,
                             Verbosity::Warning,
-                            &format!("stop-tracing-aborted: {e}"),
+                            |log| write!(log, "stop-tracing-aborted: {e}"),
                             loc.hot_location()
                         );
                         self.stats.timing_state(TimingState::None);
@@ -587,7 +590,7 @@ impl MT {
         yklog!(
             self.log,
             Verbosity::Tracing,
-            "start-tracing",
+            |log| write!(log, "start-tracing"),
             _loc.hot_location()
         );
         let tracer = {
@@ -652,7 +655,7 @@ impl MT {
                 yklog!(
                     self.log,
                     Verbosity::Tracing,
-                    "stop-tracing",
+                    |log| write!(log, "stop-tracing"),
                     _loc.hot_location()
                 );
                 self.queue_compile_job(Trace {
@@ -672,7 +675,7 @@ impl MT {
                 yklog!(
                     self.log,
                     Verbosity::Warning,
-                    &format!("stop-tracing-aborted: {e}"),
+                    |log| write!(log, "stop-tracing-aborted: {e}"),
                     _loc.hot_location()
                 );
             }
@@ -1135,7 +1138,7 @@ impl MT {
                     yklog!(
                         self.log,
                         Verbosity::Warning,
-                        &format!("tracing-aborted: {}", AbortKind::BackIntoExecution),
+                        |log| write!(log, "tracing-aborted: {}", AbortKind::BackIntoExecution),
                         Some(&*hl)
                     );
                 }
@@ -1164,7 +1167,7 @@ impl MT {
         yklog!(
             self.log,
             Verbosity::Warning,
-            &format!("tracing-aborted: {}", AbortKind::LongJmpEncountered),
+            |log| write!(log, "tracing-aborted: {}", AbortKind::LongJmpEncountered),
             Some(&*hl)
         );
         self.stats.trace_recorded_err();
@@ -1192,7 +1195,7 @@ impl MT {
                 yklog!(
                     self.log,
                     Verbosity::Tracing,
-                    "start-side-tracing",
+                    |log| write!(log, "start-side-tracing"),
                     Some(&*hl)
                 );
                 let tracer = {
@@ -1388,7 +1391,7 @@ impl MTThread {
                 yklog!(
                     mt.log,
                     Verbosity::Execution,
-                    &format!("return {{\"trid\": \"{}\"}}", trid.as_u64()),
+                    |log| write!(log, "return {{\"trid\": \"{}\"}}", trid.as_u64()),
                     None
                 );
                 mtt.pop_tstate();
@@ -1400,7 +1403,7 @@ impl MTThread {
                 yklog!(
                     mt.log,
                     Verbosity::Execution,
-                    &format!("return {{\"trid\": \"{}\"}}", trid.as_u64()),
+                    |log| write!(log, "return {{\"trid\": \"{}\"}}", trid.as_u64()),
                     None
                 );
             }


### PR DESCRIPTION
This allows the typical case -- there is no log to produce -- to avoid allocations in those cases (such as deopt) where we want to produce a relatively complex/expensive logging statement. Right now, this isn't an obviously load bearing part of the system (i.e. it doesn't make any meaningful difference to benchmarks), but at least it's one thing off my mind!