### PR TITLE
Fix x64 codegen for storing i1 values.

### DIFF
--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -866,7 +866,7 @@ impl<'a> X64HirToAsm<'a> {
             };
 
             self.asm.push_inst(match val_bitw {
-                8 => IcedInst::with2(Code::Mov_rm8_r8, memop, valr.to_reg8()),
+                1..=8 => IcedInst::with2(Code::Mov_rm8_r8, memop, valr.to_reg8()),
                 16 => IcedInst::with2(Code::Mov_rm16_r16, memop, valr.to_reg16()),
                 32 => IcedInst::with2(Code::Mov_rm32_r32, memop, valr.to_reg32()),
                 64 => IcedInst::with2(Code::Mov_rm64_r64, memop, valr.to_reg64()),
@@ -8188,6 +8188,118 @@ mod test {
 
     #[test]
     fn cg_store_int() {
+        // i1
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i1 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
+        // i2
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i2 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
+        // i3
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i3 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
+        // i4
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i4 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
+        // i5
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i5 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
+        // i6
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i6 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
+        // i7
+        codegen_and_test(
+            "
+              %0: ptr = arg [reg]
+              %1: i7 = arg [reg]
+              store %1, %0
+              term [%0, %1]
+            ",
+            &["
+              ...
+              ; store %1, %0
+              mov [r.64.x], r.8.y
+              ...
+            "],
+        );
+
         // i8
         codegen_and_test(
             "


### PR DESCRIPTION
I get this error in sompp debug mode.

Example of sompp command command with the backtrace:
```shell
RUST_BACKTRACE=1 cmake-yk-debug/SOM++ -cp 'core-lib/Examples/AreWeFastYet:core-lib/Examples/AreWeFastYet/Core:core-lib/Smalltalk:core-lib/Examples/AreWeFastYet/DeltaBlue' core-lib/Examples/AreWeFastYet/Harness.som DeltaBlue 1 500
...
thread '<unnamed>' (324145) panicked at ykrt/src/compile/j2/x64/x64hir_to_asm.rs:873:22:
not yet implemented: 1
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/d7f14d3d89c39b2c12ed4b9864a0eb2c205d20bc/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/d7f14d3d89c39b2c12ed4b9864a0eb2c205d20bc/library/core/src/panicking.rs:80:14
   2: <ykrt::compile::j2::x64::x64hir_to_asm::X64HirToAsm>::i_store_intptr
             at /home/pd/yk/ykrt/src/compile/j2/x64/x64hir_to_asm.rs:873:22
   3: <ykrt::compile::j2::x64::x64hir_to_asm::X64HirToAsm as ykrt::compile::j2::hir_to_asm::HirToAsmBackend>::i_store
             at /home/pd/yk/ykrt/src/compile/j2/x64/x64hir_to_asm.rs:3854:45
   4: <ykrt::compile::j2::hir_to_asm::HirToAsm<ykrt::compile::j2::x64::x64hir_to_asm::X64HirToAsm>>::p_block
             at /home/pd/yk/ykrt/src/compile/j2/hir_to_asm.rs:1138:43
   5: <ykrt::compile::j2::hir_to_asm::HirToAsm<ykrt::compile::j2::x64::x64hir_to_asm::X64HirToAsm>>::build
             at /home/pd/yk/ykrt/src/compile/j2/hir_to_asm.rs:215:55
   6: <ykrt::compile::j2::J2 as ykrt::compile::Compiler>::compile
             at /home/pd/yk/ykrt/src/compile/j2/mod.rs:289:62
   7: <ykrt::mt::MT>::queue_compile_job::{closure#2}
             at /home/pd/yk/ykrt/src/mt.rs:339:28
   8: <<ykrt::mt::MT>::queue_compile_job::{closure#2} as core::ops::function::FnOnce<()>>::call_once
             at /home/pd/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   9: <<ykrt::mt::MT>::queue_compile_job::{closure#2} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
             at /home/pd/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  10: <alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output = ()> + core::marker::Send> as core::ops::function::FnOnce<()>>::call_once
             at /home/pd/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2275:9
  11: <lock_api::mutex::MutexGuard<parking_lot::raw_mutex::RawMutex, alloc::collections::vec_deque::VecDeque<ykrt::job_queue::Job>>>::unlocked::<alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output = ()> + core::marker::Send>, ()>
             at /home/pd/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lock_api-0.4.14/src/mutex.rs:613:9
  12: <ykrt::job_queue::JobQueue>::push::{closure#2}
             at /home/pd/yk/ykrt/src/job_queue.rs:187:33
              
```