### PR TITLE
Allow register copying to also arrange fills.

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -1307,8 +1307,15 @@ pub(super) trait HirToAsmBackend {
     /// Adjust `dst_bitw` bits of `reg` from `src_fill` to `dst_fill`.
     fn arrange_fill(&mut self, reg: Self::Reg, src_fill: RegFill, dst_bitw: u32, dst_fill: RegFill);
 
-    /// Copy `from_reg` to `to_reg`.
-    fn copy_reg(&mut self, from_reg: Self::Reg, to_reg: Self::Reg) -> Result<(), CompilationError>;
+    /// Copy `src_reg` to `dst_reg`, adjusting the copied value's fill if necessary.
+    fn copy_reg_with_fill(
+        &mut self,
+        src_reg: Self::Reg,
+        src_fill: RegFill,
+        dst_reg: Self::Reg,
+        dst_fill: RegFill,
+        dst_bitw: u32,
+    ) -> Result<(), CompilationError>;
 
     /// If the stack is currently at offset `stack_off`, return an aligned offset suitable for a
     /// value of `bitw` bits: the value will be stored exactly at the returned offset. Note: this
@@ -2050,12 +2057,15 @@ mod test {
             ));
         }
 
-        fn copy_reg(
+        fn copy_reg_with_fill(
             &mut self,
-            from_reg: Self::Reg,
-            to_reg: Self::Reg,
+            src_reg: Self::Reg,
+            src_fill: RegFill,
+            dst_reg: Self::Reg,
+            dst_fill: RegFill,
+            dst_bitw: u32,
         ) -> Result<(), CompilationError> {
-            self.log.push(format!("copy_reg: {to_reg:?}={from_reg:?}"));
+            self.log.push(format!("copy_reg: src_reg={src_reg:?}, src_fill={src_fill:?}, dst_reg={dst_reg:?}, dst_fill={dst_fill:?}, dst_bitw={dst_bitw:?}"));
             Ok(())
         }
 
@@ -2423,8 +2433,7 @@ mod test {
           spill: reg=R0, in_fill=Undefined, stack_off=8, bitw=64
           ptradd: R0=R0 + 8
           ; %1: ptr = ptradd %0, 8
-          arrange_fill: reg=R0, from=Undefined, dst_bitw=64, to=Undefined
-          copy_reg: R0=R1
+          copy_reg: src_reg=R1, src_fill=Undefined, dst_reg=R0, dst_fill=Undefined, dst_bitw=64
           ; %0: ptr = arg [Reg("R1", Undefined)]
           guard_completed:
             fromvlocs=[Stack(8)]
@@ -2455,8 +2464,7 @@ mod test {
           spill: reg=R1, in_fill=Undefined, stack_off=8, bitw=64
           ptradd: R1=R0 + 8
           ; %1: ptr = ptradd %0, 8
-          arrange_fill: reg=R0, from=Undefined, dst_bitw=64, to=Undefined
-          copy_reg: R0=R1
+          copy_reg: src_reg=R1, src_fill=Undefined, dst_reg=R0, dst_fill=Undefined, dst_bitw=64
           ; %0: ptr = arg [Reg("R1", Undefined)]
           guard_completed:
             fromvlocs=[Stack(8)]
@@ -2489,10 +2497,8 @@ mod test {
           ; %3: ptr = dynptradd %2, %1, 8
           ptradd: R0=R0 + 8
           ; %2: ptr = ptradd %0, 8
-          arrange_fill: reg=R1, from=Undefined, dst_bitw=64, to=Zeroed
-          copy_reg: R1=R2
-          arrange_fill: reg=R0, from=Undefined, dst_bitw=64, to=Undefined
-          copy_reg: R0=R1
+          copy_reg: src_reg=R2, src_fill=Undefined, dst_reg=R1, dst_fill=Zeroed, dst_bitw=64
+          copy_reg: src_reg=R1, src_fill=Undefined, dst_reg=R0, dst_fill=Undefined, dst_bitw=64
           ; %1: i64 = arg [Reg("R2", Undefined)]
           ; %0: ptr = arg [Reg("R1", Undefined)]
           guard_completed:
@@ -2624,8 +2630,7 @@ mod test {
           spill: reg=R0, in_fill=Undefined, stack_off=8, bitw=64
           ptradd: R0=R0 + 8
           ; %1: ptr = ptradd %0, 8
-          arrange_fill: reg=R0, from=Undefined, dst_bitw=64, to=Undefined
-          copy_reg: R0=R1
+          copy_reg: src_reg=R1, src_fill=Undefined, dst_reg=R0, dst_fill=Undefined, dst_bitw=64
           ; %0: ptr = arg [Reg("R1", Undefined)]
           guard_completed:
             fromvlocs=[Stack(8)]
@@ -2681,8 +2686,7 @@ mod test {
           ; guard true, %2, [%0]
           ; %2: i1 = icmp eq %0, %1
           ; %1: i8 = 4
-          arrange_fill: reg=R1, from=Undefined, dst_bitw=8, to=Undefined
-          copy_reg: R1=R0
+          copy_reg: src_reg=R0, src_fill=Undefined, dst_reg=R1, dst_fill=Undefined, dst_bitw=8
           ; %0: i8 = arg [Reg("R0", Undefined)]
           controlpoint_loop_start 2 0
           ; term [%0]

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -553,8 +553,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
             dst_fill,
         } in ractions.distinct_copies.iter()
         {
-            be.arrange_fill(*dst_reg, *src_fill, *bitw, *dst_fill);
-            be.copy_reg(*src_reg, *dst_reg)?;
+            be.copy_reg_with_fill(*src_reg, *src_fill, *dst_reg, *dst_fill, *bitw)?;
         }
 
         for RegCopy {
@@ -2212,13 +2211,15 @@ pub(crate) mod test {
             ));
         }
 
-        fn copy_reg(
+        fn copy_reg_with_fill(
             &mut self,
-            from_reg: Self::Reg,
-            to_reg: Self::Reg,
+            src_reg: Self::Reg,
+            src_fill: RegFill,
+            dst_reg: Self::Reg,
+            dst_fill: RegFill,
+            dst_bitw: u32,
         ) -> Result<(), CompilationError> {
-            self.ra_log
-                .push(format!("copy_reg from={from_reg:?} to={to_reg:?}"));
+            self.ra_log.push(format!("copy_reg: src_reg={src_reg:?}, src_fill={src_fill:?}, dst_reg={dst_reg:?}, dst_fill={dst_fill:?}, dst_bitw={dst_bitw:?}"));
             Ok(())
         }
 
@@ -2656,13 +2657,13 @@ pub(crate) mod test {
             |s| !s.starts_with("arrange_fill"),
             &["
           alloc %7 GPR1 GPR0
-          copy_reg from=GPR2 to=GPR1
+          copy_reg: src_reg=GPR2, src_fill=Zeroed, dst_reg=GPR1, dst_fill=Zeroed, dst_bitw=8
           alloc %6 GPR1 GPR0
-          copy_reg from=GPR1 to=GPR2
+          copy_reg: src_reg=GPR1, src_fill=Undefined, dst_reg=GPR2, dst_fill=Zeroed, dst_bitw=8
           alloc %5 GPR1 GPR3
           alloc %4 GPR1 GPR2
           unspill stack_off=8 GPR1 Undefined bitw=8
-          copy_reg from=GPR1 to=GPR3
+          copy_reg: src_reg=GPR1, src_fill=Undefined, dst_reg=GPR3, dst_fill=Zeroed, dst_bitw=8
           spill GPR3 Undefined stack_off=8 bitw=8
         "],
         );
@@ -2829,11 +2830,9 @@ pub(crate) mod test {
         "#,
             |_| true,
             &["
-          arrange_fill GPR0 from=Zeroed dst_bitw=8 to=Undefined
-          copy_reg from=GPR1 to=GPR0
+          copy_reg: src_reg=GPR1, src_fill=Zeroed, dst_reg=GPR0, dst_fill=Undefined, dst_bitw=8
           alloc %1 GPR0 GPR1
-          arrange_fill GPR1 from=Undefined dst_bitw=8 to=Zeroed
-          copy_reg from=GPR0 to=GPR1
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR1, dst_fill=Zeroed, dst_bitw=8
           arrange_fill GPR0 from=Undefined dst_bitw=8 to=Zeroed
         "],
         );
@@ -2853,13 +2852,11 @@ pub(crate) mod test {
         "#,
             |_| true,
             &["
-          arrange_fill GPR0 from=Zeroed dst_bitw=8 to=Undefined
-          copy_reg from=GPR1 to=GPR0
+          copy_reg: src_reg=GPR1, src_fill=Zeroed, dst_reg=GPR0, dst_fill=Undefined, dst_bitw=8
           alloc %3 GPR0 GPR1
           shl %2 GPR0 GPR2 GPR3
           const GPR2 tgt_bitw=8 fill=Zeroed Int(ArbBitInt { bitw: 8, val: 1 })
-          arrange_fill GPR1 from=Undefined dst_bitw=8 to=Zeroed
-          copy_reg from=GPR0 to=GPR1
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR1, dst_fill=Zeroed, dst_bitw=8
           arrange_fill GPR0 from=Undefined dst_bitw=8 to=Zeroed
         "],
         );
@@ -2897,8 +2894,7 @@ pub(crate) mod test {
             |_| true,
             &["
           alloc %3 GPR0 GPR1
-          arrange_fill GPR0 from=Zeroed dst_bitw=8 to=Zeroed
-          copy_reg from=GPR1 to=GPR0
+          copy_reg: src_reg=GPR1, src_fill=Zeroed, dst_reg=GPR0, dst_fill=Zeroed, dst_bitw=8
           alloc %1 GPR0 GPR1
           const GPR1 tgt_bitw=8 fill=Zeroed Int(ArbBitInt { bitw: 8, val: 2 })
           const GPR0 tgt_bitw=8 fill=Zeroed Int(ArbBitInt { bitw: 8, val: 2 })
@@ -2918,14 +2914,11 @@ pub(crate) mod test {
         "#,
             |_| true,
             &["
-          arrange_fill GPR1 from=Undefined dst_bitw=64 to=Undefined
-          copy_reg from=GPR2 to=GPR1
+          copy_reg: src_reg=GPR2, src_fill=Undefined, dst_reg=GPR1, dst_fill=Undefined, dst_bitw=64
           alloc %2 GPR1 GPR0
           unspill stack_off=8 GPR0 Undefined bitw=64
-          arrange_fill GPR2 from=Undefined dst_bitw=64 to=Undefined
-          copy_reg from=GPR0 to=GPR2
-          arrange_fill GPR1 from=Undefined dst_bitw=64 to=Zeroed
-          copy_reg from=GPR0 to=GPR1
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR2, dst_fill=Undefined, dst_bitw=64
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR1, dst_fill=Zeroed, dst_bitw=64
           spill GPR1 Undefined stack_off=8 bitw=64
         "],
         );
@@ -2945,11 +2938,9 @@ pub(crate) mod test {
         "#,
             |_| true,
             &["
-          arrange_fill GPR0 from=Undefined dst_bitw=64 to=Undefined
-          copy_reg from=GPR1 to=GPR0
+          copy_reg: src_reg=GPR1, src_fill=Undefined, dst_reg=GPR0, dst_fill=Undefined, dst_bitw=64
           trunc %1 GPR0
-          arrange_fill GPR1 from=Undefined dst_bitw=64 to=Undefined
-          copy_reg from=GPR0 to=GPR1
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR1, dst_fill=Undefined, dst_bitw=64
         "],
         );
 
@@ -2980,8 +2971,7 @@ pub(crate) mod test {
             &["
           trunc %2 GPR1
           trunc %1 GPR1
-          arrange_fill GPR1 from=Undefined dst_bitw=64 to=Undefined
-          copy_reg from=GPR0 to=GPR1
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR1, dst_fill=Undefined, dst_bitw=64
         "],
         );
 
@@ -3015,8 +3005,7 @@ pub(crate) mod test {
           zext %2 GPR1
           arrange_fill GPR1 from=Undefined dst_bitw=32 to=Zeroed
           trunc %1 GPR1
-          arrange_fill GPR1 from=Undefined dst_bitw=64 to=Undefined
-          copy_reg from=GPR0 to=GPR1
+          copy_reg: src_reg=GPR0, src_fill=Undefined, dst_reg=GPR1, dst_fill=Undefined, dst_bitw=64
         "],
         );
     }
@@ -3079,8 +3068,7 @@ pub(crate) mod test {
           unspill stack_off=48 GPR0 Undefined bitw=8
           spill GPR0 Undefined stack_off=32 bitw=8
           alloc %3 GPR0 GPR2
-          arrange_fill GPR1 from=Undefined dst_bitw=8 to=Zeroed
-          copy_reg from=GPR3 to=GPR1
+          copy_reg: src_reg=GPR3, src_fill=Undefined, dst_reg=GPR1, dst_fill=Zeroed, dst_bitw=8
           arrange_fill GPR0 from=Undefined dst_bitw=8 to=Zeroed
           arrange_fill GPR2 from=Undefined dst_bitw=8 to=Zeroed
           arrange_fill GPR3 from=Undefined dst_bitw=8 to=Zeroed

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -1253,24 +1253,44 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         }
     }
 
-    fn copy_reg(&mut self, from_reg: Self::Reg, to_reg: Self::Reg) -> Result<(), CompilationError> {
+    fn copy_reg_with_fill(
+        &mut self,
+        src_reg: Self::Reg,
+        src_fill: RegFill,
+        dst_reg: Self::Reg,
+        dst_fill: RegFill,
+        dst_bitw: u32,
+    ) -> Result<(), CompilationError> {
         assert!(
-            (from_reg.is_gp() && to_reg.is_gp()) || (from_reg.is_fp() && to_reg.is_fp()),
-            "{from_reg:?} {to_reg:?}"
+            (src_reg.is_gp() && dst_reg.is_gp()) || (src_reg.is_fp() && dst_reg.is_fp()),
+            "{src_reg:?} {dst_reg:?}"
         );
-        if from_reg.is_gp() {
+        if src_reg.is_gp()
+            && src_fill == RegFill::Undefined
+            && dst_fill == RegFill::Zeroed
+            && dst_bitw == 32
+        {
             self.asm.push_inst(IcedInst::with2(
-                Code::Mov_r64_rm64,
-                to_reg.to_reg64(),
-                from_reg.to_reg64(),
+                Code::Mov_r32_rm32,
+                dst_reg.to_reg32(),
+                src_reg.to_reg32(),
             ));
         } else {
-            assert!(from_reg.is_fp());
-            self.asm.push_inst(IcedInst::with2(
-                Code::Movsd_xmm_xmmm64,
-                to_reg.to_xmm(),
-                from_reg.to_xmm(),
-            ));
+            self.arrange_fill(dst_reg, src_fill, dst_bitw, dst_fill);
+            if src_reg.is_gp() {
+                self.asm.push_inst(IcedInst::with2(
+                    Code::Mov_r64_rm64,
+                    dst_reg.to_reg64(),
+                    src_reg.to_reg64(),
+                ));
+            } else {
+                assert!(src_reg.is_fp());
+                self.asm.push_inst(IcedInst::with2(
+                    Code::Movsd_xmm_xmmm64,
+                    dst_reg.to_xmm(),
+                    src_reg.to_xmm(),
+                ));
+            }
         }
         Ok(())
     }
@@ -4973,6 +4993,29 @@ mod test {
               lea r.64.x, [rbp-0x20]
               ; %1: i8 = load %0
               movzx r.32._, byte [r.64.x]
+              ...
+            "],
+        );
+    }
+
+    #[test]
+    fn copy_with_fill() {
+        codegen_and_test(
+            "
+              extern getpid() -> i32
+
+              %0: ptr = @getpid
+              %1: i32 = call getpid %0()
+              %2: i64 = zext %1
+              blackbox %1
+              blackbox %2
+              term []
+            ",
+            &["
+              ...
+              call ...
+              mov r.32.x, eax
+              ; %2: i64 = zext %1
               ...
             "],
         );


### PR DESCRIPTION
Previously we often generated code that was "copy; arrange": backends can now do both at the same time with the new API in this commit. Practically speaking, modern CPUs are probably going to optimise such sequences the same, but it does mean a bit less machine code to wade through when debugging.