### PR TITLE
Call traces.

### DIFF
--- a/tests/c/call_trace.c
+++ b/tests/c/call_trace.c
@@ -1,0 +1,150 @@
+// Compiler:
+//   env-var: YKB_EXTRA_CC_FLAGS=-O0
+// Run-time:
+//   env-var: YKD_LOG_IR=hir
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   stderr:
+//     yk-tracing: start-tracing
+//     0: 5
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "0",
+//     ;   "start": {
+//     ;     "kind": "ControlPoint"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Call"
+//     ;   }
+//     ; }
+//     ...
+//     %{{15}}: i1 = 0
+//     ...
+//     %{{23}}: ptr = 0x{{_}} ; @interp
+//     call %{{23}}(%{{_}}, %{{_}}, %{{_}}, %{{_}}) ; @interp
+//     guard true, %{{15}}, ...
+//     term []
+//     --- End hir ---
+//     1: 4
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     3: 2
+//     yk-execution: deoptimise {"trid": "0", "gidx": "1"}
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "1",
+//     ;   "start": {
+//     ;     "kind": "Guard",
+//     ;     "src_trid": "0",
+//     ;     "gidx": "1"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Coupler",
+//     ;     "tgt_trid": "0"
+//     ;   }
+//     ; }
+//     ...
+//     --- End hir ---
+//     3: 1
+//     yk-execution: deoptimise {"trid": "0", "gidx": "0"}
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "2",
+//     ;   "start": {
+//     ;     "kind": "Guard",
+//     ;     "src_trid": "0",
+//     ;     "gidx": "0"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Coupler",
+//     ;     "tgt_trid": "0"
+//     ;   }
+//     ; }
+//     ...
+//     --- End hir ---
+//     2: 2
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 1
+//     yk-execution: deoptimise {"trid": "1", "gidx": "0"}
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "3",
+//     ;   "start": {
+//     ;     "kind": "Guard",
+//     ;     "src_trid": "1",
+//     ;     "gidx": "0"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Return"
+//     ;   }
+//     ; }
+//     ...
+//     term []
+//     --- End hir ---
+//     1: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 2
+//     2: 1
+//     yk-execution: return {"trid": "0"}
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1: 2
+//     1: 1
+//     yk-execution: return {"trid": "0"}
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     0: 4
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 2
+//     2: 1
+//     yk-execution: return {"trid": "0"}
+//     1: 2
+//     1: 1
+//     yk-execution: return {"trid": "0"}
+//     0: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1: 2
+//     1: 1
+//     yk-execution: return {"trid": "0"}
+//     0: 2
+//     0: 1
+//     yk-execution: return {"trid": "0"}
+//     exit
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+// Test call traces.
+
+void interp(YkMT *mt, YkLocation *loc, int recurse, int i){
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    fprintf(stderr, "%d: %d\n", recurse, i);
+    if (i > 2)
+      interp(mt, loc, recurse + 1, i - 1);
+    i--;
+  }
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  yk_mt_sidetrace_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+  interp(mt, &loc, 0, 5);
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  fprintf(stderr, "exit\n");
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/call_trace_return.c
+++ b/tests/c/call_trace_return.c
@@ -1,0 +1,156 @@
+// Compiler:
+//   env-var: YKB_EXTRA_CC_FLAGS=-O0
+// Run-time:
+//   env-var: YKD_LOG_IR=hir
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   stderr:
+//     yk-tracing: start-tracing
+//     0: 5
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "0",
+//     ;   "start": {
+//     ;     "kind": "ControlPoint"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Call"
+//     ;   }
+//     ; }
+//     ...
+//     %{{16}}: i1 = 0
+//     ...
+//     %{{24}}: ptr = 0x{{_}} ; @interp
+//     %{{25}}: i32 = call %{{23}}(%{{_}}, %{{_}}, %{{_}}, %{{_}}) ; @interp
+//     guard true, %{{16}}, [%{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{25}}]
+//     term []
+//     --- End hir ---
+//     1: 4
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     3: 2
+//     yk-execution: deoptimise {"trid": "0", "gidx": "1"}
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "1",
+//     ;   "start": {
+//     ;     "kind": "Guard",
+//     ;     "src_trid": "0",
+//     ;     "gidx": "1"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Coupler",
+//     ;     "tgt_trid": "0"
+//     ;   }
+//     ; }
+//     ...
+//     --- End hir ---
+//     3: 1
+//     yk-execution: deoptimise {"trid": "0", "gidx": "0"}
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "2",
+//     ;   "start": {
+//     ;     "kind": "Guard",
+//     ;     "src_trid": "0",
+//     ;     "gidx": "0"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Coupler",
+//     ;     "tgt_trid": "0"
+//     ;   }
+//     ; }
+//     ...
+//     --- End hir ---
+//     2: 2
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 1
+//     yk-execution: deoptimise {"trid": "1", "gidx": "0"}
+//     yk-tracing: start-side-tracing
+//     yk-tracing: stop-tracing
+//     --- Begin hir ---
+//     ; {
+//     ;   "trid": "3",
+//     ;   "start": {
+//     ;     "kind": "Guard",
+//     ;     "src_trid": "1",
+//     ;     "gidx": "0"
+//     ;   },
+//     ;   "end": {
+//     ;     "kind": "Return"
+//     ;   }
+//     ; }
+//     ...
+//     %{{9}}: i32 = add ...
+//     ...
+//     term [%{{9}}]
+//     --- End hir ---
+//     1: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 2
+//     2: 1
+//     yk-execution: return {"trid": "0"}
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1: 2
+//     1: 1
+//     yk-execution: return {"trid": "0"}
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     0: 4
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     2: 2
+//     2: 1
+//     yk-execution: return {"trid": "0"}
+//     1: 2
+//     1: 1
+//     yk-execution: return {"trid": "0"}
+//     0: 3
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1: 2
+//     1: 1
+//     yk-execution: return {"trid": "0"}
+//     0: 2
+//     0: 1
+//     yk-execution: return {"trid": "0"}
+//     rtn: 6
+//     exit
+
+// Test the call traces work with functions that return values.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+int interp(YkMT *mt, YkLocation *loc, int recurse, int i){
+  int rtn;
+  while (i > 0) {
+    yk_mt_control_point(mt, loc);
+    fprintf(stderr, "%d: %d\n", recurse, i);
+    if (i > 2)
+      rtn = interp(mt, loc, recurse + 1, i - 1);
+    i--;
+  }
+  return rtn + recurse;
+}
+
+int main(int argc, char **argv) {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  yk_mt_sidetrace_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+  int rtn = interp(mt, &loc, 0, 5);
+  fprintf(stderr, "rtn: %d\n", rtn);
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+  fprintf(stderr, "exit\n");
+  return (EXIT_SUCCESS);
+}

--- a/tests/c/longjmp_trace_end.c
+++ b/tests/c/longjmp_trace_end.c
@@ -7,17 +7,19 @@
 //     yk-tracing: start-tracing
 //     enter
 //     in loop: i=4
-//     yk-warning: abort-tracing
+//     yk-tracing: stop-tracing
 //     jumped
 //     in loop: i=3
-//     yk-tracing: start-tracing
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     yk-execution: deoptimise {"trid": "0", "gidx": "2"}
 //     jumped
 //     in loop: i=2
-//     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: irregular control flow detected (unexpected successor)
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     yk-execution: deoptimise {"trid": "0", "gidx": "2"}
 //     jumped
 //     in loop: i=1
-//     yk-tracing: start-tracing
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     yk-execution: deoptimise {"trid": "0", "gidx": "2"}
 //     jumped
 //     exit
 

--- a/tests/c/opaque_longjmp.c
+++ b/tests/c/opaque_longjmp.c
@@ -9,17 +9,18 @@
 //     I'm in g via a longjump
 //     in interp loop: i=3
 //     yk-tracing: stop-tracing
-//     yk-warning: trace-compilation-aborted: irregular control flow detected (trace ended with outline successor pending)
 //     maybe_hidden_longjump: x=3
 //     I'm in g via calling deeper
 //     in interp loop: i=2
-//     yk-tracing: start-tracing
+//     yk-execution: enter-jit-code {"trid": "0"}
 //     maybe_hidden_longjump: x=2
 //     I'm in g via calling deeper
+//     yk-execution: deoptimise {"trid": "0", "gidx": "0"}
 //     in interp loop: i=1
-//     yk-tracing: stop-tracing
+//     yk-execution: enter-jit-code {"trid": "0"}
 //     maybe_hidden_longjump: x=1
 //     I'm in g via calling deeper
+//     yk-execution: deoptimise {"trid": "0", "gidx": "0"}
 //     exit
 
 #include <assert.h>
@@ -33,6 +34,9 @@
 #define G_CALL_DEEPER 2
 
 jmp_buf buf;
+
+// This test used to trace "opaque longjmps" but after the introduction of
+// call traces implicitly tests the latter.
 
 void g(int x) {
   if (x == G_LONGJMP) {

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -251,6 +251,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         // further processing of the trace should occur.
         let termendk = self.p_blocks()?;
         match &termendk {
+            TraceEndKind::Call => (),
             TraceEndKind::Return(_) => (),
             TraceEndKind::Term => {
                 assert!(self.promotions_iter.next().is_none());
@@ -292,6 +293,11 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             } => {
                 let (entry, tys) = self.opt.build()?;
                 match termendk {
+                    TraceEndKind::Call => (
+                        hir::TraceStart::ControlPoint { entry_statepoint },
+                        hir::TraceEnd::Call { entry },
+                        tys,
+                    ),
                     TraceEndKind::Return(exit_statepoint) => (
                         hir::TraceStart::ControlPoint { entry_statepoint },
                         hir::TraceEnd::Return {
@@ -308,6 +314,14 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 }
             }
             BuildModKind::Loop { entry_statepoint } => match termendk {
+                TraceEndKind::Call => {
+                    let (entry, tys) = self.opt.build()?;
+                    (
+                        hir::TraceStart::ControlPoint { entry_statepoint },
+                        hir::TraceEnd::Call { entry },
+                        tys,
+                    )
+                }
                 TraceEndKind::Return(exit_statepoint) => {
                     let (entry, tys) = self.opt.build()?;
                     (
@@ -337,6 +351,15 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             } => {
                 let (entry, tys) = self.opt.build()?;
                 match termendk {
+                    TraceEndKind::Call => (
+                        hir::TraceStart::Guard {
+                            args_vlocs,
+                            src_ctr,
+                            src_gidx,
+                        },
+                        hir::TraceEnd::Call { entry },
+                        tys,
+                    ),
                     TraceEndKind::Return(exit_statepoint) => (
                         hir::TraceStart::Guard {
                             args_vlocs,
@@ -887,6 +910,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                     CallProcessedKind::Ignored => (),
                     CallProcessedKind::Inlined => continue,
                     CallProcessedKind::Outlined => (),
+                    CallProcessedKind::Terminated => return Ok(TraceEndKind::Call),
                 },
                 Inst::Cast { .. } => self.p_cast(pc.clone(), inst)?,
                 Inst::CondBr { .. } => self.p_condbr(pc.clone(), bid, inst)?,
@@ -900,6 +924,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                     CallProcessedKind::Ignored => (),
                     CallProcessedKind::Inlined => continue,
                     CallProcessedKind::Outlined => (),
+                    CallProcessedKind::Terminated => return Ok(TraceEndKind::Call),
                 },
                 Inst::InsertValue { .. } => todo!(),
                 Inst::Load { .. } => self.p_load(pc.clone(), inst)?,
@@ -1075,7 +1100,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             callee,
             args,
             statepoint,
-            statepoint_after: _,
+            statepoint_after,
         } = inst
         else {
             panic!()
@@ -1085,7 +1110,14 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         if inst.is_control_point(self.am) || inst.is_debug_call(self.am) {
             return Ok(CallProcessedKind::Ignored);
         }
-        self.p_static_call(iid, bid, *callee, args, statepoint.as_ref())
+        self.p_static_call(
+            iid,
+            bid,
+            *callee,
+            args,
+            statepoint.as_ref(),
+            statepoint_after.as_ref(),
+        )
     }
 
     fn p_static_call(
@@ -1095,6 +1127,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         callee: FuncIdx,
         args: &[Operand],
         statepoint: Option<&'static Statepoint>,
+        statepoint_after: Option<&'static Statepoint>,
     ) -> Result<CallProcessedKind, CompilationError> {
         let func = self.am.func(callee);
         // Ignore calls the software tracer makes to record blocks.
@@ -1126,8 +1159,12 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             {
                 let const_iidx = self.promotion_data_to_const(self.am.type_(fty.ret_ty()))?;
                 self.frames.last_mut().unwrap().set_local(iid, const_iidx);
-                self.outline_until(bid)?;
-                return Ok(CallProcessedKind::Outlined);
+                match self.outline_until(bid)? {
+                    OutliningKind::SuccessorFound => return Ok(CallProcessedKind::Outlined),
+                    OutliningKind::DidNotFindSuccessor => {
+                        panic!("Outlining in idempotent function failed")
+                    }
+                }
             }
             for _ in 0..self.am.type_(fty.ret_ty()).bytew() {
                 let _ = self.promotions_iter.next().unwrap();
@@ -1216,10 +1253,26 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             if *self.opt.ty(*rtn_tyidx) == hir::Ty::Void {
                 self.opt.feed_void(inst)?;
             } else {
-                self.push_inst_and_link_local(iid, inst)?;
+                self.push_inst_and_link_local(iid.clone(), inst)?;
             }
-            self.outline_until(bid)?;
-            Ok(CallProcessedKind::Outlined)
+            match self.outline_until(bid)? {
+                OutliningKind::SuccessorFound => Ok(CallProcessedKind::Outlined),
+                OutliningKind::DidNotFindSuccessor => {
+                    let i1_tyidx = self.opt.push_ty(hir::Ty::Int(1))?;
+                    let ciidx = self
+                        .const_to_iidx(i1_tyidx, hir::ConstKind::Int(ArbBitInt::from_u64(1, 0)))?;
+                    self.push_guard(
+                        bid,
+                        self.next_pc(iid),
+                        true,
+                        ciidx,
+                        statepoint_after.unwrap(),
+                        None,
+                    )?;
+                    self.opt.feed_void(hir::Term(Vec::new()).into())?;
+                    Ok(CallProcessedKind::Terminated)
+                }
+            }
         }
     }
 
@@ -1234,7 +1287,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             callop,
             args,
             statepoint,
-            statepoint_after: _,
+            statepoint_after,
         } = inst
         else {
             panic!()
@@ -1258,7 +1311,14 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             };
             if let Some(fname) = self.j2.dladdr(*vaddr) {
                 let callee = self.am.funcidx(&CString::new(fname).unwrap());
-                return self.p_static_call(iid.clone(), bid, callee, args, Some(statepoint));
+                return self.p_static_call(
+                    iid.clone(),
+                    bid,
+                    callee,
+                    args,
+                    Some(statepoint),
+                    Some(statepoint_after),
+                );
             }
         }
 
@@ -1275,15 +1335,24 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         if *self.opt.ty(*rtn_tyidx) == hir::Ty::Void {
             self.opt.feed_void(inst.into())?;
         } else {
-            self.push_inst_and_link_local(iid, inst)?;
+            self.push_inst_and_link_local(iid.clone(), inst)?;
         }
-        self.outline_until(bid)?;
-        Ok(CallProcessedKind::Outlined)
+        match self.outline_until(bid)? {
+            OutliningKind::SuccessorFound => Ok(CallProcessedKind::Outlined),
+            OutliningKind::DidNotFindSuccessor => {
+                let i1_tyidx = self.opt.push_ty(hir::Ty::Int(1))?;
+                let ciidx =
+                    self.const_to_iidx(i1_tyidx, hir::ConstKind::Int(ArbBitInt::from_u64(1, 0)))?;
+                self.push_guard(bid, self.next_pc(iid), true, ciidx, statepoint_after, None)?;
+                self.opt.feed_void(hir::Term(Vec::new()).into())?;
+                Ok(CallProcessedKind::Terminated)
+            }
+        }
     }
 
     /// Outline until the successor block to `bid` is encountered. Returns `Err` if irregular
     /// control flow is detected.
-    fn outline_until(&mut self, cur_bid: BBlockId) -> Result<(), CompilationError> {
+    fn outline_until(&mut self, cur_bid: BBlockId) -> Result<OutliningKind, CompilationError> {
         // Now we skip over all the blocks in this call.
         let tgt_bid = match self.am.bblock(&cur_bid).insts().last().unwrap() {
             Inst::Br { succ } => {
@@ -1306,10 +1375,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         loop {
             let ta = {
                 let Some(Ok(ta)) = self.ta_iter.peek() else {
-                    return Err(CompilationError::General(
-                "irregular control flow detected (trace ended with outline successor pending)"
-                    .into(),
-            ));
+                    return Ok(OutliningKind::DidNotFindSuccessor);
                 };
                 ta.to_owned()
             };
@@ -1358,7 +1424,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             prev_bid = cnd_bid;
             self.ta_iter.next();
         }
-        Ok(())
+        Ok(OutliningKind::SuccessorFound)
     }
 
     /// Check that `cnd_bid` is a successor to `prev_bid` returning `Err` otherwise.
@@ -2113,6 +2179,11 @@ fn iter_to_array<const N: usize>(iter: &mut dyn Iterator<Item = &u8>) -> [u8; N]
     out
 }
 
+enum OutliningKind {
+    SuccessorFound,
+    DidNotFindSuccessor,
+}
+
 /// What happened when we processed a call (static or indirect)?
 enum CallProcessedKind {
     /// We ignored the call.
@@ -2121,10 +2192,14 @@ enum CallProcessedKind {
     Inlined,
     /// We outlined the call.
     Outlined,
+    /// This process finishes with this call (i.e. this is a Call trace).
+    Terminated,
 }
 
 /// How did the trace end?
 enum TraceEndKind {
+    /// In a call.
+    Call,
     /// It looped or coupled to another trace.
     Term,
     /// It returned to an outer caller.

--- a/ykrt/src/compile/j2/compiled_trace.rs
+++ b/ykrt/src/compile/j2/compiled_trace.rs
@@ -93,6 +93,7 @@ impl<Reg: RegT> J2CompiledTrace<Reg> {
         };
 
         match trace_end {
+            TraceEnd::Call { .. } => format!("{trace_name}_call"),
             TraceEnd::Loop { .. } => format!("{trace_name}_loop"),
             TraceEnd::Coupler { .. } => {
                 let tgt = tgt_ctr.unwrap();

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -305,7 +305,10 @@ impl<Reg: RegT> Mod<Reg> {
         }
 
         match &self.trace_end {
-            TraceEnd::Coupler { .. } | TraceEnd::Loop { .. } | TraceEnd::Return { .. } => todo!(),
+            TraceEnd::Call { .. }
+            | TraceEnd::Coupler { .. }
+            | TraceEnd::Loop { .. }
+            | TraceEnd::Return { .. } => todo!(),
             #[cfg(test)]
             TraceEnd::Test { args_vlocs, block } => {
                 block.assert_well_formed(self, args_vlocs, args_vlocs);
@@ -343,6 +346,7 @@ impl<Reg: RegT> Mod<Reg> {
         }
         out.push("  },\n  \"end\": {".to_owned());
         match &self.trace_end {
+            TraceEnd::Call { .. } => out.push("    \"kind\": \"Call\"".to_owned()),
             TraceEnd::Coupler { tgt_ctr, .. } => out.push(format!(
                 "    \"kind\": \"Coupler\",\n    \"tgt_trid\": \"{}\"",
                 tgt_ctr.trid
@@ -369,6 +373,7 @@ impl<Reg: RegT> Display for Mod<Reg> {
                 .join("\n; ")
         );
         match &self.trace_end {
+            TraceEnd::Call { entry } => write!(f, "{json_info}\n{}", entry.to_string(self)),
             TraceEnd::Coupler { entry, .. } => write!(f, "{json_info}\n{}", entry.to_string(self)),
             TraceEnd::Loop { entry, peel, .. } => match peel {
                 Some(x) => write!(
@@ -441,6 +446,9 @@ pub(super) enum TraceStart<Reg: RegT> {
 /// Where did this trace end?
 #[derive(Debug)]
 pub(super) enum TraceEnd<Reg: RegT> {
+    Call {
+        entry: Block,
+    },
     /// This trace ended at a different [crate::location::Location] than it started from.
     Coupler {
         entry: Block,
@@ -448,7 +456,10 @@ pub(super) enum TraceEnd<Reg: RegT> {
     },
     /// This trace ended at the same [crate::location::Location] that it started from, thus forming
     /// a loop.
-    Loop { entry: Block, peel: Option<Block> },
+    Loop {
+        entry: Block,
+        peel: Option<Block>,
+    },
     /// This trace ended early when a `return` statement in the function containing the control
     /// point function was encountered.
     Return {

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -186,6 +186,14 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 }
 
                 let (post_stack_label, entry_stack_off) = match &self.m.trace_end {
+                    TraceEnd::Call { entry } => {
+                        let ra = RegAlloc::<AB>::new(self.m, entry, &args_vlocs, base_stack_off);
+                        let entry_stack_off = self.p_block(entry, Some(entry), ra, &args_vlocs)?;
+                        let post_stack_label = self.be.controlpoint_coupler_or_return_start(
+                            entry_stack_off - base_stack_off,
+                        )?;
+                        (post_stack_label, entry_stack_off)
+                    }
                     TraceEnd::Coupler { entry, tgt_ctr } => {
                         let mut ra =
                             RegAlloc::<AB>::new(self.m, entry, &args_vlocs, base_stack_off);
@@ -299,6 +307,10 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             } => {
                 let src_stack_off = src_ctr.guard_stack_off(*src_gridx);
                 let entry_stack_off = match &self.m.trace_end {
+                    TraceEnd::Call { entry } => {
+                        let ra = RegAlloc::<AB>::new(self.m, entry, args_vlocs, src_stack_off);
+                        self.p_block(entry, Some(entry), ra, args_vlocs)?
+                    }
                     TraceEnd::Coupler { entry, tgt_ctr } => {
                         let mut ra = RegAlloc::<AB>::new(self.m, entry, args_vlocs, src_stack_off);
                         self.be.star_coupler_end(tgt_ctr)?;

--- a/ykrt/src/compile/j2/opt/known_bits.rs
+++ b/ykrt/src/compile/j2/opt/known_bits.rs
@@ -190,12 +190,13 @@ impl KnownBits {
         if let Some(cond_b) = self.as_knownbits(opt, cond)
             && cond_b.all_known()
         {
-            // Contradictions should have been spotted before we get to here.
             let x = cond_b.as_arbbitint();
-            assert!(
-                (expect && x.to_zero_ext_u8() == Some(1))
-                    || (!expect && x.to_zero_ext_u8() == Some(0))
-            );
+            if (expect && x.to_zero_ext_u8() == Some(0))
+                || (!expect && x.to_zero_ext_u8() == Some(1))
+            {
+                // Let contradictions pass through.
+                return OptOutcome::Rewritten(inst.into());
+            }
             return OptOutcome::NotNeeded;
         }
         if expect

--- a/ykrt/src/compile/j2/opt/strength_fold.rs
+++ b/ykrt/src/compile/j2/opt/strength_fold.rs
@@ -437,10 +437,10 @@ fn opt_guard(opt: &mut PassOpt, mut inst @ Guard { expect, cond, .. }: Guard) ->
 
     let cond = opt.equiv_iidx(cond);
     if let Some(ConstKind::Int(x)) = opt.as_constkind(cond) {
-        // Contradictions should have been spotted before we get to here.
-        assert!(
-            (expect && x.to_zero_ext_u8() == Some(1)) || (!expect && x.to_zero_ext_u8() == Some(0))
-        );
+        if (expect && x.to_zero_ext_u8() == Some(0)) || (!expect && x.to_zero_ext_u8() == Some(1)) {
+            // Let contradictions pass through.
+            return OptOutcome::Rewritten(inst.into());
+        }
         // A guard that references a constant is, by definition, not needed and doesn't affect
         // future analyses.
         return OptOutcome::NotNeeded;

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -80,6 +80,7 @@ impl<'a> X64HirToAsm<'a> {
         // we may have to redo the whole compilation! The least worst option is therefore to guess
         // too much and free memory afterwards.
         let num_hir_insts = match &m.trace_end {
+            TraceEnd::Call { entry } => entry.insts_len(),
             TraceEnd::Coupler { entry, .. } => entry.insts_len(),
             TraceEnd::Loop { entry, peel } => {
                 entry.insts_len() + peel.as_ref().map(|x| x.insts_len()).unwrap_or(0)

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -844,15 +844,7 @@ impl MT {
                 let mut lk = hl.lock();
                 if seen_hls.push_and_check_any_loop_closed(Arc::clone(&hl)) {
                     // We have traced this location more than once...
-                    if frame_relationship(frameaddr, *tracing_frameaddr)
-                        == FrameRelationship::Frame2IsCallerOfFrame1
-                    {
-                        lk.kind = match lk.tracecompilation_error(self) {
-                            TraceFailed::KeepTrying => HotLocationKind::Counting(0),
-                            TraceFailed::DontTrace => HotLocationKind::DontTrace,
-                        };
-                        return TransitionControlPoint::AbortTracing;
-                    } else if seen_hls.is_loop() {
+                    if seen_hls.is_loop() {
                         // ...and the entire trace is a single loop.
                         lk.kind = HotLocationKind::Compiling(*tracing_trid);
                         return TransitionControlPoint::StopLoopTracing(*tracing_trid);
@@ -897,20 +889,10 @@ impl MT {
                         };
                         drop(lk);
                         let mut lk = tracing_hl.lock();
-                        if frame_relationship(frameaddr, *tracing_frameaddr)
-                            == FrameRelationship::Frame2IsCallerOfFrame1
-                        {
-                            lk.kind = match lk.tracecompilation_error(self) {
-                                TraceFailed::KeepTrying => HotLocationKind::Counting(0),
-                                TraceFailed::DontTrace => HotLocationKind::DontTrace,
-                            };
-                            TransitionControlPoint::AbortTracing
-                        } else {
-                            lk.kind = HotLocationKind::Compiling(*tracing_trid);
-                            TransitionControlPoint::StopCouplerTracing {
-                                start_tid: *tracing_trid,
-                                coupler_tid,
-                            }
+                        lk.kind = HotLocationKind::Compiling(*tracing_trid);
+                        TransitionControlPoint::StopCouplerTracing {
+                            start_tid: *tracing_trid,
+                            coupler_tid,
                         }
                     }
                     HotLocationKind::Counting(_) => TransitionControlPoint::NoAction,
@@ -996,21 +978,14 @@ impl MT {
                         let Some((parent_ctr, gid)) = gtrace else {
                             panic!()
                         };
-                        if frame_relationship(frameaddr, *tracing_frameaddr)
-                            == FrameRelationship::Frame2IsCallerOfFrame1
-                        {
-                            parent_ctr.guard(*gid).trace_or_compile_failed(self);
-                            TransitionControlPoint::AbortTracing
-                        } else {
-                            let gid = *gid;
-                            let parent_ctr = Arc::clone(parent_ctr);
-                            TransitionControlPoint::StopSideTracing {
-                                trid: *tracing_trid,
-                                gid,
-                                parent_ctr,
-                                coupler_tid: Some(coupler_tid),
-                                start: false,
-                            }
+                        let gid = *gid;
+                        let parent_ctr = Arc::clone(parent_ctr);
+                        TransitionControlPoint::StopSideTracing {
+                            trid: *tracing_trid,
+                            gid,
+                            parent_ctr,
+                            coupler_tid: Some(coupler_tid),
+                            start: false,
                         }
                     }
                     HotLocationKind::Counting(_) => {
@@ -1021,20 +996,13 @@ impl MT {
                             panic!()
                         };
                         let gid = *gid;
-                        if frame_relationship(frameaddr, *tracing_frameaddr)
-                            == FrameRelationship::Frame2IsCallerOfFrame1
-                        {
-                            parent_ctr.guard(gid).trace_or_compile_failed(self);
-                            TransitionControlPoint::AbortTracing
-                        } else {
-                            let parent_ctr = Arc::clone(parent_ctr);
-                            TransitionControlPoint::StopSideTracing {
-                                trid: *tracing_trid,
-                                gid,
-                                parent_ctr,
-                                coupler_tid: Some(next_tid),
-                                start: true,
-                            }
+                        let parent_ctr = Arc::clone(parent_ctr);
+                        TransitionControlPoint::StopSideTracing {
+                            trid: *tracing_trid,
+                            gid,
+                            parent_ctr,
+                            coupler_tid: Some(next_tid),
+                            start: true,
                         }
                     }
                     HotLocationKind::DontTrace => TransitionControlPoint::NoAction,
@@ -1054,20 +1022,13 @@ impl MT {
                         };
                         let gid = *gid;
                         let parent_ctr = Arc::clone(parent_ctr);
-                        if frame_relationship(frameaddr, *tracing_frameaddr)
-                            == FrameRelationship::Frame2IsCallerOfFrame1
-                        {
-                            parent_ctr.guard(gid).trace_or_compile_failed(self);
-                            return TransitionControlPoint::AbortTracing;
-                        } else {
-                            return TransitionControlPoint::StopSideTracing {
-                                trid: *tracing_trid,
-                                gid,
-                                parent_ctr,
-                                coupler_tid: Some(next_trid),
-                                start: true,
-                            };
-                        }
+                        return TransitionControlPoint::StopSideTracing {
+                            trid: *tracing_trid,
+                            gid,
+                            parent_ctr,
+                            coupler_tid: Some(next_trid),
+                            start: true,
+                        };
                     }
                 }
                 // We raced with another thread which has started tracing this


### PR DESCRIPTION
This commit adds support for traces which end in a call. A common way this happens -- but not the only way! -- is a recursive call to the main interpreter function. This commit also means that we no longer abort traces because of possible longjmp-horrors (what we previously called "opaque longjmps"). In essence, if we call an outlined function F and after F seems to do weird things, we chop the trace at the call to F, and don't worry about the weirdness.

In essence, this can be seen as the j2 version of
https://github.com/ykjit/yk/pull/1808, but there are two substantial differences: we ditch the "opaque successor" stuff, because we can support it here; (and this latter point is necessary for the former) this commit supports functions that return values (thanks to https://github.com/ykjit/ykllvm/commit/db8e3ce2783ed52a1215a95605838deda01b8486). [It also hinged on the fix in 751d70f7fc971ffac00a8ca6e2d5a3ea8d01ac7d: without that fix, this code kept going splat in perplexing ways.]

The trick, in essence, is that call traces are of the form:

```
%2: i64 = call F()
%1: i1 = false
guard true, %1, [F.stackmap_after]
```

In other words, we generate the `call` as normal, but follow it up with an always-failing guard, whose stackmap references the call's "after" stackmap (as opposed to the "before" stackmap we use elsewhere during deopt), which includes the return value (if any) of `F`. You can see that clearly in the new `call_trace_return.c` test:

```
%{{16}}: i1 = 0
...
%{{24}}: ptr = 0x{{_}} ; @interp
%{{25}}: i32 = call %{{23}}(%{{_}}, %{{_}}, %{{_}}, %{{_}}) ; @interp
guard true, %{{i16}}, [%{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{_}}, %{{25}}]
term []
```

Note the stackmap ends with `%{{25}}`.

This reduces abort traces for some programs quite a bit. So far I've not seen a benchmark in yklua where doing so makes a big difference (indeed, I think only LuLPeg currently hits this case), but it doesn't hurt, and there are probably benchmarks where it really helps. ykmicropython hits this case more often though whether it makes much performance difference is a question I can't answer yet.