### PR TITLE
Support struct-by-value returns from direct calls in j2

### DIFF
--- a/tests/c/extract_struct.c
+++ b/tests/c/extract_struct.c
@@ -1,4 +1,3 @@
-// ignore-if: true # not yet implemented in j2
 // Compiler:
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0
 // Run-time:
@@ -7,8 +6,8 @@
 //   env-var: YKD_LOG=4
 //   stderr:
 //     yk-tracing: start-tracing
-//     2
-//     999
+//     s1.a: 4, s2.a: 5
+//     s1.b: 999, s2.b: 999
 //     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
@@ -18,25 +17,33 @@
 //     ...
 //     %{{11_5}}: i64 = extractvalue %{{10_1}}, [1]
 //     ...
+//     %{{20_1}}: {0: i8, 64: i64} = call make_struct_inlined()...
+//     ...
+//     %{{21_2}}: i8 = extractvalue %{{20_1}}, [0]
+//     ...
+//     %{{21_5}}: i64 = extractvalue %{{20_1}}, [1]
+//     ...
 //     --- End aot ---
 //     --- Begin hir ---
 //     ...
 //     --- End hir ---
-//     2
-//     999
-//     yk-execution: enter-jit-code
-//     2
-//     999
-//     2
-//     999
-//     yk-execution: deoptimise ...
+//     s1.a: 3, s2.a: 4
+//     s1.b: 999, s2.b: 999
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     s1.a: 2, s2.a: 3
+//     s1.b: 999, s2.b: 999
+//     s1.a: 1, s2.a: 2
+//     s1.b: 999, s2.b: 999
+//     yk-execution: deoptimise {"trid": "0", "gidx": "0"}
 //     exit
 
-// Test that trace builder handles loading structs by rewriting `extractvalue`
-// instructions into `ptr_add`s and `load`s. We only check that the AOT IR
-// contains a struct load and check that the trace does the correct thing.
-// Matching on the JIT IR is difficult since the `ptr_add`s and `load`s are
-// not easily distinguished from unrelated `ptr_add`s and `load`s.
+// Test that `extractvalue` on a call struct return works for both representations the trace 
+// builder can produce: 
+// 1. register-packed (RAX:RDX, from a real non-inlined `call`)
+// 2. memory-backed (`ptr_add` + `load`, from an inlined callee's own struct-typed `load`. 
+// We only check that the AOT IR contains the expected `call`/`extractvalue`
+// shape and that the trace does the correct thing at runtime; matching on the JIT IR itself is
+// difficult since its `ptr_add`s and `load`s aren't easily distinguished from unrelated ones.
 
 #include <assert.h>
 #include <stdint.h>
@@ -51,7 +58,17 @@ struct S {
   uint64_t b;
 };
 
+// `yk_outline` stops the trace-builder inlining this call, so it stays a real, non-inlined
+// `call` in the trace. That's a genuine machine-call boundary, so the SysV ABI packs this
+// struct's return into RAX:RDX.
+__attribute__((yk_outline))
 struct S make_struct() {
+  struct S ret = {1, 999};
+  return ret;
+}
+
+// This call is inlined, so struct return value is always set as real memory.
+struct S make_struct_inlined() {
   struct S ret = {1, 999};
   return ret;
 }
@@ -69,9 +86,11 @@ void interp(){
   while (i > 0) {
     yk_mt_control_point(mt, &loc);
     struct S s1 = make_struct();
-    s1.a = 2;
-    fprintf(stderr, "%d\n", s1.a);
-    fprintf(stderr, "%ld\n", s1.b);
+    s1.a = i;
+    struct S s2 = make_struct_inlined();
+    s2.a = i+1;
+    fprintf(stderr, "s1.a: %d, s2.a: %d\n", s1.a, s2.a);
+    fprintf(stderr, "s1.b: %ld, s2.b: %ld\n", s1.b, s2.b);
     i--;
   }
   fprintf(stderr, "exit\n");

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -759,6 +759,69 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         self.opt.push_ty(tyidx)
     }
 
+    /// Build the HIR function type for a call. Same as [Self::p_ty] except for a `Ty::Struct`
+    /// return, always the SysV ABI's register-packed case using `RAX`/`RDX`.
+    fn p_call_func_ty<'b>(
+        &mut self,
+        aot_fty: &'b FuncTy,
+    ) -> Result<(hir::TyIdx, Option<&'b StructTy>), CompilationError> {
+        let aot_rtn_ty = self.am.type_(aot_fty.ret_ty());
+        let (rtn_tyidx, struct_ty) = match aot_rtn_ty {
+            Ty::Struct(struct_ty) => {
+                let bit_size = struct_ty.bit_size();
+                assert!(
+                    bit_size <= 128,
+                    "got {bit_size} bits, struct with >16 bytes should use a pointer return, not Struct-typed"
+                );
+                let lo_bitw = u32::try_from(bit_size.min(64)).unwrap();
+                (self.opt.push_ty(hir::Ty::Int(lo_bitw))?, Some(struct_ty))
+            }
+            _ => (self.p_ty(aot_rtn_ty)?, None),
+        };
+        let mut args_tyidxs = SmallVec::with_capacity(aot_fty.arg_tyidxs().len());
+        for arg_ty in aot_fty.arg_tyidxs() {
+            args_tyidxs.push(self.p_ty(self.am.type_(*arg_ty))?);
+        }
+        let fty = hir::FuncTy {
+            rtn_tyidx,
+            args_tyidxs,
+            has_varargs: aot_fty.is_vararg(),
+        };
+        Ok((self.opt.push_ty(hir::Ty::Func(Box::new(fty)))?, struct_ty))
+    }
+
+    /// For a register-packed struct return, feeds the low/high eightbyte(s) and rebinds `iid` to
+    /// [hir::CallStructReturnLow] -- no memory touched. No-op if `struct_ty` is `None`.
+    fn p_call_struct_return(
+        &mut self,
+        iid: InstId,
+        struct_ty: Option<&StructTy>,
+        lo_iidx: hir::InstIdx,
+    ) -> Result<(), CompilationError> {
+        let Some(struct_ty) = struct_ty else {
+            return Ok(());
+        };
+        let bit_size = struct_ty.bit_size();
+        let lo_tyidx = self
+            .opt
+            .push_ty(hir::Ty::Int(u32::try_from(bit_size.min(64)).unwrap()))?;
+        self.push_inst_and_link_local(
+            iid,
+            hir::CallStructReturnLow {
+                call: lo_iidx,
+                tyidx: lo_tyidx,
+            },
+        )?;
+        if bit_size > 64 {
+            let hi_tyidx = self
+                .opt
+                .push_ty(hir::Ty::Int(u32::try_from(bit_size - 64).unwrap()))?;
+            self.opt
+                .feed(hir::CallStructReturnHigh { tyidx: hi_tyidx }.into())?;
+        }
+        Ok(())
+    }
+
     /// Process an [Operand] and return the [hir::InstIdx] it references. Note: this can insert
     /// instructions into [self.opt]!
     fn p_operand(&mut self, op: &Operand) -> Result<hir::InstIdx, CompilationError> {
@@ -915,7 +978,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 Inst::Cast { .. } => self.p_cast(pc.clone(), inst)?,
                 Inst::CondBr { .. } => self.p_condbr(pc.clone(), bid, inst)?,
                 Inst::DebugStr { .. } => self.p_debugstr(pc.clone())?,
-                Inst::ExtractValue { .. } => todo!(),
+                Inst::ExtractValue { .. } => self.p_extractvalue(pc.clone(), inst)?,
                 Inst::FCmp { .. } => self.p_fcmp(pc.clone(), inst)?,
                 Inst::FNeg { .. } => self.p_fneg(pc.clone(), inst)?,
                 Inst::Freeze { .. } => self.p_freeze(pc.clone(), inst)?,
@@ -1209,10 +1272,9 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             //      (which could be zero, or many, and may include recursive calls) until that
             //      function returns.
 
-            let ftyidx = self.p_ty(self.am.type_(func.tyidx()))?;
-
             // Handle LLVM intrinsics.
             if func.name().starts_with("llvm.") {
+                let ftyidx = self.p_ty(self.am.type_(func.tyidx()))?;
                 self.p_llvm_intrinsic(iid, ftyidx, func.name(), jargs)?;
                 return Ok(CallProcessedKind::Outlined);
             }
@@ -1240,20 +1302,26 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 FuncMemory::ReadWrite => hir::CallEffects::ReadWrite,
             };
 
+            let Ty::Func(aot_fty) = self.am.type_(func.tyidx()) else {
+                panic!()
+            };
+            let (call_func_tyidx, struct_ty) = self.p_call_func_ty(aot_fty)?;
             let inst = hir::Call {
                 tgt: tgt_iidx,
-                func_tyidx: ftyidx,
+                func_tyidx: call_func_tyidx,
                 args: jargs,
                 effects,
             }
             .into();
-            let hir::Ty::Func(box hir::FuncTy { rtn_tyidx, .. }) = self.opt.ty(ftyidx) else {
+            let hir::Ty::Func(box hir::FuncTy { rtn_tyidx, .. }) = self.opt.ty(call_func_tyidx)
+            else {
                 panic!()
             };
             if *self.opt.ty(*rtn_tyidx) == hir::Ty::Void {
                 self.opt.feed_void(inst)?;
             } else {
-                self.push_inst_and_link_local(iid.clone(), inst)?;
+                let lo_iidx = self.push_inst_and_link_local(iid.clone(), inst)?;
+                self.p_call_struct_return(iid.clone(), struct_ty, lo_iidx)?;
             }
             match self.outline_until(bid)? {
                 OutliningKind::SuccessorFound => Ok(CallProcessedKind::Outlined),
@@ -1803,6 +1871,13 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             return Ok(());
         }
 
+        // Case for memmory packed struct. This happens whith inlined functions that return a struct.
+        if let Ty::Struct(_) = self.am.type_(*tyidx) {
+            let ptr = self.p_operand(ptr)?;
+            self.frames.last_mut().unwrap().set_local(iid, ptr);
+            return Ok(());
+        }
+
         let tyidx = self.p_ty(self.am.type_(*tyidx))?;
         let ptr = self.p_operand(ptr)?;
         self.push_inst_and_link_local(
@@ -1811,6 +1886,121 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 tyidx,
                 ptr,
                 is_volatile: *volatile,
+            },
+        )
+        .map(|_| ())
+    }
+
+    /// Read a struct field and dispatches to whichever representation the struct value is
+    /// actually in. Either in memory, or in registers packed.
+    fn p_extractvalue(&mut self, iid: InstId, inst: &Inst) -> Result<(), CompilationError> {
+        let Inst::ExtractValue { tyidx, op, indices } = inst else {
+            panic!()
+        };
+
+        let Ty::Struct(struct_ty) = op.type_(self.am) else {
+            panic!() // IR malformed: extractvalue's operand must be a struct.
+        };
+
+        if let Operand::Local(aot_iid) = op
+            && indices.len() == 1
+        {
+            let lo_iidx = self.frames.last().unwrap().get_local(&*self.opt, aot_iid);
+            match self.opt.inst(lo_iidx) {
+                hir::Inst::CallStructReturnLow(_) => {
+                    return self.p_extractvalue_register_packed(
+                        iid, *tyidx, struct_ty, indices[0], lo_iidx,
+                    );
+                }
+                _ => {}
+            }
+        }
+        self.p_extractvalue_memory_backed(iid, *tyidx, op, struct_ty, indices)
+    }
+
+    fn p_extractvalue_register_packed(
+        &mut self,
+        iid: InstId,
+        tyidx: TyIdx,
+        struct_ty: &StructTy,
+        index: usize,
+        lo_iidx: hir::InstIdx,
+    ) -> Result<(), CompilationError> {
+        let bit_size = struct_ty.bit_size();
+        let field_bit_off = struct_ty.field_bit_offs()[index];
+        // A field sharing an eightbyte with others would need a shift before truncating.
+        assert_eq!(
+            field_bit_off % 64,
+            0,
+            "extractvalue field not aligned to a register boundary"
+        );
+        let hi_iidx = lo_iidx + 1;
+        let (chunk_iidx, chunk_bitw) = if field_bit_off == 0 {
+            (lo_iidx, u32::try_from(bit_size.min(64)).unwrap())
+        } else {
+            match self.opt.inst(hi_iidx) {
+                hir::Inst::CallStructReturnHigh(_) => {}
+                _ => panic!("extractvalue field offset beyond the struct's register-pair width"),
+            }
+            (hi_iidx, u32::try_from(bit_size - 64).unwrap())
+        };
+        let res_tyidx = self.p_ty(self.am.type_(tyidx))?;
+        let res_bitw = self.opt.ty(res_tyidx).bitw();
+        if res_bitw == chunk_bitw {
+            self.frames.last_mut().unwrap().set_local(iid, chunk_iidx);
+        } else {
+            assert!(
+                res_bitw < chunk_bitw,
+                "extractvalue field wider than its chunk"
+            );
+            self.push_inst_and_link_local(
+                iid,
+                hir::Trunc {
+                    tyidx: res_tyidx,
+                    val: chunk_iidx,
+                    nuw: false,
+                    nsw: false,
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn p_extractvalue_memory_backed(
+        &mut self,
+        iid: InstId,
+        tyidx: TyIdx,
+        op: &Operand,
+        struct_ty: &StructTy,
+        indices: &[usize],
+    ) -> Result<(), CompilationError> {
+        assert_eq!(indices.len(), 1, "extractvalue with nested indices");
+        let field_bit_off = struct_ty.field_bit_offs()[indices[0]];
+
+        assert_eq!(field_bit_off % 8, 0, "field not byte-aligned");
+        let byte_off = field_bit_off / 8;
+
+        let mut ptr = self.p_operand(op)?;
+        if byte_off != 0 {
+            ptr = self.opt.feed(
+                hir::PtrAdd {
+                    ptr,
+                    off: i32::try_from(byte_off).unwrap(),
+                    in_bounds: false,
+                    nusw: false,
+                    nuw: false,
+                }
+                .into(),
+            )?;
+        }
+
+        let res_tyidx = self.p_ty(self.am.type_(tyidx))?;
+        self.push_inst_and_link_local(
+            iid,
+            hir::Load {
+                tyidx: res_tyidx,
+                ptr,
+                is_volatile: false,
             },
         )
         .map(|_| ())

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -832,6 +832,8 @@ pub(super) enum Inst {
     #[cfg(test)]
     BlackBox,
     Call,
+    CallStructReturnHigh,
+    CallStructReturnLow,
     Const,
     CtPop,
     CtTz,
@@ -1445,6 +1447,96 @@ impl InstT for Call {
 
     fn tyidx(&self, m: &dyn ModLikeT) -> TyIdx {
         m.func_ty(self.func_tyidx).rtn_tyidx
+    }
+}
+
+/// The `RDX` half of a register-packed struct call return ([Call] models the `RAX` half). Must
+/// immediately follow [CallStructReturnLow] (itself immediately after [Call]).
+#[derive(Clone, Debug)]
+pub(super) struct CallStructReturnHigh {
+    pub tyidx: TyIdx,
+}
+
+impl InstT for CallStructReturnHigh {
+    fn assert_well_formed(&self, _m: &dyn ModLikeT, _b: &dyn BlockLikeT, _iidx: InstIdx) {}
+
+    fn canonicalise<T: BlockLikeT + EquivIIdxT + ModLikeT>(&mut self, _opt: &mut T) {}
+
+    fn cse_eq(&self, _opt: &dyn EquivIIdxT, _other: &Inst) -> bool {
+        panic!();
+    }
+
+    fn read_effects(&self) -> Effects {
+        Effects::none().add_internal()
+    }
+
+    fn write_effects(&self) -> Effects {
+        Effects::none().add_internal()
+    }
+
+    fn iter_iidxs<'a>(&'a self, b: &'a dyn BlockLikeT) -> IterIidxsIterator<'a> {
+        IterIidxsIterator::none(b)
+    }
+
+    fn rewrite_iidxs<F>(&mut self, _b: &mut dyn BlockLikeT, mut _iidx_map: F)
+    where
+        F: FnMut(InstIdx) -> InstIdx,
+    {
+    }
+
+    fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
+        "call_struct_return_high".to_string()
+    }
+
+    fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
+        self.tyidx
+    }
+}
+
+/// The `RAX` half of a register-packed struct call return. May be relocated to any register
+/// except `RDX`, which [CallStructReturnHigh] needs next. Must immediately follow [Call].
+#[derive(Clone, Debug)]
+pub(super) struct CallStructReturnLow {
+    pub call: InstIdx,
+    pub tyidx: TyIdx,
+}
+
+impl InstT for CallStructReturnLow {
+    fn assert_well_formed(&self, _m: &dyn ModLikeT, _b: &dyn BlockLikeT, _iidx: InstIdx) {}
+
+    fn canonicalise<T: BlockLikeT + EquivIIdxT + ModLikeT>(&mut self, opt: &mut T) {
+        self.call = opt.equiv_iidx(self.call);
+    }
+
+    fn cse_eq(&self, _opt: &dyn EquivIIdxT, _other: &Inst) -> bool {
+        panic!();
+    }
+
+    fn read_effects(&self) -> Effects {
+        Effects::none().add_internal()
+    }
+
+    fn write_effects(&self) -> Effects {
+        Effects::none().add_internal()
+    }
+
+    fn iter_iidxs<'a>(&'a self, b: &'a dyn BlockLikeT) -> IterIidxsIterator<'a> {
+        IterIidxsIterator::one(b, self.call)
+    }
+
+    fn rewrite_iidxs<F>(&mut self, _b: &mut dyn BlockLikeT, mut iidx_map: F)
+    where
+        F: FnMut(InstIdx) -> InstIdx,
+    {
+        self.call = iidx_map(self.call);
+    }
+
+    fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
+        format!("call_struct_return_low %{}", usize::from(self.call))
+    }
+
+    fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
+        self.tyidx
     }
 }
 

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -916,6 +916,16 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     ra.blackbox(iidx, *val);
                 }
                 Inst::Call(x) => self.be.i_call(&mut ra, b, iidx, x)?,
+                Inst::CallStructReturnHigh(_) => {
+                    if ra.is_used(iidx) {
+                        self.be.i_call_struct_return_high(&mut ra, b, iidx)?;
+                    }
+                }
+                Inst::CallStructReturnLow(x) => {
+                    if ra.is_used(iidx) {
+                        self.be.i_call_struct_return_low(&mut ra, b, iidx, x)?;
+                    }
+                }
                 Inst::Const(_) => {
                     ra.alloc_const(&mut self.be, iidx)?;
                 }
@@ -1491,6 +1501,21 @@ pub(super) trait HirToAsmBackend {
         b: &Block,
         iidx: InstIdx,
         inst: &Call,
+    ) -> Result<(), CompilationError>;
+
+    fn i_call_struct_return_high(
+        &mut self,
+        ra: &mut RegAlloc<Self>,
+        b: &Block,
+        iidx: InstIdx,
+    ) -> Result<(), CompilationError>;
+
+    fn i_call_struct_return_low(
+        &mut self,
+        ra: &mut RegAlloc<Self>,
+        b: &Block,
+        iidx: InstIdx,
+        inst: &CallStructReturnLow,
     ) -> Result<(), CompilationError>;
 
     fn i_ctpop(

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -48,12 +48,11 @@ use crate::{
             },
             x64::{
                 asm::{Asm, LabelIdx, RelocKind},
-                x64regalloc::{ALL_XMM_REGS, NORMAL_GP_REGS, PeelRegsBuilder, Reg},
+                x64regalloc::{ALL_XMM_REGS, GP_REGS_NO_RDX, NORMAL_GP_REGS, PeelRegsBuilder, Reg},
             },
         },
     },
     mt::TraceId,
-    varlocs,
 };
 use array_concat::concat_arrays;
 use iced_x86::{Code, Instruction as IcedInst, MemoryOperand, Register as IcedReg};
@@ -892,35 +891,39 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         reg_fill: RegFill,
     ) -> VarLocs<Self::Reg> {
         use yksmp::Location as L;
-        assert_eq!(smp_locs.len(), 1, "Multi-locations not yet supported");
-        match &smp_locs[0] {
-            L::Register(dwarf_reg, _sz, extras) => {
-                let mut vlocs = VarLocs::new();
-                vlocs.push(VarLoc::Reg(Reg::from_dwarf_reg(*dwarf_reg), reg_fill));
-                for x in extras {
-                    if *x >= 0 {
-                        vlocs.push(VarLoc::Reg(
-                            Reg::from_dwarf_reg(x.cast_unsigned()),
-                            reg_fill,
-                        ));
-                    } else {
-                        vlocs.push(VarLoc::Stack(u32::from(x.unsigned_abs())));
+        // A register-packed struct return spanning >1 register/stack slot can surface as
+        // multiple separate top-level `Location` entries for one value, not just one with
+        // `extras`.
+        let mut vlocs = VarLocs::new();
+        for loc in smp_locs.iter() {
+            match loc {
+                L::Register(dwarf_reg, _sz, extras) => {
+                    vlocs.push(VarLoc::Reg(Reg::from_dwarf_reg(*dwarf_reg), reg_fill));
+                    for x in extras {
+                        if *x >= 0 {
+                            vlocs.push(VarLoc::Reg(
+                                Reg::from_dwarf_reg(x.cast_unsigned()),
+                                reg_fill,
+                            ));
+                        } else {
+                            vlocs.push(VarLoc::Stack(u32::from(x.unsigned_abs())));
+                        }
                     }
                 }
-                vlocs
-            }
-            L::Direct(6, off, _sz) => {
-                assert!(*off <= 0);
-                varlocs![VarLoc::StackOff(off.unsigned_abs())]
-            }
-            L::Indirect(6, off, _sz) => {
-                assert!(*off <= 0);
-                varlocs![VarLoc::Stack(off.unsigned_abs())]
-            }
-            x => {
-                todo!("{:?}", x);
+                L::Direct(6, off, _sz) => {
+                    assert!(*off <= 0);
+                    vlocs.push(VarLoc::StackOff(off.unsigned_abs()));
+                }
+                L::Indirect(6, off, _sz) => {
+                    assert!(*off <= 0);
+                    vlocs.push(VarLoc::Stack(off.unsigned_abs()));
+                }
+                x => {
+                    todo!("{:?}", x);
+                }
             }
         }
+        vlocs
     }
 
     fn tmp_reg_from_vlocs(vlocs: &[VarLocs<Self::Reg>]) -> Self::Reg {
@@ -2320,6 +2323,48 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
                 u32::try_from(fp_args_off).unwrap(),
             ));
         }
+        Ok(())
+    }
+
+    fn i_call_struct_return_high(
+        &mut self,
+        ra: &mut RegAlloc<Self>,
+        _b: &Block,
+        iidx: InstIdx,
+    ) -> Result<(), CompilationError> {
+        // No code to emit -- the preceding `Call` already ran; `RDX` holds the value, we just
+        // need the register allocator to know it lives there now.
+        let [_] = ra.alloc(
+            self,
+            iidx,
+            [RegCnstr::Output {
+                out_fill: RegCnstrFill::Undefined,
+                regs: &[Reg::RDX],
+                can_be_same_as_input: false,
+            }],
+        )?;
+        Ok(())
+    }
+
+    fn i_call_struct_return_low(
+        &mut self,
+        ra: &mut RegAlloc<Self>,
+        _b: &Block,
+        iidx: InstIdx,
+        CallStructReturnLow { call, .. }: &CallStructReturnLow,
+    ) -> Result<(), CompilationError> {
+        // No code to emit -- `call`'s value is already in `RAX`. `Cast` lets the allocator
+        // relocate it as needed (via `Call`'s own codegen) while keeping `RDX` free for
+        // `CallStructReturnHigh` to capture.
+        let [_] = ra.alloc(
+            self,
+            iidx,
+            [RegCnstr::Cast {
+                in_iidx: *call,
+                out_fill: RegCnstrFill::Undefined,
+                regs: &GP_REGS_NO_RDX,
+            }],
+        )?;
         Ok(())
     }
 

--- a/ykrt/src/compile/j2/x64/x64regalloc.rs
+++ b/ykrt/src/compile/j2/x64/x64regalloc.rs
@@ -459,6 +459,24 @@ pub(super) const NORMAL_GP_REGS: [Reg; 14] = [
     Reg::RAX,
 ];
 
+/// [NORMAL_GP_REGS] minus `RDX`, for values that must avoid it (e.g. a register-packed struct
+/// call's low eightbyte, so it doesn't clobber the high eightbyte in `RDX`).
+pub(super) const GP_REGS_NO_RDX: [Reg; 13] = [
+    Reg::R15,
+    Reg::R14,
+    Reg::R13,
+    Reg::R12,
+    Reg::R11,
+    Reg::R10,
+    Reg::R9,
+    Reg::R8,
+    Reg::RDI,
+    Reg::RSI,
+    Reg::RBX,
+    Reg::RCX,
+    Reg::RAX,
+];
+
 pub(super) const ALL_XMM_REGS: [Reg; 16] = [
     Reg::XMM0,
     Reg::XMM1,


### PR DESCRIPTION
A small struct return is packed into RAX:RDX only across a real, non-inlined call - LLVM IR never encodes that packing itself. j2 now handles both representations:

1. register-packed - reading field sstraight from RAX/RDX for a real call,
2. memory-backed - `ptr_add`+`load` path for an inlined calls.