### PR TITLE
Support extractvalue for memory-backed structs in j2.

### DIFF
--- a/tests/c/extract_struct.c
+++ b/tests/c/extract_struct.c
@@ -1,4 +1,3 @@
-// ignore-if: true # not yet implemented in j2
 // Compiler:
 //   env-var: YKB_EXTRA_CC_FLAGS=-O0
 // Run-time:
@@ -7,36 +6,50 @@
 //   env-var: YKD_LOG=4
 //   stderr:
 //     yk-tracing: start-tracing
-//     2
+//     1
 //     999
 //     yk-tracing: stop-tracing
 //     --- Begin aot ---
 //     ...
-//     %{{10_1}}: {0: i8, 64: i64} = call make_struct()...
+//     %{{s}}: {0: i8, 64: i64} = load %{{_}}
 //     ...
-//     %{{11_2}}: i8 = extractvalue %{{10_1}}, [0]
+//     %{{_}}: i8 = extractvalue %{{s}}, [0]
 //     ...
-//     %{{11_5}}: i64 = extractvalue %{{10_1}}, [1]
+//     %{{_}}: i64 = extractvalue %{{s}}, [1]
 //     ...
 //     --- End aot ---
 //     --- Begin hir ---
 //     ...
+//     %{{a}}: i8 = load %{{ptr}}
+//     store %{{a}}, %{{s1}}
+//     %{{s1b}}: ptr = ptradd %{{s1}}, 8
+//     %{{padd}}: ptr = ptradd %{{ptr}}, 8
+//     %{{b}}: i64 = load %{{padd}}
+//     store %{{b}}, %{{s1b}}
+//     ...
+//     %{{a_ext}}: i32 = zext %{{a}}
+//     ...
+//     %{{_}}: i32 = call %{{_}}(%{{_}}, %{{_}}, %{{a_ext}}) ; @fprintf
+//     ...
+//     %{{b_load}}: i64 = load %{{s1b}}
+//     ...
+//     %{{_}}: i32 = call %{{_}}(%{{_}}, %{{_}}, %{{b_load}}) ; @fprintf
+//     ...
 //     --- End hir ---
-//     2
+//     1
 //     999
-//     yk-execution: enter-jit-code
-//     2
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1
 //     999
-//     2
+//     1
 //     999
 //     yk-execution: deoptimise ...
 //     exit
 
-// Test that trace builder handles loading structs by rewriting `extractvalue`
-// instructions into `ptr_add`s and `load`s. We only check that the AOT IR
-// contains a struct load and check that the trace does the correct thing.
-// Matching on the JIT IR is difficult since the `ptr_add`s and `load`s are
-// not easily distinguished from unrelated `ptr_add`s and `load`s.
+// Test that the trace builder handles loading structs by rewriting
+// `extractvalue` instructions into `ptradd`s and `load`s. Both fields are
+// followed from their `load` to the `fprintf` that prints them, so that we
+// know we haven't matched unrelated `ptradd`s/`load`s.
 
 #include <assert.h>
 #include <stdint.h>
@@ -51,6 +64,7 @@ struct S {
   uint64_t b;
 };
 
+__attribute__((always_inline))
 struct S make_struct() {
   struct S ret = {1, 999};
   return ret;
@@ -69,7 +83,6 @@ void interp(){
   while (i > 0) {
     yk_mt_control_point(mt, &loc);
     struct S s1 = make_struct();
-    s1.a = 2;
     fprintf(stderr, "%d\n", s1.a);
     fprintf(stderr, "%ld\n", s1.b);
     i--;

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -25,7 +25,7 @@ use crate::{
             compiled_trace::{
                 CompiledGuardIdx, DeoptFrame, DeoptVar, J2CompiledTrace, J2TraceStart,
             },
-            hir,
+            hir::{self, InstT},
             opt::{OptT, fullopt::FullOpt, noopt::NoOpt},
             regalloc::{RegT, VarLoc, VarLocs},
         },
@@ -915,7 +915,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 Inst::Cast { .. } => self.p_cast(pc.clone(), inst)?,
                 Inst::CondBr { .. } => self.p_condbr(pc.clone(), bid, inst)?,
                 Inst::DebugStr { .. } => self.p_debugstr(pc.clone())?,
-                Inst::ExtractValue { .. } => todo!(),
+                Inst::ExtractValue { .. } => self.p_extractvalue(pc.clone(), inst)?,
                 Inst::FCmp { .. } => self.p_fcmp(pc.clone(), inst)?,
                 Inst::FNeg { .. } => self.p_fneg(pc.clone(), inst)?,
                 Inst::Freeze { .. } => self.p_freeze(pc.clone(), inst)?,
@@ -1803,12 +1803,67 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             return Ok(());
         }
 
+        // Case for memory packed struct. This happens with inlined functions that return a struct.
+        if let Ty::Struct(_) = self.am.type_(*tyidx) {
+            let ptr = self.p_operand(ptr)?;
+            self.frames.last_mut().unwrap().set_local(iid, ptr);
+            return Ok(());
+        }
+
         let tyidx = self.p_ty(self.am.type_(*tyidx))?;
         let ptr = self.p_operand(ptr)?;
         self.push_inst_and_link_local(
             iid,
             hir::Load {
                 tyidx,
+                ptr,
+                is_volatile: *volatile,
+            },
+        )
+        .map(|_| ())
+    }
+
+    fn p_extractvalue(&mut self, iid: InstId, inst: &Inst) -> Result<(), CompilationError> {
+        let Inst::ExtractValue { tyidx, op, indices } = inst else {
+            panic!()
+        };
+
+        let Ty::Struct(struct_ty) = op.type_(self.am) else {
+            panic!()
+        };
+        let Inst::Load { volatile, .. } = op.to_inst(self.am) else {
+            todo!()
+        };
+
+        assert_eq!(indices.len(), 1, "extractvalue with nested indices");
+        let field_bit_off = struct_ty.field_bit_offs()[indices[0]];
+        // LLVM struct fields are always byte-aligned.
+        assert_eq!(field_bit_off % 8, 0);
+        let byte_off = field_bit_off / 8;
+
+        let mut ptr = self.p_operand(op)?;
+        assert_eq!(
+            *self.opt.ty(self.opt.inst(ptr).tyidx(&*self.opt)),
+            hir::Ty::Ptr(0)
+        );
+        if byte_off > 0 {
+            ptr = self.opt.feed(
+                hir::PtrAdd {
+                    ptr,
+                    off: i32::try_from(byte_off).unwrap(),
+                    in_bounds: false,
+                    nusw: false,
+                    nuw: false,
+                }
+                .into(),
+            )?;
+        }
+
+        let res_tyidx = self.p_ty(self.am.type_(*tyidx))?;
+        self.push_inst_and_link_local(
+            iid,
+            hir::Load {
+                tyidx: res_tyidx,
                 ptr,
                 is_volatile: *volatile,
             },


### PR DESCRIPTION
Add handler for `extractvalue` in `j2` on a struct operand as `ptr_add`+`load` pair. 
This covers the memory-backed case, where the struct operand is a pointer to it.

First part of the bigger PR https://github.com/ykjit/yk/pull/2219