### PR TITLE
`OUT_DIR`s value has changed in nightly.

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -111,7 +111,7 @@ pub fn full_cargo_profile() -> String {
     let out_dir = std::env::var("OUT_DIR").unwrap();
     Path::new(&out_dir)
         .components()
-        .nth_back(3)
+        .nth_back(4)
         .map(|x| x.as_os_str().to_str().unwrap())
         .unwrap()
         .to_owned()

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -58,6 +58,8 @@ fn main() {
         .unwrap()
         .parent()
         .unwrap()
+        .parent()
+        .unwrap()
         .to_owned();
     ykllvm_build_dir.push("ykllvm");
     create_dir_all(&ykllvm_build_dir).unwrap();

--- a/ykbuild/src/lib.rs
+++ b/ykbuild/src/lib.rs
@@ -18,6 +18,8 @@ pub fn target_dir() -> PathBuf {
         .unwrap()
         .parent()
         .unwrap()
+        .parent()
+        .unwrap()
         .to_owned()
 }
 


### PR DESCRIPTION
This was changed in https://github.com/rust-lang/cargo/pull/17272. This might change back for all I know, but at least for now this unbreaks things.