### PR TITLE
Don't rely on `OUT_DIR`'s layout to find the target dir.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-# FIXME: Hack for https://github.com/rust-lang/cargo/issues/17287
-export CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT=false
-
 ROOT_DIR=$(realpath $(pwd))
 
 # What git commit hash of yklua & ykcbf will we test in buildbot?

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[unstable]
+bindeps = true

--- a/bin/yk-config
+++ b/bin/yk-config
@@ -12,6 +12,29 @@ fi
 
 OUTPUT=""
 
+# Find the directory containing `libykcapi.so` under `target/<profile>`.
+#
+# Cargo only guarantees the top-level location when `ykcapi` is built directly; if it's only a
+# dependency of whatever's being built (e.g. a plain `cargo test`), the `.so` can end up nested
+# under `build/ykcapi-<hash>/out/` instead.
+libykcapi_dir() {
+    if [ -n "${YKCAPI_DIR}" ]; then
+        echo "${YKCAPI_DIR}"
+        return
+    fi
+    profile_dir=`realpath ${DIR}/../target/${1}`
+    # Not ideal: a search can't tell us whether the match it finds was built with the features
+    # the caller actually needs, and it's the reason $YKCAPI_DIR exists as a way to skip this.
+    # But this script has no better option here. This is the last-resort fallback for
+    # callers that don't (or can't) supply $YKCAPI_DIR.
+    found=$(find "${profile_dir}/deps" "${profile_dir}/build/"ykcapi* -name libykcapi.so -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -n1 | cut -d' ' -f2)
+    if [ -z "${found}" ]; then
+        1>&2 echo "error: couldn't find libykcapi.so under ${profile_dir}"
+        exit 1
+    fi
+    dirname "${found}"
+}
+
 usage() {
     echo "Generate C compiler flags for building against the yk JIT.\n"
     echo "Usage:"
@@ -120,14 +143,15 @@ handle_arg() {
             OUTPUT="${OUTPUT} -Wl,-mllvm=--yk-no-vectorize"
 
             # Linkage to yk as a library.
-            OUTPUT="${OUTPUT} -L${DIR}/../target/${profile}/deps"
+            ykcapi_dir=`libykcapi_dir ${profile}`
+            OUTPUT="${OUTPUT} -L${ykcapi_dir}"
 
             # Encode an rpath so that we don't have to set LD_LIBRARY_PATH.
             #
             # FIXME: Adding rpaths should probably be behind a flag. It's kind
             # of rude to add local rpaths to interpreter binaries that
             # downstreams may want to distribute.
-            OUTPUT="${OUTPUT} -Wl,-rpath=${DIR}/../target/${profile}/deps"
+            OUTPUT="${OUTPUT} -Wl,-rpath=${ykcapi_dir}"
             OUTPUT="${OUTPUT} -Wl,-rpath=$(${ykllvm_bin_dir}/llvm-config --link-shared --libdir)"
             # Add a proper RPATH, not a RUNPATH:
             # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1737608

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,12 +26,15 @@ harness = false
 [dependencies]
 clap = { features = ["derive"], version = "4.4" }
 fs4 = { version="0.13.1", features=["sync"] }
+glob = "0.3.1"
 memmap2 = "0.9.4"
 num_cpus = "1.13.1"
 regex = "1.9"
 tempfile = "3.9.0"
 ykbuild = { path = "../ykbuild" }
 ykrt = { path = "../ykrt", features = ["yk_testing", "ykd"] }
+# This exists purely so that a plain `cargo build`/`cargo test` also
+# builds `ykcapi` with these features, for the sake of `bin/yk-config` consumers.
 ykcapi = { path = "../ykcapi", features = ["yk_testing", "ykd"] }
 
 [dev-dependencies]
@@ -41,6 +44,9 @@ lang_tester = "0.9"
 [build-dependencies]
 rerun_except = "1.0.0"
 ykbuild = { path = "../ykbuild" }
+# This exists purely so that a plain `cargo build`/`cargo test` also
+# builds `ykcapi` with these features, for the sake of `bin/yk-config` consumers.
+ykcapi = { path = "../ykcapi", features = ["yk_testing", "ykd"], artifact = "cdylib" }
 
 [[bench]]
 name = "promote"

--- a/tests/benches/promote.rs
+++ b/tests/benches/promote.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 use tempfile::TempDir;
-use tests::{check_output, mk_compiler};
+use tests::{artifact_path_under, check_output, full_cargo_profile, mk_compiler};
 use ykbuild::ykllvm_bin;
 
 const SAMPLE_SIZE: usize = 30;
@@ -26,6 +26,13 @@ fn compile_bench(tempdir: &TempDir, promote: bool) -> PathBuf {
     exe.push(src.file_stem().unwrap());
 
     let mut compiler = mk_compiler(&ykllvm_bin("clang"), &exe, &src, &[], true, None);
+    let root = ykbuild::cargo_target_dir().join(full_cargo_profile());
+    let tests_dir = artifact_path_under(&root, "libtests.so")
+        .parent()
+        .unwrap()
+        .to_owned();
+    compiler.arg(format!("-L{}", tests_dir.display()));
+    compiler.arg(format!("-Wl,-rpath={}", tests_dir.display()));
     compiler.arg("-ltests");
     if promote {
         compiler.arg("-DDO_PROMOTE");

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2,6 +2,9 @@ use rerun_except::rerun_except;
 use std::env;
 
 pub fn main() {
+    let ykcapi_dir = env::var("CARGO_CDYLIB_DIR_YKCAPI").unwrap();
+    println!("cargo::rustc-env=YKCAPI_DIR={ykcapi_dir}");
+
     // Don't rebuild the whole crate when only test inputs change.
     rerun_except(&[
         "c",

--- a/tests/langtest_ir_lowering.rs
+++ b/tests/langtest_ir_lowering.rs
@@ -36,10 +36,7 @@ fn main() {
             let mut compiler = Command::new(ykllvm_bin("clang"));
             let md = env::var("CARGO_MANIFEST_DIR").unwrap();
             let profile = full_cargo_profile();
-            let ykcapi_path = [&md, "..", "target", &profile, "deps"]
-                .iter()
-                .collect::<PathBuf>();
-            let ykcapi_linkdir = format!("-L{}", ykcapi_path.to_str().unwrap());
+            let ykcapi_linkdir = format!("-L{}", env!("YKCAPI_DIR"));
             compiler.args([
                 "-flto",
                 "-fuse-ld=lld",

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 use ykbuild::ykllvm_bin;
 
 const TEMPDIR_SUBST: &str = "%%TEMPDIR%%";
+
 pub static EXTRA_LINK: LazyLock<HashMap<&'static str, Vec<ExtraLinkage>>> = LazyLock::new(|| {
     let mut map = HashMap::new();
 
@@ -108,13 +109,23 @@ impl<'a> ExtraLinkage<'a> {
 // Determine the "full" cargo profile name, as it appears as an argument to `--profile` (not just
 // "debug" or "release", which is all cargo's `PROFILE` environment` can report).
 pub fn full_cargo_profile() -> String {
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    Path::new(&out_dir)
-        .components()
-        .nth_back(3)
-        .map(|x| x.as_os_str().to_str().unwrap())
+    ykbuild::target_dir()
+        .file_name()
+        .unwrap()
+        .to_str()
         .unwrap()
         .to_owned()
+}
+
+/// Find `filename` (e.g. "libykcapi.so") under given `root`.
+/// If more than one match exists (e.g. a stale artifact left over from an earlier build), the
+/// most recently modified one wins.
+pub fn artifact_path_under(root: &Path, filename: &str) -> PathBuf {
+    glob::glob(&format!("{}/**/{}", root.display(), filename))
+        .expect("invalid glob pattern")
+        .filter_map(Result::ok)
+        .max_by_key(|p| p.metadata().and_then(|m| m.modified()).ok())
+        .unwrap_or_else(|| panic!("couldn't find {filename} under {}", root.display()))
 }
 
 /// Make a compiler command that compiles `src` to `exe`.
@@ -144,6 +155,7 @@ pub fn mk_compiler(
     let profile = full_cargo_profile();
     let mut yk_config = Command::new(yk_config);
     yk_config.args([&profile, "--cflags", "--cppflags", "--ldflags", "--libs"]);
+    yk_config.env("YKCAPI_DIR", env!("YKCAPI_DIR"));
     if let Some(extra_env) = extra_env {
         yk_config.envs(extra_env);
     }

--- a/ykbuild/Cargo.toml
+++ b/ykbuild/Cargo.toml
@@ -9,10 +9,12 @@ license = "Apache-2.0 OR MIT"
 links = "ykbuild"
 
 [dependencies]
+cargo_metadata = "0.23.1"
 glob = "0.3.1"
 tempfile = "3.8"
 
 [build-dependencies]
+cargo_metadata = "0.23.1"
 fs4 = { version="0.13.1", features=["sync"] }
 rerun_except = "1.0.0"
 which = "8.0.0"

--- a/ykbuild/build.rs
+++ b/ykbuild/build.rs
@@ -6,7 +6,7 @@ use std::{
     collections::HashMap,
     env,
     fs::{File, canonicalize, create_dir_all, read_to_string, write},
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
 };
 use which::which;
@@ -50,15 +50,30 @@ fn main() {
     rerun_except(&[]).unwrap();
 
     // Build ykllvm in "target/<cargo-profile>". Note that the directory used here *must* be
-    // exactly the same as that produced by `ykbuild/src/lib.rs:llvm_bin_dir` and yk-config.
-    let mut ykllvm_build_dir = Path::new(&env::var("OUT_DIR").unwrap())
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_owned();
+    // exactly the same as that produced by `ykbuild/src/lib.rs:target_dir` and yk-config.
+    let target_dir = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .expect("failed to run `cargo metadata`")
+        .target_directory
+        .into_std_path_buf();
+    // OUT_DIR is `<target_dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`. The `<triple>/`
+    // component is only present when cargo was invoked with an explicit `--target`, so we can't
+    // assume a fixed depth for `<profile>`.
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir)
+        .strip_prefix(&target_dir)
+        .expect("OUT_DIR is not inside cargo's target directory");
+    let build_dir_idx = out_dir
+        .components()
+        .position(|c| c.as_os_str() == "build")
+        .expect("couldn't find `build` component in OUT_DIR");
+    let profile = out_dir
+        .components()
+        .take(build_dir_idx)
+        .collect::<PathBuf>();
+    let mut ykllvm_build_dir = target_dir.join(profile);
+    assert!(ykllvm_build_dir.is_dir());
     ykllvm_build_dir.push("ykllvm");
     create_dir_all(&ykllvm_build_dir).unwrap();
 

--- a/ykbuild/src/lib.rs
+++ b/ykbuild/src/lib.rs
@@ -7,18 +7,39 @@ use std::{
 
 pub mod completion_wrapper;
 
+/// Cargo's top-level `target` directory (`target_directory` from `cargo metadata`), before any
+/// `<triple>/<profile>` components are appended.
+pub fn cargo_target_dir() -> PathBuf {
+    cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .expect("failed to run `cargo metadata`")
+        .target_directory
+        .into_std_path_buf()
+}
+
 /// Return the subdirectory of Cargo's `target` directory where we should be building things.
 ///
 /// There are no guarantees about where this directory will be or what its name is.
 pub fn target_dir() -> PathBuf {
-    Path::new(env!("OUT_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_owned()
+    let target_dir = cargo_target_dir();
+    // OUT_DIR is `<target_dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`. The `<triple>/`
+    // component is only present when cargo was invoked with an explicit `--target`, so we can't
+    // assume a fixed depth for `<profile>`.
+    let out_dir = Path::new(env!("OUT_DIR"))
+        .strip_prefix(&target_dir)
+        .expect("OUT_DIR is not inside cargo's target directory");
+    let build_dir_idx = out_dir
+        .components()
+        .position(|c| c.as_os_str() == "build")
+        .expect("couldn't find `build` component in OUT_DIR");
+    let profile = out_dir
+        .components()
+        .take(build_dir_idx)
+        .collect::<PathBuf>();
+    let target_dir = target_dir.join(profile);
+    assert!(target_dir.is_dir());
+    target_dir
 }
 
 /// Return a [Path] to the directory containing a ykllvm installation.

--- a/ykcapi/Cargo.toml
+++ b/ykcapi/Cargo.toml
@@ -18,4 +18,4 @@ ykbuild = { path = "../ykbuild" }
 
 [features]
 yk_testing = ["ykrt/yk_testing"]
-ykd = []
+ykd = ["ykrt/ykd"]


### PR DESCRIPTION
Cargo has changed the layout on nightly
(https://github.com/rust-lang/cargo/pull/17272), so counting path
components back from `OUT_DIR` no longer lands on the profile directory,
and may change again in the future.

In this change we ask `cargo metadata` where the target directory is:
the profile is then the first component of `OUT_DIR` beneath it.
Tested on (`cargo build` and `cargo test`)
```
$ rustc --version
rustc 1.99.0-nightly (73dc9167f 2026-08-01)
```