### PR TITLE
Guard compatibility

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -763,18 +763,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 // about-to-be-created sidetrace is, so we can't factor that into our comparison.
                 if gextra.bid == gbody.bid
                     && deopt_frames == gbody.deopt_frames
-                    && deopt_vars.len() == gbody.deopt_vars.len()
-                    && deopt_vars
-                        .iter()
-                        .zip(gbody.deopt_vars.iter())
-                        .all(|(x, y)| {
-                            x.bitw == y.bitw
-                                && x.fromvlocs.len() == y.fromvlocs.len()
-                                && x.fromvlocs
-                                    .iter()
-                                    .zip(y.fromvlocs.iter())
-                                    .all(|(x, y)| x == y)
-                        })
+                    && deopt_vars_compatible(&gbody.deopt_vars, &deopt_vars)
                     && gextra.switch == gbody.switch
                 {
                     gidx = cnd_gidx;
@@ -1273,6 +1262,22 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
 
         Ok(ra.stack_off())
     }
+}
+
+/// Are the "from" deopt vars in `cnd` compatible with those in `with`? Note: this relationship is
+/// not necessarily symmetric.
+fn deopt_vars_compatible<Reg: RegT>(cnd: &[DeoptVar<Reg>], with: &[DeoptVar<Reg>]) -> bool {
+    if cnd.len() != with.len() {
+        return false;
+    }
+    cnd.iter().zip(with.iter()).all(|(x, y)| {
+        x.bitw == y.bitw
+            && x.fromvlocs.len() == y.fromvlocs.len()
+            && x.fromvlocs
+                .iter()
+                .zip(y.fromvlocs.iter())
+                .all(|(x, y)| x == y)
+    })
 }
 
 /// The trait that backends must implement to assemble a trace into machine code.
@@ -1933,6 +1938,7 @@ mod test {
         },
         location::{HotLocation, HotLocationKind},
         mt::TraceId,
+        varlocs,
     };
     use fm::{FMBuilder, FMatcher};
 
@@ -1941,6 +1947,41 @@ mod test {
     use regex::Regex;
     use std::sync::Arc;
     use strum::{Display, EnumCount, FromRepr};
+
+    #[test]
+    fn deopt_vars_compatibility() {
+        let x = vec![DeoptVar {
+            bitw: 64,
+            fromvlocs: varlocs![
+                VarLoc::Stack(8),
+                VarLoc::Reg(TestReg::R0, RegFill::Undefined)
+            ],
+            tovlocs: VarLocs::new(),
+        }];
+        let y = vec![DeoptVar {
+            bitw: 64,
+            fromvlocs: varlocs![
+                VarLoc::Stack(8),
+                VarLoc::Reg(TestReg::R0, RegFill::Undefined)
+            ],
+            tovlocs: VarLocs::new(),
+        }];
+        let z = vec![DeoptVar {
+            bitw: 64,
+            fromvlocs: varlocs![
+                VarLoc::Stack(8),
+                VarLoc::Reg(TestReg::R0, RegFill::Zeroed)
+            ],
+            tovlocs: VarLocs::new(),
+        }];
+
+        assert!(deopt_vars_compatible(&x, &x));
+        assert!(deopt_vars_compatible(&y, &y));
+        assert!(deopt_vars_compatible(&x, &y));
+        assert!(deopt_vars_compatible(&y, &x));
+        assert!(!deopt_vars_compatible(&x, &z));
+        assert!(!deopt_vars_compatible(&y, &z));
+    }
 
     #[derive(Copy, Clone, Debug, Display, EnumCount, FromRepr, PartialEq)]
     #[repr(u8)]

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -1276,7 +1276,21 @@ fn deopt_vars_compatible<Reg: RegT>(cnd: &[DeoptVar<Reg>], with: &[DeoptVar<Reg>
             && x.fromvlocs
                 .iter()
                 .zip(y.fromvlocs.iter())
-                .all(|(x, y)| x == y)
+                // OPT: We could do this unsorted, but then we have to do the checks in both
+                // directions. It's unclear if that's worth it, when the common case is "both sides
+                // have 1 entry".
+                .all(|(x, y)| match (x, y) {
+                    (VarLoc::Stack(lhs), VarLoc::Stack(rhs)) => lhs == rhs,
+                    (VarLoc::StackOff(lhs), VarLoc::StackOff(rhs)) => lhs == rhs,
+                    (VarLoc::Reg(reglhs, reglhs_fill), VarLoc::Reg(regrhs, regrhs_fill)) => {
+                        reglhs == regrhs
+                            && (reglhs_fill == regrhs_fill
+                                || *reglhs_fill == RegFill::Undefined
+                                || *regrhs_fill == RegFill::Undefined)
+                    }
+                    (VarLoc::Const(lhs), VarLoc::Const(rhs)) => lhs == rhs,
+                    _ => false,
+                })
     })
 }
 
@@ -1968,10 +1982,7 @@ mod test {
         }];
         let z = vec![DeoptVar {
             bitw: 64,
-            fromvlocs: varlocs![
-                VarLoc::Stack(8),
-                VarLoc::Reg(TestReg::R0, RegFill::Zeroed)
-            ],
+            fromvlocs: varlocs![VarLoc::Stack(8), VarLoc::Reg(TestReg::R0, RegFill::Zeroed)],
             tovlocs: VarLocs::new(),
         }];
 
@@ -1979,8 +1990,16 @@ mod test {
         assert!(deopt_vars_compatible(&y, &y));
         assert!(deopt_vars_compatible(&x, &y));
         assert!(deopt_vars_compatible(&y, &x));
-        assert!(!deopt_vars_compatible(&x, &z));
-        assert!(!deopt_vars_compatible(&y, &z));
+        assert!(deopt_vars_compatible(&x, &z));
+        assert!(deopt_vars_compatible(&z, &x));
+
+        let sgn = vec![DeoptVar {
+            bitw: 64,
+            fromvlocs: varlocs![VarLoc::Stack(8), VarLoc::Reg(TestReg::R0, RegFill::Signed)],
+            tovlocs: VarLocs::new(),
+        }];
+        assert!(!deopt_vars_compatible(&z, &sgn));
+        assert!(!deopt_vars_compatible(&sgn, &z));
     }
 
     #[derive(Copy, Clone, Debug, Display, EnumCount, FromRepr, PartialEq)]


### PR DESCRIPTION
This PR slightly refactors and then (safely) weakens the guard compatibility check so that more guards can be identified as compatible. This isn't a huge win, but we should always have done this, so better late than never!