### PR TITLE
Move from `IndexVec` to `IndexType`.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -12,7 +12,7 @@ enum_dispatch = "0.3.13"
 deku = { version = "0.18.1", features = ["std"] }
 iced-x86 = { version = "1.21.0", features = ["encoder"] }
 indexmap = "2.2.6"
-index_vec = "0.1.4"
+index_type = "0.7.1"
 libc = "0.2.148"
 memmap2 = "0.9"
 num-traits = "0.2.16"

--- a/ykrt/src/aotsmp.rs
+++ b/ykrt/src/aotsmp.rs
@@ -1,4 +1,4 @@
-use index_vec::{IndexVec, define_index_type};
+use index_type::{IndexType, vec::TypedVec};
 use object::{Object, ObjectSection};
 use std::sync::LazyLock;
 #[cfg(not(test))]
@@ -6,10 +6,15 @@ use std::thread;
 use ykaddr::obj::SELF_BIN_MMAP;
 use yksmp::{PrologueInfo, Record, StackMapParser};
 
-define_index_type! {
-    /// The index of a given stackmap in a module's [Record]s.
-    pub struct StackMapIdx = usize;
-    DISPLAY_FORMAT = "{}";
+/// The index of a given stackmap in a module's [Record]s.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub struct StackMapIdx(usize);
+
+impl std::fmt::Display for StackMapIdx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_raw_index().fmt(f)
+    }
 }
 
 /// Parsed stackmap information of the AOT module.
@@ -18,7 +23,7 @@ pub(crate) struct AOTStackmapInfo {
     pinfos: Vec<PrologueInfo>,
     /// All stackmap records of the module, and the index of the prologue info relevant for each
     /// record.
-    records: IndexVec<StackMapIdx, (Record, usize)>,
+    records: TypedVec<StackMapIdx, (Record, usize)>,
 }
 
 impl AOTStackmapInfo {
@@ -47,7 +52,7 @@ pub(crate) static AOT_STACKMAPS: LazyLock<Result<AOTStackmapInfo, String>> = Laz
         let (pinfos, records) = StackMapParser::parse(data);
         Ok(AOTStackmapInfo {
             pinfos,
-            records: IndexVec::from_vec(records),
+            records: TypedVec::from_vec(records),
         })
     }
 

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -36,8 +36,9 @@ use crate::{
     mt::{MT, TraceId},
     trace::TraceAction,
 };
+use index_type::IndexType;
 #[cfg(test)]
-use index_vec::IndexVec;
+use index_type::vec::TypedVec;
 use parking_lot::Mutex;
 use smallvec::{SmallVec, smallvec};
 use std::{
@@ -209,7 +210,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                     .as_any()
                     .downcast::<J2CompiledTrace<Reg>>()
                     .unwrap();
-                let src_gidx = CompiledGuardIdx::from(usize::from(*src_gid));
+                let src_gidx = CompiledGuardIdx::from_raw_index(usize::from(*src_gid));
                 let prev_bid = src_ctr.bid(src_gidx);
                 self.prev_bid = Some(prev_bid);
                 let tgt_ctr = tgt_ctr.as_ref().map(|x| {
@@ -398,7 +399,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             tyidx_void,
             addr_name_map: self.addr_name_map,
             #[cfg(test)]
-            smaps: IndexVec::new(),
+            smaps: TypedVec::new(),
         };
 
         let ds = if let Some(x) = &self.hl.lock().debug_str {
@@ -494,7 +495,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 pc,
                 pc_statepoint,
                 #[cfg(test)]
-                smapidx: StackMapIdx::new(0),
+                smapidx: StackMapIdx::from_raw_index(0),
             });
         }
 

--- a/ykrt/src/compile/j2/compiled_trace.rs
+++ b/ykrt/src/compile/j2/compiled_trace.rs
@@ -12,7 +12,7 @@ use crate::{
     location::HotLocation,
     mt::{MT, TraceId},
 };
-use index_vec::IndexVec;
+use index_type::{IndexType, vec::TypedVec};
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::{
@@ -28,7 +28,7 @@ pub(super) struct J2CompiledTrace<Reg: RegT> {
     pub trid: TraceId,
     pub hl: Weak<Mutex<HotLocation>>,
     codebuf: ExeCodeBuf,
-    pub guards: IndexVec<CompiledGuardIdx, J2CompiledGuard<Reg>>,
+    pub guards: TypedVec<CompiledGuardIdx, J2CompiledGuard<Reg>>,
     pub trace_start: J2TraceStart<Reg>,
     /// The name used for this trace as linker symbol.
     symbol_name: String,
@@ -40,7 +40,7 @@ impl<Reg: RegT> J2CompiledTrace<Reg> {
         m: &Mod<Reg>,
         hl: Weak<Mutex<HotLocation>>,
         codebuf: ExeCodeBuf,
-        guards: IndexVec<CompiledGuardIdx, J2CompiledGuard<Reg>>,
+        guards: TypedVec<CompiledGuardIdx, J2CompiledGuard<Reg>>,
         trace_start: J2TraceStart<Reg>,
     ) -> Self {
         // Extract source trace ID for guard traces.
@@ -169,7 +169,7 @@ impl<Reg: RegT + 'static> CompiledTrace for J2CompiledTrace<Reg> {
     }
 
     fn guard(&self, gid: GuardId) -> &Guard {
-        let gidx = CompiledGuardIdx::from(usize::from(gid));
+        let gidx = CompiledGuardIdx::from_raw_index(usize::from(gid));
         self.guards[gidx].guard()
     }
 
@@ -177,7 +177,7 @@ impl<Reg: RegT + 'static> CompiledTrace for J2CompiledTrace<Reg> {
     // / J2CompiledTrace makes this awkward.
     #[cfg(target_arch = "x86_64")]
     fn patch_guard(&self, gid: GuardId, tgt: *const std::ffi::c_void) {
-        let gidx = CompiledGuardIdx::from(usize::from(gid));
+        let gidx = CompiledGuardIdx::from_raw_index(usize::from(gid));
         for patch_off in &self.guards[gidx].patch_offs {
             let patch_off = usize::try_from(*patch_off).unwrap();
             self.codebuf.patch(patch_off, 10, |patch_addr| {
@@ -322,9 +322,8 @@ pub(super) struct DeoptVar<Reg: RegT> {
     pub tovlocs: VarLocs<Reg>,
 }
 
-index_vec::define_index_type! {
-    pub(super) struct CompiledGuardIdx = u16;
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub(super) struct CompiledGuardIdx(u16);
 
 #[cfg(test)]
 mod tests {
@@ -336,19 +335,19 @@ mod tests {
             x64::Reg,
         },
     };
-    use index_vec::IndexVec;
+    use index_type::vec::TypedVec;
     use std::sync::LazyLock;
 
     fn empty_block() -> Block {
         Block {
-            insts: IndexVec::new(),
-            guard_extras: IndexVec::new(),
+            insts: TypedVec::new(),
+            guard_extras: TypedVec::new(),
         }
     }
 
     // Dummy DeoptStatepoint for testing
     static TEST_DEOPT_STATEPOINT: LazyLock<Statepoint> = LazyLock::new(|| Statepoint {
-        smapidx: StackMapIdx::new(0),
+        smapidx: StackMapIdx::from_raw_index(0),
         lives: Vec::new(),
     });
 

--- a/ykrt/src/compile/j2/hir.rs
+++ b/ykrt/src/compile/j2/hir.rs
@@ -180,7 +180,7 @@ use crate::{
     mt::TraceId,
 };
 use enum_dispatch::enum_dispatch;
-use index_vec::IndexVec;
+use index_type::{IndexType, vec::TypedVec};
 use smallvec::SmallVec;
 use std::{
     assert_matches,
@@ -280,7 +280,7 @@ pub(super) struct Mod<Reg: RegT> {
     pub trid: TraceId,
     pub trace_start: TraceStart<Reg>,
     pub trace_end: TraceEnd<Reg>,
-    pub tys: IndexVec<TyIdx, Ty>,
+    pub tys: TypedVec<TyIdx, Ty>,
     /// The [TyIdx] for [Ty::Int(1)].
     pub tyidx_int1: TyIdx,
     /// The [TyIdx] for [Ty::Ptr(0)].
@@ -290,7 +290,7 @@ pub(super) struct Mod<Reg: RegT> {
     /// A map of names to pointers. Will be `None` if logging was disabled.
     pub addr_name_map: Option<HashMap<usize, Option<String>>>,
     #[cfg(test)]
-    pub smaps: IndexVec<StackMapIdx, Vec<VarLocs<Reg>>>,
+    pub smaps: TypedVec<StackMapIdx, Vec<VarLocs<Reg>>>,
 }
 
 impl<Reg: RegT> Mod<Reg> {
@@ -334,12 +334,15 @@ impl<Reg: RegT> Mod<Reg> {
             "  \"start\": {".to_owned(),
         ];
         match &self.trace_start {
-            TraceStart::ControlPoint { .. } => out.push("    \"kind\": \"ControlPoint\"".to_owned()),
+            TraceStart::ControlPoint { .. } => {
+                out.push("    \"kind\": \"ControlPoint\"".to_owned())
+            }
             TraceStart::Guard {
                 src_ctr, src_gidx, ..
             } => out.push(format!(
-                "    \"kind\": \"Guard\",\n    \"src_trid\": \"{}\",\n    \"gidx\": \"{src_gidx:?}\"",
-                src_ctr.trid
+                "    \"kind\": \"Guard\",\n    \"src_trid\": \"{}\",\n    \"gidx\": \"{}\"",
+                src_ctr.trid,
+                src_gidx.to_raw_index()
             )),
             #[cfg(test)]
             TraceStart::Test => out.push("    \"kind\": \"Test\"".to_owned()),
@@ -484,9 +487,9 @@ pub(super) enum TraceEnd<Reg: RegT> {
 /// An ordered sequence of instructions.
 #[derive(Debug)]
 pub(super) struct Block {
-    pub insts: IndexVec<InstIdx, Inst>,
+    pub insts: TypedVec<InstIdx, Inst>,
     /// Extra information that is too big to fit in a [Guard] instruction.
-    pub guard_extras: IndexVec<GuardExtraIdx, GuardExtra>,
+    pub guard_extras: TypedVec<GuardExtraIdx, GuardExtra>,
 }
 
 impl Block {
@@ -498,7 +501,7 @@ impl Block {
         exit_vlocs: &[VarLocs<Reg>],
     ) {
         for (iidx, inst) in self.insts_iter(..) {
-            if iidx < InstIdx::from(args_vlocs.len()) {
+            if iidx < InstIdx::from_raw_index(args_vlocs.len()) {
                 assert_matches!(
                     inst,
                     Inst::Arg(_) | Inst::Const(_),
@@ -506,7 +509,7 @@ impl Block {
                 );
             } else if let Inst::Arg(_) = inst {
                 panic!("%{iidx:?}: 'arg' instructions cannot appear after trace entry");
-            } else if iidx == self.insts.last_idx()
+            } else if iidx == self.insts.indices().next_back().unwrap()
                 && let Inst::Term(Term(term_vars)) = inst
             {
                 assert_eq!(
@@ -516,7 +519,7 @@ impl Block {
                 );
 
                 for (i, (x, y)) in args_vlocs.iter().zip(exit_vlocs.iter()).enumerate() {
-                    let entry_tyidx = self.insts[InstIdx::from(i)].tyidx(m);
+                    let entry_tyidx = self.insts[InstIdx::from_raw_index(i)].tyidx(m);
                     let exit_tyidx = self.insts[term_vars[i]].tyidx(m);
                     if entry_tyidx != exit_tyidx {
                         panic!(
@@ -543,7 +546,7 @@ impl Block {
             if let Inst::Term(_) = inst {
                 assert_eq!(
                     iidx,
-                    self.insts.last_idx(),
+                    self.insts.indices().next_back().unwrap(),
                     "%{iidx:?}: term must be the last instruction in a trace"
                 );
             }
@@ -559,17 +562,23 @@ impl Block {
         T: RangeBounds<InstIdx>,
     {
         let start = match range.start_bound() {
-            Bound::Included(x) => min(usize::from(*x), self.insts.len()),
-            Bound::Excluded(x) => min(usize::from(*x + 1), self.insts.len()),
+            Bound::Included(x) => min(x.to_raw_index(), self.insts.len_usize()),
+            Bound::Excluded(x) => min(
+                x.to_raw_index().checked_add(1).unwrap(),
+                self.insts.len_usize(),
+            ),
             Bound::Unbounded => 0,
         };
         let end = match range.end_bound() {
-            Bound::Included(x) => min(usize::from(*x + 1), self.insts.len()),
-            Bound::Excluded(x) => min(usize::from(*x), self.insts.len()),
-            Bound::Unbounded => self.insts.len(),
+            Bound::Included(x) => min(
+                x.to_raw_index().checked_add(1).unwrap(),
+                self.insts.len_usize(),
+            ),
+            Bound::Excluded(x) => min(x.to_raw_index(), self.insts.len_usize()),
+            Bound::Unbounded => self.insts.len_usize(),
         };
         (start..end).map(|i| {
-            let i = InstIdx::from(i);
+            let i = InstIdx::from_raw_index(i);
             (i, &self.insts[i])
         })
     }
@@ -620,26 +629,26 @@ impl Block {
                 show.set(i, true);
             }
             for (iidx, inst) in self.insts_iter(..).rev() {
-                if show[usize::from(iidx)]
+                if show[iidx.to_raw_index()]
                     || inst.write_effects().interferes(Effects::all())
                     || inst
                         .read_effects()
                         .interferes(Effects::none().add_volatile())
                 {
-                    show.set(usize::from(iidx), true);
+                    show.set(iidx.to_raw_index(), true);
                     for op_iidx in inst.iter_iidxs(self) {
-                        show.set(usize::from(op_iidx), true);
+                        show.set(op_iidx.to_raw_index(), true);
                     }
                 }
             }
             show
         };
 
-        let mut out = Vec::with_capacity(self.insts.len());
+        let mut out = Vec::with_capacity(self.insts.len_usize());
         for (iidx, inst) in self
             .insts
             .iter_enumerated()
-            .filter(|(iidx, _)| show[usize::from(*iidx)])
+            .filter(|(iidx, _)| show[iidx.to_raw_index()])
         {
             let ty = m.ty(inst.tyidx(m));
             if ty == &Ty::Void {
@@ -647,7 +656,7 @@ impl Block {
             } else {
                 out.push(format!(
                     "%{}: {} = {}",
-                    usize::from(iidx),
+                    iidx.to_raw_index(),
                     ty.to_string(m),
                     inst.to_string(m, self)
                 ));
@@ -659,11 +668,11 @@ impl Block {
 
 impl BlockLikeT for Block {
     fn inst(&self, idx: InstIdx) -> &Inst {
-        &self.insts[usize::from(idx)]
+        &self.insts[idx]
     }
 
     fn insts_len(&self) -> usize {
-        self.insts.len()
+        self.insts.len_usize()
     }
 
     fn gextra(&self, geidx: GuardExtraIdx) -> &GuardExtra {
@@ -740,38 +749,40 @@ pub(super) struct FuncTy {
     pub rtn_tyidx: TyIdx,
 }
 
-index_vec::define_index_type! {
-    /// The index type for guard blocks.
-    pub(super) struct GuardBlockIdx = u16;
-}
+/// The index type for guard blocks.
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+#[allow(dead_code)]
+pub(super) struct GuardBlockIdx(u16);
 
-index_vec::define_index_type! {
-    /// The index type for extra information about guards that doesn't fit into a [Guard] object.
-    pub(super) struct GuardExtraIdx = u16;
-}
+/// The index type for extra information about guards that doesn't fit into a [Guard] object.
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub(super) struct GuardExtraIdx(u16);
 
 impl GuardExtraIdx {
     /// The maximum representable [GuardExtraIdx].
-    pub(super) const MAX: GuardExtraIdx = GuardExtraIdx::from_raw_unchecked(u16::MAX);
+    pub(super) const MAX: GuardExtraIdx = GuardExtraIdx::MAX_INDEX;
 }
 
-// Note: if you change the `u32` here, `MAX` must also be updated.
-index_vec::define_index_type! {
-    pub(super) struct InstIdx = u32;
-}
+#[derive(Clone, Copy, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub(super) struct InstIdx(u32);
 
 impl InstIdx {
     /// The maximum representable [InstIdx].
-    pub(super) const MAX: InstIdx = InstIdx::from_raw_unchecked(u32::MAX);
+    pub(super) const MAX: InstIdx = InstIdx::MAX_INDEX;
 }
 
-index_vec::define_index_type! {
-    pub(super) struct TyIdx = u16;
+impl std::fmt::Debug for InstIdx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.to_raw_index(), f)
+    }
 }
 
-index_vec::define_index_type! {
-    pub(super) struct ThreadLocalIdx = u16;
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub(super) struct TyIdx(u16);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+#[allow(dead_code)]
+pub(super) struct ThreadLocalIdx(u16);
 
 /// The trait that HIR instructions must conform to.
 #[enum_dispatch]
@@ -941,7 +952,7 @@ impl InstT for Abs {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "abs %{}{}",
-            usize::from(self.val),
+            self.val.to_raw_index(),
             if self.int_min_poison {
                 ", int_min_poison"
             } else {
@@ -1028,7 +1039,11 @@ impl InstT for Add {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("add %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "add %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -1099,7 +1114,11 @@ impl InstT for And {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("and %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "and %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -1215,8 +1234,8 @@ impl InstT for AShr {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "ashr %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -1282,7 +1301,7 @@ impl InstT for BitCast {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("bitcast %{}", usize::from(self.val))
+        format!("bitcast %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -1328,7 +1347,7 @@ impl InstT for BlackBox {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("blackbox %{}", usize::from(self.val))
+        format!("blackbox %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, m: &dyn ModLikeT) -> TyIdx {
@@ -1434,10 +1453,10 @@ impl InstT for Call {
         };
         format!(
             "call %{}({}){fname}",
-            usize::from(self.tgt),
+            (self.tgt).to_raw_index(),
             self.args
                 .iter()
-                .map(|x| format!("%{}", usize::from(*x)))
+                .map(|x| format!("%{}", x.to_raw_index()))
                 .collect::<Vec<_>>()
                 .join(", "),
         )
@@ -1609,7 +1628,7 @@ impl InstT for CtPop {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("ctpop %{}", usize::from(self.val))
+        format!("ctpop %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -1668,7 +1687,7 @@ impl InstT for CtTz {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("cttz %{}", usize::from(self.val))
+        format!("cttz %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -1781,8 +1800,8 @@ impl InstT for DynPtrAdd {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "dynptradd %{}, %{}, {}",
-            usize::from(self.ptr),
-            usize::from(self.num_elems),
+            self.ptr.to_raw_index(),
+            (self.num_elems).to_raw_index(),
             self.elem_size
         )
     }
@@ -1856,8 +1875,8 @@ impl InstT for FAdd {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "fadd %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -1927,8 +1946,8 @@ impl InstT for FCmp {
         format!(
             "fcmp {} %{}, %{}",
             self.pred.to_str(),
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -2040,8 +2059,8 @@ impl InstT for FDiv {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "fdiv %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -2107,7 +2126,7 @@ impl InstT for Floor {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("floor %{}", usize::from(self.val))
+        format!("floor %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2179,8 +2198,8 @@ impl InstT for FMul {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "fmul %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -2241,7 +2260,7 @@ impl InstT for FNeg {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("fneg %{}", usize::from(self.val),)
+        format!("fneg %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2310,7 +2329,7 @@ impl InstT for FPClass {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("fpclass %{}, 0b{:b}", usize::from(self.val), self.test)
+        format!("fpclass %{}, 0b{:b}", self.val.to_raw_index(), self.test)
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2377,8 +2396,8 @@ impl InstT for FSub {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "fsub %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -2446,7 +2465,7 @@ impl InstT for FPExt {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("fpext %{}", usize::from(self.val))
+        format!("fpext %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2511,7 +2530,7 @@ impl InstT for FPToSI {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("fptosi %{}", usize::from(self.val))
+        format!("fptosi %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2570,7 +2589,7 @@ impl InstT for Freeze {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("freeze %{}", usize::from(self.val))
+        format!("freeze %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2639,11 +2658,11 @@ impl InstT for Guard {
         format!(
             "guard {}, %{}, [{}]",
             if self.expect { "true" } else { "false" },
-            usize::from(self.cond),
+            self.cond.to_raw_index(),
             b.gextra(self.geidx)
                 .deopt_vars
                 .iter()
-                .map(|iidx| format!("%{}", usize::from(*iidx)))
+                .map(|iidx| format!("%{}", iidx.to_raw_index()))
                 .collect::<Vec<_>>()
                 .join(", ")
         )
@@ -2785,8 +2804,8 @@ impl InstT for ICmp {
         format!(
             "icmp {} %{}, %{}",
             self.pred.as_str(),
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -2892,7 +2911,7 @@ impl InstT for IntToPtr {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("inttoptr %{}", usize::from(self.val))
+        format!("inttoptr %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -2949,9 +2968,9 @@ impl InstT for Load {
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         if self.is_volatile {
-            format!("load volatile %{}", usize::from(self.ptr))
+            format!("load volatile %{}", self.ptr.to_raw_index())
         } else {
-            format!("load %{}", usize::from(self.ptr))
+            format!("load %{}", self.ptr.to_raw_index())
         }
     }
 
@@ -3026,8 +3045,8 @@ impl InstT for LShr {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "lshr %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -3100,9 +3119,9 @@ impl InstT for MemCpy {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "memcpy %{}, %{}, %{}, {}",
-            usize::from(self.dst),
-            usize::from(self.src),
-            usize::from(self.len),
+            self.dst.to_raw_index(),
+            self.src.to_raw_index(),
+            self.len.to_raw_index(),
             if self.is_volatile { "true" } else { "false" }
         )
     }
@@ -3182,9 +3201,9 @@ impl InstT for MemSet {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "memset %{}, %{}, %{}, {}",
-            usize::from(self.dst),
-            usize::from(self.val),
-            usize::from(self.len),
+            self.dst.to_raw_index(),
+            self.val.to_raw_index(),
+            self.len.to_raw_index(),
             if self.is_volatile { "true" } else { "false" }
         )
     }
@@ -3267,7 +3286,11 @@ impl InstT for Mul {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("mul %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "mul %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -3345,7 +3368,11 @@ impl InstT for Or {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("or %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "or %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -3414,7 +3441,7 @@ impl InstT for PtrAdd {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("ptradd %{}, {}", usize::from(self.ptr), self.off)
+        format!("ptradd %{}, {}", self.ptr.to_raw_index(), self.off)
     }
 
     fn tyidx(&self, m: &dyn ModLikeT) -> TyIdx {
@@ -3479,7 +3506,7 @@ impl InstT for PtrToInt {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("ptrtoint %{}", usize::from(self.val))
+        format!("ptrtoint %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -3553,8 +3580,8 @@ impl InstT for SDiv {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "sdiv %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -3634,9 +3661,9 @@ impl InstT for Select {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "select %{}, %{}, %{}",
-            usize::from(self.cond),
-            usize::from(self.truev),
-            usize::from(self.falsev)
+            self.cond.to_raw_index(),
+            self.truev.to_raw_index(),
+            self.falsev.to_raw_index()
         )
     }
 
@@ -3707,7 +3734,7 @@ impl InstT for SExt {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("sext %{}", usize::from(self.val))
+        format!("sext %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -3782,7 +3809,11 @@ impl InstT for Shl {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("shl %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "shl %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -3847,7 +3878,7 @@ impl InstT for SIToFP {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("sitofp %{}", usize::from(self.val))
+        format!("sitofp %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -3920,8 +3951,8 @@ impl InstT for SMax {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "smax %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -3995,8 +4026,8 @@ impl InstT for SMin {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "smin %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -4064,8 +4095,8 @@ impl InstT for SRem {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "srem %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -4128,8 +4159,8 @@ impl InstT for Store {
         format!(
             "store {}%{}, %{}",
             if self.is_volatile { "volatile " } else { "" },
-            usize::from(self.val),
-            usize::from(self.ptr)
+            self.val.to_raw_index(),
+            self.ptr.to_raw_index()
         )
     }
 
@@ -4205,7 +4236,11 @@ impl InstT for Sub {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("sub %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "sub %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -4248,7 +4283,7 @@ impl InstT for Term {
             "term [{}]",
             self.0
                 .iter()
-                .map(|x| format!("%{}", usize::from(*x)))
+                .map(|x| format!("%{}", x.to_raw_index()))
                 .collect::<Vec<_>>()
                 .join(", ")
         )
@@ -4389,7 +4424,7 @@ impl InstT for Trunc {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("trunc %{}", usize::from(self.val))
+        format!("trunc %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -4463,8 +4498,8 @@ impl InstT for UDiv {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "udiv %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -4532,7 +4567,7 @@ impl InstT for UIToFP {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("uitofp %{}", usize::from(self.val))
+        format!("uitofp %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -4605,8 +4640,8 @@ impl InstT for UMax {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "umax %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -4680,8 +4715,8 @@ impl InstT for UMin {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "umin %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -4749,8 +4784,8 @@ impl InstT for URem {
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
         format!(
             "urem %{}, %{}",
-            usize::from(self.lhs),
-            usize::from(self.rhs)
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
         )
     }
 
@@ -4822,7 +4857,11 @@ impl InstT for Xor {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("xor %{}, %{}", usize::from(self.lhs), usize::from(self.rhs))
+        format!(
+            "xor %{}, %{}",
+            self.lhs.to_raw_index(),
+            self.rhs.to_raw_index()
+        )
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -4892,7 +4931,7 @@ impl InstT for ZExt {
     }
 
     fn to_string<M: ModLikeT, B: BlockLikeT>(&self, _m: &M, _b: &B) -> String {
-        format!("zext %{}", usize::from(self.val))
+        format!("zext %{}", self.val.to_raw_index())
     }
 
     fn tyidx(&self, _m: &dyn ModLikeT) -> TyIdx {
@@ -5070,7 +5109,8 @@ mod test {
 
     impl RegT for DummyReg {
         type RegIdx = DummyRegIdx;
-        const MAX_REGIDX: DummyRegIdx = DummyRegIdx::from_usize_unchecked(DummyReg::COUNT);
+        // `DummyReg` has fewer than `u8::MAX` variants, so its count fits in `DummyRegIdx`.
+        const MAX_REGIDX: DummyRegIdx = DummyRegIdx(DummyReg::COUNT as u8);
 
         fn undefined() -> Self {
             todo!()
@@ -5097,9 +5137,8 @@ mod test {
         }
     }
 
-    index_vec::define_index_type! {
-        pub(crate) struct DummyRegIdx = u8;
-    }
+    #[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+    pub(crate) struct DummyRegIdx(u8);
 
     struct DummyRegTestIter {}
 
@@ -5132,7 +5171,7 @@ mod test {
         };
         assert!(
             block
-                .inst(InstIdx::new(0))
+                .inst(InstIdx::from_raw_index(0))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>()
                 .is_empty()
@@ -5150,10 +5189,10 @@ mod test {
         };
         assert_eq!(
             block
-                .inst(InstIdx::new(1))
+                .inst(InstIdx::from_raw_index(1))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>(),
-            [InstIdx::new(0)]
+            [InstIdx::from_raw_index(0)]
         );
 
         // The `Two` case.
@@ -5169,10 +5208,10 @@ mod test {
         };
         assert_eq!(
             block
-                .inst(InstIdx::new(2))
+                .inst(InstIdx::from_raw_index(2))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>(),
-            [InstIdx::new(0), InstIdx::new(1)]
+            [InstIdx::from_raw_index(0), InstIdx::from_raw_index(1)]
         );
 
         // The `Three` case.
@@ -5189,10 +5228,14 @@ mod test {
         };
         assert_eq!(
             block
-                .inst(InstIdx::new(3))
+                .inst(InstIdx::from_raw_index(3))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>(),
-            [InstIdx::new(0), InstIdx::new(1), InstIdx::new(2)]
+            [
+                InstIdx::from_raw_index(0),
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(2)
+            ]
         );
 
         // The `Call` case.
@@ -5210,10 +5253,10 @@ mod test {
         };
         assert_eq!(
             block
-                .inst(InstIdx::new(2))
+                .inst(InstIdx::from_raw_index(2))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>(),
-            [InstIdx::new(0), InstIdx::new(1),]
+            [InstIdx::from_raw_index(0), InstIdx::from_raw_index(1),]
         );
 
         // The `Guard` case.
@@ -5230,10 +5273,14 @@ mod test {
         };
         assert_eq!(
             block
-                .inst(InstIdx::new(3))
+                .inst(InstIdx::from_raw_index(3))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>(),
-            [InstIdx::new(0), InstIdx::new(1), InstIdx::new(2)]
+            [
+                InstIdx::from_raw_index(0),
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(2)
+            ]
         );
 
         // The `Term` case.
@@ -5249,10 +5296,10 @@ mod test {
         };
         assert_eq!(
             block
-                .inst(InstIdx::new(2))
+                .inst(InstIdx::from_raw_index(2))
                 .iter_iidxs(block)
                 .collect::<Vec<_>>(),
-            [InstIdx::new(0), InstIdx::new(1)]
+            [InstIdx::from_raw_index(0), InstIdx::from_raw_index(1)]
         );
     }
 
@@ -6447,10 +6494,10 @@ mod test {
                 opt.feed(inst).unwrap();
             }
         }
-        let tyidx = TyIdx::from_usize(0);
-        let tyidx1 = TyIdx::from_usize(1);
-        let val = InstIdx::from_usize(0);
-        let val1 = InstIdx::from_usize(1);
+        let tyidx = TyIdx::from_raw_index(0);
+        let tyidx1 = TyIdx::from_raw_index(1);
+        let val = InstIdx::from_raw_index(0);
+        let val1 = InstIdx::from_raw_index(1);
 
         // FIXME: We need the series of tests below for every HIR element.
         let rhs = Inst::Abs(Abs {

--- a/ykrt/src/compile/j2/hir_parser.rs
+++ b/ykrt/src/compile/j2/hir_parser.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     mt::TraceId,
 };
-use index_vec::IndexVec;
+use index_type::{IndexType, vec::TypedVec};
 use lrlex::{DefaultLexerTypes, LRNonStreamingLexer, lrlex_mod};
 use lrpar::{NonStreamingLexer, Span, lrpar_mod};
 use smallvec::SmallVec;
@@ -49,15 +49,15 @@ type StorageT = u16;
 /// binary, not a ykllvm compiled C program. If we want to use a [DeoptStatepoint] in tests, we
 /// have to create a dummy.
 static TEST_DEOPT_STATEPOINT: LazyLock<Statepoint> = LazyLock::new(|| Statepoint {
-    smapidx: StackMapIdx::from(0),
+    smapidx: StackMapIdx::from_raw_index(0),
     lives: Vec::new(),
 });
 
 struct HirParser<'lexer, 'input: 'lexer, Reg: RegT> {
     lexer: &'lexer LRNonStreamingLexer<'lexer, 'input, DefaultLexerTypes<StorageT>>,
     externs: HashMap<&'input str, (TyIdx, Vec<AstFuncAttr>)>,
-    insts: IndexVec<InstIdx, Inst>,
-    tys: IndexVec<TyIdx, Ty>,
+    insts: TypedVec<InstIdx, Inst>,
+    tys: TypedVec<TyIdx, Ty>,
     /// The [TyIdx] for [Ty::Int(1)].
     tyidx_int1: TyIdx,
     /// The [TyIdx] for [Ty::Ptr(0)].
@@ -133,11 +133,11 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
         }
 
         let mut args_vlocs = Vec::new();
-        let mut guards = IndexVec::new();
+        let mut guards = TypedVec::new();
         let mut testregiter = Reg::iter_test_regs();
         let mut autoregused = false;
         let mut manualregused = false;
-        let mut smaps = IndexVec::new();
+        let mut smaps: TypedVec<StackMapIdx, Vec<VarLocs<Reg>>> = TypedVec::new();
         for inst in astinsts {
             match inst {
                 AstInst::Blackbox(span) => {
@@ -528,7 +528,7 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
                         .into_iter()
                         .map(|x| self.p_local(x))
                         .collect::<Vec<_>>();
-                    let mut deopt_frames = SmallVec::with_capacity(smaps.len());
+                    let mut deopt_frames = SmallVec::with_capacity(smaps.len_usize());
                     for x in gsmaps {
                         let lives = x
                             .into_iter()
@@ -541,7 +541,7 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
                                 BBlockInstIdx::new(0),
                             ),
                             pc_statepoint: &TEST_DEOPT_STATEPOINT,
-                            smapidx: smaps.len_idx(),
+                            smapidx: smaps.len(),
                         });
                         smaps.push(lives);
                     }
@@ -1054,7 +1054,7 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
         if n != self.insts.len() {
             self.err_span(
                 span,
-                &format!("Incorrect local: should be '%{}'", self.insts.len()),
+                &format!("Incorrect local: should be '%{}'", self.insts.len_usize()),
             );
         }
     }
@@ -1064,7 +1064,7 @@ impl<'lexer, 'input: 'lexer, Reg: RegT> HirParser<'lexer, 'input, Reg> {
         assert_eq!(s.chars().nth(0).unwrap(), '%');
         s[1..]
             .parse::<u32>()
-            .map(|x| InstIdx::from(usize::try_from(x).unwrap()))
+            .map(|x| InstIdx::from_raw_index(usize::try_from(x).unwrap()))
             .unwrap_or_else(|e| self.err_span(span, &e.to_string()))
     }
 
@@ -1219,7 +1219,7 @@ pub(super) fn str_to_mod<Reg: RegT>(s: &str) -> Mod<Reg> {
         panic!("No AST produced")
     };
 
-    let mut tys = IndexVec::new();
+    let mut tys = TypedVec::new();
     let mut ty_map = HashMap::new();
     let tyidx_void = tys.push(Ty::Void);
     ty_map.insert(Ty::Void, tyidx_void);
@@ -1231,7 +1231,7 @@ pub(super) fn str_to_mod<Reg: RegT>(s: &str) -> Mod<Reg> {
     let hp = HirParser {
         lexer: &lexer,
         externs: HashMap::new(),
-        insts: IndexVec::new(),
+        insts: TypedVec::new(),
         tys,
         tyidx_int1,
         tyidx_ptr0,

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -110,7 +110,7 @@ use crate::{
     mt::{MT, TraceId},
     varlocs,
 };
-use index_vec::IndexVec;
+use index_type::{IndexType, vec::TypedVec};
 use parking_lot::Mutex;
 use smallvec::{SmallVec, smallvec};
 use std::{ffi::c_void, sync::Arc};
@@ -124,9 +124,9 @@ pub(super) struct HirToAsm<'a, AB: HirToAsmBackend> {
     log: bool,
     /// The intermediate [AsmGuard] for each [Guard] block in a trace's "main" (i.e. non-[Guard])
     /// blocks. These use [GuardBlockIdx] to emphasise that there is a 1:1 mapping between
-    /// [GuardExtra::gbidx] and this [IndexVec].
+    /// [GuardExtra::gbidx] and this [TypedVec].
     /// These will initially be set to `None`; as the main blocks are processed, they will be set
-    /// to `Some`. Note: [Self::asm_guards] will empty this [IndexVec] completely.
+    /// to `Some`. Note: [Self::asm_guards] will empty this [TypedVec] completely.
     gexits: Vec<GuardExit<'a, AB>>,
 }
 
@@ -149,7 +149,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
                 // FIXME: Relying on stackmap 0 being the control point is a horrible hack.
                 let base_stack_off = u32::try_from({
-                    let (smap, prologue) = aot_smaps.get(StackMapIdx::from(0));
+                    let (smap, prologue) = aot_smaps.get(StackMapIdx::from_raw_index(0));
                     if prologue.hasfp {
                         // FIXME: This needs porting! https://github.com/ykjit/yk/issues/1936
                         #[cfg(not(target_arch = "x86_64"))]
@@ -266,7 +266,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                         self.be.star_return_end(
                             &mut ra,
                             entry,
-                            InstIdx::from(entry.insts_len() - 1),
+                            InstIdx::from_raw_index(entry.insts_len() - 1),
                             exit_statepoint,
                             rtn_val,
                         )?;
@@ -337,7 +337,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                         self.be.star_return_end(
                             &mut ra,
                             entry,
-                            InstIdx::from(entry.insts_len() - 1),
+                            InstIdx::from_raw_index(entry.insts_len() - 1),
                             exit_statepoint,
                             rtn_val,
                         )?;
@@ -388,7 +388,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     )
                 },
             )
-            .collect::<IndexVec<_, _>>();
+            .collect::<TypedVec<_, _>>();
 
         if self.log {
             let ds = if let Some(x) = &self.hl.lock().debug_str {
@@ -485,7 +485,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             .iter()
             .enumerate()
             .map(|(iidx, vlocs)| {
-                if matches!(peel.inst(InstIdx::from(iidx)), Inst::Const(_)) {
+                if matches!(peel.inst(InstIdx::from_raw_index(iidx)), Inst::Const(_)) {
                     VarLocs::new()
                 } else if let Some(x) = vlocs.iter().find(|x| matches!(x, VarLoc::Reg(_, _))) {
                     let mut new_vlocs = vlocs.clone();
@@ -520,7 +520,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                            cur_iidx: InstIdx,
                            op_iidx: InstIdx| {
             if let Inst::Arg(_) = peel.inst(op_iidx)
-                && !peel_vlocs[usize::from(op_iidx)]
+                && !peel_vlocs[op_iidx.to_raw_index()]
                     .iter()
                     .any(|x| matches!(x, VarLoc::Reg(_, _)))
                 && let Some(reg) =
@@ -529,13 +529,13 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 if peel.term_vars().contains(&op_iidx) {
                     // For loop invariant values, we want to reuse stack values if there are any:
                     // donig so means we won't need to respill in the peel.
-                    peel_vlocs[usize::from(op_iidx)].push(VarLoc::Reg(reg, RegFill::Undefined));
+                    peel_vlocs[op_iidx.to_raw_index()].push(VarLoc::Reg(reg, RegFill::Undefined));
                 } else {
                     // If this value isn't loop invariant, erasing any stack values is a win: if
                     // we're really lucky the value will never need to be spilt; if we're unlucky,
                     // it will at worst be spilt part of the way through a trace (and won't need a
                     // costly move at the trace's end).
-                    peel_vlocs[usize::from(op_iidx)] =
+                    peel_vlocs[op_iidx.to_raw_index()] =
                         varlocs![VarLoc::Reg(reg, RegFill::Undefined)];
                 }
             }
@@ -570,7 +570,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
     /// Assemble guards.
     fn asm_guards(
         &mut self,
-    ) -> Result<IndexVec<CompiledGuardIdx, GuardBody<AB>>, CompilationError> {
+    ) -> Result<TypedVec<CompiledGuardIdx, GuardBody<AB>>, CompilationError> {
         // For each guard we've encountered while assembling the main [Block]s, we now get the
         // backend to produce code for the associated guard body. We've already identified which
         // instructions should end up in the guard body, so this isn't too difficult: we create a
@@ -579,7 +579,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
 
         // Since we're creating temporary [Block]s, we can reuse the allocation for its
         // instructions and term_vars, so we hoist these out of the loop.
-        let mut ginsts: IndexVec<InstIdx, Inst> = IndexVec::new();
+        let mut ginsts: TypedVec<InstIdx, Inst> = TypedVec::new();
         let mut gterms: Vec<InstIdx> = Vec::new();
 
         // There is a little bit of awkwardness in testing mode, where there are no stackmaps:
@@ -588,8 +588,8 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
         let aot_smaps = AOT_STACKMAPS.as_ref().unwrap();
 
         let gexits = std::mem::take(&mut self.gexits);
-        let mut gbodies: IndexVec<CompiledGuardIdx, GuardBody<AB>> =
-            IndexVec::with_capacity(gexits.len());
+        let mut gbodies: TypedVec<CompiledGuardIdx, GuardBody<AB>> =
+            TypedVec::with_capacity(gexits.len());
         for gexit in gexits.into_iter() {
             let gextra = gexit.block.gextra(gexit.geidx);
 
@@ -606,7 +606,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             ginsts.clear();
             let mut gblock = Block {
                 insts: std::mem::take(&mut ginsts),
-                guard_extras: IndexVec::new(),
+                guard_extras: TypedVec::new(),
             };
 
             // Given an [InstIdx] `x` from the main `Block`, return its position in the guard's
@@ -615,9 +615,9 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             // be done with a binary search.
             let map = |x: InstIdx| {
                 if let Ok(i) = gexit.exit_vars.binary_search(&x) {
-                    InstIdx::from(i)
+                    InstIdx::from_raw_index(i)
                 } else if let Ok(i) = gexit.copy_in.binary_search(&x) {
-                    InstIdx::from(gexit.exit_vars.len() + i)
+                    InstIdx::from_raw_index(gexit.exit_vars.len() + i)
                 } else {
                     panic!()
                 }
@@ -659,7 +659,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     .iter()
                     .take(frame.pc_statepoint.lives.len());
                 #[cfg(test)]
-                let smap_lives_iter = self.m.smaps[usize::from(frame.smapidx)].iter();
+                let smap_lives_iter = self.m.smaps[frame.smapidx].iter();
 
                 for smap_loc in smap_lives_iter {
                     let (deopt_iidx, term_iidx) = deopt_term_iter.next().unwrap();
@@ -757,7 +757,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             assert!(!gblock.insts.is_empty());
 
             let mut merged = false;
-            let mut gidx = gbodies.len_idx();
+            let mut gidx = gbodies.len();
             for (cnd_gidx, gbody) in gbodies.iter_mut_enumerated() {
                 // NOTE: at this point we don't know what the `extra_stack_len` of the
                 // about-to-be-created sidetrace is, so we can't factor that into our comparison.
@@ -788,7 +788,10 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 .map(|x| x.fromvlocs.clone())
                 .collect::<Vec<_>>();
             let patch_label = self.be.guard_end(self.m.trid, gidx, &vlocs)?;
-            ra.keep_alive_at_term(InstIdx::from(gblock.insts.len() - 1), gblock.term_vars());
+            ra.keep_alive_at_term(
+                InstIdx::from_raw_index(gblock.insts.len_usize() - 1),
+                gblock.term_vars(),
+            );
             stack_off = self.p_block(&gblock, None, ra, &gexit.exit_vlocs)?;
             let extra_stack_len = stack_off - gexit.stack_off;
             if merged {
@@ -824,7 +827,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 });
             }
             if self.log {
-                self.be.log(format!("gidx {gidx:?}"));
+                self.be.log(format!("gidx {}", gidx.to_raw_index()));
             }
 
             // Make sure we reuse the `ginsts` and `gterms` allocations.
@@ -853,7 +856,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
         } else {
             self.be.log(format!(
                 "%{}: {} = {}{extra}",
-                usize::from(iidx),
+                iidx.to_raw_index(),
                 ty.to_string(self.m),
                 inst.to_string(self.m, b)
             ));
@@ -882,15 +885,15 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 show.set(i, true);
             }
             for (iidx, inst) in b.insts_iter(..).rev() {
-                if show[usize::from(iidx)]
+                if show[iidx.to_raw_index()]
                     || inst.write_effects().interferes(Effects::all())
                     || inst
                         .read_effects()
                         .interferes(Effects::none().add_volatile())
                 {
-                    show.set(usize::from(iidx), true);
+                    show.set(iidx.to_raw_index(), true);
                     for op_iidx in inst.iter_iidxs(b) {
-                        show.set(usize::from(op_iidx), true);
+                        show.set(op_iidx.to_raw_index(), true);
                     }
                 }
             }
@@ -1062,12 +1065,13 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                             // We can copy non-volatile `Load`s in if there are no write effects
                             // between the `Load` and the current guard.
                             if ra.is_used(giidx)
-                                || b.insts_iter(giidx + 1..iidx).any(|(_, inst)| {
-                                    inst.write_effects()
-                                        .interferes(Effects::all().minus_guard())
-                                })
+                                || b.insts_iter(giidx.checked_add_scalar(1).unwrap()..iidx)
+                                    .any(|(_, inst)| {
+                                        inst.write_effects()
+                                            .interferes(Effects::all().minus_guard())
+                                    })
                             {
-                                gexit_vars.set(usize::from(giidx), true);
+                                gexit_vars.set((giidx).to_raw_index(), true);
                                 continue;
                             }
                         } else if inst.read_write_effects().interferes(Effects::all())
@@ -1078,12 +1082,12 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                             // We don't copy instructions that are used by non-guard instructions
                             // unless: they're a `Const`; aren't in a register; don't have
                             // side-effects.
-                            gexit_vars.set(usize::from(giidx), true);
+                            gexit_vars.set((giidx).to_raw_index(), true);
                             continue;
                         }
 
                         // We can copy this instruction!
-                        gcopy.set(usize::from(giidx), true);
+                        gcopy.set((giidx).to_raw_index(), true);
                         // Add all this instruction's operand references to the queue.
                         for op_iidx in inst.iter_iidxs(b) {
                             gqueue.push(op_iidx);
@@ -1094,7 +1098,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     // guard.
                     let exit_vars = gexit_vars
                         .iter_set_bits(..)
-                        .map(InstIdx::from)
+                        .map(InstIdx::from_raw_index)
                         .collect::<Vec<_>>();
                     let label = self.be.i_guard(&mut ra, b, iidx, x, &exit_vars)?;
                     let exit_vlocs = ra.vlocs_from_iidxs(&exit_vars);
@@ -1106,7 +1110,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                         exit_vlocs,
                         copy_in: gcopy
                             .iter_set_bits(..)
-                            .map(InstIdx::from)
+                            .map(InstIdx::from_raw_index)
                             .collect::<Vec<_>>(),
                         stack_off: ra.stack_off(),
                     });
@@ -1251,7 +1255,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     }
                 }
             }
-            if self.log && logging_show[usize::from(iidx)] {
+            if self.log && logging_show[iidx.to_raw_index()] {
                 self.log_inst(b, iidx, "");
             }
         }
@@ -1262,7 +1266,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
         ra.set_args_vlocs_at_start(&mut self.be, args_vlocs);
         if self.log {
             for (iidx, _inst) in insts_iter {
-                let pp_vlocs = args_vlocs[usize::from(iidx)]
+                let pp_vlocs = args_vlocs[iidx.to_raw_index()]
                     .iter()
                     .map(|x| x.to_string())
                     .collect::<Vec<_>>()
@@ -1956,18 +1960,19 @@ mod test {
 
     impl RegT for TestReg {
         type RegIdx = TestRegIdx;
-        const MAX_REGIDX: TestRegIdx = TestRegIdx::from_usize_unchecked(TestReg::COUNT);
+        // `TestReg` has fewer than `u8::MAX` variants, so its count fits in `TestRegIdx`.
+        const MAX_REGIDX: TestRegIdx = TestRegIdx(TestReg::COUNT as u8);
 
         fn undefined() -> Self {
             TestReg::Undefined
         }
 
         fn from_regidx(idx: Self::RegIdx) -> Self {
-            TestReg::from_repr(idx.raw()).unwrap()
+            TestReg::from_repr(idx.to_scalar()).unwrap()
         }
 
         fn regidx(&self) -> Self::RegIdx {
-            TestRegIdx::from(*self as usize)
+            TestRegIdx::from_raw_index(*self as usize)
         }
 
         fn is_caller_saved(&self) -> bool {
@@ -1989,9 +1994,8 @@ mod test {
         }
     }
 
-    index_vec::define_index_type! {
-        pub(crate) struct TestRegIdx = u8;
-    }
+    #[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+    pub(crate) struct TestRegIdx(u8);
 
     struct TestRegTestIter<Reg> {
         gp_regs: Box<dyn Iterator<Item = Reg>>,
@@ -2030,9 +2034,13 @@ mod test {
         }
     }
 
-    index_vec::define_index_type! {
-        struct TestLabelIdx = u32;
-        IMPL_RAW_CONVERSIONS = true;
+    #[derive(Clone, Copy, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+    struct TestLabelIdx(u32);
+
+    impl std::fmt::Debug for TestLabelIdx {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Debug::fmt(&self.to_raw_index(), f)
+        }
     }
 
     struct TestPeelRegsBuilder {
@@ -2049,7 +2057,7 @@ mod test {
 
     impl PeelRegsBuilderT<TestReg> for TestPeelRegsBuilder {
         fn force_set(&mut self, reg: TestReg) {
-            self.set_regs[usize::from(reg.regidx())] = true;
+            self.set_regs[reg.regidx().to_raw_index()] = true;
         }
 
         fn is_full(&self, _ignore_caller_save: bool) -> bool {
@@ -2163,13 +2171,13 @@ mod test {
 
         fn controlpoint_loop_end(&mut self) -> Result<Self::Label, CompilationError> {
             self.log.push("controlpoint_loop_end".to_owned());
-            Ok(TestLabelIdx::new(1))
+            Ok(TestLabelIdx::from_raw_index(1))
         }
 
         fn controlpoint_peel_start(&mut self, peel_label: Self::Label) -> Self::Label {
             self.log
                 .push(format!("controlpoint_peel_start {peel_label:?}"));
-            TestLabelIdx::new(2)
+            TestLabelIdx::from_raw_index(2)
         }
 
         fn controlpoint_loop_start(&mut self, post_stack_label: Self::Label, stack_off: u32) {
@@ -2189,7 +2197,7 @@ mod test {
             _gidx: CompiledGuardIdx,
             _args_vlocs: &[VarLocs<Self::Reg>],
         ) -> Result<Self::Label, CompilationError> {
-            Ok(TestLabelIdx::new(0))
+            Ok(TestLabelIdx::from_raw_index(0))
         }
 
         fn guard_completed(
@@ -2289,7 +2297,7 @@ mod test {
                     .collect::<Vec<_>>()
                     .join(", "),
             ));
-            Ok(TestLabelIdx::new(0))
+            Ok(TestLabelIdx::from_raw_index(0))
         }
 
         fn i_load(

--- a/ykrt/src/compile/j2/opt/cse.rs
+++ b/ykrt/src/compile/j2/opt/cse.rs
@@ -24,7 +24,7 @@ use crate::compile::j2::{
         fullopt::{CommitInstOpt, OptOutcome, PassOpt, PassT},
     },
 };
-use index_vec::IndexVec;
+use index_type::{IndexType, vec::TypedVec};
 use strum::EnumCount;
 
 /// Common supexpression elimination.
@@ -47,10 +47,10 @@ impl CSE {
         // Because we use `HEAD_UINT::MAX` as our "we haven't seen anything here yet" value, we
         // have to make sure we won't overlap with a genuine value.
         const {
-            assert!(InstIdx::MAX_INDEX > Inst::COUNT);
+            assert!(InstIdx::MAX_RAW_INDEX > Inst::COUNT);
         }
         Self {
-            heads: [InstIdx::from_usize(InstIdx::MAX_INDEX); Inst::COUNT],
+            heads: [InstIdx::MAX_INDEX; Inst::COUNT],
             predecessors: Vec::new(),
         }
     }
@@ -71,14 +71,17 @@ impl PassT for CSE {
 
         // Work out what the maximum iidx this instruction refers to: we know there's no point
         // going further back than that.
-        let max_ref = inst.iter_iidxs(opt).max().unwrap_or(InstIdx::from(0));
+        let max_ref = inst
+            .iter_iidxs(opt)
+            .max()
+            .unwrap_or(InstIdx::from_raw_index(0));
         let mut cur = self.heads[InstDiscriminants::from(&inst) as usize];
         while cur != InstIdx::MAX_INDEX && cur >= max_ref {
             let equiv = opt.equiv_iidx(cur);
             if equiv >= max_ref && opt.inst(equiv).cse_eq(opt, &inst) {
                 return OptOutcome::Equiv(equiv);
             }
-            cur = self.predecessors[usize::from(cur)];
+            cur = self.predecessors[(cur).to_raw_index()];
         }
         OptOutcome::Rewritten(inst)
     }
@@ -92,7 +95,7 @@ impl PassT for CSE {
         let dim_off = InstDiscriminants::from(inst) as usize;
         let prev = self.heads[dim_off];
         self.predecessors.push(prev);
-        self.heads[dim_off] = InstIdx::from_usize(self.predecessors.len() - 1);
+        self.heads[dim_off] = InstIdx::from_raw_index(self.predecessors.len() - 1);
     }
 
     fn equiv_committed(&mut self, _equiv1: InstIdx, _equiv2: InstIdx) {}
@@ -101,9 +104,9 @@ impl PassT for CSE {
         &mut self,
         opt: &mut PassOpt,
         _entry: &Block,
-        _map: &IndexVec<InstIdx, InstIdx>,
+        _map: &TypedVec<InstIdx, InstIdx>,
     ) {
-        self.heads = [InstIdx::from_usize(InstIdx::MAX_INDEX); Inst::COUNT];
+        self.heads = [InstIdx::MAX_INDEX; Inst::COUNT];
         self.predecessors.clear();
         for _ in 0..opt.insts_len() {
             self.predecessors.push(InstIdx::MAX);

--- a/ykrt/src/compile/j2/opt/fullopt.rs
+++ b/ykrt/src/compile/j2/opt/fullopt.rs
@@ -132,7 +132,7 @@ use crate::compile::{
         },
     },
 };
-use index_vec::*;
+use index_type::{IndexType, typed_vec, vec::TypedVec};
 use smallvec::SmallVec;
 use std::{
     assert_matches,
@@ -153,7 +153,7 @@ pub(in crate::compile::j2) struct FullOpt {
 
 impl FullOpt {
     pub(in crate::compile::j2) fn new() -> Self {
-        let mut tys = IndexVec::new();
+        let mut tys = TypedVec::new();
         let mut ty_map = HashMap::new();
         let tyidx_void = tys.push(Ty::Void);
         ty_map.insert(Ty::Void, tyidx_void);
@@ -169,9 +169,9 @@ impl FullOpt {
                 Box::new(CSE::new()),
             ],
             inner: OptInternal {
-                insts: IndexVec::new(),
+                insts: TypedVec::new(),
                 consts_map: HashMap::new(),
-                guard_extras: IndexVec::new(),
+                guard_extras: TypedVec::new(),
                 tys,
                 tyidx_int1,
                 tyidx_ptr0,
@@ -182,11 +182,11 @@ impl FullOpt {
     }
 
     #[cfg(test)]
-    pub(in crate::compile::j2) fn new_testing(tys: IndexVec<TyIdx, Ty>) -> Self {
+    pub(in crate::compile::j2) fn new_testing(tys: TypedVec<TyIdx, Ty>) -> Self {
         let ty_map = HashMap::from_iter(
             tys.iter()
                 .enumerate()
-                .map(|(x, y)| (y.to_owned(), TyIdx::from(x))),
+                .map(|(x, y)| (y.to_owned(), TyIdx::from_raw_index(x))),
         );
         let tyidx_ptr0 = *ty_map.get(&Ty::Ptr(0)).unwrap_or_else(|| panic!());
         let tyidx_void = *ty_map.get(&Ty::Void).unwrap_or_else(|| panic!());
@@ -199,9 +199,9 @@ impl FullOpt {
                 Box::new(CSE::new()),
             ],
             inner: OptInternal {
-                insts: IndexVec::new(),
+                insts: TypedVec::new(),
                 consts_map: HashMap::new(),
-                guard_extras: IndexVec::new(),
+                guard_extras: TypedVec::new(),
                 tys,
                 tyidx_int1,
                 tyidx_ptr0,
@@ -280,7 +280,7 @@ impl FullOpt {
         F: FnMut(&mut dyn PassT, &CommitInstOpt, InstIdx),
     {
         if let Inst::Const(x) = &inst {
-            let iidx = self.inner.insts.len_idx();
+            let iidx = self.inner.insts.len();
             self.inner
                 .consts_map
                 .insert(HashableConst(x.to_owned()), iidx);
@@ -322,11 +322,11 @@ impl ModLikeT for FullOpt {
 
 impl BlockLikeT for FullOpt {
     fn inst(&self, idx: InstIdx) -> &Inst {
-        &self.inner.insts[usize::from(idx)].inst
+        &self.inner.insts[idx].inst
     }
 
     fn insts_len(&self) -> usize {
-        self.inner.insts.len()
+        self.inner.insts.len_usize()
     }
 
     fn gextra(&self, geidx: GuardExtraIdx) -> &GuardExtra {
@@ -339,7 +339,7 @@ impl BlockLikeT for FullOpt {
 }
 
 impl OptT for FullOpt {
-    fn build(self: Box<Self>) -> Result<(Block, IndexVec<TyIdx, Ty>), CompilationError> {
+    fn build(self: Box<Self>) -> Result<(Block, TypedVec<TyIdx, Ty>), CompilationError> {
         Ok((
             Block {
                 insts: self
@@ -347,7 +347,7 @@ impl OptT for FullOpt {
                     .insts
                     .into_iter()
                     .map(|x| x.inst)
-                    .collect::<IndexVec<_, _>>(),
+                    .collect::<TypedVec<_, _>>(),
                 guard_extras: self.inner.guard_extras,
             },
             self.inner.tys,
@@ -356,14 +356,14 @@ impl OptT for FullOpt {
 
     fn build_with_peel(
         mut self: Box<Self>,
-    ) -> Result<(Block, Option<Block>, IndexVec<TyIdx, Ty>), CompilationError> {
+    ) -> Result<(Block, Option<Block>, TypedVec<TyIdx, Ty>), CompilationError> {
         // First of all create the entry iteration `Block`. This is useful when we're creating the
         // peel `Block` below.
         let entry = Block {
             insts: mem::take(&mut self.inner.insts)
                 .into_iter()
                 .map(|x| x.inst)
-                .collect::<IndexVec<_, _>>(),
+                .collect::<TypedVec<_, _>>(),
             guard_extras: mem::take(&mut self.inner.guard_extras),
         };
         self.inner.consts_map.clear();
@@ -371,26 +371,26 @@ impl OptT for FullOpt {
 
         // Dead code analysis: we don't want to waste energy feeding things into the peel that
         // can't possibly be used.
-        let mut is_used = Vob::from_elem(false, entry.insts.len());
+        let mut is_used = Vob::from_elem(false, entry.insts.len_usize());
         for (iidx, inst) in entry.insts_iter(..).rev() {
-            if is_used[usize::from(iidx)]
+            if is_used[iidx.to_raw_index()]
                 || inst
                     .read_effects()
                     .interferes(Effects::none().add_volatile())
                 || inst.write_effects().interferes(Effects::all())
             {
-                is_used.set(usize::from(iidx), true);
+                is_used.set(iidx.to_raw_index(), true);
                 for op_iidx in inst.iter_iidxs(&entry) {
-                    is_used.set(usize::from(op_iidx), true);
+                    is_used.set(op_iidx.to_raw_index(), true);
                 }
             }
         }
 
         // For each terminal exit variable in the entry block, create an arg/const in the peel
         // block.
-        let mut map = index_vec![InstIdx::MAX; entry.insts.len()];
+        let mut map = typed_vec![InstIdx::MAX; entry.insts.len_usize()];
         for entry_iidx in entry.term_vars() {
-            let peel_iidx = self.inner.insts.len_idx();
+            let peel_iidx = self.inner.insts.len();
             // FIXME: The next line won't work when we do loop-invariant code motion.
             map[peel_iidx] = peel_iidx;
             map[*entry_iidx] = peel_iidx;
@@ -430,8 +430,8 @@ impl OptT for FullOpt {
         }
 
         // Feed each instruction from `entry` (except the arguments!) into the peel.
-        for iidx in (entry.term_vars().len()..entry.insts_len()).map(InstIdx::new) {
-            if !is_used[usize::from(iidx)] {
+        for iidx in (entry.term_vars().len()..entry.insts_len()).map(InstIdx::from_raw_index) {
+            if !is_used[iidx.to_raw_index()] {
                 continue;
             }
             let mut inst = entry.inst(iidx).clone();
@@ -477,7 +477,7 @@ impl OptT for FullOpt {
             insts: mem::take(&mut self.inner.insts)
                 .into_iter()
                 .map(|x| x.inst)
-                .collect::<IndexVec<_, _>>(),
+                .collect::<TypedVec<_, _>>(),
             guard_extras: mem::take(&mut self.inner.guard_extras),
         };
 
@@ -525,13 +525,13 @@ impl EquivIIdxT for FullOpt {
 // The shared part of the optimiser.
 
 struct OptInternal {
-    insts: IndexVec<InstIdx, InstEquiv>,
+    insts: TypedVec<InstIdx, InstEquiv>,
     /// A map allowing us to deduplicate constants. Note the use of [HashableConst]: constant
     /// deduplication is "best effort" because of the difficulties imposed by floating point
     /// numbers.
     consts_map: HashMap<HashableConst, InstIdx>,
-    guard_extras: IndexVec<GuardExtraIdx, GuardExtra>,
-    tys: IndexVec<TyIdx, Ty>,
+    guard_extras: TypedVec<GuardExtraIdx, GuardExtra>,
+    tys: TypedVec<TyIdx, Ty>,
     /// The [TyIdx] for [Ty::Int(1)].
     tyidx_int1: TyIdx,
     /// The [TyIdx] for [Ty::Ptr(0)].
@@ -661,7 +661,7 @@ pub(super) trait PassT {
         &mut self,
         opt: &mut PassOpt,
         entry: &Block,
-        map: &IndexVec<InstIdx, InstIdx>,
+        map: &TypedVec<InstIdx, InstIdx>,
     );
 }
 
@@ -704,7 +704,9 @@ impl PassOpt<'_> {
         {
             return *x;
         }
-        let iidx = InstIdx::from_usize(self.optinternal.insts.len() + self.inner.pre_insts.len());
+        let iidx = InstIdx::from_raw_index(
+            self.optinternal.insts.len_usize() + self.inner.pre_insts.len(),
+        );
         self.inner.pre_insts.push(preinst);
         iidx
     }
@@ -729,7 +731,7 @@ impl BlockLikeT for PassOpt<'_> {
     }
 
     fn insts_len(&self) -> usize {
-        self.optinternal.insts.len()
+        self.optinternal.insts.len_usize()
     }
 
     fn gextra(&self, geidx: GuardExtraIdx) -> &GuardExtra {
@@ -812,7 +814,7 @@ impl BlockLikeT for CommitInstOpt<'_> {
     }
 
     fn insts_len(&self) -> usize {
-        self.inner.insts.len()
+        self.inner.insts.len_usize()
     }
 
     fn gextra(&self, _geidx: GuardExtraIdx) -> &GuardExtra {
@@ -857,7 +859,7 @@ pub(in crate::compile::j2) mod test {
     use super::*;
     use crate::compile::j2::{hir_parser::str_to_mod, regalloc::RegT, regalloc::test::TestReg};
     use fm::FMBuilder;
-    use index_vec::IndexVec;
+    use index_type::vec::TypedVec;
     use lazy_static::lazy_static;
     use regex::Regex;
 
@@ -897,10 +899,10 @@ pub(in crate::compile::j2) mod test {
         // all, so when we get to `blackbox %2` there is no `%2` to reference: we'd get an
         // out-of-bounds error! We thus need to rewrite this to `blackbox %0` _before_ feeding the
         // instruction to the optimiser.
-        let mut opt_map = IndexVec::with_capacity(insts.len());
+        let mut opt_map = TypedVec::with_capacity(insts.len_usize());
         let mut insts_iter = insts.into_iter();
         for _ in 0..args_vlocs.len() {
-            opt_map.push(opt_map.len_idx());
+            opt_map.push(opt_map.len());
             fopt.feed_arg(insts_iter.next().unwrap().clone()).unwrap();
         }
         for inst in insts_iter {
@@ -910,14 +912,14 @@ pub(in crate::compile::j2) mod test {
                 x.geidx = GuardExtraIdx::MAX;
                 fopt.feed_guard(x, fopt.inner.guard_extras[geidx].clone())
                     .unwrap();
-                opt_map.push(opt_map.len_idx());
+                opt_map.push(opt_map.len());
             } else if let Inst::Arg(_) = inst {
                 unreachable!();
             } else if *m.ty(inst.tyidx(&m)) == Ty::Void {
                 if let Some(x) = fopt.feed_void(inst).unwrap() {
                     opt_map.push(x);
                 } else {
-                    opt_map.push(opt_map.len_idx());
+                    opt_map.push(opt_map.len());
                 }
             } else {
                 opt_map.push(fopt.feed(inst).unwrap());
@@ -1000,7 +1002,7 @@ pub(in crate::compile::j2) mod test {
         }
         // We need to maintain a manual map of iidxs the user has written in their test to the
         // current state of the actual optimiser. See the comment in [full_opt_test].
-        let mut opt_map = IndexVec::with_capacity(insts.len());
+        let mut opt_map = TypedVec::with_capacity(insts.len_usize());
         for mut inst in insts.into_iter() {
             inst.rewrite_iidxs(&mut *fopt, |x| opt_map[x]);
             let mut popt_inner = PassOptInner::new();
@@ -1042,7 +1044,7 @@ pub(in crate::compile::j2) mod test {
                 }
             }
 
-            let iidx = fopt.inner.insts.len_idx();
+            let iidx = fopt.inner.insts.len();
             opt_map.push(iidx);
             fopt.inner.insts.push(InstEquiv {
                 inst,

--- a/ykrt/src/compile/j2/opt/known_bits.rs
+++ b/ykrt/src/compile/j2/opt/known_bits.rs
@@ -13,14 +13,14 @@ use crate::compile::{
     },
     jitc_yk::arbbitint::ArbBitInt,
 };
-use index_vec::IndexVec;
+use index_type::vec::TypedVec;
 
 /// Known-bits analysis.
 pub(super) struct KnownBits {
     /// Maps an SSA value to its corresponding known bits.  The value is None by default when
     /// unpopulated. When querying for the value, a None value is returned as a `KnownBitValue`
     /// with all bits set to unknown.
-    known_bits: IndexVec<InstIdx, Option<KnownBitValue>>,
+    known_bits: TypedVec<InstIdx, Option<KnownBitValue>>,
     /// The KnownBitValue of the current instruction being processed. This is only committed at
     /// the end of the instruction's analysis.
     pending_commit: Option<KnownBitValue>,
@@ -78,10 +78,10 @@ impl PassT for KnownBits {
         &mut self,
         opt: &mut PassOpt,
         entry: &Block,
-        map: &IndexVec<InstIdx, InstIdx>,
+        map: &TypedVec<InstIdx, InstIdx>,
     ) {
         assert!(self.pending_commit.is_none());
-        let mut new = IndexVec::with_capacity(entry.insts_len());
+        let mut new = TypedVec::with_capacity(entry.insts_len());
         for iidx in entry.term_vars().iter().cloned() {
             if let Some(ConstKind::Int(x)) = opt.as_constkind(map[iidx]) {
                 new.push(Some(KnownBitValue::from_const(x.clone())));
@@ -97,7 +97,7 @@ impl KnownBits {
     /// Create an empty known bits analysis object.
     pub(super) fn new() -> Self {
         KnownBits {
-            known_bits: IndexVec::new(),
+            known_bits: TypedVec::new(),
             pending_commit: None,
         }
     }

--- a/ykrt/src/compile/j2/opt/load_store.rs
+++ b/ykrt/src/compile/j2/opt/load_store.rs
@@ -28,7 +28,7 @@ use crate::compile::j2::{
         fullopt::{CommitInstOpt, OptOutcome, PassOpt, PassT},
     },
 };
-use index_vec::IndexVec;
+use index_type::vec::TypedVec;
 use std::{collections::HashMap, mem};
 
 /// Load/Store elimination
@@ -209,7 +209,7 @@ impl PassT for LoadStore {
         &mut self,
         opt: &mut PassOpt,
         entry: &Block,
-        map: &IndexVec<InstIdx, InstIdx>,
+        map: &TypedVec<InstIdx, InstIdx>,
     ) {
         let mut new_hv = HashMap::new();
 

--- a/ykrt/src/compile/j2/opt/mod.rs
+++ b/ykrt/src/compile/j2/opt/mod.rs
@@ -6,7 +6,7 @@
 //! then used by optimisation passes.
 
 use crate::compile::{CompilationError, j2::hir::*};
-use index_vec::IndexVec;
+use index_type::vec::TypedVec;
 
 mod cse;
 pub(super) mod fullopt;
@@ -20,14 +20,14 @@ mod strength_fold;
 pub(super) trait OptT: EquivIIdxT + ModLikeT + BlockLikeT {
     /// The optimiser has now been fed the complete input and should turn it into: an entry
     /// [Block]; and a set of types (suitable for putting in a [Mod]).
-    fn build(self: Box<Self>) -> Result<(Block, IndexVec<TyIdx, Ty>), CompilationError>;
+    fn build(self: Box<Self>) -> Result<(Block, TypedVec<TyIdx, Ty>), CompilationError>;
 
     /// The optimiser has now been fed the complete input and should turn it into: an entry
     /// [Block]; (optionally) a peeled [Block]; and a set of types (suitable for putting in a
     /// [Mod]).
     fn build_with_peel(
         self: Box<Self>,
-    ) -> Result<(Block, Option<Block>, IndexVec<TyIdx, Ty>), CompilationError>;
+    ) -> Result<(Block, Option<Block>, TypedVec<TyIdx, Ty>), CompilationError>;
 
     /// Feed a non-[Ty::Void] instruction into the optimiser and return an [InstIdx]. The returned
     /// [InstIdx] may refer to a previously inserted instruction, as an optimiser might prove that
@@ -84,7 +84,7 @@ pub(super) trait EquivIIdxT {
     /// %6: i32 = sub %0, %1
     /// ```
     ///
-    /// From instructions 1..=5 `equiv_iidx(InstIdx::from(0))` will return `0`; from that point
+    /// From instructions 1..=5 `equiv_iidx(InstIdx::from_raw_index(0))` will return `0`; from that point
     /// onwards it may (depending on the optimiser!) return `3` because the `guard` proves that it
     /// is equivalent.
     ///

--- a/ykrt/src/compile/j2/opt/noopt.rs
+++ b/ykrt/src/compile/j2/opt/noopt.rs
@@ -9,13 +9,13 @@ use crate::compile::{
         opt::{EquivIIdxT, OptT},
     },
 };
-use index_vec::*;
+use index_type::vec::TypedVec;
 use std::{assert_matches, collections::HashMap};
 
 pub(in crate::compile::j2) struct NoOpt {
-    insts: IndexVec<InstIdx, Inst>,
-    guard_extras: IndexVec<GuardExtraIdx, GuardExtra>,
-    tys: IndexVec<TyIdx, Ty>,
+    insts: TypedVec<InstIdx, Inst>,
+    guard_extras: TypedVec<GuardExtraIdx, GuardExtra>,
+    tys: TypedVec<TyIdx, Ty>,
     /// The [TyIdx] for [Ty::Int(1)].
     tyidx_int1: TyIdx,
     /// The [TyIdx] for [Ty::Ptr(0)].
@@ -28,7 +28,7 @@ pub(in crate::compile::j2) struct NoOpt {
 
 impl NoOpt {
     pub(in crate::compile::j2) fn new() -> Self {
-        let mut tys = IndexVec::new();
+        let mut tys = TypedVec::new();
         let mut ty_map = HashMap::new();
         let tyidx_void = tys.push(Ty::Void);
         ty_map.insert(Ty::Void, tyidx_void);
@@ -37,8 +37,8 @@ impl NoOpt {
         let tyidx_int1 = tys.push(Ty::Int(1));
         ty_map.insert(Ty::Int(1), tyidx_int1);
         Self {
-            insts: IndexVec::new(),
-            guard_extras: IndexVec::new(),
+            insts: TypedVec::new(),
+            guard_extras: TypedVec::new(),
             tys,
             tyidx_int1,
             tyidx_ptr0,
@@ -72,11 +72,11 @@ impl ModLikeT for NoOpt {
 
 impl BlockLikeT for NoOpt {
     fn inst(&self, idx: InstIdx) -> &Inst {
-        &self.insts[usize::from(idx)]
+        &self.insts[idx]
     }
 
     fn insts_len(&self) -> usize {
-        self.insts.len()
+        self.insts.len_usize()
     }
 
     fn gextra(&self, _geidx: GuardExtraIdx) -> &GuardExtra {
@@ -89,7 +89,7 @@ impl BlockLikeT for NoOpt {
 }
 
 impl OptT for NoOpt {
-    fn build(self: Box<Self>) -> Result<(Block, IndexVec<TyIdx, Ty>), CompilationError> {
+    fn build(self: Box<Self>) -> Result<(Block, TypedVec<TyIdx, Ty>), CompilationError> {
         Ok((
             Block {
                 insts: self.insts,
@@ -101,7 +101,7 @@ impl OptT for NoOpt {
 
     fn build_with_peel(
         self: Box<Self>,
-    ) -> Result<(Block, Option<Block>, IndexVec<TyIdx, Ty>), CompilationError> {
+    ) -> Result<(Block, Option<Block>, TypedVec<TyIdx, Ty>), CompilationError> {
         self.build().map(|(bk, tys)| (bk, None, tys))
     }
 

--- a/ykrt/src/compile/j2/opt/strength_fold.rs
+++ b/ykrt/src/compile/j2/opt/strength_fold.rs
@@ -12,7 +12,7 @@ use crate::compile::{
     },
     jitc_yk::arbbitint::ArbBitInt,
 };
-use index_vec::IndexVec;
+use index_type::vec::TypedVec;
 use num_traits::FromPrimitive;
 
 pub(super) struct StrengthFold;
@@ -73,7 +73,7 @@ impl PassT for StrengthFold {
         &mut self,
         _opt: &mut PassOpt,
         _entry: &Block,
-        _map: &IndexVec<InstIdx, InstIdx>,
+        _map: &TypedVec<InstIdx, InstIdx>,
     ) {
     }
 }

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -61,7 +61,7 @@ use crate::compile::{
         hir_to_asm::HirToAsmBackend,
     },
 };
-use index_vec::{Idx, IndexVec, index_vec};
+use index_type::{IndexType, typed_vec, vec::TypedVec};
 use smallvec::{SmallVec, smallvec};
 use std::{
     assert_matches,
@@ -76,7 +76,7 @@ pub(super) struct RegAlloc<'a, AB: HirToAsmBackend + ?Sized> {
     /// The [VarLocs] for each `arg` in [Self::b].
     args_vlocs: &'a [VarLocs<AB::Reg>],
     /// The state of each instruction.
-    istates: IndexVec<InstIdx, IState>,
+    istates: TypedVec<InstIdx, IState>,
     /// The state of each register.
     rstates: RStates<AB::Reg>,
     /// For each instruction, has it yet been used?
@@ -96,11 +96,11 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
         // Before processing the main body of a trace, set the stack offset (if any) of entry
         // variables, so that we don't end up unnecessarily spilling them twice during execution.
         // This is an optimisation rather than a necessity.
-        let mut istates = index_vec![IState::None; b.insts_len()];
+        let mut istates = typed_vec![IState::None; b.insts_len()];
         for (iidx, vlocs) in args_vlocs
             .iter()
             .enumerate()
-            .map(|(i, x)| (InstIdx::from_usize(i), x))
+            .map(|(i, x)| (InstIdx::from_raw_index(i), x))
         {
             for vloc in vlocs.iter() {
                 match vloc {
@@ -175,7 +175,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
         for (iidx, vlocs) in args_vlocs
             .iter()
             .enumerate()
-            .map(|(x, y)| (InstIdx::from(x), y))
+            .map(|(x, y)| (InstIdx::from_raw_index(x), y))
         {
             for vloc in vlocs.iter() {
                 if let VarLoc::Reg(reg, fill) = vloc {
@@ -202,7 +202,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
         for (iidx, vlocs) in args_vlocs
             .iter()
             .enumerate()
-            .map(|(x, y)| (InstIdx::from(x), y))
+            .map(|(x, y)| (InstIdx::from_raw_index(x), y))
         {
             if let IState::Stack(stack_off) = self.istates[iidx]
                 && !vlocs.iter().any(|vloc| matches!(vloc, VarLoc::Stack(_)))
@@ -307,7 +307,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                 continue;
             }
             assert!(!b.insts.is_empty());
-            self.is_used.set(usize::from(*iidx), true);
+            self.is_used.set(iidx.to_raw_index(), true);
             let bitw = self.b.inst_bitw(self.m, *iidx);
             for vloc in term_vlocs.iter() {
                 if term_vlocs
@@ -318,9 +318,9 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                 }
                 match vloc {
                     VarLoc::Stack(to_stack_off) => {
-                        if usize::from(*iidx) < all_args_vlocs.len()
+                        if iidx.to_raw_index() < all_args_vlocs.len()
                             && let Some(VarLoc::Stack(from_stack_off)) = all_args_vlocs
-                                [usize::from(*iidx)]
+                                [iidx.to_raw_index()]
                             .iter()
                             .find(|vloc| matches!(vloc, VarLoc::Stack(_)))
                         {
@@ -384,7 +384,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
     /// For guard bodies, ensure that the instructions `iidxs` are marked as used at `term_iidx`.
     pub(super) fn keep_alive_at_term(&mut self, _term_iidx: InstIdx, iidxs: &[InstIdx]) {
         for iidx in iidxs {
-            self.is_used.set(usize::from(*iidx), true);
+            self.is_used.set(iidx.to_raw_index(), true);
         }
     }
 
@@ -416,14 +416,14 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
 
             // Work out all the nodes (i.e. registers) and the number of incoming edges (i.e.
             // register copies) to those nodes.
-            let mut nodes = Vob::from_elem(false, AB::Reg::MAX_REGIDX.index());
-            let mut indegrees = index_vec![0; AB::Reg::MAX_REGIDX.index()];
+            let mut nodes = Vob::from_elem(false, AB::Reg::MAX_REGIDX.to_raw_index());
+            let mut indegrees = typed_vec![0; AB::Reg::MAX_REGIDX.to_raw_index()];
             for RegCopy {
                 src_reg, dst_reg, ..
             } in &ractions.distinct_copies
             {
-                nodes.set(src_reg.regidx().index(), true);
-                nodes.set(dst_reg.regidx().index(), true);
+                nodes.set(src_reg.regidx().to_raw_index(), true);
+                nodes.set(dst_reg.regidx().to_raw_index(), true);
                 indegrees[dst_reg.regidx()] += 1;
             }
 
@@ -431,7 +431,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
             // that happens naturally because of our `Vob` representation of `nodes`.
             let mut queue = nodes
                 .iter_set_bits(..)
-                .map(|x| AB::Reg::from_regidx(<AB::Reg as RegT>::RegIdx::from_usize(x)))
+                .map(|x| AB::Reg::from_regidx(<AB::Reg as RegT>::RegIdx::from_raw_index(x)))
                 .filter(|reg| indegrees[reg.regidx()] == 0)
                 .collect::<Vec<_>>();
 
@@ -598,13 +598,13 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
     ///
     /// Note: being used in a guard's entry_vars counts as "being used".
     pub(super) fn is_used(&self, iidx: InstIdx) -> bool {
-        self.is_used[usize::from(iidx)]
+        self.is_used[iidx.to_raw_index()]
     }
 
     /// Force the value `iidx` to be marked as used at `cur_iidx`. Must only be used for testing purposes.
     #[cfg(test)]
     pub(super) fn blackbox(&mut self, _cur_iidx: InstIdx, iidx: InstIdx) {
-        self.is_used.set(usize::from(iidx), true);
+        self.is_used.set(iidx.to_raw_index(), true);
     }
 
     /// Return an iterator which will produce all the registers in which `iidx` is contained.
@@ -853,7 +853,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
             match cnstr {
                 RegCnstr::Clobber { .. } | RegCnstr::Temp { .. } => (),
                 RegCnstr::Input { in_iidx, .. } => {
-                    self.is_used.set(usize::from(*in_iidx), true);
+                    self.is_used.set((*in_iidx).to_raw_index(), true);
                 }
                 RegCnstr::InputOutput {
                     in_iidx, out_fill, ..
@@ -870,7 +870,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                             out_bitw,
                         )?;
                     }
-                    self.is_used.set(usize::from(*in_iidx), true);
+                    self.is_used.set((*in_iidx).to_raw_index(), true);
                 }
                 RegCnstr::Output {
                     out_fill,
@@ -984,7 +984,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                             self.istates[*ka_iidx] = IState::Stack(self.stack_off);
                         }
                     }
-                    self.is_used.set(usize::from(*ka_iidx), true);
+                    self.is_used.set((*ka_iidx).to_raw_index(), true);
                 }
             }
         }
@@ -1171,7 +1171,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                     continue;
                 }
                 if let RegCnstr::Input { regs, in_iidx, .. } = cnstr
-                    && !self.is_used[usize::from(*in_iidx)]
+                    && !self.is_used[(*in_iidx).to_raw_index()]
                     && regs.contains(&output_reg)
                 {
                     allocs[i] = Some(output_reg);
@@ -1217,7 +1217,7 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
             // their register.
             for (j, in_cnstr) in cnstrs.iter().enumerate() {
                 if let RegCnstr::Input { regs, in_iidx, .. } = in_cnstr
-                    && !self.is_used[usize::from(*in_iidx)]
+                    && !self.is_used[(*in_iidx).to_raw_index()]
                     && regs.contains(&allocs[j].unwrap())
                 {
                     allocs[i] = allocs[j];
@@ -1381,13 +1381,13 @@ enum IState {
 
 #[derive(Clone, Debug)]
 struct RStates<Reg: RegT> {
-    rstate: IndexVec<Reg::RegIdx, RState>,
+    rstate: TypedVec<Reg::RegIdx, RState>,
 }
 
 impl<Reg: RegT> RStates<Reg> {
     fn new() -> Self {
         Self {
-            rstate: index_vec![RState::default(); Reg::MAX_REGIDX.index()],
+            rstate: typed_vec![RState::default(); Reg::MAX_REGIDX.to_raw_index()],
         }
     }
 
@@ -1448,7 +1448,7 @@ impl Default for RState {
 ///     to consider registers as (sensible!) indexes.
 pub(super) trait RegT: Clone + Copy + Debug + Display + PartialEq + Send + Sync {
     /// A register's index. Every register must be convertible to/from this type.
-    type RegIdx: Idx;
+    type RegIdx: Debug + IndexType;
     /// How many registers are available in this system?
     const MAX_REGIDX: Self::RegIdx;
     /// Return the undefined register for this backend: this will be "allocated" by constraints
@@ -2002,18 +2002,19 @@ pub(crate) mod test {
 
     impl RegT for TestReg {
         type RegIdx = TestRegIdx;
-        const MAX_REGIDX: TestRegIdx = TestRegIdx::from_usize_unchecked(TestReg::COUNT);
+        // `TestReg` has fewer than `u8::MAX` variants, so its count fits in `TestRegIdx`.
+        const MAX_REGIDX: TestRegIdx = TestRegIdx(TestReg::COUNT as u8);
 
         fn undefined() -> Self {
             TestReg::Undefined
         }
 
         fn from_regidx(idx: Self::RegIdx) -> Self {
-            TestReg::from_repr(idx.raw()).unwrap()
+            TestReg::from_repr(idx.to_scalar()).unwrap()
         }
 
         fn regidx(&self) -> Self::RegIdx {
-            TestRegIdx::from(*self as usize)
+            TestRegIdx::from_raw_index(*self as usize)
         }
 
         fn is_caller_saved(&self) -> bool {
@@ -2035,9 +2036,8 @@ pub(crate) mod test {
         }
     }
 
-    index_vec::define_index_type! {
-        pub(crate) struct TestRegIdx = u8;
-    }
+    #[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+    pub(crate) struct TestRegIdx(u8);
 
     struct TestRegTestIter<Reg> {
         fp_regs: Box<dyn Iterator<Item = Reg>>,
@@ -2096,7 +2096,7 @@ pub(crate) mod test {
 
     impl PeelRegsBuilderT<TestReg> for TestPeelRegsBuilder {
         fn force_set(&mut self, reg: TestReg) {
-            self.set_regs[usize::from(reg.regidx())] = true;
+            self.set_regs[reg.regidx().to_raw_index()] = true;
         }
 
         fn is_full(&self, _ignore_caller_save: bool) -> bool {
@@ -2172,7 +2172,7 @@ pub(crate) mod test {
             hint_iidx: InstIdx,
         ) -> Option<Self::Reg> {
             if let Inst::Arg(_) = b.inst(hint_iidx)
-                && let Some(VarLoc::Reg(reg, _)) = args_vlocs[usize::from(hint_iidx)]
+                && let Some(VarLoc::Reg(reg, _)) = args_vlocs[(hint_iidx).to_raw_index()]
                     .iter()
                     .find(|x| matches!(x, VarLoc::Reg(_, _)))
             {
@@ -2267,13 +2267,13 @@ pub(crate) mod test {
 
         fn controlpoint_loop_end(&mut self) -> Result<Self::Label, CompilationError> {
             self.ra_log.push("controlpoint_loop_end".to_owned());
-            Ok(TestLabelIdx::new(1))
+            Ok(TestLabelIdx::from_raw_index(1))
         }
 
         fn controlpoint_peel_start(&mut self, peel_label: Self::Label) -> Self::Label {
             self.ra_log
                 .push(format!("controlpoint_peel_start {peel_label:?}"));
-            TestLabelIdx::new(2)
+            TestLabelIdx::from_raw_index(2)
         }
 
         fn controlpoint_loop_start(&mut self, _post_stack_label: Self::Label, _stack_off: u32) {}
@@ -2286,7 +2286,7 @@ pub(crate) mod test {
             _gridx: CompiledGuardIdx,
             _args_vlocs: &[VarLocs<Self::Reg>],
         ) -> Result<Self::Label, CompilationError> {
-            Ok(TestLabelIdx::new(0))
+            Ok(TestLabelIdx::from_raw_index(0))
         }
 
         fn guard_completed(
@@ -2384,7 +2384,7 @@ pub(crate) mod test {
             )?;
 
             self.ra_log.push(format!("alloc %{iidx:?} {cndr:?}"));
-            Ok(TestLabelIdx::new(0))
+            Ok(TestLabelIdx::from_raw_index(0))
         }
 
         fn i_icmp(
@@ -2503,9 +2503,13 @@ pub(crate) mod test {
         }
     }
 
-    index_vec::define_index_type! {
-        struct TestLabelIdx = u32;
-        IMPL_RAW_CONVERSIONS = true;
+    #[derive(Clone, Copy, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+    struct TestLabelIdx(u32);
+
+    impl std::fmt::Debug for TestLabelIdx {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Debug::fmt(&self.to_raw_index(), f)
+        }
     }
 
     lazy_static! {

--- a/ykrt/src/compile/j2/x64/asm.rs
+++ b/ykrt/src/compile/j2/x64/asm.rs
@@ -27,7 +27,7 @@ use crate::compile::{
     j2::codebuf::{CodeBufInProgress, ExeCodeBuf},
 };
 use iced_x86::{Encoder, Formatter, Instruction as Op, NasmFormatter};
-use index_vec::{IndexVec, index_vec};
+use index_type::{IndexType, typed_vec, vec::TypedVec};
 use std::slice;
 
 pub(super) struct Asm {
@@ -43,7 +43,7 @@ pub(super) struct Asm {
     fmtr: Option<NasmFormatter>,
     /// Labels. New labels start with a value of `None`; when they are assigned to an instruction,
     /// this will become `Some(...)`.
-    labels: IndexVec<LabelIdx, Option<u32>>,
+    labels: TypedVec<LabelIdx, Option<u32>>,
     /// Operations (CALLs, JMPs), which need relocating. These are not stored in any particular
     /// order.
     relocs: Vec<(u32, u8, RelocKind)>,
@@ -71,7 +71,7 @@ impl Asm {
             buf_end_off: buf_used,
             enc: Encoder::new(64),
             fmtr,
-            labels: index_vec![],
+            labels: typed_vec![],
             relocs: Vec::new(),
             log: if log { Some(Vec::new()) } else { None },
         }
@@ -95,7 +95,7 @@ impl Asm {
     /// before `attach_label` is called).
     pub(super) fn attach_label(&mut self, lidx: LabelIdx) {
         if let Some(log) = &mut self.log {
-            log.push(format!("; l{}", usize::from(lidx)));
+            log.push(format!("; l{}", (lidx).to_raw_index()));
         }
         self.labels[lidx] = Some(self.buf_end_off);
     }
@@ -221,7 +221,7 @@ impl Asm {
             let off = s.rfind(' ').unwrap();
             match &reloc {
                 RelocKind::AbsoluteWithLabel(lidx) | RelocKind::NearWithLabel(lidx) => {
-                    s.replace_range(off.., &format!(" l{}", usize::from(*lidx)));
+                    s.replace_range(off.., &format!(" l{}", (*lidx).to_raw_index()));
                 }
                 RelocKind::NearWithAddr(addr) | RelocKind::NearCallWithAddr(addr) => {
                     s.replace_range(off.., &format!(" 0x{addr:X}"));
@@ -352,15 +352,14 @@ pub(super) enum RelocKind {
     NearCallWithAddr(usize),
 }
 
-index_vec::define_index_type! {
-    struct BlockIdx = u16;
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+#[allow(dead_code)]
+struct BlockIdx(u16);
 
-index_vec::define_index_type! {
-    /// The offset of an operation in a [Block].
-    struct OpIdx = u32;
-}
+/// The offset of an operation in a [Block].
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+#[allow(dead_code)]
+struct OpIdx(u32);
 
-index_vec::define_index_type! {
-    pub(in crate::compile::j2) struct LabelIdx = u32;
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub(in crate::compile::j2) struct LabelIdx(u32);

--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -14,6 +14,7 @@ use crate::{
     log::Verbosity,
     mt::{MTThread, TraceId},
 };
+use index_type::IndexType;
 use std::{
     alloc::{Layout, alloc},
     ffi::c_void,
@@ -140,7 +141,7 @@ thread_local! {
 #[unsafe(no_mangle)]
 pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> ! {
     let gid = GuardId::from(usize::try_from(gid).unwrap());
-    let gidx = CompiledGuardIdx::from(usize::from(gid));
+    let gidx = CompiledGuardIdx::from_raw_index(usize::from(gid));
     let ctr = MTThread::with_borrow(|mtt| mtt.compiled_trace(TraceId::from_u64(trid)))
         .as_any()
         .downcast::<J2CompiledTrace<Reg>>()
@@ -155,7 +156,7 @@ pub(super) extern "C" fn __yk_j2_deopt(faddr: *mut u8, trid: u64, gid: u32) -> !
             log,
             "deoptimise {{\"trid\": \"{:?}\", \"gidx\": \"{}\"}}",
             ctr.ctrid().as_u64(),
-            usize::from(gidx)
+            gidx.to_raw_index()
         )
     });
 

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -57,7 +57,7 @@ use crate::{
 };
 use array_concat::concat_arrays;
 use iced_x86::{Code, Instruction as IcedInst, MemoryOperand, Register as IcedReg};
-use index_vec::IndexVec;
+use index_type::{IndexType, vec::TypedVec};
 use smallvec::SmallVec;
 use std::{assert_matches, collections::HashMap, debug_assert_matches, ffi::c_void, sync::Arc};
 
@@ -67,7 +67,7 @@ pub(in crate::compile::j2) struct X64HirToAsm<'a> {
     /// The label for the main entry point into the trace we're about to compile. We create this
     /// up-front and only attach it later.
     entry_label: LabelIdx,
-    reg_hints: IndexVec<InstIdx, Reg>,
+    reg_hints: TypedVec<InstIdx, Reg>,
     /// The data section: we map any given (align, byte sequence) pair to [LabelIdx]s, which will
     /// eventually be output as their own pseudo-block.
     data_sec: HashMap<Vec<u8>, (u32, LabelIdx)>,
@@ -101,7 +101,7 @@ impl<'a> X64HirToAsm<'a> {
             m,
             asm,
             entry_label,
-            reg_hints: IndexVec::new(),
+            reg_hints: TypedVec::new(),
             data_sec: HashMap::new(),
         }
     }
@@ -211,11 +211,13 @@ impl<'a> X64HirToAsm<'a> {
         }) = b.inst(op_iidx)
         {
             assert!(op_iidx < cur_iidx);
-            if b.insts_iter(op_iidx + 1..cur_iidx).all(|(_, inst)| {
-                !inst
-                    .write_effects()
-                    .interferes(Effects::all().minus_guard())
-            }) {
+            if b.insts_iter(op_iidx.checked_add_scalar(1).unwrap()..cur_iidx)
+                .all(|(_, inst)| {
+                    !inst
+                        .write_effects()
+                        .interferes(Effects::all().minus_guard())
+                })
+            {
                 return self.flatten_ptradd_chain(b, *ptr);
             }
         }
@@ -783,11 +785,12 @@ impl<'a> X64HirToAsm<'a> {
                 .flatten_ptradd_chain(b, *load_ptr)
                 .unwrap_or((*load_ptr, 0));
             if (ptr, off) == (load_ptr, load_off)
-                && b.insts_iter(*lhs + 1..iidx).all(|(_, inst)| {
-                    !inst
-                        .write_effects()
-                        .interferes(Effects::all().minus_guard())
-                })
+                && b.insts_iter(lhs.checked_add_scalar(1).unwrap()..iidx)
+                    .all(|(_, inst)| {
+                        !inst
+                            .write_effects()
+                            .interferes(Effects::all().minus_guard())
+                    })
             {
                 let [ptrr] = ra.alloc(
                     self,
@@ -972,7 +975,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         // There's no point giving register hints for caller saved registers that span `Call`s.
         if cnd == Reg::Undefined
             || (cnd.is_caller_saved()
-                && b.insts_iter(hint_iidx + 1..cur_iidx)
+                && b.insts_iter(hint_iidx.checked_add_scalar(1).unwrap()..cur_iidx)
                     .any(|(_, inst)| matches!(inst, Inst::Call(_))))
         {
             None
@@ -1000,9 +1003,9 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         // Make sure that we reserve enough space in `self.reg_hints` in one shot, but don't shrink
         // it if it has more space than we need.
         self.reg_hints
-            .reserve(b.insts_len().saturating_sub(self.reg_hints.len()));
+            .reserve(b.insts_len().saturating_sub(self.reg_hints.len_usize()));
 
-        let mut last_call = InstIdx::new(0);
+        let mut last_call = InstIdx::from_raw_index(0);
         for (iidx, inst) in b.insts_iter(..) {
             // Instructions that want to forward a register hint return a `cnd_iidx`: those that
             // have a definite register hint `continue` and avoid the code after this `let`.
@@ -1025,7 +1028,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
 
                 // Args are special.
                 Inst::Arg(_) => {
-                    if let Some(x) = args_vlocs[usize::from(iidx)].iter().find_map(|x| {
+                    if let Some(x) = args_vlocs[iidx.to_raw_index()].iter().find_map(|x| {
                         if let VarLoc::Reg(reg, _) = x {
                             Some(*reg)
                         } else {
@@ -1084,7 +1087,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
                 self.reg_hints.push(cnd_reg);
             }
         }
-        assert_eq!(b.insts_len(), self.reg_hints.len());
+        assert_eq!(b.insts_len(), self.reg_hints.len_usize());
     }
 
     fn build_exe(
@@ -1510,7 +1513,10 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
 
         #[cfg(test)]
         let csrs = {
-            assert_eq!(exit_statepoint.smapidx, 0);
+            assert_eq!(
+                exit_statepoint.smapidx,
+                crate::StackMapIdx::from_raw_index(0)
+            );
             [(3, -6), (12, -5), (13, -4), (14, -3), (15, -2)]
         };
 
@@ -1665,7 +1671,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         self.asm.push_inst(IcedInst::with2(
             Code::Mov_r32_imm32,
             IcedReg::EDX,
-            i32::try_from(usize::from(gidx)).unwrap(),
+            i32::try_from(gidx.to_raw_index()).unwrap(),
         ));
         self.asm.push_inst(IcedInst::with2(
             Code::Mov_r64_imm64,
@@ -4500,6 +4506,7 @@ mod test {
         varlocs,
     };
     use fm::{FMBuilder, FMatcher};
+    use index_type::IndexType;
     use lazy_static::lazy_static;
     use parking_lot::Mutex;
     use regex::{Regex, RegexBuilder};
@@ -4509,7 +4516,7 @@ mod test {
     };
 
     static TEST_EXIT_STATEPOINT: LazyLock<Statepoint> = LazyLock::new(|| Statepoint {
-        smapidx: StackMapIdx::from(0),
+        smapidx: StackMapIdx::from_raw_index(0),
         lives: Vec::new(),
     });
 
@@ -4707,7 +4714,7 @@ mod test {
             [] => None,
             _ => panic!(),
         };
-        let term_iidx = InstIdx::from(block.insts_len() - 1);
+        let term_iidx = InstIdx::from_raw_index(block.insts_len() - 1);
         let mut be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), true);
         let mut ra = RegAlloc::new(&m, block, args_vlocs, 0);
         be.star_return_end(&mut ra, block, term_iidx, &TEST_EXIT_STATEPOINT, ret_val)
@@ -4750,12 +4757,24 @@ mod test {
         };
         let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), false);
 
-        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(0)), Some(0));
-        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(1)), Some(0xFF));
-        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(2)), Some(0));
-        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(3)), Some(0xFF));
-        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(4)), None);
-        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from(5)), None);
+        assert_eq!(
+            be.zero_ext_op_for_imm8(b, InstIdx::from_raw_index(0)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm8(b, InstIdx::from_raw_index(1)),
+            Some(0xFF)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm8(b, InstIdx::from_raw_index(2)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm8(b, InstIdx::from_raw_index(3)),
+            Some(0xFF)
+        );
+        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from_raw_index(4)), None);
+        assert_eq!(be.zero_ext_op_for_imm8(b, InstIdx::from_raw_index(5)), None);
     }
 
     #[test]
@@ -4788,39 +4807,96 @@ mod test {
         };
         let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), false);
 
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(6)), Some(0));
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(7)), Some(-1));
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(8)), Some(0));
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(9)), None);
         assert_eq!(
-            be.sign_ext_op_for_imm32(b, InstIdx::from(10)),
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(6)),
+            Some(0)
+        );
+        assert_eq!(
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(7)),
+            Some(-1)
+        );
+        assert_eq!(
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(8)),
+            Some(0)
+        );
+        assert_eq!(
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(9)),
+            None
+        );
+        assert_eq!(
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(10)),
             Some(0x10000000)
         );
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(11)), None);
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(12)), Some(-1));
-        assert_eq!(be.sign_ext_op_for_imm32(b, InstIdx::from(13)), Some(-2));
-
-        assert_eq!(be.zero_ext_op_for_imm32(b, 1, InstIdx::from(0)), Some(0));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 1, InstIdx::from(1)), Some(1));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 8, InstIdx::from(2)), Some(0));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 8, InstIdx::from(3)), Some(255));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 16, InstIdx::from(4)), Some(0));
         assert_eq!(
-            be.zero_ext_op_for_imm32(b, 16, InstIdx::from(5)),
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(11)),
+            None
+        );
+        assert_eq!(
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(12)),
+            Some(-1)
+        );
+        assert_eq!(
+            be.sign_ext_op_for_imm32(b, InstIdx::from_raw_index(13)),
+            Some(-2)
+        );
+
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 1, InstIdx::from_raw_index(0)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 1, InstIdx::from_raw_index(1)),
+            Some(1)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 8, InstIdx::from_raw_index(2)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 8, InstIdx::from_raw_index(3)),
+            Some(255)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 16, InstIdx::from_raw_index(4)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 16, InstIdx::from_raw_index(5)),
             Some(65535)
         );
-        assert_eq!(be.zero_ext_op_for_imm32(b, 32, InstIdx::from(6)), Some(0));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 32, InstIdx::from(7)), Some(-1));
-
-        assert_eq!(be.zero_ext_op_for_imm32(b, 64, InstIdx::from(8)), Some(0));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 64, InstIdx::from(9)), None);
         assert_eq!(
-            be.zero_ext_op_for_imm32(b, 64, InstIdx::from(10)),
+            be.zero_ext_op_for_imm32(b, 32, InstIdx::from_raw_index(6)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 32, InstIdx::from_raw_index(7)),
+            Some(-1)
+        );
+
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 64, InstIdx::from_raw_index(8)),
+            Some(0)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 64, InstIdx::from_raw_index(9)),
+            None
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 64, InstIdx::from_raw_index(10)),
             Some(0x10000000)
         );
-        assert_eq!(be.zero_ext_op_for_imm32(b, 64, InstIdx::from(11)), None);
-        assert_eq!(be.zero_ext_op_for_imm32(b, 64, InstIdx::from(12)), Some(-1));
-        assert_eq!(be.zero_ext_op_for_imm32(b, 64, InstIdx::from(13)), Some(-2));
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 64, InstIdx::from_raw_index(11)),
+            None
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 64, InstIdx::from_raw_index(12)),
+            Some(-1)
+        );
+        assert_eq!(
+            be.zero_ext_op_for_imm32(b, 64, InstIdx::from_raw_index(13)),
+            Some(-2)
+        );
     }
 
     #[test]
@@ -4857,36 +4933,36 @@ mod test {
         let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), false);
 
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(3), InstIdx::from(1)),
-            Some((InstIdx::from(0), 0))
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(3), InstIdx::from_raw_index(1)),
+            Some((InstIdx::from_raw_index(0), 0))
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(5), InstIdx::from(1)),
-            Some((InstIdx::from(0), 0))
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(5), InstIdx::from_raw_index(1)),
+            Some((InstIdx::from_raw_index(0), 0))
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(6), InstIdx::from(4)),
-            Some((InstIdx::from(0), 0))
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(6), InstIdx::from_raw_index(4)),
+            Some((InstIdx::from_raw_index(0), 0))
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(8), InstIdx::from(4)),
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(8), InstIdx::from_raw_index(4)),
             None
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(10), InstIdx::from(4)),
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(10), InstIdx::from_raw_index(4)),
             None
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(10), InstIdx::from(9)),
-            Some((InstIdx::from(0), 0))
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(10), InstIdx::from_raw_index(9)),
+            Some((InstIdx::from_raw_index(0), 0))
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(14), InstIdx::from(9)),
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(14), InstIdx::from_raw_index(9)),
             None
         );
         assert_eq!(
-            be.try_load_to_mem_op(b, InstIdx::from(14), InstIdx::from(13)),
-            Some((InstIdx::from(0), 0))
+            be.try_load_to_mem_op(b, InstIdx::from_raw_index(14), InstIdx::from_raw_index(13)),
+            Some((InstIdx::from_raw_index(0), 0))
         );
     }
 
@@ -4917,19 +4993,39 @@ mod test {
         let mut x64be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), false);
         x64be.about_to_process_block(b, args_vlocs);
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(2), InstIdx::new(0)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(2),
+                InstIdx::from_raw_index(0)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(3), InstIdx::new(2)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(3),
+                InstIdx::from_raw_index(2)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(5), InstIdx::new(1)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R9)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(6), InstIdx::new(1)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(6),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R9)
         );
     }
@@ -4962,15 +5058,30 @@ mod test {
         let mut x64be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), false);
         x64be.about_to_process_block(b, args_vlocs);
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(4), InstIdx::new(3)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(4),
+                InstIdx::from_raw_index(3)
+            ),
             None
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(5), InstIdx::new(4)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(4)
+            ),
             Some(Reg::RAX)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(6), InstIdx::new(5)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(6),
+                InstIdx::from_raw_index(5)
+            ),
             Some(Reg::XMM0)
         );
     }
@@ -5002,45 +5113,95 @@ mod test {
         let mut x64be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), false);
         x64be.about_to_process_block(b, args_vlocs);
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(2), InstIdx::new(0)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(2),
+                InstIdx::from_raw_index(0)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(2), InstIdx::new(1)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(2),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R13)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(3), InstIdx::new(2)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(3),
+                InstIdx::from_raw_index(2)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(5), InstIdx::new(3)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(3)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(5), InstIdx::new(4)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(4)
+            ),
             None
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(6), InstIdx::new(5)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(6),
+                InstIdx::from_raw_index(5)
+            ),
             Some(Reg::RAX)
         );
 
         // Check clobbers either side of the `call`
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(5), InstIdx::new(0)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(0)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(5), InstIdx::new(1)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R13)
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(7), InstIdx::new(0)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(7),
+                InstIdx::from_raw_index(0)
+            ),
             None
         );
         assert_eq!(
-            x64be.reg_hint(b, args_vlocs, InstIdx::new(7), InstIdx::new(1)),
+            x64be.reg_hint(
+                b,
+                args_vlocs,
+                InstIdx::from_raw_index(7),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R13)
         );
     }

--- a/ykrt/src/compile/j2/x64/x64regalloc.rs
+++ b/ykrt/src/compile/j2/x64/x64regalloc.rs
@@ -7,6 +7,7 @@ use crate::compile::j2::{
     regalloc::{PeelRegsBuilderT, RegT},
 };
 use iced_x86::Register;
+use index_type::IndexType;
 use std::marker::PhantomData;
 use strum::{EnumCount, FromRepr};
 
@@ -244,18 +245,19 @@ impl Reg {
 
 impl RegT for Reg {
     type RegIdx = RegIdx;
-    const MAX_REGIDX: RegIdx = RegIdx::from_usize_unchecked(Reg::COUNT);
+    // `Reg` has fewer than `u8::MAX` variants, so its variant count fits in `RegIdx`.
+    const MAX_REGIDX: RegIdx = RegIdx(Reg::COUNT as u8);
 
     fn undefined() -> Reg {
         Reg::Undefined
     }
 
     fn from_regidx(idx: Self::RegIdx) -> Self {
-        Reg::from_repr(idx.raw()).unwrap()
+        Reg::from_repr(idx.to_scalar()).unwrap()
     }
 
     fn regidx(&self) -> Self::RegIdx {
-        RegIdx::from(*self as u8)
+        RegIdx::from_raw_index(usize::from(*self as u8))
     }
 
     #[cfg(target_os = "linux")]
@@ -433,10 +435,8 @@ impl TestRegIter<Reg> for X64TestRegIter<Reg> {
     }
 }
 
-index_vec::define_index_type! {
-    pub(in crate::compile::j2) struct RegIdx = u8;
-    IMPL_RAW_CONVERSIONS = true;
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, IndexType, Ord, PartialEq, PartialOrd)]
+pub(in crate::compile::j2) struct RegIdx(u8);
 
 /// The normal, usable, general purposes x64 registers (excluding RSP, RBP, and so on).
 pub(super) const NORMAL_GP_REGS: [Reg; 14] = [
@@ -673,51 +673,123 @@ mod test {
         // Test that we leave some registers spare.
         let mut prb = PeelRegsBuilder::new();
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R11)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R10)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R9)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R8)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RDI)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RSI)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RDX)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RCX)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RAX)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R15)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R14)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             None
         );
         // RBX, R12, R13 left free
@@ -725,35 +797,83 @@ mod test {
         // Test that we don't allocate caller saved registers after a call.
         let mut prb = PeelRegsBuilder::new();
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R11)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R10)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R15)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R14)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R13)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R12)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RBX)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(1), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(1),
+                InstIdx::from_raw_index(1)
+            ),
             None
         );
     }
@@ -786,27 +906,63 @@ mod test {
         // Check that we put call arguments in sensible registers.
         let mut prb = PeelRegsBuilder::new();
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(5), InstIdx::new(0)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(0)
+            ),
             Some(Reg::RDI)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, false, InstIdx::new(5), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                false,
+                InstIdx::from_raw_index(5),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::RSI)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(6), InstIdx::new(0)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(6),
+                InstIdx::from_raw_index(0)
+            ),
             Some(Reg::R15)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(6), InstIdx::new(1)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(6),
+                InstIdx::from_raw_index(1)
+            ),
             Some(Reg::R14)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(7), InstIdx::new(2)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(7),
+                InstIdx::from_raw_index(2)
+            ),
             Some(Reg::R13)
         );
         assert_eq!(
-            prb.try_alloc_reg_for(&m, b, true, InstIdx::new(8), InstIdx::new(3)),
+            prb.try_alloc_reg_for(
+                &m,
+                b,
+                true,
+                InstIdx::from_raw_index(8),
+                InstIdx::from_raw_index(3)
+            ),
             Some(Reg::R12)
         );
     }

--- a/ykrt/src/compile/jitc_yk/aot_ir.rs
+++ b/ykrt/src/compile/jitc_yk/aot_ir.rs
@@ -30,6 +30,7 @@
 use crate::aotsmp::StackMapIdx;
 use byteorder::{NativeEndian, ReadBytesExt};
 use deku::prelude::*;
+use index_type::IndexType;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -402,8 +403,8 @@ index!(ArgIdx);
 /// avoid type inference errors, so it's easier to have a single helper function rather than inline
 /// this into each `map` attribute.
 fn map_to_stackmapidx(v: u64) -> Result<StackMapIdx, DekuError> {
-    match usize::try_from(v).map(StackMapIdx::try_from) {
-        Ok(Ok(x)) => Ok(x),
+    match usize::try_from(v).map(StackMapIdx::from_raw_index) {
+        Ok(x) => Ok(x),
         _ => Err(DekuError::Parse(Cow::Borrowed("Couldn't map StackMapIdx"))),
     }
 }


### PR DESCRIPTION
Unfortunately `index_vec` seems unmaintained (nothing since 2024, PRs starting to pile up, and now warnings on nightly for the code it generates). This commit moves ykrt over to `IndexType`. Most of this commit is extremely mechanical, but there is a lot of churn, because the APIs are similar in intent, but different in detail. This seems to boil down to more-or-less the same machine code: benchmarking doesn't show any differences on yklua.