### PR TITLE
Don't reprocess items in `gqueue`.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -257,8 +257,8 @@ cd ykcbf
 git fetch --depth=1 origin "$YKCBF_COMMIT"
 git checkout "$YKCBF_COMMIT"
 PATH=${ROOT_DIR}/bin:${PATH} YK_BUILD_TYPE=debug make
-./bf_simple_yk lang_tests/bench.bf
-./bf_simple_yk lang_tests/hanoi-opt.bf
+YKD_SERIALISE_COMPILATION=1 ./bf_simple_yk lang_tests/bench.bf
+YKD_SERIALISE_COMPILATION=1 ./bf_simple_yk lang_tests/hanoi-opt.bf
 cd ..
 
 # Check licenses.

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -906,7 +906,7 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
         // below to see how these are used.
         let mut gexit_vars = Vob::from_elem(false, b.insts_len());
         let mut gcopy = Vob::from_elem(false, b.insts_len());
-        let mut gqueue = Vec::new();
+        let mut gqueue: Vec<InstIdx> = Vec::new();
 
         self.be.about_to_process_block(b, args_vlocs);
 
@@ -1056,6 +1056,9 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     gqueue.extend(&gextra.deopt_vars);
 
                     while let Some(giidx) = gqueue.pop() {
+                        if gcopy.get(giidx.to_raw_index()).unwrap() {
+                            continue;
+                        }
                         let inst = b.inst(giidx);
 
                         if let Inst::Load(Load {
@@ -1082,12 +1085,12 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                             // We don't copy instructions that are used by non-guard instructions
                             // unless: they're a `Const`; aren't in a register; don't have
                             // side-effects.
-                            gexit_vars.set((giidx).to_raw_index(), true);
+                            gexit_vars.set(giidx.to_raw_index(), true);
                             continue;
                         }
 
                         // We can copy this instruction!
-                        gcopy.set((giidx).to_raw_index(), true);
+                        gcopy.set(giidx.to_raw_index(), true);
                         // Add all this instruction's operand references to the queue.
                         for op_iidx in inst.iter_iidxs(b) {
                             gqueue.push(op_iidx);


### PR DESCRIPTION
It turns out that -- irony of irony because it's one of our oldest tests! -- `bf_simple_yk lang_test/hanoi-opt.bf` was broken, but we didn't notice it for timing reasons. Serialised compilation reliably exposes the problem: when building guards we could get stuck in an endless loop reprocessing items we've seen.

The fix for this is trivial: we have an implicit way of checking "we've seen this item" already. And now buildbot.sh should check that this really does fix things!