### PR TITLE
Turn a hard error into a warning.

### DIFF
--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -256,7 +256,12 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             TraceEndKind::Return(_) => (),
             TraceEndKind::Term => {
                 assert!(self.promotions_iter.next().is_none());
-                assert_eq!(self.frames.len(), 1);
+                if self.frames.len() > 1 {
+                    // FIXME
+                    return Err(CompilationError::General(
+                        "Finishing in recursive control points not yet supported".into(),
+                    ));
+                }
                 let exit_statepoint = match &bmk {
                     BuildModKind::Loop { entry_statepoint } => entry_statepoint,
                     BuildModKind::Coupler { tgt_ctr, .. } => match &tgt_ctr.trace_start {


### PR DESCRIPTION
I've been experimenting with cases where we hit this `assert`: I think I know (roughly) what to do to solve the (new) `FIXME`, but at least for the time being, a warning is better than borking.