### PR TITLE
We don't need to pass ``loc``.

### DIFF
--- a/tests/lua/nested_loops.lua
+++ b/tests/lua/nested_loops.lua
@@ -40,7 +40,7 @@ io.stderr:write(x)
 --     yk-tracing: start-side-tracing: nested_loops.lua:5: ADDI
 --     yk-tracing: stop-tracing: nested_loops.lua:3: ADDI
 --     yk-tracing: start-tracing: nested_loops.lua:3: ADDI
---     yk-tracing: stop-tracing: nested_loops.lua:5: ADDI
+--     yk-tracing: stop-tracing: nested_loops.lua:3: ADDI
 --     --- Begin debugstrs: nested_loops.lua:3: ADDI ---
 --     ; {
 --     ;   "trid": "2",

--- a/tests/lua/recursive_function_indirect.lua
+++ b/tests/lua/recursive_function_indirect.lua
@@ -52,7 +52,7 @@ io.stderr:write("exit\n")
 --     --- End debugstrs ---
 --     4
 --     yk-tracing: start-tracing: recursive_function_indirect.lua:9: GETTABUP
---     yk-tracing: stop-tracing: recursive_function_indirect.lua:2: GETTABUP
+--     yk-tracing: stop-tracing: recursive_function_indirect.lua:9: GETTABUP
 --     --- Begin debugstrs: recursive_function_indirect.lua:9: GETTABUP ---
 --     ; {
 --     ;   "trid": "1",

--- a/tests/lua/unrolling.lua
+++ b/tests/lua/unrolling.lua
@@ -48,7 +48,7 @@ io.stderr:write("exit\n")
 --     j 2
 --     i 3
 --     yk-tracing: start-tracing: unrolling.lua:2: GTI
---     yk-tracing: stop-tracing: unrolling.lua:4: GETTABUP
+--     yk-tracing: stop-tracing: unrolling.lua:2: GTI
 --     --- Begin debugstrs: unrolling.lua:2: GTI ---
 --     ; {
 --     ;   "trid": "2",

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -474,13 +474,13 @@ impl MT {
                 start_tid,
                 coupler_tid,
             } => {
-                self.stop_tracing(loc, start_tid, TraceEnd::Coupler(coupler_tid));
+                self.stop_tracing(start_tid, TraceEnd::Coupler(coupler_tid));
             }
             TransitionControlPoint::StopLoopTracing(trid) => {
-                self.stop_tracing(loc, trid, TraceEnd::Loop);
+                self.stop_tracing(trid, TraceEnd::Loop);
             }
             TransitionControlPoint::StopReturnTracing(trid) => {
-                self.stop_tracing(loc, trid, TraceEnd::Loop);
+                self.stop_tracing(trid, TraceEnd::Loop);
             }
             TransitionControlPoint::StopUnrollTracing {
                 inner_hl,
@@ -637,8 +637,7 @@ impl MT {
     ///
     /// If an error occurs while tracing, the original tracing [Location] will be put back into
     /// either the `Counting` or `DontTrace` states.
-    fn stop_tracing(self: &Arc<Self>, loc: &Location, ctrid: TraceId, trace_end: TraceEnd) {
-        let _loc = loc; // Only used in `cfg(test)`.
+    fn stop_tracing(self: &Arc<Self>, ctrid: TraceId, trace_end: TraceEnd) {
         // Assuming no bugs elsewhere, the `unwrap`s cannot fail, because `StartTracing`
         // will have put a `Some` in the `Rc`.
         let (hl, thread_tracer, promotions, debug_strs) =
@@ -664,7 +663,7 @@ impl MT {
                     self.log,
                     Verbosity::Tracing,
                     |log| write!(log, "stop-tracing"),
-                    _loc.hot_location()
+                    Some(&hl)
                 );
                 self.queue_compile_job(Trace {
                     trace_start: TraceStart::ControlPoint { hl },
@@ -695,7 +694,7 @@ impl MT {
                     self.log,
                     Verbosity::Warning,
                     |log| write!(log, "stop-tracing-aborted: {e}"),
-                    _loc.hot_location()
+                    Some(&hl)
                 );
             }
         }


### PR DESCRIPTION
The `Tracing` state holds the location we care about as a `HotLocation`.