### PR TITLE
Don't fail if ykllvm's inst directory already exists.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -117,7 +117,7 @@ cd ykllvm
 ykllvm_hash=$(git rev-parse HEAD)
 cached_ykllvm=0
 if [ -f /opt/ykllvm_cache/ykllvm-release-with-assertions-"${ykllvm_hash}".tgz ]; then
-    mkdir inst
+    mkdir -p inst
     cd inst
     tar xfz /opt/ykllvm_cache/ykllvm-release-with-assertions-"${ykllvm_hash}".tgz
     # Minimally check that we can at least run `clang --version`: if we can't,


### PR DESCRIPTION
`mkdir inst` aborts the script when the directory is already there, which happens if ykllvm is bind-mounted into the container (e.g. by tryci). Changing to `mkdir -p` lets the script to continue with the exeisting directory.

I was using [tryci](https://github.com/softdevteam/tryci) as following:
```shell
tryci -m /vol/.cache/tryci-ykllvm/build:/ci/ykllvm/build,/vol/.cache/tryci-ykllvm/inst:/ci/ykllvm/inst
```