### PR TITLE
Don't use `--no-rosegment`.

### DIFF
--- a/bin/yk-config
+++ b/bin/yk-config
@@ -132,9 +132,6 @@ handle_arg() {
             # Add a proper RPATH, not a RUNPATH:
             # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1737608
             OUTPUT="${OUTPUT} -Wl,--disable-new-dtags"
-
-            # Improve the quality of profiling data.
-            OUTPUT="${OUTPUT} -Wl,--no-rosegment"
             ;;
         --libs)
             OUTPUT="${OUTPUT} -lykcapi"


### PR DESCRIPTION
The problem with this is that it can cause code in a binary to be non-page-aligned, which can cause significant performance swings (5-10%) for no apparent reason.

If/when we want to do profiling again, we can perhaps find a way to bring this flag back for that specific purpose.