### PR TITLE
Ignore the llvm.prefetch intrinsic.

### DIFF
--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -1585,6 +1585,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                 };
                 self.opt.feed_void(hinst.into()).map(|_| ())
             }
+            "prefetch" => Ok(()),
             "smax" => {
                 let [lhs, rhs]: [hir::InstIdx; 2] = jargs.into_vec().try_into().unwrap();
                 let fty = self.opt.func_ty(ftyidx);


### PR DESCRIPTION
Prefetch is an LLVM optimisation hint with no effect on correctness, so aot_to_hir can ignore it instead of hitting the todo!().
Seen in mruby MRB_MEM_PREFETCH.