### PR TITLE
Drop stale cfg ykd on debug_str.

### DIFF
--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -2501,7 +2501,6 @@ mod test {
         let hl = Arc::new(Mutex::new(HotLocation {
             kind: HotLocationKind::Tracing(TraceId::testing()),
             tracecompilation_errors: 0,
-            #[cfg(feature = "ykd")]
             debug_str: None,
         }));
 
@@ -2532,7 +2531,6 @@ mod test {
         let hl = Arc::new(Mutex::new(HotLocation {
             kind: HotLocationKind::Tracing(TraceId::testing()),
             tracecompilation_errors: 0,
-            #[cfg(feature = "ykd")]
             debug_str: None,
         }));
 

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -2588,7 +2588,6 @@ pub(crate) mod test {
         let hl = Arc::new(Mutex::new(HotLocation {
             kind: HotLocationKind::Tracing(TraceId::testing()),
             tracecompilation_errors: 0,
-            #[cfg(feature = "ykd")]
             debug_str: None,
         }));
 
@@ -2640,7 +2639,6 @@ pub(crate) mod test {
         let hl = Arc::new(Mutex::new(HotLocation {
             kind: HotLocationKind::Tracing(TraceId::testing()),
             tracecompilation_errors: 0,
-            #[cfg(feature = "ykd")]
             debug_str: None,
         }));
 

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -4753,7 +4753,6 @@ mod test {
         let hl = Arc::new(Mutex::new(HotLocation {
             kind: HotLocationKind::Tracing(mt.next_trace_id()),
             tracecompilation_errors: 0,
-            #[cfg(feature = "ykd")]
             debug_str: None,
         }));
         let be = X64HirToAsm::new(&m, CodeBufInProgress::new_testing(), true);


### PR DESCRIPTION
This change removes the stale `#[cfg(feature = "ykd")]` attribute from 5 test locaitons in `ykrt`.

Noticed it when running`cargo test -p ykrt --lib` on `master`:

```shell
$ cargo test -p ykrt --lib
    --> ykrt/src/compile/j2/hir_to_asm.rs:2501:38
     |
2501 |         let hl = Arc::new(Mutex::new(HotLocation {
     |                                      ^^^^^^^^^^^ missing `debug_str`

error[E0063]: missing field `debug_str` in initializer of `location::HotLocation`
    --> ykrt/src/compile/j2/hir_to_asm.rs:2532:38
     |
2532 |         let hl = Arc::new(Mutex::new(HotLocation {
     |                                      ^^^^^^^^^^^ missing `debug_str`

error[E0063]: missing field `debug_str` in initializer of `location::HotLocation`
    --> ykrt/src/compile/j2/regalloc.rs:2588:38
     |
2588 |         let hl = Arc::new(Mutex::new(HotLocation {
     |                                      ^^^^^^^^^^^ missing `debug_str`

error[E0063]: missing field `debug_str` in initializer of `location::HotLocation`
    --> ykrt/src/compile/j2/regalloc.rs:2640:38
     |
2640 |         let hl = Arc::new(Mutex::new(HotLocation {
     |                                      ^^^^^^^^^^^ missing `debug_str`

error[E0063]: missing field `debug_str` in initializer of `location::HotLocation`
    --> ykrt/src/compile/j2/x64/x64hir_to_asm.rs:4753:38
     |
4753 |         let hl = Arc::new(Mutex::new(HotLocation {
     |                                      ^^^^^^^^^^^ missing `debug_str`

```