### PR TITLE
Faster software tracing

### DIFF
--- a/tests/ir_lowering/empty.ll
+++ b/tests/ir_lowering/empty.ll
@@ -4,7 +4,7 @@
 ;     # Num funcs: 3
 ;     # Num consts: 0
 ;     # Num global decls: 0
-;     # Num types: 4
+;     # Num types: ...
 ;
 ;     func main() {
 ;       bb0:

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -3,22 +3,26 @@
 use super::{
     AOTTraceIterator, AOTTraceIteratorError, TraceAction, TraceRecorder, TraceRecorderError, Tracer,
 };
-use crate::mt::MTThread;
 use std::{
     cell::UnsafeCell,
     error::Error,
     mem::{self, MaybeUninit},
+    ptr,
     sync::Arc,
 };
 
 /// Traces with more than this many items will be turned into [TraceRecorderError::TraceTooLong].
 static TRACE_TOO_LONG: usize = 15000;
 
-#[derive(Debug, Eq, PartialEq, Clone)]
-struct TracingBBlock {
-    function_index: u16,
-    block_index: u16,
-}
+// This is no_mangle because its name is relied upon by ykllvm (see `BasicBlockTracer.cpp`), and
+// it needs to survive linking.
+#[allow(non_upper_case_globals)]
+#[unsafe(no_mangle)]
+#[thread_local]
+static mut __yk_trace_buffer: TraceBuffer = TraceBuffer {
+    cursor: ptr::null_mut(),
+    end: ptr::null_mut(),
+};
 
 thread_local! {
     // Collection of traced basic blocks. Because this is only accessed in this module, it's
@@ -26,22 +30,10 @@ thread_local! {
     static BASIC_BLOCKS: UnsafeCell<BasicBlocks> = UnsafeCell::new(BasicBlocks::new());
 }
 
-/// Records the specified basic block into the software tracing buffer.
-///
-/// This must only be called if the current thread is tracing.
-///
-/// # Arguments
-///
-/// * `block_id` specifies the block to be recorded. The upper 16-bits are the function index, the
-///   lower 16-bits are the basic block index.
-#[cfg(tracer_swt)]
-#[unsafe(no_mangle)]
-pub extern "C" fn __yk_trace_basicblock(block_id: u32) {
-    debug_assert!(MTThread::is_tracing());
-    BASIC_BLOCKS.with(|bbs| {
-        let bbs = unsafe { &mut *bbs.get() };
-        bbs.push(block_id);
-    })
+#[derive(Debug, Eq, PartialEq, Clone)]
+struct TracingBBlock {
+    function_index: u16,
+    block_index: u16,
 }
 
 pub(crate) struct SWTracer {}
@@ -54,7 +46,16 @@ impl SWTracer {
 
 impl Tracer for SWTracer {
     fn start_recorder(self: Arc<Self>) -> Result<Box<dyn TraceRecorder>, Box<dyn Error>> {
-        debug_assert!(BASIC_BLOCKS.with(|bbs| unsafe { &*bbs.get() }.is_empty()));
+        BASIC_BLOCKS.with(|bbs| {
+            let bbs = unsafe { &mut *bbs.get() };
+            let tb = &raw mut __yk_trace_buffer;
+            unsafe {
+                let start = bbs.data.as_mut_ptr().cast::<u32>();
+                debug_assert!((*tb).cursor.is_null() || (*tb).cursor == start);
+                (*tb).cursor = start;
+                (*tb).end = start.add(TRACE_TOO_LONG);
+            }
+        });
         Ok(Box::new(SWTTraceRecorder {}))
     }
 }
@@ -64,9 +65,7 @@ struct SWTTraceRecorder {}
 
 impl TraceRecorder for SWTTraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, TraceRecorderError> {
-        let bbs = BASIC_BLOCKS.with(|tb| {
-            unsafe { &mut *tb.get() }.extract()
-        });
+        let bbs = BASIC_BLOCKS.with(|bbs| unsafe { &*bbs.get() }.extract());
         match bbs {
             Some(x) => {
                 assert!(!x.is_empty()); // FIXME: who should handle an empty trace?
@@ -104,46 +103,38 @@ impl Iterator for SWTraceIterator {
 
 impl AOTTraceIterator for SWTraceIterator {}
 
+/// The struct shared with ykllvm in `BasicBlockTracer.h`.
+#[repr(C)]
+struct TraceBuffer {
+    cursor: *mut u32,
+    end: *mut u32,
+}
+
 /// A thread-local buffer of basic blocks being gathered during tracing. Internally this reuses the
 /// same buffer for each trace in a given thread, so no allocation is needed to start tracing,
 /// no resizing happens during tracing, and at completion a single allocation of a "perfectly
 /// sized" [Vec] can be made.
 struct BasicBlocks {
-    len: usize,
-    /// The safety property we use on this allocation is that we never write elements when `len >=
-    /// TRACE_TOO_LONG` (indeed, we cap `len` at `TRACE_TOO_LONG`).
+    /// The safety property we use on this allocation is that the trace-buffer TLS cursor never
+    /// advances beyond the end of this allocation.
     data: Box<[MaybeUninit<u32>]>,
 }
 
 impl BasicBlocks {
     fn new() -> Self {
         Self {
-            len: 0,
             data: Box::new_uninit_slice(TRACE_TOO_LONG),
         }
     }
 
-    fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    /// Push a [TracingBBlock] if there is capacity for it.
-    fn push(&mut self, value: u32) {
-        if self.len < TRACE_TOO_LONG {
-            unsafe {
-                self.data
-                    .as_mut_ptr()
-                    .add(self.len)
-                    .write(MaybeUninit::new(value));
-            }
-            self.len += 1;
-        }
-    }
-
     /// Return the blocks recorded as a `Vec` or `None` if the trace was too long.
-    fn extract(&mut self) -> Option<Vec<TracingBBlock>> {
-        let len = mem::replace(&mut self.len, 0);
-        if len < TRACE_TOO_LONG {
+    fn extract(&self) -> Option<Vec<TracingBBlock>> {
+        let tb = &raw mut __yk_trace_buffer;
+        // We continually reuse the same allocation, so put `cursor` back to the start.
+        let start = self.data.as_ptr().cast::<u32>().cast_mut();
+        let cursor = unsafe { mem::replace(&mut (*tb).cursor, start) };
+        let len = unsafe { cursor.offset_from(start) as usize };
+        if cursor != unsafe { (*tb).end } {
             let mut v = Vec::with_capacity(len);
             let slice =
                 unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast::<u32>(), len) };

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -4,7 +4,7 @@ use super::{
     AOTTraceIterator, AOTTraceIteratorError, TraceAction, TraceRecorder, TraceRecorderError, Tracer,
 };
 use crate::mt::MTThread;
-use std::{cell::RefCell, error::Error, sync::Arc};
+use std::{cell::UnsafeCell, error::Error, mem, sync::Arc};
 
 /// Traces with more than this many items will be turned into [TraceRecorderError::TraceTooLong].
 static TRACE_TOO_LONG: usize = 15000;
@@ -16,8 +16,9 @@ struct TracingBBlock {
 }
 
 thread_local! {
-    // Collection of traced basic blocks.
-    static BASIC_BLOCKS: RefCell<Vec<TracingBBlock>> = const { RefCell::new(vec![]) };
+    // Collection of traced basic blocks. Because this is only accessed in this module, it's
+    // relatively easy for us to reason about the safety of the [UnsafeCell].
+    static BASIC_BLOCKS: UnsafeCell<Vec<TracingBBlock>> = const { UnsafeCell::new(vec![]) };
 }
 
 /// Records the specified basic block into the software tracing buffer.
@@ -33,7 +34,8 @@ thread_local! {
 pub extern "C" fn __yk_trace_basicblock(block_id: u32) {
     debug_assert!(MTThread::is_tracing());
     BASIC_BLOCKS.with(|v| {
-        v.borrow_mut().push(TracingBBlock {
+        let v = unsafe { &mut *v.get() };
+        v.push(TracingBBlock {
             function_index: u16::try_from(block_id >> 16).unwrap(),
             block_index: u16::try_from(block_id & 0xffff).unwrap(),
         });
@@ -50,7 +52,7 @@ impl SWTracer {
 
 impl Tracer for SWTracer {
     fn start_recorder(self: Arc<Self>) -> Result<Box<dyn TraceRecorder>, Box<dyn Error>> {
-        debug_assert!(BASIC_BLOCKS.with(|bbs| bbs.borrow().is_empty()));
+        debug_assert!(BASIC_BLOCKS.with(|bbs| unsafe { &*bbs.get() }.is_empty()));
         Ok(Box::new(SWTTraceRecorder {}))
     }
 }
@@ -60,7 +62,10 @@ struct SWTTraceRecorder {}
 
 impl TraceRecorder for SWTTraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, TraceRecorderError> {
-        let bbs = BASIC_BLOCKS.with(|tb| tb.replace(Vec::new()));
+        let bbs = BASIC_BLOCKS.with(|tb| {
+            let tb = unsafe { &mut *tb.get() };
+            mem::replace(tb, Vec::new())
+        });
         if bbs.is_empty() {
             // FIXME: who should handle an empty trace?
             panic!();

--- a/ykrt/src/trace/swt/mod.rs
+++ b/ykrt/src/trace/swt/mod.rs
@@ -4,7 +4,12 @@ use super::{
     AOTTraceIterator, AOTTraceIteratorError, TraceAction, TraceRecorder, TraceRecorderError, Tracer,
 };
 use crate::mt::MTThread;
-use std::{cell::UnsafeCell, error::Error, mem, sync::Arc};
+use std::{
+    cell::UnsafeCell,
+    error::Error,
+    mem::{self, MaybeUninit},
+    sync::Arc,
+};
 
 /// Traces with more than this many items will be turned into [TraceRecorderError::TraceTooLong].
 static TRACE_TOO_LONG: usize = 15000;
@@ -18,7 +23,7 @@ struct TracingBBlock {
 thread_local! {
     // Collection of traced basic blocks. Because this is only accessed in this module, it's
     // relatively easy for us to reason about the safety of the [UnsafeCell].
-    static BASIC_BLOCKS: UnsafeCell<Vec<TracingBBlock>> = const { UnsafeCell::new(vec![]) };
+    static BASIC_BLOCKS: UnsafeCell<BasicBlocks> = UnsafeCell::new(BasicBlocks::new());
 }
 
 /// Records the specified basic block into the software tracing buffer.
@@ -33,12 +38,9 @@ thread_local! {
 #[unsafe(no_mangle)]
 pub extern "C" fn __yk_trace_basicblock(block_id: u32) {
     debug_assert!(MTThread::is_tracing());
-    BASIC_BLOCKS.with(|v| {
-        let v = unsafe { &mut *v.get() };
-        v.push(TracingBBlock {
-            function_index: u16::try_from(block_id >> 16).unwrap(),
-            block_index: u16::try_from(block_id & 0xffff).unwrap(),
-        });
+    BASIC_BLOCKS.with(|bbs| {
+        let bbs = unsafe { &mut *bbs.get() };
+        bbs.push(block_id);
     })
 }
 
@@ -63,18 +65,14 @@ struct SWTTraceRecorder {}
 impl TraceRecorder for SWTTraceRecorder {
     fn stop(self: Box<Self>) -> Result<Box<dyn AOTTraceIterator>, TraceRecorderError> {
         let bbs = BASIC_BLOCKS.with(|tb| {
-            let tb = unsafe { &mut *tb.get() };
-            mem::replace(tb, Vec::new())
+            unsafe { &mut *tb.get() }.extract()
         });
-        if bbs.is_empty() {
-            // FIXME: who should handle an empty trace?
-            panic!();
-        } else {
-            if bbs.len() > TRACE_TOO_LONG {
-                Err(TraceRecorderError::TraceTooLong)
-            } else {
-                Ok(Box::new(SWTraceIterator::new(bbs)))
+        match bbs {
+            Some(x) => {
+                assert!(!x.is_empty()); // FIXME: who should handle an empty trace?
+                Ok(Box::new(SWTraceIterator::new(x)))
             }
+            None => Err(TraceRecorderError::TraceTooLong),
         }
     }
 }
@@ -105,3 +103,60 @@ impl Iterator for SWTraceIterator {
 }
 
 impl AOTTraceIterator for SWTraceIterator {}
+
+/// A thread-local buffer of basic blocks being gathered during tracing. Internally this reuses the
+/// same buffer for each trace in a given thread, so no allocation is needed to start tracing,
+/// no resizing happens during tracing, and at completion a single allocation of a "perfectly
+/// sized" [Vec] can be made.
+struct BasicBlocks {
+    len: usize,
+    /// The safety property we use on this allocation is that we never write elements when `len >=
+    /// TRACE_TOO_LONG` (indeed, we cap `len` at `TRACE_TOO_LONG`).
+    data: Box<[MaybeUninit<u32>]>,
+}
+
+impl BasicBlocks {
+    fn new() -> Self {
+        Self {
+            len: 0,
+            data: Box::new_uninit_slice(TRACE_TOO_LONG),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Push a [TracingBBlock] if there is capacity for it.
+    fn push(&mut self, value: u32) {
+        if self.len < TRACE_TOO_LONG {
+            unsafe {
+                self.data
+                    .as_mut_ptr()
+                    .add(self.len)
+                    .write(MaybeUninit::new(value));
+            }
+            self.len += 1;
+        }
+    }
+
+    /// Return the blocks recorded as a `Vec` or `None` if the trace was too long.
+    fn extract(&mut self) -> Option<Vec<TracingBBlock>> {
+        let len = mem::replace(&mut self.len, 0);
+        if len < TRACE_TOO_LONG {
+            let mut v = Vec::with_capacity(len);
+            let slice =
+                unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast::<u32>(), len) };
+            v.extend(slice.iter().map(|block_id| {
+                let block_id = *block_id;
+                TracingBBlock {
+                    function_index: u16::try_from(block_id >> 16).unwrap(),
+                    block_index: u16::try_from(block_id & 0xffff).unwrap(),
+                }
+            }));
+            Some(v)
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
This PR speeds up software tracing (by about 1/3 in terms of `YKD_LOG_STATS`). Although it is already pretty fast (often only spending a few hundredths of a second), this is the first step towards trying to reduce interpreter overhead.

[The impact on yklua benchmarks is a bit random. Sometimes by tracing a bit faster we cause a slightly different set of traces. Unless we've trigger a bug somewhere, which I don't think this does, I think we have to accept temporary randomness in benchmarks until we get all the way through this. This PR is still an improvement in of itself, albeit a small one.]