### PR TITLE
Ensure that constants are deduplicated across the peel.

### DIFF
--- a/ykrt/src/compile/j2/opt/fullopt.rs
+++ b/ykrt/src/compile/j2/opt/fullopt.rs
@@ -696,13 +696,27 @@ impl PassOpt<'_> {
     /// is equivalent to an existing instruction. However, that cannot be guaranteed, and must not
     /// be relied upon in any way.undefined behaviour.
     pub(super) fn push_pre_inst(&mut self, preinst: Inst) -> InstIdx {
-        if let Inst::Const(c) = &preinst
-            && let Some(x) = self
+        if let Inst::Const(c) = &preinst {
+            // Try and find a match in the overall trace.
+            if let Some(x) = self
                 .optinternal
                 .consts_map
                 .get(&HashableConst(c.to_owned()))
-        {
-            return *x;
+            {
+                return *x;
+            }
+            if !self.inner.pre_insts.is_empty() {
+                // Do a linear search through the preinsts for a match. This is potentially quite
+                // slow, though in practise there tend to be zero pre_insts so we don't even hit
+                // this branch.
+                let ch = HashableConst(c.to_owned());
+                if let Some(x) = self.inner.pre_insts.iter().position(|x| match x {
+                    Inst::Const(c) => HashableConst(c.to_owned()) == ch,
+                    _ => false,
+                }) {
+                    return InstIdx::from_raw_index(self.optinternal.insts.len_usize() + x);
+                }
+            }
         }
         let iidx = InstIdx::from_raw_index(
             self.optinternal.insts.len_usize() + self.inner.pre_insts.len(),

--- a/ykrt/src/compile/j2/opt/load_store.rs
+++ b/ykrt/src/compile/j2/opt/load_store.rs
@@ -196,8 +196,8 @@ impl PassT for LoadStore {
     }
 
     fn equiv_committed(&mut self, equiv1: InstIdx, equiv2: InstIdx) {
-        // FIXME: This is of a hack until `prepare_for_peel` can properly determine equivalences.
-        // At that point, there's no need for this method to do anything.
+        // FIXME: This is a hack until `prepare_for_peel` can properly determine equivalences. At
+        // that point, there's no need for this method to do anything.
         for hv_val in self.hv.values_mut() {
             if *hv_val == equiv1 {
                 *hv_val = equiv2;
@@ -802,6 +802,29 @@ mod test {
           %0: ptr = arg
           %1: i8 = 2
           store %1, %0
+          term [%0]
+          ; peel
+          %0: ptr = arg
+          term [%0]
+        ",
+        );
+
+        // Ensure that constants are properly deduplicated across the peel.
+        full_opt_test(
+            r#"
+          %0: ptr = arg [reg("GPR0", undefined)]
+          %1: ptr = ptradd %0, 8
+          %2: i8 = 3
+          store %2, %0
+          store %2, %1
+          term [%0]
+        "#,
+            "
+          %0: ptr = arg
+          %1: ptr = ptradd %0, 8
+          %2: i8 = 3
+          store %2, %0
+          store %2, %1
           term [%0]
           ; peel
           %0: ptr = arg


### PR DESCRIPTION
Before this commit, the same constant could end up being duplicated by `push_pre_inst` which would mean that post-peel load_store would not notice that things could be optimised. To make this even more frustrating the effects of this depended on the traversal order in `load_store::prepare_for_peel`!