### PR TITLE
Patch guards with an indirect pointer.

### DIFF
--- a/ykrt/src/compile/j2/compiled_trace.rs
+++ b/ykrt/src/compile/j2/compiled_trace.rs
@@ -17,7 +17,6 @@ use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::{
     any::Any,
-    assert_matches,
     ffi::c_void,
     sync::{Arc, Weak},
 };
@@ -180,10 +179,8 @@ impl<Reg: RegT + 'static> CompiledTrace for J2CompiledTrace<Reg> {
         let gidx = CompiledGuardIdx::from_raw_index(usize::from(gid));
         for patch_off in &self.guards[gidx].patch_offs {
             let patch_off = usize::try_from(*patch_off).unwrap();
-            self.codebuf.patch(patch_off, 10, |patch_addr| {
-                // We can only patch `mov r64, imm64`.
-                assert_matches!(unsafe { patch_addr.read() }, 0x48 | 0x49);
-                let patch_addr = unsafe { patch_addr.byte_add(2) };
+            self.codebuf.patch(patch_off, 8, |patch_addr| {
+                assert_eq!(patch_addr.addr() % 8, 0);
                 unsafe {
                     (patch_addr as *mut u64).write(u64::try_from(tgt.addr()).unwrap());
                 }

--- a/ykrt/src/compile/j2/x64/asm.rs
+++ b/ykrt/src/compile/j2/x64/asm.rs
@@ -104,57 +104,6 @@ impl Asm {
         self.buf_end_off = (self.buf_end_off / align) * align;
     }
 
-    /// Return the current offset, in bytes, from the end of the code buffer. That end is
-    /// guaranteed to be aligned to a page boundary.
-    pub(super) fn buf_end_off(&self) -> usize {
-        usize::try_from(self.buf_end_off).unwrap()
-    }
-
-    /// Push `n` bytes of `nop` instructions.
-    pub(super) fn push_nops(&mut self, mut n: usize) {
-        // From https://en.wikipedia.org/wiki/NOP_(code)
-        while n > 0 {
-            let bytes: &[u8] = match n {
-                1 => &[0x90],
-                2 => &[0x66, 0x90],
-                3 => &[0x0F, 0x1F, 0x00],
-                4 => &[0x0F, 0x1F, 0x40, 0x00],
-                5 => &[0x0F, 0x1F, 0x44, 0x00, 0x00],
-                6 => &[0x66, 0x0F, 0x1F, 0x44, 0x00, 0x00],
-                7 => &[0x0F, 0x1F, 0x80, 0x00, 0x00, 0x00, 0x00],
-                8 => &[0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00],
-                _ => &[0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00],
-            };
-            self.buf_end_off = self
-                .buf_end_off
-                .checked_sub(u32::try_from(bytes.len()).unwrap())
-                .expect("Would exceed preallocated code buffer");
-            unsafe {
-                self.buf
-                    .as_ptr()
-                    .byte_add(usize::try_from(self.buf_end_off).unwrap())
-                    .copy_from_nonoverlapping(bytes.as_ptr(), bytes.len())
-            };
-            if let Some(log) = &mut self.log {
-                log.push(
-                    match n {
-                        1 => "nop",
-                        2 => "xchg ax, ax",
-                        3 => "nop dword ptr [rax]",
-                        4 => "nop dword ptr [rax+0x0]",
-                        5 => "nop dword ptr [rax+rax*1+0x0]",
-                        6 => "nop word ptr [rax+rax*1+0x0]",
-                        7 => "nop dword ptr [rax+0x0]",
-                        8 => "nop dword ptr [rax+rax*1+0x0]",
-                        _ => "nop word ptr [rax+rax*1+0x0]",
-                    }
-                    .to_string(),
-                );
-            }
-            n -= bytes.len();
-        }
-    }
-
     /// Push an icedx64 [Op].
     pub(super) fn push_inst(&mut self, op: Result<Op, iced_x86::IcedError>) {
         let mut inst = op.unwrap();
@@ -270,18 +219,15 @@ impl Asm {
             // which part of it we write the relocation to.
             match reloc {
                 RelocKind::AbsoluteWithLabel(lidx) => {
-                    let patch_off = if let 0x48 | 0x49 = bufs[off] {
-                        off + 2 // mov r64, imm64
-                    } else {
-                        todo!("{:?}", &bufs[off..off + 2])
-                    };
                     let addr = base + usize::try_from(self.labels[lidx].unwrap()).unwrap();
-                    bufs[patch_off..patch_off + 8].copy_from_slice(&addr.to_le_bytes());
+                    bufs[off..off + 8].copy_from_slice(&addr.to_le_bytes());
                 }
                 RelocKind::NearWithAddr(_) | RelocKind::NearWithLabel(_) => {
                     #[allow(clippy::if_same_then_else)]
                     let patch_off = if bufs[off] == 0xe9 {
                         off + 1 // JMP
+                    } else if bufs[off] == 0xFF && bufs[off + 1] == 0x25 {
+                        off + 2 // JMP [rip+disp32]
                     } else if bufs[off] == 0x0F && bufs[off + 1] >= 0x80 && bufs[off + 1] <= 0x08F {
                         off + 2 // JCC
                     } else if bufs[off] == 0x66
@@ -338,7 +284,7 @@ impl Asm {
 /// A relocation kind: these are all relative to the eventual address of the associated operation.
 #[derive(Clone, Debug)]
 pub(super) enum RelocKind {
-    /// A relocation to an absolute address referenced by `LabelIdx`.
+    /// A data position referencing the absolute address of `LabelIdx`.
     AbsoluteWithLabel(LabelIdx),
     /// A relative branch to the address at `usize`.
     NearWithAddr(usize),

--- a/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+++ b/ykrt/src/compile/j2/x64/x64hir_to_asm.rs
@@ -71,6 +71,9 @@ pub(in crate::compile::j2) struct X64HirToAsm<'a> {
     /// The data section: we map any given (align, byte sequence) pair to [LabelIdx]s, which will
     /// eventually be output as their own pseudo-block.
     data_sec: HashMap<Vec<u8>, (u32, LabelIdx)>,
+    /// A pair (patch_label, deopt_label): each guard, at address `patch_label`, has an 8 byte
+    /// pointer which initially points to `deopt_label`.
+    guard_targets: Vec<(LabelIdx, LabelIdx)>,
 }
 
 impl<'a> X64HirToAsm<'a> {
@@ -103,6 +106,7 @@ impl<'a> X64HirToAsm<'a> {
             entry_label,
             reg_hints: TypedVec::new(),
             data_sec: HashMap::new(),
+            guard_targets: Vec::new(),
         }
     }
 
@@ -1102,6 +1106,18 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         mut self,
         labels: &[Self::Label],
     ) -> Result<(ExeCodeBuf, Option<String>, Vec<usize>), CompilationError> {
+        // We put all the guard jump targets at the end. We assume the start of each block is
+        // aligned, and we know -- because each jump target is 8 bytes -- that the block will end
+        // aligned to 8 bytes.
+        for (patch, deopt) in self.guard_targets.drain(..) {
+            self.asm.align(8);
+            self.asm.push_reloc(
+                IcedInst::with_declare_qword(&[0]),
+                RelocKind::AbsoluteWithLabel(deopt),
+            );
+            self.asm.attach_label(patch);
+        }
+
         // Push the data section as its own block. This rests on the assumption that the start of
         // each block is aligned.
         for (data, (align, lidx)) in self.data_sec.into_iter() {
@@ -1667,7 +1683,7 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
         gidx: CompiledGuardIdx,
         _vlocs: &[VarLocs<Self::Reg>],
     ) -> Result<LabelIdx, CompilationError> {
-        // For both the call to `__yk_j2_deopt` and the patchable jump, we use `RAX`.
+        // The call to `__yk_j2_deopt` uses `RAX`.
         self.asm
             .push_inst(IcedInst::with1(Code::Call_rm64, IcedReg::RAX));
         self.asm.push_inst(IcedInst::with2(
@@ -1692,29 +1708,20 @@ impl HirToAsmBackend for X64HirToAsm<'_> {
             IcedReg::RBP,
         ));
 
-        // This is the "dummy" jump that we will modify if a side-trace is created.
+        // Guards end with a `JMP [rip+...]` where `...` is `patch_label`. Initially the pointer
+        // stored at this address will be `deopt_label`. If/when a side-trace is created, the
+        // pointer stored will be updated and point to the start of the side-trace.
+        let deopt_label = self.asm.mk_label();
+        self.asm.attach_label(deopt_label);
         let patch_label = self.asm.mk_label();
-        let dummy_label = self.asm.mk_label();
-        self.asm.attach_label(dummy_label);
-        self.asm
-            .push_inst(IcedInst::with1(Code::Jmp_rm64, IcedReg::RAX));
-        // mov r64, imm64 is 10 bytes long, of which the immediate is the last 8 bytes. We need
-        // those entire 10 bytes to sit within a naturally aligned 16 byte block (which by
-        // definition cannot span a cache line).
-        let off = self.asm.buf_end_off() - 10;
-        let mut align = (off + 2) % 8;
-        if (off + 2 - align).is_multiple_of(16) {
-            align += 8
-        }
-        self.asm.push_nops(align);
         self.asm.push_reloc(
-            IcedInst::with2(Code::Mov_r64_imm64, IcedReg::RAX, 0),
-            RelocKind::AbsoluteWithLabel(dummy_label),
+            IcedInst::with1(
+                Code::Jmp_rm64,
+                MemoryOperand::with_base_displ(IcedReg::RIP, 0),
+            ),
+            RelocKind::NearWithLabel(patch_label),
         );
-        // Check that we've aligned the immediate to 8 bytes...
-        assert_eq!((self.asm.buf_end_off() + 2) % 8, 0);
-        assert_eq!((self.asm.buf_end_off() + 2) % 16, 8);
-        self.asm.attach_label(patch_label);
+        self.guard_targets.push((patch_label, deopt_label));
 
         Ok(patch_label)
     }
@@ -7298,15 +7305,14 @@ mod test {
               term [%0]
             ",
             &["
+              ; l{{3}}
+              dq l{{2}}
               ; gidx 0
               ; l{{1}}
               sub rsp, 0x80
               ; term []
+              jmp qword l{{3}}
               ; l{{2}}
-              mov r.64.x, l{{3}}
-              ...
-              jmp r.64.x
-              ; l{{3}}
               mov rdi, rbp
               mov rsi, 0
               mov edx, 0
@@ -7327,15 +7333,14 @@ mod test {
               term [%0]
             ",
             &["
+              ; l{{3}}
+              dq l{{2}}
               ; gidx 0
               ; l{{1}}
               sub rsp, 0x80
               ; term []
+              jmp qword l{{3}}
               ; l{{2}}
-              mov r.64.x, l{{3}}
-              ...
-              jmp r.64.x
-              ; l{{3}}
               mov rdi, rbp
               mov rsi, 0
               mov edx, 0


### PR DESCRIPTION
This simplifies this part of the code considerably. It also allows us to avoid clobbering a register which may soon be useful.