### PR TITLE
Don't spill everything when jumping to side-traces.

### DIFF
--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -705,23 +705,28 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         let mut deopt_vars_off = 0;
         for DeoptFrame { pc, pc_statepoint } in &guard.deopt_frames {
             let mut locals = HashMap::with_capacity(pc_statepoint.lives.len());
-            for (iid, DeoptVar { fromvlocs, .. }) in
+            for (
+                iid,
+                DeoptVar {
+                    coupler_fromvlocs, ..
+                },
+            ) in
                 pc_statepoint.lives.iter().map(|x| x.to_inst_id()).zip(
                     &guard.deopt_vars[deopt_vars_off..deopt_vars_off + pc_statepoint.lives.len()],
                 )
             {
                 let tyidx = self.p_ty(self.am.inst(&iid).def_type(self.am).unwrap())?;
-                let iidx = if fromvlocs
+                let iidx = if coupler_fromvlocs
                     .iter()
                     .any(|vloc| matches!(vloc, VarLoc::Const(_)))
                 {
-                    assert_eq!(fromvlocs.len(), 1);
-                    self.vloc_arg_to_const(fromvlocs.iter().nth(0).unwrap())?
+                    assert_eq!(coupler_fromvlocs.len(), 1);
+                    self.vloc_arg_to_const(coupler_fromvlocs.iter().nth(0).unwrap())?
                 } else {
                     self.opt.feed_arg(hir::Arg { tyidx }.into())?
                 };
                 locals.insert(iid.clone(), iidx);
-                entry_vars.push(fromvlocs.clone());
+                entry_vars.push(coupler_fromvlocs.clone());
             }
             self.frames.push(Frame {
                 // aot_ir::Arg instructions come at the start of functions; by definition any frame

--- a/ykrt/src/compile/j2/compiled_trace.rs
+++ b/ykrt/src/compile/j2/compiled_trace.rs
@@ -312,10 +312,15 @@ impl PartialEq for DeoptFrame {
     }
 }
 
+/// The variables recorded on entry to a guard.
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct DeoptVar<Reg: RegT> {
     pub bitw: u32,
-    pub fromvlocs: VarLocs<Reg>,
+    /// The variable locations relevant to a coupler. Some of these might be only in registers.
+    pub coupler_fromvlocs: VarLocs<Reg>,
+    /// The variable locations relevant to deopt. None of these will be [VarLoc::Reg] only: they
+    /// will contain at least one `Const`, `Stack`, or `StackOff`.
+    pub deopt_fromvlocs: VarLocs<Reg>,
     pub tovlocs: VarLocs<Reg>,
 }
 

--- a/ykrt/src/compile/j2/hir_to_asm.rs
+++ b/ykrt/src/compile/j2/hir_to_asm.rs
@@ -703,7 +703,8 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                     let tovlocs = smap_loc.clone();
                     deopt_vars.push(DeoptVar {
                         bitw: gblock.inst_bitw(self.m, *term_iidx),
-                        fromvlocs,
+                        coupler_fromvlocs: VarLocs::new(),
+                        deopt_fromvlocs: fromvlocs,
                         tovlocs,
                     });
                 }
@@ -733,9 +734,9 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
                 // the latter from scratch); and `Const` / `Reg` `StackOff` / `Const`s are no-ops
                 // everywhere.
                 for deopt_var in frame_deopt_vars {
-                    if deopt_var.fromvlocs == deopt_var.tovlocs
+                    if deopt_var.deopt_fromvlocs == deopt_var.tovlocs
                         && (frame_idx == 0
-                            || deopt_var.fromvlocs.iter().all(|vloc| {
+                            || deopt_var.deopt_fromvlocs.iter().all(|vloc| {
                                 matches!(
                                     vloc,
                                     VarLoc::Const(_) | VarLoc::Reg(_, _) | VarLoc::StackOff(_)
@@ -756,6 +757,26 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
             assert!(deopt_term_iter.next().is_none());
             assert!(!gblock.insts.is_empty());
 
+            // All values passed to deopt must be spillable (or just a const), but for values
+            // passed to another coupler trace they can be register only. `coupler_vlocs` is thus
+            // the same length as `from_vlocs` but doesn't force everything to be spilled.
+            let coupler_vlocs = gextra
+                .deopt_vars
+                .iter()
+                .zip(&mut deopt_vars)
+                .map(|(iidx, deopt_var)| {
+                    let vlocs = if let Inst::Const(Const { kind, .. }) = gexit.block.inst(*iidx) {
+                        varlocs![VarLoc::Const(kind.clone())]
+                    } else if let Ok(i) = gexit.exit_vars.binary_search(iidx) {
+                        gexit.exit_vlocs[i].clone()
+                    } else {
+                        deopt_var.deopt_fromvlocs.clone()
+                    };
+                    deopt_var.coupler_fromvlocs = vlocs.clone();
+                    vlocs
+                })
+                .collect::<Vec<_>>();
+
             let mut merged = false;
             let mut gidx = gbodies.len();
             for (cnd_gidx, gbody) in gbodies.iter_mut_enumerated() {
@@ -774,9 +795,16 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
 
             let vlocs = deopt_vars
                 .iter()
-                .map(|x| x.fromvlocs.clone())
+                .map(|x| x.deopt_fromvlocs.clone())
                 .collect::<Vec<_>>();
             let patch_label = self.be.guard_end(self.m.trid, gidx, &vlocs)?;
+            ra.set_term_vlocs(
+                &mut self.be,
+                &gblock,
+                false,
+                &gexit.exit_vlocs,
+                &coupler_vlocs,
+            )?;
             ra.keep_alive_at_term(
                 InstIdx::from_raw_index(gblock.insts.len_usize() - 1),
                 gblock.term_vars(),
@@ -1286,18 +1314,17 @@ impl<'a, AB: HirToAsmBackend> HirToAsm<'a, AB> {
     }
 }
 
-/// Are the "from" deopt vars in `cnd` compatible with those in `with`? Note: this relationship is
-/// not necessarily symmetric.
+/// Are the `deopt_fromvlocs` vars in `cnd` compatible with those in `with`? Note: this
+/// relationship is not necessarily symmetric.
 fn deopt_vars_compatible<Reg: RegT>(cnd: &[DeoptVar<Reg>], with: &[DeoptVar<Reg>]) -> bool {
     if cnd.len() != with.len() {
         return false;
     }
-    cnd.iter().zip(with.iter()).all(|(x, y)| {
-        x.bitw == y.bitw
-            && x.fromvlocs.len() == y.fromvlocs.len()
-            && x.fromvlocs
-                .iter()
-                .zip(y.fromvlocs.iter())
+
+    fn is_compatible<Reg: RegT>(x: &VarLocs<Reg>, y: &VarLocs<Reg>) -> bool {
+        x.len() == y.len()
+            && x.iter()
+                .zip(y.iter())
                 // OPT: We could do this unsorted, but then we have to do the checks in both
                 // directions. It's unclear if that's worth it, when the common case is "both sides
                 // have 1 entry".
@@ -1313,6 +1340,12 @@ fn deopt_vars_compatible<Reg: RegT>(cnd: &[DeoptVar<Reg>], with: &[DeoptVar<Reg>
                     (VarLoc::Const(lhs), VarLoc::Const(rhs)) => lhs == rhs,
                     _ => false,
                 })
+    }
+
+    cnd.iter().zip(with.iter()).all(|(x, y)| {
+        x.bitw == y.bitw
+            && is_compatible(&x.coupler_fromvlocs, &y.coupler_fromvlocs)
+            && is_compatible(&x.deopt_fromvlocs, &y.deopt_fromvlocs)
     })
 }
 
@@ -2011,7 +2044,8 @@ mod test {
     fn deopt_vars_compatibility() {
         let x = vec![DeoptVar {
             bitw: 64,
-            fromvlocs: varlocs![
+            coupler_fromvlocs: VarLocs::new(),
+            deopt_fromvlocs: varlocs![
                 VarLoc::Stack(8),
                 VarLoc::Reg(TestReg::R0, RegFill::Undefined)
             ],
@@ -2019,7 +2053,8 @@ mod test {
         }];
         let y = vec![DeoptVar {
             bitw: 64,
-            fromvlocs: varlocs![
+            coupler_fromvlocs: VarLocs::new(),
+            deopt_fromvlocs: varlocs![
                 VarLoc::Stack(8),
                 VarLoc::Reg(TestReg::R0, RegFill::Undefined)
             ],
@@ -2027,7 +2062,8 @@ mod test {
         }];
         let z = vec![DeoptVar {
             bitw: 64,
-            fromvlocs: varlocs![VarLoc::Stack(8), VarLoc::Reg(TestReg::R0, RegFill::Zeroed)],
+            coupler_fromvlocs: VarLocs::new(),
+            deopt_fromvlocs: varlocs![VarLoc::Stack(8), VarLoc::Reg(TestReg::R0, RegFill::Zeroed)],
             tovlocs: VarLocs::new(),
         }];
 
@@ -2040,7 +2076,8 @@ mod test {
 
         let sgn = vec![DeoptVar {
             bitw: 64,
-            fromvlocs: varlocs![VarLoc::Stack(8), VarLoc::Reg(TestReg::R0, RegFill::Signed)],
+            coupler_fromvlocs: VarLocs::new(),
+            deopt_fromvlocs: varlocs![VarLoc::Stack(8), VarLoc::Reg(TestReg::R0, RegFill::Signed)],
             tovlocs: VarLocs::new(),
         }];
         assert!(!deopt_vars_compatible(&z, &sgn));
@@ -2313,7 +2350,7 @@ mod test {
                     .iter()
                     .map(|x| format!(
                         "  fromvlocs=[{}]\n  tovlocs=[{}]",
-                        x.fromvlocs
+                        x.deopt_fromvlocs
                             .iter()
                             .map(|x| format!("{x:?}"))
                             .collect::<Vec<_>>()

--- a/ykrt/src/compile/j2/regalloc.rs
+++ b/ykrt/src/compile/j2/regalloc.rs
@@ -344,9 +344,16 @@ impl<'a, AB: HirToAsmBackend> RegAlloc<'a, AB> {
                         }
                     }
                     VarLoc::Reg(reg, fill) => {
-                        assert!(!self.rstates.iidxs(*reg).contains(iidx));
-                        self.rstates.set_fill(*reg, *fill);
-                        self.rstates.iidxs_mut(*reg).push(*iidx);
+                        if !self.rstates.iidxs(*reg).contains(iidx) {
+                            self.rstates.set_fill(*reg, *fill);
+                            self.rstates.iidxs_mut(*reg).push(*iidx);
+                        } else {
+                            assert!(
+                                self.rstates.fill(*reg) == *fill
+                                    || *fill == RegFill::Undefined
+                                    || self.rstates.fill(*reg) == RegFill::Undefined
+                            );
+                        }
                     }
                     VarLoc::Const(_) => (),
                 }

--- a/ykrt/src/compile/j2/x64/deopt.rs
+++ b/ykrt/src/compile/j2/x64/deopt.rs
@@ -340,10 +340,12 @@ fn reconstruct(
 ) {
     for DeoptVar {
         bitw,
-        fromvlocs,
+        deopt_fromvlocs,
         tovlocs,
+        ..
     } in varlocs.iter().filter(|x| !x.tovlocs.is_empty())
     {
+        let fromvlocs = deopt_fromvlocs;
         // FIXME: For now, we only deal with 1 fromvloc.
         assert_eq!(fromvlocs.len(), 1, "{fromvlocs:?}");
         let fromvloc = fromvlocs.iter().next().unwrap();


### PR DESCRIPTION
To make deopt simple, we ensure that every value that can be deopted is spilt. However, this also forced jumps to coupler traces to also spill everything, even when there were plenty of free registers. This commit splits apart "VarLocs for deopt" from "VarLocs for jumping to another trace": the latter do not have to force every variable to have a spilt version. This can be a useful speedup depending on the pattern of traces a program creates.