### PR TITLE
Lower InsertValue in aot_to_hir

### DIFF
--- a/tests/c/insertvalue_struct.c
+++ b/tests/c/insertvalue_struct.c
@@ -1,0 +1,101 @@
+// Compiler:
+//   env-var: YKB_EXTRA_CC_FLAGS=-O1
+// Run-time:
+//   env-var: YKD_LOG_IR=aot,hir
+//   env-var: YKD_SERIALISE_COMPILATION=1
+//   env-var: YKD_LOG=4
+//   stderr:
+//     yk-tracing: start-tracing
+//     1
+//     999
+//     yk-tracing: stop-tracing
+//     --- Begin aot ---
+//     ...
+//     func make_struct(%{{_}}: i8, %{{_}}: i64) -> {0: i8, 64: i64} {
+//     ...
+//     %{{parg_a}}: i8 = arg(0)
+//     %{{parg_b}}: i64 = arg(1)
+//     ...
+//     %{{s0}}: {0: i8, 64: i64} = insert_val poison<{0: i8, 64: i64}>, %{{parg_a}}
+//     %{{s}}: {0: i8, 64: i64} = insert_val %{{s0}}, %{{parg_b}}
+//     ret %{{s}}
+//     ...
+//     %{{call_ret}}: {0: i8, 64: i64} = call make_struct(%{{_}}, %{{_}})...
+//     ...
+//     %{{a}}: i8 = extractvalue %{{call_ret}}, [0]
+//     %{{b}}: i64 = extractvalue %{{call_ret}}, [1]
+//     ...
+//     --- End aot ---
+//     --- Begin hir ---
+//     ...
+//     %{{a2}}: i8 = load %{{_}}
+//     %{{b2}}: i64 = load %{{_}}
+//     ...
+//     %{{a2_ext}}: i32 = zext %{{a2}}
+//     ...
+//     %{{_}}: i32 = call %{{_}}(%{{_}}, %{{_}}, %{{a2_ext}}) ; @fprintf
+//     ...
+//     %{{_}}: i32 = call %{{_}}(%{{_}}, %{{_}}, %{{b2}}) ; @fprintf
+//     ...
+//     --- End hir ---
+//     1
+//     999
+//     yk-execution: enter-jit-code {"trid": "0"}
+//     1
+//     999
+//     1
+//     999
+//     yk-execution: deoptimise ...
+//     exit
+
+// Test that the trace builder handles a struct built via a chain of `insertvalue` instructions.
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+struct S {
+  uint8_t a;
+  uint64_t b;
+};
+
+__attribute__((noinline)) struct S make_struct(uint8_t a, uint64_t b) {
+  struct S ret = {a, b};
+  return ret;
+}
+
+void interp() {
+  YkMT *mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(mt, 0);
+  YkLocation loc = yk_location_new();
+
+  int res = 9998;
+  int i = 4;
+  uint8_t a_val = 1;
+  uint64_t b_val = 999;
+  NOOPT_VAL(loc);
+  NOOPT_VAL(res);
+  NOOPT_VAL(i);
+  NOOPT_VAL(a_val);
+  NOOPT_VAL(b_val);
+  while (i > 0) {
+    yk_mt_control_point(mt, &loc);
+    struct S s1 = make_struct(a_val, b_val);
+    fprintf(stderr, "%d\n", s1.a);
+    fprintf(stderr, "%ld\n", s1.b);
+    i--;
+  }
+  fprintf(stderr, "exit\n");
+  NOOPT_VAL(res);
+  yk_location_drop(loc);
+  yk_mt_shutdown(mt);
+}
+
+int main(int argc, char **argv) {
+  interp();
+  return (EXIT_SUCCESS);
+}

--- a/ykrt/src/compile/j2/aot_to_hir.rs
+++ b/ykrt/src/compile/j2/aot_to_hir.rs
@@ -98,7 +98,7 @@ pub(super) struct AotToHir<'a, Reg: RegT> {
     frames: Vec<Frame>,
     /// If logging is enabled, create a map of addresses -> names to make IR printing nicer.
     addr_name_map: Option<FxHashMap<usize, Option<String>>>,
-    /// Mapping of struct-returning Calls to its ExtractVals per struct field instructions.
+    /// Mapping of struct-building Calls/InsertVals to their per-field ExtractVal instructions.
     call_extractvals: FxHashMap<hir::InstIdx, Vec<hir::InstIdx>>,
     /// The JIT IR this struct builds.
     phantom: PhantomData<Reg>,
@@ -941,7 +941,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
                     CallProcessedKind::Outlined => (),
                     CallProcessedKind::Terminated => return Ok(TraceEndKind::Call),
                 },
-                Inst::InsertValue { .. } => todo!(),
+                Inst::InsertValue { .. } => self.p_insertvalue(pc.clone(), inst)?,
                 Inst::Load { .. } => self.p_load(pc.clone(), inst)?,
                 Inst::LoadArg { .. } => self.p_loadarg(pc.clone(), inst)?,
                 Inst::Phi { .. } => unreachable!(),
@@ -1967,6 +1967,41 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         .map(|_| ())
     }
 
+    fn p_insertvalue(&mut self, iid: InstId, inst: &Inst) -> Result<(), CompilationError> {
+        let Inst::InsertValue { agg, elem } = inst else {
+            panic!()
+        };
+        let Ty::Struct(struct_ty) = agg.type_(self.am) else {
+            panic!()
+        };
+        let num_fields = struct_ty.field_tyidxs().len();
+        let mut field_iidxs: Vec<hir::InstIdx> = match agg {
+            Operand::Const(cidx) => {
+                let Const::Poison(_) = self.am.const_(*cidx) else {
+                    panic!()
+                };
+                Vec::with_capacity(num_fields)
+            }
+            Operand::Local(_) => {
+                let Inst::InsertValue { .. } = agg.to_inst(self.am) else {
+                    panic!()
+                };
+                let prev_iid = agg.to_inst_id();
+                let inst_idx = self.frames.last().unwrap().get_local(&*self.opt, &prev_iid);
+                self.call_extractvals[&inst_idx].clone()
+            }
+            _ => panic!(),
+        };
+        // Builds a struct via a chain of `insertvalue`, one field at a time, so a fully
+        // built struct never reaches this point.
+        field_iidxs.push(self.p_operand(elem)?);
+
+        let handle = field_iidxs[0];
+        self.call_extractvals.insert(handle, field_iidxs);
+        self.frames.last_mut().unwrap().set_local(iid, handle);
+        Ok(())
+    }
+
     fn p_extractvalue(&mut self, iid: InstId, inst: &Inst) -> Result<(), CompilationError> {
         let Inst::ExtractValue { tyidx, op, indices } = inst else {
             panic!()
@@ -1977,7 +2012,7 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
         };
 
         match op.to_inst(self.am) {
-            Inst::Call { .. } => {
+            Inst::Call { .. } | Inst::InsertValue { .. } => {
                 assert_eq!(indices.len(), 1);
                 let aot_iid = op.to_inst_id();
                 let val_iidx = self.frames.last().unwrap().get_local(&*self.opt, &aot_iid);
@@ -2211,6 +2246,37 @@ impl<'a, Reg: RegT + 'static> AotToHir<'a, Reg> {
             panic!()
         };
         let ptr = self.p_operand(tgt)?;
+        if let Ty::Struct(struct_ty) = val.type_(self.am) {
+            let aot_iid = val.to_inst_id();
+            let inst_idx = self.frames.last().unwrap().get_local(&*self.opt, &aot_iid);
+            let field_iidxs = &self.call_extractvals[&inst_idx];
+            let bitoffs = struct_ty.field_bit_offs();
+            assert_eq!(field_iidxs.len(), bitoffs.len());
+            for (field_iidx, bitoff) in field_iidxs.iter().zip(bitoffs.iter()) {
+                assert_eq!(bitoff % 8, 0);
+                let byte_off = u32::try_from(bitoff / 8).unwrap();
+                let field_ptr = self.opt.feed(
+                    hir::PtrAdd {
+                        ptr,
+                        off: i32::try_from(byte_off).unwrap(),
+                        in_bounds: false,
+                        nusw: false,
+                        nuw: false,
+                    }
+                    .into(),
+                )?;
+                self.opt.feed_void(
+                    hir::Store {
+                        ptr: field_ptr,
+                        val: *field_iidx,
+                        is_volatile: *volatile,
+                    }
+                    .into(),
+                )?;
+            }
+            return Ok(());
+        }
+
         let val = self.p_operand(val)?;
         self.opt
             .feed_void(


### PR DESCRIPTION
Adding support for a struct return value via a chain of `InsertValue`. 
Structs are never map to a single HIR value, `p_insertvalue` doesn't emit a real HIR instruction - it just extends the field-index already used for struct-returning `Call`s so `p_extractvalue` and `p_store` can resolve fields in the same way. 
